### PR TITLE
Minor spelling correction. Altered description of how `data.table` optim...

### DIFF
--- a/vignettes/benchmark-baseball.Rmd
+++ b/vignettes/benchmark-baseball.Rmd
@@ -108,7 +108,7 @@ microbenchmark(
 
 NB: base implementation captures computation but not output format, gives considerably less output.
 
-However, this comparison is slightly unfair because both data.table and `summarise.tbl_cpp` use tricks to find a more efficient implementation of `mean()`. Data table calls `.Internal(mean(x))` directly (thus avoiding the overhead of S3 method dispatch), while `summarise.tbl_cpp` calls an C++ implementation of the mean, which also avoids R function call overhead.
+However, this comparison is slightly unfair because both data.table and `summarise.tbl_cpp` use tricks to find a more efficient implementation of `mean()`. Data table calls a `C` implementation of the `mean (using `.External(Cfastmean, B, FALSE)`   and thus avoiding the overhead of S3 method dispatch), while `summarise.tbl_cpp` calls an C++ implementation of the mean, which also avoids R function call overhead.
 
 ```{r}
 mean_ <- function(x) .Internal(mean(x))
@@ -122,7 +122,7 @@ microbenchmark(
 )
 ```
 
-Using a somewhat more compliated summary function is also revelaing.
+Using a somewhat more compliated summary function is also revealing.
 
 ```{r}
 microbenchmark( 


### PR DESCRIPTION
...izes calls to `mean`

`.External(Cfastmean, B, FALSE)` is used instead of `.Internal(mean(x))`. See https://r-forge.r-project.org/scm/viewvc.php/pkg/src/fastmean.c?view=markup&root=datatable for details. fastmean is (almost) identical to the base R implementation, except that it deals with `NA` values within the C code, not within R.
