### PR TITLE
Pass all values directly to dbi_connect()

### DIFF
--- a/R/src-mysql.r
+++ b/R/src-mysql.r
@@ -93,7 +93,7 @@ src_mysql <- function(dbname, host = NULL, port = 0L, user = "root", ...) {
     stop("RMySQL package required to connect to mysql/mariadb", call. = FALSE)
   }
   
-  con <- dbi_connect(MySQL(), dbname = dbname , host = host, port = port, password = password, ...)
+  con <- dbi_connect(MySQL(), dbname = dbname , host = host, port = port, user = user, ...)
   info <- db_info(con)
   
   src_sql("mysql", con, 


### PR DESCRIPTION
Using `...` instead of these default values makes it possible to use a my.cnf file's values for "password" without storing it in plaintext.
