### PR TITLE
Add names attribute to the output of do.grouped_df

### DIFF
--- a/R/manip-df.r
+++ b/R/manip-df.r
@@ -100,6 +100,6 @@ do.grouped_df <- function(.data, .f, ...) {
     subs <- .data[index[[i]] + 1L, , drop = FALSE]
     out[[i]] <- .f(subs, ...)
   }
-  nms <- apply(attr(.data,"labels"), 1, paste, "_")
+  nms <- apply(attr(.data,"labels"), 1, paste, collapse = "_")
   setNames(out,nms)
 }


### PR DESCRIPTION
This change adds the behaviour expressed in

http://stackoverflow.com/questions/21991168/assigning-names-to-the-list-output-of-dplyr-do-operation

This makes the output similar to the dlply from the package plyr, i.e. the names are assigned to the output list, so it is easier to track which element came from which grouping.

I imagine there is more efficient to achieve that, or this idea was already discarded. 
