### PR TITLE
'as.tbl_cube' is missing a dispatch for matrix 

### DIFF
--- a/R/tbl-cube.r
+++ b/R/tbl-cube.r
@@ -194,6 +194,10 @@ as.tbl_cube.table <- as.tbl_cube.array
 
 #' @export
 #' @rdname as.tbl_cube
+as.tbl_cube.matrix <- as.tbl_cube.array
+
+#' @export
+#' @rdname as.tbl_cube
 as.tbl_cube.data.frame <- function(x, dim_names, ...) {
   if (!is.character(dim_names)) {
     dim_names <- names(x)[dim_names]


### PR DESCRIPTION
At the moment, as.tbl_cube() has no dispatch for matrix, which makes it inapplicable for matrices/two dimensional arrays:

```
m <- array(1, c(3, 3), list(x=1:3, y=1:3))
as.tbl_cube(m)
# Error in UseMethod("as.tbl_cube") :   
# no applicable method for 'as.tbl_cube' applied to an object of class "c('matrix', 'double', 'numeric')
```
