### PR TITLE
Add missing n argument for grouped df and dt

### DIFF
--- a/R/grouped-df.r
+++ b/R/grouped-df.r
@@ -24,11 +24,11 @@ grouped_df <- function(data, vars, drop = TRUE) {
 is.grouped_df <- function(x) inherits(x, "grouped_df")
 
 #' @export
-print.grouped_df <- function(x, ..., n=NULL) {
+print.grouped_df <- function(x, ..., n = NULL) {
   cat("Source: local data frame ", dim_desc(x), "\n", sep = "")
   cat("Groups: ", commas(deparse_all(groups(x))), "\n", sep = "")
   cat("\n")
-  trunc_mat(x, n=n)
+  trunc_mat(x, n = n)
 }
 
 #' @export

--- a/R/grouped-dt.r
+++ b/R/grouped-dt.r
@@ -45,11 +45,11 @@ groups.grouped_dt <- function(x) {
 is.grouped_dt <- function(x) inherits(x, "grouped_dt")
 
 #' @export
-print.grouped_dt <- function(x, ..., n=NULL) {
+print.grouped_dt <- function(x, ..., n = NULL) {
   cat("Source: local data table ", dim_desc(x), "\n", sep = "")
   cat("Groups: ", commas(deparse_all(groups(x))), "\n", sep = "")
   cat("\n")
-  trunc_mat(x, n=n)
+  trunc_mat(x, n = n)
 }
 
 #' @export


### PR DESCRIPTION
The print methods for grouped_df and grouped_df were missing the n argument to specify the number of rows to print.  This fixes the issue.
