### PR TITLE
Postgresql schema

### DIFF
--- a/R/tbl-sql.r
+++ b/R/tbl-sql.r
@@ -15,40 +15,7 @@
 tbl_sql <- function(subclass, src, from, ..., vars = NULL) {
   assert_that(is.character(from), length(from) == 1)
 
-
-  if (!is.sql(from)) { # Must be a character string
-    tblschema <- NA
-    if (is.character(from)) {
-      parts <- strsplit(from, "\\.")[[1]]
-      if (length(parts) == 1) {
-        tblname <- parts[[1]]
-      }
-      else if (length(parts)== 2) {
-        tblschema <- parts[[1]]
-        tblname <- parts[[2]]
-      }
-      else {
-        stop("Invalid table format ", from, call. = FALSE)
-      }
-    }
-    else {
-      tblname <- from
-    }
-
-    if (isFALSE(db_has_table(src$con, tblname))) {
-      stop("Table ", from, " not found in database ", src$path, call. = FALSE)
-    }
-
-    if (!is.na(tblschema)) {
-      from <- build_sql(ident(tblschema), ".", ident(tblname))
-    }
-    else {
-      from <- ident(tblname)
-    }
-  } else if (!is.join(from)) { # Must be arbitrary sql
-    # Abitrary sql needs to be wrapped into a named subquery
-    from <- build_sql("(", from, ") AS ", ident(unique_name()), con = src$con)
-  }
+  from <- db_table_source(src$con, src$path, from)
 
   tbl <- make_tbl(c(subclass, "sql"),
     src = src,              # src object


### PR DESCRIPTION
Fix for #244.

Seems that PostgreSQL treats dot in table name as a special character which splits two identifiers and shouldn't be escaped or put into quotes.

Although I tried to preserve original behavior, I didn't try if it works.
