### PR TITLE
Re-export `%>%` without a copy

### DIFF
--- a/R/chain.r
+++ b/R/chain.r
@@ -93,7 +93,8 @@ chain_q <- function(calls, env = parent.frame()) {
   chain_q(list(substitute(lhs), substitute(rhs)), env = parent.frame())
 }
 
+#' @importFrom magrittr %>%
+#' @name %>%
 #' @export
 #' @rdname chain
-`%>%` <- magrittr::`%>%`
-
+NULL


### PR DESCRIPTION
Fixes #488

I did commit oxygenized documentation in this commit as that has not been done in awhile.  I did verify that this change fixes the issue once `document()` is run however. 
