### PR TITLE
DOCS: convention to use mtcars.by_vs in group_by

### DIFF
--- a/R/group-by.r
+++ b/R/group-by.r
@@ -30,28 +30,28 @@
 #'   use \code{add = TRUE}
 #' @export
 #' @examples
-#' by_cyl <- group_by(mtcars, cyl)
-#' summarise(by_cyl, mean(disp), mean(hp))
-#' filter(by_cyl, disp == max(disp))
+#' mtcars.by_cyl <- group_by(mtcars, cyl)
+#' summarise(mtcars.by_cyl, mean(disp), mean(hp))
+#' filter(mtcars.by_cyl, disp == max(disp))
 #'
 #' # summarise peels off a single layer of grouping
-#' by_vs_am <- group_by(mtcars, vs, am)
-#' by_vs <- summarise(by_vs_am, n = n())
-#' by_vs
-#' summarise(by_vs, n = sum(n))
+#' mtcars.by_vs_am <- group_by(mtcars, vs, am)
+#' mtcars.by_vs <- summarise(mtcars.by_vs_am, n = n())
+#' mtcars.by_vs
+#' summarise(mtcars.by_vs, n = sum(n))
 #' # use ungroup() to remove if not wanted
-#' summarise(ungroup(by_vs), n = sum(n))
+#' summarise(ungroup(mtcars.by_vs), n = sum(n))
 #'
 #' # You can group by expressions: this is just short-hand for
 #' # a mutate followed by a simple group_by
 #' group_by(mtcars, vsam = vs + am)
 #'
 #' # By default, group_by sets groups. Use add = TRUE to add groups
-#' groups(group_by(by_cyl, vs, am))
-#' groups(group_by(by_cyl, vs, am, add = TRUE))
+#' groups(group_by(mtcars.by_cyl, vs, am))
+#' groups(group_by(mtcars.by_cyl, vs, am, add = TRUE))
 #'
 #' # Duplicate groups are silently dropped
-#' groups(group_by(by_cyl, cyl, cyl))
+#' groups(group_by(mtcars.by_cyl, cyl, cyl))
 group_by <- function(x, ..., add = FALSE) {
   new_groups <- named_dots(...)
 


### PR DESCRIPTION
This is a suggestion for a naming convention for variables created with group_by.

I think it would be clearer to use a convention like the following:
    <original tbl name>.<by grouping variable name> 
for naming variables created with group by. 

For example, in the documentation of group_by, mtcars grouped by cyl would be named "mtcars.by_cyl", making it easier to remember which dataset was grouped and how.

If you include this suggestion, the documentation of group_by will be slightly clearer, and maybe more people will use this naming convention for grouped dataset, making the world a slightly better place :-). Otherwise, it will be fine as well. 

There are examples of group_by in dplyr documentation, but since they are included in other functions' documentation, I think it would be more concise to leave them as they are.
