### PR TITLE
Avoid compiler warning

### DIFF
--- a/src/between.cpp
+++ b/src/between.cpp
@@ -21,7 +21,7 @@ LogicalVector between(NumericVector x, double left, double right) {
   for (int i = 0; i < n; ++i) {
     if (NumericVector::is_na(x[i])) {
       out[i] = NA_REAL;
-    } else if ((x[i] >= left) & (x[i] <= right)) {
+    } else if ((x[i] >= left) && (x[i] <= right)) {
       out[i] = true;
     } else {
       out[i] = false;


### PR DESCRIPTION
Compiling on Windows I get the following warning, now fixed.

```
between.cpp: In function 'Rcpp::LogicalVector between(Rcpp::NumericVector, double, double)':
between.cpp:24:39: warning: suggest parentheses around comparison in operand of '&' [-Wparentheses]
```
