### PR TITLE
Update order-by.R

### DIFF
--- a/R/order-by.R
+++ b/R/order-by.R
@@ -49,7 +49,8 @@ order_by <- function(order_by, call) {
 with_order <- function(order_by, fun, x, ...) {
   ord <- order(order_by)
   undo <- match(seq_along(order_by), ord)
-  
-  out <- fun(x[ord], ...)
-  out[undo]
+  z <- fun(x[ord], ...)
+  out <- z[undo]
+  attributes(out) <- attributes(x)
+  out
 }


### PR DESCRIPTION
I correct the following problem: attributes are lost when order_by is specified

``` R
v<- c(1,1)
date <- c(1,2)
attr(v, "my_attribute") <- "This is a vector"
lag(v,1)
#> [1] NA  1
#> attr(,"my_attribute")
#> [1] "This is a vector"
lag(v,1, order_by = date)
#> [1] NA  1
```
