### PR TITLE
Update join.Rd

### DIFF
--- a/man/join.Rd
+++ b/man/join.Rd
@@ -58,7 +58,8 @@ Currently dplyr supports four join types:
    between x and y, all combination of the matches are returned.}
 
    \item{\code{left_join}}{return all rows from x, and all columns from x
-   and y. If there are multiple matches between x and y, all combination of
+   and y. Rows in x with no match in y will have NA values in the new
+   columns. If there are multiple matches between x and y, all combination of
    the matches are returned.}
 
    \item{\code{semi_join}}{return all rows from x where there are matching


### PR DESCRIPTION
Clarify the behaviour of `left_join` to make it even clearer that all x rows are kept and what happens when not all x ids are present in y. This helps differentiate `left_join` from `inner_join`.
