### PR TITLE
Fix right_join()

### DIFF
--- a/src/dplyr.cpp
+++ b/src/dplyr.cpp
@@ -1159,7 +1159,7 @@ DataFrame right_join_impl( DataFrame x, DataFrame y, CharacterVector by_x, Chara
             push_back( indices_x,    it->second ) ;
             push_back( indices_y, i, it->second.size() ) ;
         } else {
-            indices_x.push_back(-1) ; // mark NA
+            indices_x.push_back(-i-1) ; // point to the i-th row in the right table
             indices_y.push_back(i) ;
         }
     }

--- a/tests/testthat/test-joins.r
+++ b/tests/testthat/test-joins.r
@@ -46,6 +46,22 @@ test_that("univariate anti join has x columns, missing rows", {
   expect_equal(j2$z, 4)
 })
 
+test_that("univariate right join has all columns, all rows", {
+  j1 <- right_join(a, b, "x")
+  j2 <- right_join(b, a, "x")
+
+  expect_equal(names(j1), c("x", "y", "z"))
+  expect_equal(names(j2), c("x", "z", "y"))
+
+  expect_equal(j1$x, c(1, 1, 2, 2, 4))
+  expect_equal(j1$y, c(1, 2, 3, 3, NA))
+  expect_equal(j1$z, c(1, 1, 2, 3, 4))
+
+  expect_equal(j2$x, c(1, 1, 2, 2, 3))
+  expect_equal(j2$y, c(1, 2, 3, 3, 4))
+  expect_equal(j2$z, c(1, 1, 2, 3, NA))
+})
+
 # Bivariate keys ---------------------------------------------------------------
 
 c <- data.frame(


### PR DESCRIPTION
PR fixes the bug in a `right_join_impl()`: if a corresponding row was missing in the left frame, the values were taken from the first row of the right frame.
The same bug still exists in the `left_join_impl()`: right frame indices reference incorrect left frame rows, but it's not exposed. 
