### PR TITLE
Strict matching for .data

### DIFF
--- a/inst/include/dplyr/Result/GroupedHybridCall.h
+++ b/inst/include/dplyr/Result/GroupedHybridCall.h
@@ -63,13 +63,19 @@ private:
     // If bindr (via bindrcpp) supported the creation of a child environment, we could save the
     // call to Rcpp_eval() triggered by active_env.new_child()
     Environment bottom = active_env.new_child(true);
-    bottom[".data"] = active_env;
+    bottom[".data"] = rlang_new_data_source(active_env);
 
     // Install definitions for formula self-evaluation and unguarding
     Function new_overscope = rlang_object("new_overscope");
     overscope = new_overscope(bottom, active_env, env);
 
     has_overscope = true;
+  }
+
+  static List rlang_new_data_source(Environment env) {
+    List ret = List::create(_["src"] = env, _["lookup_msg"] = "Column `%s` not found in data");
+    set_class(ret, "data_source");
+    return ret;
   }
 
   static SEXP hybrid_get_callback(const String& name, bindrcpp::PAYLOAD payload) {

--- a/inst/include/dplyr/Result/GroupedHybridCall.h
+++ b/inst/include/dplyr/Result/GroupedHybridCall.h
@@ -73,7 +73,7 @@ private:
   }
 
   static List rlang_new_data_source(Environment env) {
-    List ret = List::create(_["src"] = env, _["lookup_msg"] = "Column `%s` not found in data");
+    List ret = List::create(_["src"] = env, _["lookup_msg"] = "Column `%s`: not found in data");
     set_class(ret, "data_source");
     return ret;
   }

--- a/tests/testthat/test-overscope.R
+++ b/tests/testthat/test-overscope.R
@@ -3,11 +3,11 @@ context("overscope")
 test_that(".data has strict matching semantics (#2591)", {
   expect_error(
     data_frame(a = 1) %>% mutate(c = .data$b),
-    "Column `b` not found"
+    "Column `b`: not found in data"
   )
 
   expect_error(
     data_frame(a = 1:3) %>% group_by(a) %>% mutate(c = .data$b),
-    "Column `b` not found"
+    "Column `b`: not found in data"
   )
 })

--- a/tests/testthat/test-overscope.R
+++ b/tests/testthat/test-overscope.R
@@ -1,0 +1,13 @@
+context("overscope")
+
+test_that(".data has strict matching semantics (#2591)", {
+  expect_error(
+    data_frame(a = 1) %>% mutate(c = .data$b),
+    "Column `b` not found"
+  )
+
+  expect_error(
+    data_frame(a = 1:3) %>% group_by(a) %>% mutate(c = .data$b),
+    "Column `b` not found"
+  )
+})


### PR DESCRIPTION
I think strict matching for .env needs to be fixed in rlang, CC @lionel-.

Fixes #2591.