### PR TITLE
Fix hybrid handling of summarised symbols

### DIFF
--- a/src/hybrid.cpp
+++ b/src/hybrid.cpp
@@ -105,7 +105,7 @@ public:
   VariableResult(const ILazySubsets& subsets_, const SymbolString& name_) : subsets(subsets_), name(name_)  {}
 
   SEXP process(const GroupedDataFrame& gdf) {
-    if (subsets.count(name) && subsets.is_summary(name)) {
+    if (subsets.is_summary(name)) {
       // No need to check length since the summary has already been checked
       return subsets.get_variable(name);
     } else {

--- a/src/hybrid.cpp
+++ b/src/hybrid.cpp
@@ -105,8 +105,13 @@ public:
   VariableResult(const ILazySubsets& subsets_, const SymbolString& name_) : subsets(subsets_), name(name_)  {}
 
   SEXP process(const GroupedDataFrame& gdf) {
-    check_length(gdf.max_group_size(), 1, "a summary value", name);
-    return process(*gdf.group_begin());
+    if (subsets.count(name) && subsets.is_summary(name)) {
+      // No need to check length since the summary has already been checked
+      return subsets.get_variable(name);
+    } else {
+      check_length(gdf.max_group_size(), 1, "a summary value", name);
+      return process(*gdf.group_begin());
+    }
   }
 
   SEXP process(const RowwiseDataFrame&) {

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -950,4 +950,5 @@ test_that("proper handling of NA factors (#2588)", {
 
 test_that("can refer to previously summarised symbols", {
   expect_identical(summarise(group_by(mtcars, cyl), x = 1, z = x)[2:3], tibble(x = c(1, 1, 1), z = x))
+  expect_identical(summarise(group_by(mtcars, cyl), x = n(), z = x)[2:3], tibble(x = c(11L, 7L, 14L), z = x))
 })

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -947,3 +947,7 @@ test_that("proper handling of NA factors (#2588)", {
   ret <- df %>% group_by(x) %>% summarise(y = y[1])
   expect_identical(as.character(ret$y), c(NA, NA, "3"))
 })
+
+test_that("can refer to previously summarised symbols", {
+  expect_identical(summarise(group_by(mtcars, cyl), x = 1, z = x)[2:3], tibble(x = c(1, 1, 1), z = x))
+})


### PR DESCRIPTION
So this works: `summarise(group_by(mtcars, cyl), x = 1, z = x)`

Closes #2632