### PR TITLE
Create Makevars on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,5 @@ include:
 before_install:
 - mkdir -p ~/.R; echo 'PKG_CXXFLAGS := ${PKG_CXXFLAGS} -Wall -Wextra -pedantic -Werror' > ~/.R/Makevars
 
-before_script:
-- R -q -e 'devtools::install_github("tidyverse/dbplyr")'
-
 after_success:
 - Rscript -e 'covr::codecov()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ include:
 - r: oldrel
 - r: devel
 
+before_install:
+- mkdir -p ~/.R; echo 'PKG_CXXFLAGS := ${PKG_CXXFLAGS} -Wall -Wextra -pedantic -Werror' > ~/.R/Makevars
+
 before_script:
 - R -q -e 'devtools::install_github("tidyverse/dbplyr")'
 


### PR DESCRIPTION
that set additional warning flags. The build is aborted in case of warnings.

This requires RcppCore/Rcpp#671 or a workaround.