### PR TITLE
Remove references to obsolete vignettes in "Introduction to dplyr"

### DIFF
--- a/vignettes/dplyr.Rmd
+++ b/vignettes/dplyr.Rmd
@@ -237,7 +237,7 @@ Grouping affects the verbs as follows:
 * grouped `select()` is the same as ungrouped `select()`, except that 
   grouping variables are always retained. 
    
-* grouped `arrange()` orders first by the grouping variables
+* grouped `arrange()` is the same as ungrouped, but, with `.by_group = TRUE`, it orders first by the grouping variables
 
 * `mutate()` and `filter()` are most useful in conjunction with window 
   functions (like `rank()`, or `min(x) == x`). They are described in detail in 

--- a/vignettes/dplyr.Rmd
+++ b/vignettes/dplyr.Rmd
@@ -33,10 +33,7 @@ The dplyr package makes these steps fast and easy:
 
 This document introduces you to dplyr's basic set of tools, and shows you how to apply them to data frames. Other vignettes provide more details on specific topics:
 
-* databases: Besides in-memory data frames, dplyr also connects to out-of-memory, remote databases. And by translating your R code into the appropriate SQL, it allows you to work with both types of data using the same set of tools.
-
-* benchmark-baseball: see how dplyr compares to other tools for data
-  manipulation on a realistic use case.
+* dbplyr: Besides in-memory data frames, dplyr also connects to out-of-memory, remote databases. And by translating your R code into the appropriate SQL, it allows you to work with both types of data using the same set of tools.
 
 * window-functions: a window function is a variation on an aggregation
   function. Where an aggregate function uses `n` inputs to produce 1 


### PR DESCRIPTION
The vignette "Introduction to dplyr" refers to some deleted/moved vignettes yet. Do you have some other plan to rewrite this vignette?