### PR TITLE
Protect duplicated data

### DIFF
--- a/inst/include/dplyr/NamedListAccumulator.h
+++ b/inst/include/dplyr/NamedListAccumulator.h
@@ -11,7 +11,7 @@ template <typename Data>
 class NamedListAccumulator {
 public:
   SymbolMap symbol_map;
-  std::vector<SEXP> data;
+  std::vector<RObject> data;
 
   NamedListAccumulator() {}
 

--- a/inst/include/dplyr/NamedListAccumulator.h
+++ b/inst/include/dplyr/NamedListAccumulator.h
@@ -15,7 +15,7 @@ public:
 
   NamedListAccumulator() {}
 
-  inline void set(const SymbolString& name, SEXP x) {
+  inline void set(const SymbolString& name, RObject x) {
     if (! Rcpp::traits::same_type<Data, RowwiseDataFrame>::value)
       check_supported_type(x, name);
 


### PR DESCRIPTION
after removing names.

This is just a hotfix, I'll work separately on getting names right.

Fixes #2680.