### PR TITLE
Remove names only for grouped summarise() and mutate()

### DIFF
--- a/inst/include/dplyr/NamedListAccumulator.h
+++ b/inst/include/dplyr/NamedListAccumulator.h
@@ -9,20 +9,16 @@ namespace dplyr {
 
 template <typename Data>
 class NamedListAccumulator {
-public:
+private:
   SymbolMap symbol_map;
-  std::vector<RObject> data;
+  std::vector<RObject> data; // owns the results
 
+public:
   NamedListAccumulator() {}
 
   inline void set(const SymbolString& name, RObject x) {
     if (! Rcpp::traits::same_type<Data, RowwiseDataFrame>::value)
       check_supported_type(x, name);
-
-    if (!Rf_isNull(Rf_getAttrib(x, R_NamesSymbol))) {
-      x = Rf_shallow_duplicate(x);
-      Rf_setAttrib(x, R_NamesSymbol, R_NilValue);
-    }
 
     SymbolMapIndex index = symbol_map.insert(name);
     if (index.origin == NEW) {

--- a/src/mutate.cpp
+++ b/src/mutate.cpp
@@ -67,7 +67,6 @@ SEXP mutate_not_grouped(DataFrame df, const QuosureList& dots) {
   }
 
   CallProxy call_proxy(df);
-  List results(nexpr);
 
   for (int i = 0; i < nexpr; i++) {
     Rcpp::checkUserInterrupt();
@@ -79,19 +78,20 @@ SEXP mutate_not_grouped(DataFrame df, const QuosureList& dots) {
     Environment env = quosure.env();
     call_proxy.set_env(env);
 
+    RObject variable;
     if (TYPEOF(call) == SYMSXP) {
       SymbolString call_name = SymbolString(Symbol(call));
       if (call_proxy.has_variable(call_name)) {
-        results[i] = call_proxy.get_variable(call_name);
+        variable = call_proxy.get_variable(call_name);
       } else {
-        results[i] = shared_SEXP(env.find(call_name.get_string()));
+        variable = shared_SEXP(env.find(call_name.get_string()));
       }
     } else if (TYPEOF(call) == LANGSXP) {
       call_proxy.set_call(call);
-      results[i] = call_proxy.eval();
+      variable = call_proxy.eval();
     } else if (Rf_length(call) == 1) {
       boost::scoped_ptr<Gatherer> gather(constant_gatherer(call, nrows, name));
-      results[i] = gather->collect();
+      variable = gather->collect();
     } else if (Rf_isNull(call)) {
       accumulator.rm(name);
       continue;
@@ -99,22 +99,22 @@ SEXP mutate_not_grouped(DataFrame df, const QuosureList& dots) {
       stop("cannot handle");
     }
 
-    if (Rf_inherits(results[i], "POSIXlt")) {
+    if (Rf_inherits(variable, "POSIXlt")) {
       bad_col(quosure.name(), "POSIXlt results not supported");
     }
 
-    const int n_res = Rf_length(results[i]);
-    check_supported_type(results[i], name);
+    const int n_res = Rf_length(variable);
+    check_supported_type(variable, name);
     check_length(n_res, nrows, "the number of rows", name);
 
     if (n_res == 1 && nrows != 1) {
       // recycle
-      boost::scoped_ptr<Gatherer> gather(constant_gatherer(results[i], nrows, name));
-      results[i] = gather->collect();
+      boost::scoped_ptr<Gatherer> gather(constant_gatherer(variable, nrows, name));
+      variable = gather->collect();
     }
 
-    call_proxy.input(name, results[i]);
-    accumulator.set(name, results[i]);
+    call_proxy.input(name, variable);
+    accumulator.set(name, variable);
   }
   List res = structure_mutate(accumulator, df, classes_not_grouped(), false);
 
@@ -153,7 +153,6 @@ SEXP mutate_grouped(const DataFrame& df, const QuosureList& dots) {
 
   LOG_VERBOSE << "processing " << nexpr << " variables";
 
-  List variables(nexpr);
   for (int i = 0; i < nexpr; i++) {
     Rcpp::checkUserInterrupt();
     const NamedQuosure& quosure = dots[i];
@@ -166,23 +165,24 @@ SEXP mutate_grouped(const DataFrame& df, const QuosureList& dots) {
 
     LOG_VERBOSE << "processing " << name.get_utf8_cstring();
 
+    RObject variable;
+
     if (TYPEOF(call) == LANGSXP || TYPEOF(call) == SYMSXP) {
       proxy.set_call(call);
       boost::scoped_ptr<Gatherer> gather(gatherer<Data, Subsets>(proxy, gdf, name));
-      SEXP variable = variables[i] = gather->collect();
-      proxy.input(name, variable);
-      accumulator.set(name, variable);
+      variable = gather->collect();
     } else if (Rf_length(call) == 1) {
       boost::scoped_ptr<Gatherer> gather(constant_gatherer(call, gdf.nrows(), name));
-      SEXP variable = variables[i] = gather->collect();
-      proxy.input(name, variable);
-      accumulator.set(name, variable);
+      variable = gather->collect();
     } else if (Rf_isNull(call)) {
       accumulator.rm(name);
       continue;
     } else {
       stop("cannot handle");
     }
+
+    proxy.input(name, variable);
+    accumulator.set(name, variable);
   }
 
   return structure_mutate(accumulator, df, get_class(df));

--- a/src/mutate.cpp
+++ b/src/mutate.cpp
@@ -181,6 +181,7 @@ SEXP mutate_grouped(const DataFrame& df, const QuosureList& dots) {
       stop("cannot handle");
     }
 
+    Rf_setAttrib(variable, R_NamesSymbol, R_NilValue);
     proxy.input(name, variable);
     accumulator.set(name, variable);
   }

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -264,9 +264,9 @@ test_that("mutate remove variables with = NULL syntax (#462)", {
   expect_false("cyl" %in% names(data))
 })
 
-test_that("mutate strips names (#1689)", {
+test_that("mutate strips names, but only if grouped (#1689, #2675)", {
   data <- data_frame(a = 1:3) %>% mutate(b = setNames(nm = a))
-  expect_null(names(data$b))
+  expect_equal(names(data$b), as.character(1:3))
 
   data <- data_frame(a = 1:3) %>% rowwise %>% mutate(b = setNames(nm = a))
   expect_null(names(data$b))
@@ -275,12 +275,12 @@ test_that("mutate strips names (#1689)", {
   expect_null(names(data$b))
 })
 
-test_that("mutate strips names of list-columns, but keeps names in original data (#2523)", {
+test_that("mutate does not strip names of list-columns (#2675)", {
   vec <- list(a = 1, b = 2)
   data <- data_frame(x = vec)
   data <- mutate(data, x)
   expect_identical(names(vec), c("a", "b"))
-  expect_null(names(data$x))
+  expect_identical(names(data$x), c("a", "b"))
 })
 
 test_that("mutate gives a nice error message if an expression evaluates to NULL (#2187)", {

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -200,9 +200,9 @@ test_that("summarise propagate attributes (#194)", {
 
 })
 
-test_that("summarise strips names (#2231)", {
+test_that("summarise strips names, but only if grouped (#2231, #2675)", {
   data <- data_frame(a = 1:3) %>% summarise(b = setNames(nm = a[[1]]))
-  expect_null(names(data$b))
+  expect_equal(names(data$b), "1")
 
   data <- data_frame(a = 1:3) %>% rowwise %>% summarise(b = setNames(nm = a))
   expect_null(names(data$b))


### PR DESCRIPTION
Includes a refactoring, the second commit contains the essential change.

Fixes #2675.

Closes #2679.

Do we support unnesting grouped data frames in tidyr?