### PR TITLE
Avoid partial matching on select_vars() arguments

### DIFF
--- a/R/dataframe.R
+++ b/R/dataframe.R
@@ -106,7 +106,8 @@ arrange_.data.frame <- function(.data, ..., .dots = list()) {
 
 #' @export
 select.data.frame <- function(.data, ...) {
-  vars <- select_vars(names(.data), ...)
+  # Pass via splicing to avoid matching select_vars() arguments
+  vars <- select_vars(names(.data), !!! quos(...))
   select_impl(.data, vars)
 }
 #' @export

--- a/R/grouped-df.r
+++ b/R/grouped-df.r
@@ -120,7 +120,8 @@ cbind.grouped_df <- function(...) {
 
 #' @export
 select.grouped_df <- function(.data, ...) {
-  vars <- select_vars(names(.data), ...)
+  # Pass via splicing to avoid matching select_vars() arguments
+  vars <- select_vars(names(.data), !!! quos(...))
   vars <- ensure_group_vars(vars, .data)
   select_impl(.data, vars)
 }

--- a/tests/testthat/test-select.r
+++ b/tests/testthat/test-select.r
@@ -164,3 +164,13 @@ test_that("select succeeds in presence of raw columns (#1803)", {
   expect_identical(select(df, b), df["b"])
   expect_identical(select(df, -b), df["a"])
 })
+
+test_that("arguments to select() don't match select_vars() arguments", {
+  df <- tibble(a = 1)
+  expect_identical(select(df, var = a), tibble(var = 1))
+  expect_identical(select(group_by(df, a), var = a), group_by(tibble(var = 1), var))
+  expect_identical(select(df, exclude = a), tibble(exclude = 1))
+  expect_identical(select(df, include = a), tibble(include = 1))
+  expect_identical(select(group_by(df, a), exclude = a), group_by(tibble(exclude = 1), exclude))
+  expect_identical(select(group_by(df, a), include = a), group_by(tibble(include = 1), include))
+})


### PR DESCRIPTION
Fixes #2692 

It is probably too late to rename `vars` to `.vars`, even if it is first argument.

@topepo did you copy `select_vars()` implementation for recipes? If so it's better to prefix arguments of functions taking data via dots with `.` to avoid this issue. Any variable named `var` passed to `select_vars()` will partial match on `vars` :/