### PR TITLE
Fix off-by-one error in bind_rows() error msg

### DIFF
--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -64,7 +64,7 @@ R_xlen_t cols_length(SEXP x) {
 static
 void inner_vector_check(SEXP x, int nrows, int arg) {
   if (!is_vector(x))
-    bad_pos_arg(arg, "list must contain atomic vectors");
+    bad_pos_arg(arg + 1, "list must contain atomic vectors");
 
   if (OBJECT(x)) {
     if (Rf_inherits(x, "data.frame"))

--- a/tests/testthat/helper-combine.R
+++ b/tests/testthat/helper-combine.R
@@ -26,7 +26,7 @@ combine_pair_test <- function(item_pair, var1, var2, result,
     expect_warning(
       expect_error(
         combine(item_pair),
-        "^Argument 2: can't convert [^ ]* to [^ ]*$",
+        "^Evaluation error: Argument 2: can't convert [^ ]* to [^ ]*$",
         label = label_if_fail
       ),
       regexp = warning_regexp,

--- a/tests/testthat/helper-combine.R
+++ b/tests/testthat/helper-combine.R
@@ -26,7 +26,7 @@ combine_pair_test <- function(item_pair, var1, var2, result,
     expect_warning(
       expect_error(
         combine(item_pair),
-        "^Evaluation error: Argument 2: can't convert [^ ]* to [^ ]*$",
+        "^Argument 2: can't convert [^ ]* to [^ ]*$",
         label = label_if_fail
       ),
       regexp = warning_regexp,

--- a/tests/testthat/test-binds.R
+++ b/tests/testthat/test-binds.R
@@ -119,7 +119,7 @@ test_that("bind_rows only accepts data frames or vectors", {
   ll <- list(1:5, get_env())
   expect_error(
     bind_rows(ll),
-    "Argument 1: list must contain atomic vectors",
+    "Argument 2: list must contain atomic vectors",
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-binds.R
+++ b/tests/testthat/test-binds.R
@@ -116,7 +116,7 @@ test_that("bind_rows ignores NULL", {
 })
 
 test_that("bind_rows only accepts data frames or vectors", {
-  ll <- list(1:5, get_env())
+  ll <- list(1:5, rlang::get_env())
   expect_error(
     bind_rows(ll),
     "Argument 2: list must contain atomic vectors",


### PR DESCRIPTION
~~The 2nd commit holds an unrelated fix I needed to pass tests. I can remove if that is somehow peculiar to me.~~ *removed* Also added `rlang::` while poking around this test. Some rlang calls are namespaced in the tests while others are not, so not sure how it should be.