### PR TITLE
Allow top_n() argument `wt` to be a call

### DIFF
--- a/R/top-n.R
+++ b/R/top-n.R
@@ -68,5 +68,5 @@ top_n <- function(x, n, wt) {
 
 # Works with lazy tibbles
 tbl_rows_n <- function(tbl) {
-  pull(summarise(tbl, n = n()))
+  pull(summarise(ungroup(tbl), n = n()))
 }

--- a/R/top-n.R
+++ b/R/top-n.R
@@ -50,9 +50,6 @@ top_n <- function(x, n, wt) {
     wt <- eval_tidy(wt, x)
   }
 
-  if (length(wt) != tbl_rows_n(x)) {
-    abort("`wt` must be as long as the number of rows of `x`")
-  }
   if (!is_scalar_integerish(n)) {
     abort("`n` must be a scalar integer")
   }
@@ -64,9 +61,4 @@ top_n <- function(x, n, wt) {
   }
 
   eval_tidy(quo)
-}
-
-# Works with lazy tibbles
-tbl_rows_n <- function(tbl) {
-  pull(summarise(ungroup(tbl), n = n()))
 }

--- a/tests/testthat/test-tbl.R
+++ b/tests/testthat/test-tbl.R
@@ -7,3 +7,8 @@ test_that("tbl_nongroup_vars() excludes group variables", {
   gdf <- group_by(mtcars, cyl)
   expect_identical(tbl_nongroup_vars(gdf), setdiff(tbl_vars(gdf), "cyl"))
 })
+
+test_that("tbl_rows_n() handles grouped data frames", {
+  gdf <- group_by(mtcars, cyl)
+  expect_identical(tbl_rows_n(gdf), 32L)
+})

--- a/tests/testthat/test-tbl.R
+++ b/tests/testthat/test-tbl.R
@@ -7,8 +7,3 @@ test_that("tbl_nongroup_vars() excludes group variables", {
   gdf <- group_by(mtcars, cyl)
   expect_identical(tbl_nongroup_vars(gdf), setdiff(tbl_vars(gdf), "cyl"))
 })
-
-test_that("tbl_rows_n() handles grouped data frames", {
-  gdf <- group_by(mtcars, cyl)
-  expect_identical(tbl_rows_n(gdf), 32L)
-})

--- a/tests/testthat/test-top-n.R
+++ b/tests/testthat/test-top-n.R
@@ -13,6 +13,6 @@ test_that("top_n() handles missing `wt`", {
   )
 })
 
-test_that("top_n() aborts if not a vector as long as the tibble", {
-  expect_error(top_n(mtcars, 5, "mpg"), "must be as long as")
+test_that("top_n() handles calls", {
+  expect_identical(top_n(mtcars, 2, -disp), top_n(mtcars, -2, disp))
 })

--- a/tests/testthat/test-top-n.R
+++ b/tests/testthat/test-top-n.R
@@ -6,14 +6,13 @@ test_that("top_n returns n rows", {
   expect_equal(dim(top_four), c(4, 2))
 })
 
-test_that("top_n errs if wt argument is not a symbol (#2279)", {
-  # error message from assertthat
-  expect_error(data.frame(x = 1:10) %>% top_n(10, "x"))
-})
-
 test_that("top_n() handles missing `wt`", {
   df <- data.frame(x = c(10, 4, 1, 6, 3, 1, 1))
   expect_message(regexp = "Selecting by x",
     expect_identical(top_n(df, 2)$x, c(10, 6))
   )
+})
+
+test_that("top_n() aborts if not a vector as long as the tibble", {
+  expect_error(top_n(mtcars, 5, "mpg"), "must be as long as")
 })


### PR DESCRIPTION
Closes #2705

The new tidyeval implementation of `filter()` has fixed https://github.com/tidyverse/dplyr/issues/2279. However it makes sense to check that `wt` evaluate to a vector as long as the number of rows.

@hadley I'm not sure what's the generic way of retrieving the number of rows. Should `tbl_rows_n()` (added in this PR) be exported at some point?