### PR TITLE
Tidy naming for pronouns

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Imports:
     magrittr,
     methods,
     pkgconfig,
-    rlang (>= 0.0.0.9018),
+    rlang (>= 0.0.0.9019),
     R6,
     Rcpp (>= 0.12.6),
     tibble (>= 1.3.0.9001),
@@ -53,7 +53,7 @@ License: MIT + file LICENSE
 RoxygenNote: 6.0.1
 Roxygen: list(markdown = TRUE, roclets = c("rd", "namespace", "collate"))
 Remotes:
-    hadley/rlang@b22ce1c,
+    lionel-/rlang@250e7fa,
     hadley/dbplyr,
     tidyverse/glue,
     tidyverse/tibble

--- a/R/dataframe.R
+++ b/R/dataframe.R
@@ -68,7 +68,7 @@ filter_.data.frame <- function(.data, ..., .dots = list()) {
 
 #' @export
 slice.data.frame <- function(.data, ...) {
-  dots <- quos(..., .named = TRUE)
+  dots <- named_quos(...)
   slice_impl(.data, dots)
 }
 #' @export
@@ -179,7 +179,7 @@ setequal.data.frame <-  function(x, y, ...) equal_data_frame(x, y)
 
 #' @export
 distinct.data.frame <- function(.data, ..., .keep_all = FALSE) {
-  dist <- distinct_vars(.data, quos(..., .named = TRUE), .keep_all = .keep_all)
+  dist <- distinct_vars(.data, named_quos(...), .keep_all = .keep_all)
   distinct_impl(dist$data, dist$vars, dist$keep)
 }
 #' @export

--- a/R/group-by.r
+++ b/R/group-by.r
@@ -118,7 +118,7 @@ group_by_prepare <- function(.data, ..., .dots = list(), add = FALSE) {
 
   # Once we've done the mutate, we no longer need lazy objects, and
   # can instead just use symbols
-  new_groups <- exprs_auto_name(new_groups)
+  new_groups <- quos_auto_name(new_groups)
   group_names <- names(new_groups)
   if (add) {
     group_names <- c(group_vars(.data), group_names)

--- a/R/group-by.r
+++ b/R/group-by.r
@@ -118,7 +118,7 @@ group_by_prepare <- function(.data, ..., .dots = list(), add = FALSE) {
 
   # Once we've done the mutate, we no longer need lazy objects, and
   # can instead just use symbols
-  new_groups <- quos_auto_name(new_groups)
+  new_groups <- exprs_auto_name(new_groups, printer = tidy_text)
   group_names <- names(new_groups)
   if (add) {
     group_names <- c(group_vars(.data), group_names)

--- a/R/grouped-df.r
+++ b/R/grouped-df.r
@@ -238,7 +238,7 @@ do_.grouped_df <- function(.data, ..., env = caller_env(), .dots = list()) {
 distinct.grouped_df <- function(.data, ..., .keep_all = FALSE) {
   dist <- distinct_vars(
     .data,
-    vars = quos(..., .named = TRUE),
+    vars = named_quos(...),
     group_vars = group_vars(.data),
     .keep_all = .keep_all
   )

--- a/R/manip.r
+++ b/R/manip.r
@@ -285,7 +285,7 @@ transmute_ <- function(.data, ..., .dots = list()) {
 
 #' @export
 transmute.default <- function(.data, ...) {
-  dots <- quos(..., .named = TRUE)
+  dots <- named_quos(...)
   out <- mutate(.data, !!! dots)
 
   keep <- names(dots)

--- a/R/tbl-cube.r
+++ b/R/tbl-cube.r
@@ -390,7 +390,7 @@ group_vars.tbl_cube <- function(x) {
 
 #' @export
 summarise.tbl_cube <- function(.data, ...) {
-  dots <- quos(..., .named = TRUE)
+  dots <- named_quos(...)
 
   out_dims <- .data$dims[.data$groups]
   n <- map_int(out_dims, length)

--- a/R/tbl-df.r
+++ b/R/tbl-df.r
@@ -72,7 +72,7 @@ filter_.tbl_df <- function(.data, ..., .dots = list()) {
 
 #' @export
 slice.tbl_df <- function(.data, ...) {
-  dots <- quos(..., .named = TRUE)
+  dots <- named_quos(...)
   slice_impl(.data, dots)
 }
 #' @export
@@ -83,7 +83,7 @@ slice_.tbl_df <- function(.data, ..., .dots = list()) {
 
 #' @export
 mutate.tbl_df <- function(.data, ...) {
-  dots <- quos(..., .named = TRUE)
+  dots <- named_quos(...)
   mutate_impl(.data, dots)
 }
 #' @export
@@ -94,7 +94,7 @@ mutate_.tbl_df <- function(.data, ..., .dots = list()) {
 
 #' @export
 summarise.tbl_df <- function(.data, ...) {
-  dots <- quos(..., .named = TRUE)
+  dots <- named_quos(...)
   summarise_impl(.data, dots)
 }
 #' @export

--- a/R/utils-expr.R
+++ b/R/utils-expr.R
@@ -29,3 +29,19 @@ expr_substitute <- function(expr, old, new) {
   )
   expr
 }
+
+is_pronoun <- function(expr) {
+  is_lang(expr, quote(`$`)) && identical(node_cadr(expr), quote(.data))
+}
+tidy_text <- function(quo, width = 60L) {
+  expr <- f_rhs(quo)
+  if (is_pronoun(expr)) {
+    as_string(node_cadr(node_cdr(expr)))
+  } else {
+    quo_text(quo, width = width)
+  }
+}
+named_quos <- function(...) {
+  quos <- quos(...)
+  exprs_auto_name(quos, printer = tidy_text)
+}

--- a/R/utils-expr.R
+++ b/R/utils-expr.R
@@ -30,12 +30,15 @@ expr_substitute <- function(expr, old, new) {
   expr
 }
 
-is_pronoun <- function(expr) {
-  is_lang(expr, quote(`$`)) && identical(node_cadr(expr), quote(.data))
+sym_dollar <- quote(`$`)
+sym_brackets2 <- quote(`[[`)
+is_data_pronoun <- function(expr) {
+  is_lang(expr, list(sym_dollar, sym_brackets2)) &&
+    identical(node_cadr(expr), quote(.data))
 }
 tidy_text <- function(quo, width = 60L) {
   expr <- f_rhs(quo)
-  if (is_pronoun(expr)) {
+  if (is_data_pronoun(expr)) {
     as_string(node_cadr(node_cdr(expr)))
   } else {
     quo_text(quo, width = width)

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -279,3 +279,8 @@ test_that("rowwise fails gracefully on raw columns (#1803)", {
     fixed = TRUE
   )
 })
+
+test_that("group_by() names pronouns correctly (#2686)", {
+  gdf <- group_by(tibble(x = 1), .data$x)
+  expect_named(gdf, "x")
+})

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -281,6 +281,6 @@ test_that("rowwise fails gracefully on raw columns (#1803)", {
 })
 
 test_that("group_by() names pronouns correctly (#2686)", {
-  gdf <- group_by(tibble(x = 1), .data$x)
-  expect_named(gdf, "x")
+  expect_named(group_by(tibble(x = 1), .data$x), "x")
+  expect_named(group_by(tibble(x = 1), .data[["x"]]), "x")
 })

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -702,8 +702,8 @@ test_that("ntile falls back to R (#1750)", {
 })
 
 test_that("mutate() names pronouns correctly (#2686)", {
-  df <- mutate(tibble(x = 1), .data$x)
-  expect_named(df, "x")
+  expect_named(mutate(tibble(x = 1), .data$x), "x")
+  expect_named(mutate(tibble(x = 1), .data[["x"]]), "x")
 })
 
 

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -701,6 +701,11 @@ test_that("ntile falls back to R (#1750)", {
   expect_equal(res$a, rep(1, 150))
 })
 
+test_that("mutate() names pronouns correctly (#2686)", {
+  df <- mutate(tibble(x = 1), .data$x)
+  expect_named(df, "x")
+})
+
 
 # Error messages ----------------------------------------------------------
 
@@ -735,4 +740,3 @@ test_that("grouped mutate errors on incompatible column type (#1641)", {
     fixed = TRUE
   )
 })
-


### PR DESCRIPTION
Requires https://github.com/hadley/rlang/pull/109 (Travis will fail due to rlang version mismatch).

That currently only deals with pronouns at the top of the call tree.