### PR TITLE
Throw exceptions from C++

### DIFF
--- a/R/error.R
+++ b/R/error.R
@@ -40,10 +40,10 @@ bad_measures <- function(measures, ..., .envir = parent.frame()) {
   glubort(fmt_measures(measures), ..., .envir = .envir)
 }
 
-glubort <- function(header, ..., .envir = parent.frame()) {
+glubort <- function(header, ..., .envir = parent.frame(), .abort = abort) {
   text <- glue(..., .envir = .envir)
   if (!is_null(header)) text <- paste0(header, ": ", text)
-  abort(text)
+  .abort(text)
 }
 
 fmt_args <- function(x) {

--- a/inst/include/dplyr/bad.h
+++ b/inst/include/dplyr/bad.h
@@ -5,65 +5,83 @@ namespace dplyr {
 
 template<class C1>
 void NORET bad_arg(const SymbolString& arg, C1 arg1) {
-  Function bad_fun = Function("bad_args", Environment::namespace_env("dplyr"));
-  bad_fun(CharacterVector::create(arg.get_string()), wrap(arg1));
-  stop("");
+  static Function bad_fun = Function("bad_args", Environment::namespace_env("dplyr"));
+  static Function identity = Function("identity", Environment::base_env());
+  String message = bad_fun(CharacterVector::create(arg.get_string()), wrap(arg1), _[".abort"] = identity);
+  message.set_encoding(CE_UTF8);
+  stop(message.get_cstring());
 }
 
 template<class C1, class C2>
 void NORET bad_arg(const SymbolString& arg, C1 arg1, C2 arg2) {
-  Function bad_fun = Function("bad_args", Environment::namespace_env("dplyr"));
-  bad_fun(CharacterVector::create(arg.get_string()), wrap(arg1), arg2);
-  stop("");
+  static Function bad_fun = Function("bad_args", Environment::namespace_env("dplyr"));
+  static Function identity = Function("identity", Environment::base_env());
+  String message = bad_fun(CharacterVector::create(arg.get_string()), wrap(arg1), arg2, _[".abort"] = identity);
+  message.set_encoding(CE_UTF8);
+  stop(message.get_cstring());
 }
 
 template<class C1, class C2, class C3>
 void NORET bad_arg(const SymbolString& arg, C1 arg1, C2 arg2, C3 arg3) {
-  Function bad_fun = Function("bad_args", Environment::namespace_env("dplyr"));
-  bad_fun(CharacterVector::create(arg.get_string()), wrap(arg1), arg2, arg3);
-  stop("");
+  static Function bad_fun = Function("bad_args", Environment::namespace_env("dplyr"));
+  static Function identity = Function("identity", Environment::base_env());
+  String message = bad_fun(CharacterVector::create(arg.get_string()), wrap(arg1), arg2, arg3, _[".abort"] = identity);
+  message.set_encoding(CE_UTF8);
+  stop(message.get_cstring());
 }
 
 template<class C1>
 void NORET bad_pos_arg(int pos_arg, C1 arg1) {
-  Function bad_fun = Function("bad_pos_args", Environment::namespace_env("dplyr"));
-  bad_fun(wrap(pos_arg), wrap(arg1));
-  stop("");
+  static Function bad_fun = Function("bad_pos_args", Environment::namespace_env("dplyr"));
+  static Function identity = Function("identity", Environment::base_env());
+  String message = bad_fun(wrap(pos_arg), wrap(arg1), _[".abort"] = identity);
+  message.set_encoding(CE_UTF8);
+  stop(message.get_cstring());
 }
 
 template<class C1, class C2>
 void NORET bad_pos_arg(int pos_arg, C1 arg1, C2 arg2) {
-  Function bad_fun = Function("bad_pos_args", Environment::namespace_env("dplyr"));
-  bad_fun(wrap(pos_arg), wrap(arg1), arg2);
-  stop("");
+  static Function bad_fun = Function("bad_pos_args", Environment::namespace_env("dplyr"));
+  static Function identity = Function("identity", Environment::base_env());
+  String message = bad_fun(wrap(pos_arg), wrap(arg1), arg2, _[".abort"] = identity);
+  message.set_encoding(CE_UTF8);
+  stop(message.get_cstring());
 }
 
 template<class C1, class C2, class C3>
 void NORET bad_pos_arg(int pos_arg, C1 arg1, C2 arg2, C3 arg3) {
-  Function bad_fun = Function("bad_pos_args", Environment::namespace_env("dplyr"));
-  bad_fun(wrap(pos_arg), wrap(arg1), arg2, arg3);
-  stop("");
+  static Function bad_fun = Function("bad_pos_args", Environment::namespace_env("dplyr"));
+  static Function identity = Function("identity", Environment::base_env());
+  String message = bad_fun(wrap(pos_arg), wrap(arg1), arg2, arg3, _[".abort"] = identity);
+  message.set_encoding(CE_UTF8);
+  stop(message.get_cstring());
 }
 
 template<class C1>
 void NORET bad_col(const SymbolString& col, C1 arg1) {
-  Function bad_fun = Function("bad_cols", Environment::namespace_env("dplyr"));
-  bad_fun(CharacterVector::create(col.get_string()), wrap(arg1));
-  stop("");
+  static Function bad_fun = Function("bad_cols", Environment::namespace_env("dplyr"));
+  static Function identity = Function("identity", Environment::base_env());
+  String message = bad_fun(CharacterVector::create(col.get_string()), wrap(arg1), _[".abort"] = identity);
+  message.set_encoding(CE_UTF8);
+  stop(message.get_cstring());
 }
 
 template<class C1, class C2>
 void NORET bad_col(const SymbolString& col, C1 arg1, C2 arg2) {
-  Function bad_fun = Function("bad_cols", Environment::namespace_env("dplyr"));
-  bad_fun(CharacterVector::create(col.get_string()), wrap(arg1), arg2);
-  stop("");
+  static Function bad_fun = Function("bad_cols", Environment::namespace_env("dplyr"));
+  static Function identity = Function("identity", Environment::base_env());
+  String message = bad_fun(CharacterVector::create(col.get_string()), wrap(arg1), arg2, _[".abort"] = identity);
+  message.set_encoding(CE_UTF8);
+  stop(message.get_cstring());
 }
 
 template<class C1, class C2, class C3>
 void NORET bad_col(const SymbolString& col, C1 arg1, C2 arg2, C3 arg3) {
-  Function bad_fun = Function("bad_cols", Environment::namespace_env("dplyr"));
-  bad_fun(CharacterVector::create(col.get_string()), wrap(arg1), arg2, arg3);
-  stop("");
+  static Function bad_fun = Function("bad_cols", Environment::namespace_env("dplyr"));
+  static Function identity = Function("identity", Environment::base_env());
+  String message = bad_fun(CharacterVector::create(col.get_string()), wrap(arg1), arg2, arg3, _[".abort"] = identity);
+  message.set_encoding(CE_UTF8);
+  stop(message.get_cstring());
 }
 
 }


### PR DESCRIPTION
instead of throwing from R, to avoid formatting of error messages by recent versions of Rcpp.

Fixes #2702.