### PR TITLE
Turn off hybrid evaluaton of summary variables

### DIFF
--- a/inst/include/dplyr/Result/GroupedCallProxy.h
+++ b/inst/include/dplyr/Result/GroupedCallProxy.h
@@ -79,7 +79,7 @@ public:
   }
 
   inline bool has_variable(const SymbolString& name) const {
-    return subsets.count(name);
+    return subsets.has_variable(name);
   }
 
   inline SEXP get_variable(const SymbolString& name) const {

--- a/inst/include/dplyr/Result/ILazySubsets.h
+++ b/inst/include/dplyr/Result/ILazySubsets.h
@@ -18,10 +18,15 @@ public:
   virtual SEXP get_variable(const SymbolString& symbol) const = 0;
   virtual SEXP get(const SymbolString& symbol, const SlicingIndex& indices) const = 0;
   virtual bool is_summary(const SymbolString& symbol) const = 0;
-  virtual int count(const SymbolString& symbol) const = 0;
+  virtual bool has_variable(const SymbolString& symbol) const = 0;
   virtual void input(const SymbolString& symbol, SEXP x) = 0;
   virtual int size() const = 0;
   virtual int nrows() const = 0;
+
+public:
+  bool has_non_summary_variable(const SymbolString& symbol) const {
+    return has_variable(symbol) && !is_summary(symbol);
+  }
 };
 
 }

--- a/inst/include/dplyr/Result/LazyGroupedSubsets.h
+++ b/inst/include/dplyr/Result/LazyGroupedSubsets.h
@@ -71,9 +71,8 @@ public:
     return subsets[symbol_map.get(symbol)]->is_summary();
   }
 
-  virtual int count(const SymbolString& head) const {
-    int res = symbol_map.has(head);
-    return res;
+  virtual bool has_variable(const SymbolString& head) const {
+    return symbol_map.has(head);
   }
 
   virtual void input(const SymbolString& symbol, SEXP x) {

--- a/inst/include/dplyr/Result/LazySubsets.h
+++ b/inst/include/dplyr/Result/LazySubsets.h
@@ -47,9 +47,8 @@ public:
     return summary_map.has(symbol);
   }
 
-  virtual int count(const SymbolString& symbol) const {
-    int res = symbol_map.has(symbol);
-    return res;
+  virtual bool has_variable(const SymbolString& symbol) const {
+    return symbol_map.has(symbol);
   }
 
   virtual void input(const SymbolString& symbol, SEXP x) {

--- a/src/hybrid.cpp
+++ b/src/hybrid.cpp
@@ -165,7 +165,7 @@ Result* get_handler(SEXP call, const ILazySubsets& subsets, const Environment& e
 
     LOG_VERBOSE << "Searching hybrid handler for symbol " << sym.get_utf8_cstring();
 
-    if (subsets.count(sym)) {
+    if (subsets.has_variable(sym)) {
       LOG_VERBOSE << "Using hybrid variable handler";
       return variable_handler(subsets, sym);
     }

--- a/src/hybrid_in.cpp
+++ b/src/hybrid_in.cpp
@@ -20,7 +20,7 @@ Result* in_prototype(SEXP call, const ILazySubsets& subsets, int) {
   SymbolString name = SymbolString(Symbol(lhs));
 
   // if the lhs is not in the data, let R handle it
-  if (!subsets.count(name)) return 0;
+  if (!subsets.has_variable(name)) return 0;
 
   SEXP v = subsets.get_variable(name);
 

--- a/src/hybrid_minmax.cpp
+++ b/src/hybrid_minmax.cpp
@@ -37,7 +37,7 @@ Result* minmax_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
   bool is_summary = false;
   if (TYPEOF(arg) == SYMSXP) {
     SymbolString name = SymbolString(Symbol(arg));
-    if (subsets.count(name)) {
+    if (subsets.has_variable(name)) {
       is_summary = subsets.is_summary(name);
       arg = subsets.get_variable(name);
     }

--- a/src/hybrid_nth.cpp
+++ b/src/hybrid_nth.cpp
@@ -145,7 +145,7 @@ Result* nth_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
     return 0;
 
   SymbolString name = SymbolString(Symbol(data));
-  if (subsets.count(name) == 0) {
+  if (subsets.has_non_summary_variable(name) == 0) {
     return 0;
   }
   data = subsets.get_variable(name);
@@ -213,7 +213,7 @@ Result* nth_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
       return 0;
 
     SymbolString order_by_name = SymbolString(Symbol(order_by));
-    if (subsets.count(order_by_name) == 0)
+    if (subsets.has_non_summary_variable(order_by_name) == 0)
       return 0;
 
     order_by = subsets.get_variable(order_by_name);
@@ -255,7 +255,7 @@ Result* nth_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
     return 0;
 
   SymbolString order_by_name = SymbolString(Symbol(order_by));
-  if (subsets.count(order_by_name) == 0)
+  if (subsets.has_non_summary_variable(order_by_name) == 0)
     return 0;
 
   order_by = subsets.get_variable(order_by_name);

--- a/src/hybrid_nth.cpp
+++ b/src/hybrid_nth.cpp
@@ -85,11 +85,43 @@ private:
   STORAGE def;
 };
 
+Result* nth_(SEXP data, int idx) {
+  switch (TYPEOF(data)) {
+  case LGLSXP:
+    return new Nth<LGLSXP>(data, idx);
+  case INTSXP:
+    return new Nth<INTSXP>(data, idx);
+  case REALSXP:
+    return new Nth<REALSXP>(data, idx);
+  case CPLXSXP:
+    return new Nth<CPLXSXP>(data, idx);
+  case STRSXP:
+    return new Nth<STRSXP>(data, idx);
+  default:
+    return 0;
+  }
 }
 
 template <int RTYPE>
 Result* nth_noorder_default(Vector<RTYPE> data, int idx, Vector<RTYPE> def) {
   return new Nth<RTYPE>(data, idx, def[0]);
+}
+
+Result* nth_noorder_default_(SEXP data, int idx, SEXP def) {
+  switch (TYPEOF(data)) {
+  case LGLSXP:
+    return nth_noorder_default<LGLSXP>(data, idx, def);
+  case INTSXP:
+    return nth_noorder_default<INTSXP>(data, idx, def);
+  case REALSXP:
+    return nth_noorder_default<REALSXP>(data, idx, def);
+  case CPLXSXP:
+    return nth_noorder_default<CPLXSXP>(data, idx, def);
+  case STRSXP:
+    return nth_noorder_default<STRSXP>(data, idx, def);
+  default:
+    return 0;
+  }
 }
 
 template <int RTYPE>
@@ -111,6 +143,23 @@ Result* nth_with(Vector<RTYPE> data, int idx, SEXP order) {
   stop("unsupported vector type %s", Rf_type2char(TYPEOF(order)));
 }
 
+Result* nth_with_(SEXP data, int idx, SEXP order_by) {
+  switch (TYPEOF(data)) {
+  case LGLSXP:
+    return nth_with<LGLSXP>(data, idx, order_by);
+  case INTSXP:
+    return nth_with<INTSXP>(data, idx, order_by);
+  case REALSXP:
+    return nth_with<REALSXP>(data, idx, order_by);
+  case CPLXSXP:
+    return nth_with<CPLXSXP>(data, idx, order_by);
+  case STRSXP:
+    return nth_with<STRSXP>(data, idx, order_by);
+  default:
+    return 0;
+  }
+}
+
 template <int RTYPE>
 Result* nth_with_default(Vector<RTYPE> data, int idx, SEXP order, Vector<RTYPE> def) {
   switch (TYPEOF(order)) {
@@ -130,7 +179,22 @@ Result* nth_with_default(Vector<RTYPE> data, int idx, SEXP order, Vector<RTYPE> 
   stop("unsupported vector type %s", Rf_type2char(TYPEOF(order)));
 }
 
-namespace dplyr {
+Result* nth_with_default_(SEXP data, int idx, SEXP order_by, SEXP def) {
+  switch (TYPEOF(data)) {
+  case LGLSXP:
+    return nth_with_default<LGLSXP>(data, idx, order_by, def);
+  case INTSXP:
+    return nth_with_default<INTSXP>(data, idx, order_by, def);
+  case REALSXP:
+    return nth_with_default<REALSXP>(data, idx, order_by, def);
+  case CPLXSXP:
+    return nth_with_default<CPLXSXP>(data, idx, order_by, def);
+  case STRSXP:
+    return nth_with_default<STRSXP>(data, idx, order_by, def);
+  default:
+    return 0;
+  }
+}
 
 Result* nth_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
   // has to have at least two arguments
@@ -165,23 +229,10 @@ Result* nth_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
 
   // easy case : just a single variable: first(x,n)
   if (nargs == 2) {
-    switch (TYPEOF(data)) {
-    case LGLSXP:
-      return new Nth<LGLSXP>(data, idx);
-    case INTSXP:
-      return new Nth<INTSXP>(data, idx);
-    case REALSXP:
-      return new Nth<REALSXP>(data, idx);
-    case CPLXSXP:
-      return new Nth<CPLXSXP>(data, idx);
-    case STRSXP:
-      return new Nth<STRSXP>(data, idx);
-    default:
-      return 0;
-    }
+    return nth_(data, idx);
   }
 
-  // now get `order_by` and default
+  // now get `order_by` and `default`
   SEXP order_by = R_NilValue;
   SEXP def    = R_NilValue;
   bool has_order_by = false;
@@ -218,37 +269,11 @@ Result* nth_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
 
     order_by = subsets.get_variable(order_by_name);
 
-    switch (TYPEOF(data)) {
-    case LGLSXP:
-      return nth_with<LGLSXP>(data, idx, order_by);
-    case INTSXP:
-      return nth_with<INTSXP>(data, idx, order_by);
-    case REALSXP:
-      return nth_with<REALSXP>(data, idx, order_by);
-    case CPLXSXP:
-      return nth_with<CPLXSXP>(data, idx, order_by);
-    case STRSXP:
-      return nth_with<STRSXP>(data, idx, order_by);
-    default:
-      return 0;
-    }
+    return nth_with_(data, idx, order_by);
   }
 
   if (Rf_isNull(order_by)) {
-    switch (TYPEOF(data)) {
-    case LGLSXP:
-      return nth_noorder_default<LGLSXP>(data, idx, def);
-    case INTSXP:
-      return nth_noorder_default<INTSXP>(data, idx, def);
-    case REALSXP:
-      return nth_noorder_default<REALSXP>(data, idx, def);
-    case CPLXSXP:
-      return nth_noorder_default<CPLXSXP>(data, idx, def);
-    case STRSXP:
-      return nth_noorder_default<STRSXP>(data, idx, def);
-    default:
-      return 0;
-    }
+    return nth_noorder_default_(data, idx, def);
   }
 
   if (TYPEOF(order_by) != SYMSXP)
@@ -260,20 +285,7 @@ Result* nth_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
 
   order_by = subsets.get_variable(order_by_name);
 
-  switch (TYPEOF(data)) {
-  case LGLSXP:
-    return nth_with_default<LGLSXP>(data, idx, order_by, def);
-  case INTSXP:
-    return nth_with_default<INTSXP>(data, idx, order_by, def);
-  case REALSXP:
-    return nth_with_default<REALSXP>(data, idx, order_by, def);
-  case CPLXSXP:
-    return nth_with_default<CPLXSXP>(data, idx, order_by, def);
-  case STRSXP:
-    return nth_with_default<STRSXP>(data, idx, order_by, def);
-  default:
-    return 0;
-  }
+  return nth_with_default_(data, idx, order_by, def);
 }
 
 Result* firstlast_prototype(SEXP call, const ILazySubsets& subsets, int nargs, int pos) {

--- a/src/hybrid_offset.cpp
+++ b/src/hybrid_offset.cpp
@@ -69,7 +69,7 @@ Result* leadlag_prototype(SEXP call, const ILazySubsets& subsets, int) {
     return 0;
 
   SymbolString name = SymbolString(Symbol(data));
-  if (subsets.count(name) == 0)
+  if (subsets.has_variable(name) == 0)
     return 0;
 
   bool is_summary = subsets.is_summary(name);

--- a/src/hybrid_simple.cpp
+++ b/src/hybrid_simple.cpp
@@ -36,7 +36,7 @@ Result* simple_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
   bool is_summary = false;
   if (TYPEOF(arg) == SYMSXP) {
     SymbolString name = SymbolString(Symbol(arg));
-    if (subsets.count(name)) {
+    if (subsets.has_variable(name)) {
       // we have a symbol from the data - great
       is_summary = subsets.is_summary(name);
       arg = subsets.get_variable(name);

--- a/src/hybrid_window.cpp
+++ b/src/hybrid_window.cpp
@@ -20,7 +20,7 @@ Result* row_number_prototype(SEXP call, const ILazySubsets& subsets, int nargs) 
 
     if (TYPEOF(data) == SYMSXP) {
       SymbolString name = SymbolString(Symbol(data));
-      if (subsets.count(name)) data = subsets.get_variable(name);
+      if (subsets.has_non_summary_variable(name)) data = subsets.get_variable(name);
       else return 0;
     }
     if (Rf_length(data) == subsets.nrows()) {
@@ -39,7 +39,7 @@ Result* row_number_prototype(SEXP call, const ILazySubsets& subsets, int nargs) 
   }
   if (TYPEOF(data) == SYMSXP) {
     SymbolString name = SymbolString(Symbol(data));
-    if (subsets.count(name)) data = subsets.get_variable(name);
+    if (subsets.has_non_summary_variable(name)) data = subsets.get_variable(name);
     else return 0;
   }
   if (subsets.nrows() != Rf_length(data)) return 0;
@@ -73,7 +73,7 @@ Result* ntile_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
 
     if (TYPEOF(data) == SYMSXP) {
       SymbolString name = SymbolString(Symbol(data));
-      if (subsets.count(name)) data = subsets.get_variable(name);
+      if (subsets.has_non_summary_variable(name)) data = subsets.get_variable(name);
       else return 0;
     }
     switch (TYPEOF(data)) {
@@ -89,7 +89,7 @@ Result* ntile_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
   }
   if (TYPEOF(data) == SYMSXP) {
     SymbolString name = SymbolString(Symbol(data));
-    if (subsets.count(name)) data = subsets.get_variable(name);
+    if (subsets.has_non_summary_variable(name)) data = subsets.get_variable(name);
     else return 0;
   }
   if (subsets.nrows() != Rf_length(data)) return 0;
@@ -117,7 +117,7 @@ Result* rank_impl_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
     data = CADR(data);
     if (TYPEOF(data) == SYMSXP) {
       SymbolString name = SymbolString(Symbol(data));
-      if (subsets.count(name)) data = subsets.get_variable(name);
+      if (subsets.has_non_summary_variable(name)) data = subsets.get_variable(name);
       else return 0;
     }
 
@@ -135,7 +135,7 @@ Result* rank_impl_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
 
   if (TYPEOF(data) == SYMSXP) {
     SymbolString name = SymbolString(Symbol(data));
-    if (subsets.count(name)) data = subsets.get_variable(name);
+    if (subsets.has_non_summary_variable(name)) data = subsets.get_variable(name);
     else return 0;
   }
   if (subsets.nrows() != Rf_length(data)) return 0;

--- a/src/hybrid_window.cpp
+++ b/src/hybrid_window.cpp
@@ -9,53 +9,75 @@
 using namespace Rcpp;
 using namespace dplyr;
 
+namespace dplyr {
+
+template <bool ascending>
+Result* row_number_asc(const RObject& data) {
+  switch (TYPEOF(data)) {
+  case INTSXP:
+    return new RowNumber<INTSXP, ascending>(data);
+  case REALSXP:
+    return new RowNumber<REALSXP, ascending>(data);
+  case STRSXP:
+    return new RowNumber<STRSXP, ascending>(data);
+  default:
+    return 0;
+  }
+}
+
+Result* row_number(const RObject& data, const bool ascending) {
+  if (ascending) {
+    return row_number_asc<true>(data);
+  }
+  else {
+    return row_number_asc<false>(data);
+  }
+}
+
 Result* row_number_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
-  if (nargs >  1 || subsets.size() == 0) return 0;
+  if (nargs > 1 || subsets.size() == 0) return 0;
 
   if (nargs == 0) return new RowNumber_0();
 
   RObject data(CADR(call));
+  bool ascending = true;
   if (TYPEOF(data) == LANGSXP && CAR(data) == Rf_install("desc")) {
     data = CADR(data);
-
-    if (TYPEOF(data) == SYMSXP) {
-      SymbolString name = SymbolString(Symbol(data));
-      if (subsets.has_non_summary_variable(name)) data = subsets.get_variable(name);
-      else return 0;
-    }
-    if (Rf_length(data) == subsets.nrows()) {
-      switch (TYPEOF(data)) {
-      case INTSXP:
-        return new RowNumber<INTSXP,  false>(data);
-      case REALSXP:
-        return new RowNumber<REALSXP, false>(data);
-      case STRSXP:
-        return new RowNumber<STRSXP,  false>(data);
-      default:
-        break;
-      }
-    }
-    return 0;
+    ascending = false;
   }
+
   if (TYPEOF(data) == SYMSXP) {
     SymbolString name = SymbolString(Symbol(data));
     if (subsets.has_non_summary_variable(name)) data = subsets.get_variable(name);
     else return 0;
   }
+
   if (subsets.nrows() != Rf_length(data)) return 0;
 
+  return row_number(data, ascending);
+}
+
+template <bool ascending>
+Result* ntile_asc(const RObject& data, const int number_tiles) {
   switch (TYPEOF(data)) {
   case INTSXP:
-    return new RowNumber<INTSXP, true>(data);
+    return new Ntile<INTSXP, ascending>(data, number_tiles);
   case REALSXP:
-    return new RowNumber<REALSXP, true>(data);
+    return new Ntile<REALSXP, ascending>(data, number_tiles);
   case STRSXP:
-    return new RowNumber<STRSXP, true>(data);
+    return new Ntile<STRSXP, ascending>(data, number_tiles);
   default:
-    break;
+    return 0;
   }
-  // we don't know how to handle it.
-  return 0;
+}
+
+Result* ntile(const RObject& data, const int number_tiles, const bool ascending) {
+  if (ascending) {
+    return ntile_asc<true>(data, number_tiles);
+  }
+  else {
+    return ntile_asc<false>(data, number_tiles);
+  }
 }
 
 Result* ntile_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
@@ -68,69 +90,57 @@ Result* ntile_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
   if (number_tiles == NA_INTEGER) return 0;
 
   RObject data(CADR(call));
+  bool ascending = true;
   if (TYPEOF(data) == LANGSXP && CAR(data) == Rf_install("desc")) {
     data = CADR(data);
-
-    if (TYPEOF(data) == SYMSXP) {
-      SymbolString name = SymbolString(Symbol(data));
-      if (subsets.has_non_summary_variable(name)) data = subsets.get_variable(name);
-      else return 0;
-    }
-    switch (TYPEOF(data)) {
-    case INTSXP:
-      return new Ntile<INTSXP,  false>(data, number_tiles);
-    case REALSXP:
-      return new Ntile<REALSXP, false>(data, number_tiles);
-    case STRSXP:
-      return new Ntile<STRSXP,  false>(data, number_tiles);
-    default:
-      break;
-    }
+    ascending = false;
   }
+
   if (TYPEOF(data) == SYMSXP) {
     SymbolString name = SymbolString(Symbol(data));
     if (subsets.has_non_summary_variable(name)) data = subsets.get_variable(name);
     else return 0;
   }
+
   if (subsets.nrows() != Rf_length(data)) return 0;
 
+  return ntile(data, number_tiles, ascending);
+}
+
+template <typename Increment, bool ascending>
+Result* rank_asc(const RObject& data) {
   switch (TYPEOF(data)) {
   case INTSXP:
-    return new Ntile<INTSXP, true>(data, number_tiles);
+    return new Rank_Impl<INTSXP, Increment, ascending>(data);
   case REALSXP:
-    return new Ntile<REALSXP, true>(data, number_tiles);
+    return new Rank_Impl<REALSXP, Increment, ascending>(data);
   case STRSXP:
-    return new Ntile<STRSXP, true>(data, number_tiles);
+    return new Rank_Impl<STRSXP, Increment, ascending>(data);
   default:
-    break;
+    return 0;
   }
-  // we don't know how to handle it.
-  return 0;
+}
+
+template <typename Increment>
+Result* rank(const RObject& data, bool ascending) {
+  if (ascending) {
+    return rank_asc<Increment, true>(data);
+  }
+  else {
+    return rank_asc<Increment, false>(data);
+  }
 }
 
 template <typename Increment>
 Result* rank_impl_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
   if (nargs != 1) return 0;
+
   RObject data(CADR(call));
+  bool ascending = true;
 
   if (TYPEOF(data) == LANGSXP && CAR(data) == Rf_install("desc")) {
     data = CADR(data);
-    if (TYPEOF(data) == SYMSXP) {
-      SymbolString name = SymbolString(Symbol(data));
-      if (subsets.has_non_summary_variable(name)) data = subsets.get_variable(name);
-      else return 0;
-    }
-
-    switch (TYPEOF(data)) {
-    case INTSXP:
-      return new Rank_Impl<INTSXP,  Increment, false>(data);
-    case REALSXP:
-      return new Rank_Impl<REALSXP, Increment, false>(data);
-    case STRSXP:
-      return new Rank_Impl<STRSXP,  Increment, false>(data);
-    default:
-      break;
-    }
+    ascending = false;
   }
 
   if (TYPEOF(data) == SYMSXP) {
@@ -138,20 +148,12 @@ Result* rank_impl_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
     if (subsets.has_non_summary_variable(name)) data = subsets.get_variable(name);
     else return 0;
   }
+
   if (subsets.nrows() != Rf_length(data)) return 0;
 
-  switch (TYPEOF(data)) {
-  case INTSXP:
-    return new Rank_Impl<INTSXP,  Increment, true>(data);
-  case REALSXP:
-    return new Rank_Impl<REALSXP, Increment, true>(data);
-  case STRSXP:
-    return new Rank_Impl<STRSXP,  Increment, true>(data);
-  default:
-    break;
-  }
-  // we don't know how to handle it.
-  return 0;
+  return rank<Increment>(data, ascending);
+}
+
 }
 
 void install_window_handlers(HybridHandlerMap& handlers) {

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -273,6 +273,14 @@ test_that("first(), last(), and nth() work", {
     first(a, order_by = b), a = 1:5, b = 5:1,
     expected = 5L
   )
+
+  expect_equal(
+    tibble(a = c(1, 1, 2), b = letters[1:3]) %>%
+      group_by(a) %>%
+      summarize(b = b[1], b = first(b)) %>%
+      ungroup,
+    tibble(a = c(1, 2), b = c("a", "c"))
+  )
 })
 
 test_that("lead() and lag() work", {
@@ -471,6 +479,14 @@ test_that("row_number(), ntile(), min_rank(), percent_rank(), dense_rank(), and 
   check_not_hybrid_result(
     ntile("a", 2), a = 5:1,
     expected = 1L
+  )
+
+  expect_equal(
+    tibble(a = c(1, 1, 2), b = letters[1:3]) %>%
+      group_by(a) %>%
+      summarize(b = b[1], b = min_rank(desc(b))) %>%
+      ungroup,
+    tibble(a = c(1, 2), b = c(1L, 1L))
   )
 })
 


### PR DESCRIPTION
for handlers that don't support them.

Many handlers actually do have special handling for summary variables, but I think this unnecessarily complicates the code. This PR falls back to R if a summary variable is detected, it remains to be seen when the reuse of a summary variable requires the performance benefits of hybrid evaluation.

Closes #2721.

Fixes #2673. Related to #2312.

Review might be easier if you look at individual commits.