### PR TITLE
Join warnings

### DIFF
--- a/R/utils.r
+++ b/R/utils.r
@@ -102,3 +102,18 @@ inc_seq <- function(from, to) {
 random_table_name <- function(n = 10) {
   paste0(sample(letters, n, replace = TRUE), collapse = "")
 }
+
+attr_equal <- function(x, y) {
+  attr_x <- attributes(x)
+  if (!is.null(attr_x)) {
+    attr_x <- attr_x[sort(names(attr_x))]
+  }
+
+  attr_y <- attributes(y)
+  if (!is.null(attr_y)) {
+    attr_y <- attr_y[sort(names(attr_y))]
+  }
+
+  isTRUE(all.equal(attr_x, attr_y))
+}
+

--- a/src/join.cpp
+++ b/src/join.cpp
@@ -29,7 +29,7 @@ void warn_bad_var(const SymbolString& var_left, const SymbolString& var_right,
   if (var_left == var_right) {
     std::string var_utf8 = var_left.get_utf8_cstring();
     Rf_warningcall(R_NilValue,
-      "Variable `%s` %s",
+      "Column `%s` %s",
       var_utf8.c_str(),
       message.c_str()
     );
@@ -37,7 +37,7 @@ void warn_bad_var(const SymbolString& var_left, const SymbolString& var_right,
     std::string left_utf8 = var_left.get_utf8_cstring();
     std::string right_utf8 = var_right.get_utf8_cstring();
     Rf_warningcall(R_NilValue,
-      "Variable `%s`/`%s` %s",
+      "Column `%s`/`%s` %s",
       left_utf8.c_str(),
       right_utf8.c_str(),
       message.c_str()
@@ -56,7 +56,7 @@ void check_attribute_compatibility(SEXP left, SEXP right, const SymbolString& na
   static Function attr_equal = Function("attr_equal", Environment::namespace_env("dplyr"));
   bool ok = as<bool>(attr_equal(left, right));
   if (!ok) {
-    warn_bad_var(name_left, name_right, "has different attributes on RHS and LHS of join");
+    warn_bad_var(name_left, name_right, "has different attributes on LHS and RHS of join");
   }
 }
 

--- a/tests/testthat/test-joins.r
+++ b/tests/testthat/test-joins.r
@@ -838,8 +838,15 @@ test_that("join takes LHS with warning if attributes inconsistent", {
     c = 2:1
   )
 
-  expect_warning(out1 <- left_join(df1, df2, by = "a"), "different attributes")
-  expect_warning(out2 <- left_join(df2, df1, by = "a"), "different attributes")
+  expect_warning(
+    out1 <- left_join(df1, df2, by = "a"),
+    "Column `a` has different attributes on LHS and RHS of join"
+  )
+  expect_warning(out2 <- left_join(df2, df1, by = "a"))
+  expect_warning(
+    out3 <- left_join(df1, df2, by = c("b" = "a")),
+    "Column `b`/`a` has different attributes on LHS and RHS of join"
+  )
 
   expect_equal(attr(out1$a, "foo"), NULL)
   expect_equal(attr(out2$a, "foo"), "bar")

--- a/tests/testthat/test-joins.r
+++ b/tests/testthat/test-joins.r
@@ -830,3 +830,17 @@ test_that("join accepts tz attributes (#2643)", {
   result <- inner_join(df1, df2, by = "a")
   expect_equal(nrow(result), 1)
 })
+
+test_that("join takes LHS with warning if attributes inconsistent", {
+  df1 <- tibble(a = 1:2, b = 2:1)
+  df2 <- tibble(
+    a = structure(1:2, foo = "bar"),
+    c = 2:1
+  )
+
+  expect_warning(out1 <- left_join(df1, df2, by = "a"), "different attributes")
+  expect_warning(out2 <- left_join(df2, df1, by = "a"), "different attributes")
+
+  expect_equal(attr(out1$a, "foo"), NULL)
+  expect_equal(attr(out2$a, "foo"), "bar")
+})


### PR DESCRIPTION
The main purpose of this PR is to switch from an error to a warning when the attributes don't match.  I also used this as an opportunity to pull down the join variable names so that we can start to make better warnings and errors.