### PR TITLE
Fix typo in wrap_dbplyr_obj

### DIFF
--- a/R/compat-dbplyr.R
+++ b/R/compat-dbplyr.R
@@ -36,7 +36,7 @@ wrap_dbplyr_obj <- function(obj_name) {
     pass_on <- map(set_names(names(args)), sym)
 
     dbplyr_call <- expr(UQ(dbplyr_sym)(!!!pass_on))
-    dplyr_call <- expr(UQ(dbplyr_sym)(!!!pass_on))
+    dplyr_call <- expr(UQ(dplyr_sym)(!!!pass_on))
   } else {
     args <- list()
 


### PR DESCRIPTION
I believe the expression for `dplyr_call` should use `dplyr_sym` not `dbplyr_sym`.