### PR TITLE
Fix join warnings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -115,7 +115,9 @@ If you've implemented a database backend for dplyr, please read the [backend new
 
 ## Tidyeval
 
-dplyr has a new approach to non-standard evaluation (NSE) called tidyeval. Tidyeval is described in detail in `vignette("programming")` but, in brief, gives you the ability to interpolate values in contexts where dplyr usually works with expressions:
+dplyr has a new approach to non-standard evaluation (NSE) called tidyeval.
+It is described in detail in `vignette("programming")` but, in brief, gives you
+the ability to interpolate values in contexts where dplyr usually works with expressions:
 
 ```{r}
 my_var <- quo(homeworld)
@@ -125,7 +127,8 @@ starwars %>%
   summarise_at(vars(height:mass), mean, na.rm = TRUE)
 ```
 
-This means that the underscored version of each main verb is no longer needed, and so these functions have been deprecated (but remain around for backward compatibility).
+This means that the underscored version of each main verb is no longer needed,
+and so these functions have been deprecated (but remain around for backward compatibility).
 
 * `order_by()`, `top_n()`, `sample_n()` and `sample_frac()` now use
   tidyeval to capture their arguments by expression. This makes it
@@ -174,6 +177,11 @@ This means that the underscored version of each main verb is no longer needed, a
 
 * One of the two join suffixes can now be an empty string, dplyr no longer 
   hangs (#2228, #2445).
+
+* Anti- and semi-joins warn if factor levels are inconsistent (#2741).
+
+* Warnings about join column inconsistencies now contain the column names
+  (#2728).
 
 ### Select
 
@@ -669,9 +677,12 @@ There were two other tweaks to the exported API, but these are less likely to af
   to avoid creating repeated column names (#1460).  Joins on string columns
   should be substantially faster (#1386). Extra attributes are ok if they are
   identical (#1636). Joins work correct when factor levels not equal
-  (#1712, #1559), and anti and semi joins give correct result when by variable
-  is a  factor (#1571). A clear error message is given for joins where an
-  explicit `by` contains unavailable columns (#1928, #1932, @krlmlr).
+  (#1712, #1559). Anti- and semi-joins give correct result when by variable
+  is a factor (#1571), but warn if factor levels are inconsistent (#2741).
+  A clear error message is given for joins where an
+  explicit `by` contains unavailable columns (#1928, #1932).
+  Warnings about join column inconsistencies now contain the column names
+  (#2728).
 
 * `inner_join()`, `left_join()`, `right_join()`, and `full_join()` gain a
   `suffix` argument which allows you to control what suffix duplicated variable

--- a/inst/include/dplyr/Column.h
+++ b/inst/include/dplyr/Column.h
@@ -1,0 +1,26 @@
+#ifndef DPLYR_DPLYR_COLUMN_H
+#define DPLYR_DPLYR_COLUMN_H
+
+class Column {
+public:
+  Column(SEXP data_, const SymbolString& name_) : data(data_), name(name_) {}
+
+public:
+  const RObject& get_data() const {
+    return data;
+  }
+
+  const SymbolString& get_name() const {
+    return name;
+  }
+
+  Column update_data(SEXP new_data) const {
+    return Column(new_data, name);
+  }
+
+private:
+  RObject data;
+  SymbolString name;
+};
+
+#endif //DPLYR_DPLYR_COLUMN_H

--- a/inst/include/dplyr/JoinVisitor.h
+++ b/inst/include/dplyr/JoinVisitor.h
@@ -1,6 +1,7 @@
 #ifndef dplyr_JoinVisitor_H
 #define dplyr_JoinVisitor_H
 
+#include <dplyr/Column.h>
 #include <dplyr/visitor_set/VisitorSetIndexSet.h>
 
 namespace dplyr {
@@ -19,7 +20,7 @@ public:
 
 };
 
-JoinVisitor* join_visitor(SEXP left, SEXP right, const SymbolString& left_name, const SymbolString& right_name, bool warn, bool accept_na_match = true);
+JoinVisitor* join_visitor(const Column& left, const Column& right, bool warn, bool accept_na_match = true);
 
 }
 

--- a/inst/include/dplyr/JoinVisitorImpl.h
+++ b/inst/include/dplyr/JoinVisitorImpl.h
@@ -133,7 +133,8 @@ protected:
   typedef typename Storage::Vec Vec;
 
 public:
-  JoinVisitorImpl(const Column& left, const Column& right) : dual((SEXP)left.get_data(), (SEXP)right.get_data()) {
+  JoinVisitorImpl(const Column& left, const Column& right, const bool warn) : dual((SEXP)left.get_data(), (SEXP)right.get_data()) {
+    if (warn) check_attribute_compatibility(left, right);
   }
 
   inline size_t hash(int i) {
@@ -181,7 +182,7 @@ class POSIXctJoinVisitor : public JoinVisitorImpl<REALSXP, REALSXP, ACCEPT_NA_MA
 
 public:
   POSIXctJoinVisitor(const Column& left, const Column& right) :
-    Parent(left, right),
+    Parent(left, right, false),
     tzone(R_NilValue)
   {
     RObject tzone_left  = left.get_data().attr("tzone");
@@ -236,7 +237,7 @@ class DateJoinVisitor : public JoinVisitorImpl<LHS_RTYPE, RHS_RTYPE, ACCEPT_NA_M
   typedef JoinVisitorImpl<LHS_RTYPE, RHS_RTYPE, ACCEPT_NA_MATCH> Parent;
 
 public:
-  DateJoinVisitor(const Column& left, const Column& right) : Parent(left, right) {}
+  DateJoinVisitor(const Column& left, const Column& right) : Parent(left, right, false) {}
 
   inline SEXP subset(const std::vector<int>& indices) {
     return promote(Parent::subset(indices));

--- a/inst/include/dplyr/JoinVisitorImpl.h
+++ b/inst/include/dplyr/JoinVisitorImpl.h
@@ -6,12 +6,13 @@
 
 #include <dplyr/join_match.h>
 #include <dplyr/JoinVisitor.h>
+#include <dplyr/Column.h>
 
 namespace dplyr {
 
 CharacterVector get_uniques(const CharacterVector& left, const CharacterVector& right);
 
-void check_attribute_compatibility(SEXP left, SEXP right, const SymbolString& name_left, const SymbolString& name_right);
+void check_attribute_compatibility(const Column& left, const Column& right);
 
 template <int LHS_RTYPE, int RHS_RTYPE>
 class DualVector {
@@ -27,9 +28,7 @@ public:
   typedef typename Rcpp::traits::storage_type<RTYPE>::type STORAGE;
 
 public:
-  DualVector(LHS_Vec left_, RHS_Vec right_, const SymbolString& name_left_, const SymbolString& name_right_) : left(left_), right(right_) {
-    check_attribute_compatibility(left, right, name_left_, name_right_);
-  }
+  DualVector(LHS_Vec left_, RHS_Vec right_) : left(left_), right(right_) {}
 
   LHS_STORAGE get_left_value(const int i) const {
     if (i < 0) stop("get_left_value() called with negative argument");
@@ -134,10 +133,8 @@ protected:
   typedef typename Storage::Vec Vec;
 
 public:
-  JoinVisitorImpl(
-    typename Storage::LHS_Vec left, typename Storage::RHS_Vec right,
-    const SymbolString& name_left, const SymbolString& name_right) :
-  dual(left, right, name_left, name_right), name_left_(name_left), name_right_(name_right) {}
+  JoinVisitorImpl(const Column& left, const Column& right) : dual((SEXP)left.get_data(), (SEXP)right.get_data()) {
+  }
 
   inline size_t hash(int i) {
     // If NAs don't match, we want to distribute their hashes as evenly as possible
@@ -176,7 +173,6 @@ public:
 
 private:
   Storage dual;
-  const SymbolString& name_left_, name_right_;
 };
 
 template <bool ACCEPT_NA_MATCH>
@@ -184,12 +180,12 @@ class POSIXctJoinVisitor : public JoinVisitorImpl<REALSXP, REALSXP, ACCEPT_NA_MA
   typedef JoinVisitorImpl<REALSXP, REALSXP, ACCEPT_NA_MATCH> Parent;
 
 public:
-  POSIXctJoinVisitor(NumericVector left, NumericVector right, const SymbolString& name_left, const SymbolString name_right) :
-    Parent(left, right, name_left, name_right),
+  POSIXctJoinVisitor(const Column& left, const Column& right) :
+    Parent(left, right),
     tzone(R_NilValue)
   {
-    RObject tzone_left  = left.attr("tzone");
-    RObject tzone_right = right.attr("tzone");
+    RObject tzone_left  = left.get_data().attr("tzone");
+    RObject tzone_right = right.get_data().attr("tzone");
     if (tzone_left.isNULL() && tzone_right.isNULL()) return;
 
     if (tzone_left.isNULL()) {
@@ -240,9 +236,7 @@ class DateJoinVisitor : public JoinVisitorImpl<LHS_RTYPE, RHS_RTYPE, ACCEPT_NA_M
   typedef JoinVisitorImpl<LHS_RTYPE, RHS_RTYPE, ACCEPT_NA_MATCH> Parent;
 
 public:
-  DateJoinVisitor(typename Parent::LHS_Vec left, typename Parent::RHS_Vec right,
-    const SymbolString& name_left, const SymbolString& name_right) :
-  Parent(left, right, name_left, name_right) {}
+  DateJoinVisitor(const Column& left, const Column& right) : Parent(left, right) {}
 
   inline SEXP subset(const std::vector<int>& indices) {
     return promote(Parent::subset(indices));

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -83,7 +83,12 @@ DataFrameJoinVisitors::DataFrameJoinVisitors(const DataFrame& left_, const DataF
       stop("'%s' column not found in rhs, cannot join", name_right.get_utf8_cstring());
     }
 
-    visitors[i] = join_visitor(left[indices_left[i] - 1], right[indices_right[i] - 1], name_left, name_right, warn, na_match);
+    visitors[i] =
+      join_visitor(
+        Column(left[indices_left[i] - 1], name_left),
+        Column(right[indices_right[i] - 1], name_right),
+        warn, na_match
+      );
   }
 }
 

--- a/src/join.cpp
+++ b/src/join.cpp
@@ -28,7 +28,8 @@ void warn_bad_var(const SymbolString& var_left, const SymbolString& var_right,
 
   if (var_left == var_right) {
     std::string var_utf8 = var_left.get_utf8_cstring();
-    Rf_warningcall(R_NilValue,
+    Rf_warningcall(
+      R_NilValue,
       "Column `%s` %s",
       var_utf8.c_str(),
       message.c_str()
@@ -36,7 +37,8 @@ void warn_bad_var(const SymbolString& var_left, const SymbolString& var_right,
   } else {
     std::string left_utf8 = var_left.get_utf8_cstring();
     std::string right_utf8 = var_right.get_utf8_cstring();
-    Rf_warningcall(R_NilValue,
+    Rf_warningcall(
+      R_NilValue,
       "Column `%s`/`%s` %s",
       left_utf8.c_str(),
       right_utf8.c_str(),
@@ -46,17 +48,17 @@ void warn_bad_var(const SymbolString& var_left, const SymbolString& var_right,
 
 }
 
-void check_attribute_compatibility(SEXP left, SEXP right, const SymbolString& name_left, const SymbolString& name_right) {
+void check_attribute_compatibility(const Column& left, const Column& right) {
   // Ignore attributes for POSIXct
-  if (Rf_inherits(left, "POSIXct") && Rf_inherits(right, "POSIXct")) {
+  if (Rf_inherits(left.get_data(), "POSIXct") && Rf_inherits(right.get_data(), "POSIXct")) {
     return;
   }
 
   // Otherwise rely on R function based on all.equal
   static Function attr_equal = Function("attr_equal", Environment::namespace_env("dplyr"));
-  bool ok = as<bool>(attr_equal(left, right));
+  bool ok = as<bool>(attr_equal(left.get_data(), right.get_data()));
   if (!ok) {
-    warn_bad_var(name_left, name_right, "has different attributes on LHS and RHS of join");
+    warn_bad_var(left.get_name(), right.get_name(), "has different attributes on LHS and RHS of join");
   }
 }
 
@@ -113,38 +115,38 @@ CharacterVector reencode_factor(IntegerVector x) {
 }
 
 template <int LHS_RTYPE, bool ACCEPT_NA_MATCH>
-JoinVisitor* date_join_visitor_right(SEXP left, SEXP right, const SymbolString& name_left, const SymbolString& name_right) {
-  switch (TYPEOF(right)) {
+JoinVisitor* date_join_visitor_right(const Column& left, const Column& right) {
+  switch (TYPEOF(right.get_data())) {
   case INTSXP:
-    return new DateJoinVisitor<LHS_RTYPE, INTSXP, ACCEPT_NA_MATCH>(left, right, name_left, name_right);
+    return new DateJoinVisitor<LHS_RTYPE, INTSXP, ACCEPT_NA_MATCH>(left, right);
   case REALSXP:
-    return new DateJoinVisitor<LHS_RTYPE, REALSXP, ACCEPT_NA_MATCH>(left, right, name_left, name_right);
+    return new DateJoinVisitor<LHS_RTYPE, REALSXP, ACCEPT_NA_MATCH>(left, right);
   default:
     stop("Date objects should be represented as integer or numeric");
   }
 }
 
 template <bool ACCEPT_NA_MATCH>
-JoinVisitor* date_join_visitor(SEXP left, SEXP right, const SymbolString& name_left, const SymbolString name_right) {
-  switch (TYPEOF(left)) {
+JoinVisitor* date_join_visitor(const Column& left, const Column& right) {
+  switch (TYPEOF(left.get_data())) {
   case INTSXP:
-    return date_join_visitor_right<INTSXP, ACCEPT_NA_MATCH>(left, right, name_left, name_right);
+    return date_join_visitor_right<INTSXP, ACCEPT_NA_MATCH>(left, right);
   case REALSXP:
-    return date_join_visitor_right<REALSXP, ACCEPT_NA_MATCH>(left, right, name_left, name_right);
+    return date_join_visitor_right<REALSXP, ACCEPT_NA_MATCH>(left, right);
   default:
     stop("Date objects should be represented as integer or numeric");
   }
 }
 
 template <bool ACCEPT_NA_MATCH>
-JoinVisitor* join_visitor(SEXP left, SEXP right, const SymbolString& name_left, const SymbolString& name_right, bool warn_) {
+JoinVisitor* join_visitor(const Column& left, const Column& right, bool warn_) {
   // handle Date separately
-  bool lhs_date = Rf_inherits(left, "Date");
-  bool rhs_date = Rf_inherits(right, "Date");
+  bool lhs_date = Rf_inherits(left.get_data(), "Date");
+  bool rhs_date = Rf_inherits(right.get_data(), "Date");
 
   switch (lhs_date + rhs_date) {
   case 2:
-    return date_join_visitor<ACCEPT_NA_MATCH>(left, right, name_left, name_right);
+    return date_join_visitor<ACCEPT_NA_MATCH>(left, right);
   case 1:
     stop("cannot join a Date object with an object that is not a Date object");
   case 0:
@@ -153,11 +155,11 @@ JoinVisitor* join_visitor(SEXP left, SEXP right, const SymbolString& name_left, 
     break;
   }
 
-  bool lhs_time = Rf_inherits(left, "POSIXct");
-  bool rhs_time = Rf_inherits(right, "POSIXct");
+  bool lhs_time = Rf_inherits(left.get_data(), "POSIXct");
+  bool rhs_time = Rf_inherits(right.get_data(), "POSIXct");
   switch (lhs_time + rhs_time) {
   case 2:
-    return new POSIXctJoinVisitor<ACCEPT_NA_MATCH>(left, right, name_left, name_right);
+    return new POSIXctJoinVisitor<ACCEPT_NA_MATCH>(left, right);
   case 1:
     stop("cannot join a POSIXct object with an object that is not a POSIXct object");
   case 0:
@@ -166,12 +168,12 @@ JoinVisitor* join_visitor(SEXP left, SEXP right, const SymbolString& name_left, 
     break;
   }
 
-  switch (TYPEOF(left)) {
+  switch (TYPEOF(left.get_data())) {
   case CPLXSXP:
   {
-    switch (TYPEOF(right)) {
+    switch (TYPEOF(right.get_data())) {
     case CPLXSXP:
-      return new JoinVisitorImpl<CPLXSXP, CPLXSXP, ACCEPT_NA_MATCH>(left, right, name_left, name_right);
+      return new JoinVisitorImpl<CPLXSXP, CPLXSXP, ACCEPT_NA_MATCH>(left, right);
     default:
       break;
     }
@@ -179,31 +181,35 @@ JoinVisitor* join_visitor(SEXP left, SEXP right, const SymbolString& name_left, 
   }
   case INTSXP:
   {
-    bool lhs_factor = Rf_inherits(left, "factor");
-    switch (TYPEOF(right)) {
+    bool lhs_factor = Rf_inherits(left.get_data(), "factor");
+    switch (TYPEOF(right.get_data())) {
     case INTSXP:
     {
-      bool rhs_factor = Rf_inherits(right, "factor");
+      bool rhs_factor = Rf_inherits(right.get_data(), "factor");
       if (lhs_factor && rhs_factor) {
-        if (same_levels(left, right)) {
-          return new JoinVisitorImpl<INTSXP, INTSXP, ACCEPT_NA_MATCH>(left, right, name_left, name_right);
+        if (same_levels(left.get_data(), right.get_data())) {
+          return new JoinVisitorImpl<INTSXP, INTSXP, ACCEPT_NA_MATCH>(left, right);
         } else {
           warn_bad_var(
-            name_left, name_right,
+            left.get_name(), right.get_name(),
             "joining factors with different levels, coercing to character vector",
             warn_
           );
-          return new JoinVisitorImpl<STRSXP, STRSXP, ACCEPT_NA_MATCH>(reencode_char(left), reencode_char(right), name_left, name_right);
+          return
+            new JoinVisitorImpl<STRSXP, STRSXP, ACCEPT_NA_MATCH>(
+              left.update_data(reencode_char(left.get_data())),
+              right.update_data(reencode_char(right.get_data()))
+            );
         }
       } else if (!lhs_factor && !rhs_factor) {
-        return new JoinVisitorImpl<INTSXP, INTSXP, ACCEPT_NA_MATCH>(left, right, name_left, name_right);
+        return new JoinVisitorImpl<INTSXP, INTSXP, ACCEPT_NA_MATCH>(left, right);
       }
       break;
     }
     case REALSXP:
     {
-      if (!lhs_factor && is_bare_vector(right)) {
-        return new JoinVisitorImpl<INTSXP, REALSXP, ACCEPT_NA_MATCH>(left, right, name_left, name_right);
+      if (!lhs_factor && is_bare_vector(right.get_data())) {
+        return new JoinVisitorImpl<INTSXP, REALSXP, ACCEPT_NA_MATCH>(left, right);
       }
       break;
       // what else: perhaps we can have INTSXP which is a Date and REALSXP which is a Date too ?
@@ -211,7 +217,7 @@ JoinVisitor* join_visitor(SEXP left, SEXP right, const SymbolString& name_left, 
     case LGLSXP:
     {
       if (!lhs_factor) {
-        return new JoinVisitorImpl<INTSXP, LGLSXP, ACCEPT_NA_MATCH>(left, right, name_left, name_right);
+        return new JoinVisitorImpl<INTSXP, LGLSXP, ACCEPT_NA_MATCH>(left, right);
       }
       break;
     }
@@ -219,11 +225,15 @@ JoinVisitor* join_visitor(SEXP left, SEXP right, const SymbolString& name_left, 
     {
       if (lhs_factor) {
         warn_bad_var(
-          name_left, name_right,
+          left.get_name(), right.get_name(),
           "joining factor and character vector, coercing into character vector",
           warn_
         );
-        return new JoinVisitorImpl<STRSXP, STRSXP, ACCEPT_NA_MATCH>(reencode_char(left), reencode_char(right), name_left, name_right);
+        return
+          new JoinVisitorImpl<STRSXP, STRSXP, ACCEPT_NA_MATCH>(
+            left.update_data(reencode_char(left.get_data())),
+            right.update_data(reencode_char(right.get_data()))
+          );
       }
     }
     default:
@@ -233,11 +243,11 @@ JoinVisitor* join_visitor(SEXP left, SEXP right, const SymbolString& name_left, 
   }
   case REALSXP:
   {
-    switch (TYPEOF(right)) {
+    switch (TYPEOF(right.get_data())) {
     case REALSXP:
-      return new JoinVisitorImpl<REALSXP, REALSXP, ACCEPT_NA_MATCH>(left, right, name_left, name_right);
+      return new JoinVisitorImpl<REALSXP, REALSXP, ACCEPT_NA_MATCH>(left, right);
     case INTSXP:
-      return new JoinVisitorImpl<REALSXP, INTSXP, ACCEPT_NA_MATCH>(left, right, name_left, name_right);
+      return new JoinVisitorImpl<REALSXP, INTSXP, ACCEPT_NA_MATCH>(left, right);
     default:
       break;
     }
@@ -245,13 +255,13 @@ JoinVisitor* join_visitor(SEXP left, SEXP right, const SymbolString& name_left, 
   }
   case LGLSXP:
   {
-    switch (TYPEOF(right)) {
+    switch (TYPEOF(right.get_data())) {
     case LGLSXP:
-      return new JoinVisitorImpl<LGLSXP, LGLSXP, ACCEPT_NA_MATCH> (left, right, name_left, name_right);
+      return new JoinVisitorImpl<LGLSXP, LGLSXP, ACCEPT_NA_MATCH> (left, right);
     case INTSXP:
-      return new JoinVisitorImpl<LGLSXP, INTSXP, ACCEPT_NA_MATCH>(left, right, name_left, name_right);
+      return new JoinVisitorImpl<LGLSXP, INTSXP, ACCEPT_NA_MATCH>(left, right);
     case REALSXP:
-      return new JoinVisitorImpl<LGLSXP, REALSXP, ACCEPT_NA_MATCH>(left, right, name_left, name_right);
+      return new JoinVisitorImpl<LGLSXP, REALSXP, ACCEPT_NA_MATCH>(left, right);
     default:
       break;
     }
@@ -259,22 +269,30 @@ JoinVisitor* join_visitor(SEXP left, SEXP right, const SymbolString& name_left, 
   }
   case STRSXP:
   {
-    switch (TYPEOF(right)) {
+    switch (TYPEOF(right.get_data())) {
     case INTSXP:
     {
-      if (Rf_inherits(right, "factor")) {
+      if (Rf_inherits(right.get_data(), "factor")) {
         warn_bad_var(
-          name_left, name_right,
+          left.get_name(), right.get_name(),
           "joining character vector and factor, coercing into character vector",
           warn_
         );
-        return new JoinVisitorImpl<STRSXP, STRSXP, ACCEPT_NA_MATCH>(reencode_char(left), reencode_char(right), name_left, name_right);
+        return
+          new JoinVisitorImpl<STRSXP, STRSXP, ACCEPT_NA_MATCH>(
+            left.update_data(reencode_char(left.get_data())),
+            right.update_data(reencode_char(right.get_data()))
+          );
       }
       break;
     }
     case STRSXP:
     {
-      return new JoinVisitorImpl<STRSXP, STRSXP, ACCEPT_NA_MATCH>(reencode_char(left), reencode_char(right), name_left, name_right);
+      return
+        new JoinVisitorImpl<STRSXP, STRSXP, ACCEPT_NA_MATCH>(
+          left.update_data(reencode_char(left.get_data())),
+          right.update_data(reencode_char(right.get_data()))
+        );
     }
     default:
       break;
@@ -285,17 +303,18 @@ JoinVisitor* join_visitor(SEXP left, SEXP right, const SymbolString& name_left, 
     break;
   }
 
-  stop("Can't join on '%s' x '%s' because of incompatible types (%s / %s)",
-       name_left.get_utf8_cstring(), name_right.get_utf8_cstring(), get_single_class(left), get_single_class(right)
-      );
-  return 0;
+  stop(
+    "Can't join on '%s' x '%s' because of incompatible types (%s / %s)",
+    left.get_name().get_utf8_cstring(), right.get_name().get_utf8_cstring(),
+    get_single_class(left.get_data()), get_single_class(right.get_data())
+  );
 }
 
-JoinVisitor* join_visitor(SEXP left, SEXP right, const SymbolString& left_name, const SymbolString& right_name, bool warn, bool accept_na_match) {
+JoinVisitor* join_visitor(const Column& left, const Column& right, bool warn, bool accept_na_match) {
   if (accept_na_match)
-    return join_visitor<true>(left, right, left_name, right_name, warn);
+    return join_visitor<true>(left, right, warn);
   else
-    return join_visitor<false>(left, right, left_name, right_name, warn);
+    return join_visitor<false>(left, right, warn);
 }
 
 }

--- a/src/join_exports.cpp
+++ b/src/join_exports.cpp
@@ -30,7 +30,7 @@ DataFrame subset_join(DataFrame x, DataFrame y,
   }
 
   // first the joined columns
-  DataFrameJoinVisitors join_visitors(x, y, SymbolVector(by_x), SymbolVector(by_y), false, false);
+  DataFrameJoinVisitors join_visitors(x, y, SymbolVector(by_x), SymbolVector(by_y), true, false);
   int n_join_visitors = join_visitors.size();
 
   // then columns from x but not y
@@ -162,7 +162,7 @@ DataFrame semi_join_impl(DataFrame x, DataFrame y, CharacterVector by_x, Charact
   check_by(by_x);
 
   typedef VisitorSetIndexMap<DataFrameJoinVisitors, std::vector<int> > Map;
-  DataFrameJoinVisitors visitors(x, y, SymbolVector(by_x), SymbolVector(by_y), false, na_match);
+  DataFrameJoinVisitors visitors(x, y, SymbolVector(by_x), SymbolVector(by_y), true, na_match);
   Map map(visitors);
 
   // train the map in terms of x
@@ -195,7 +195,7 @@ DataFrame anti_join_impl(DataFrame x, DataFrame y, CharacterVector by_x, Charact
   check_by(by_x);
 
   typedef VisitorSetIndexMap<DataFrameJoinVisitors, std::vector<int> > Map;
-  DataFrameJoinVisitors visitors(x, y, SymbolVector(by_x), SymbolVector(by_y), false, na_match);
+  DataFrameJoinVisitors visitors(x, y, SymbolVector(by_x), SymbolVector(by_y), true, na_match);
   Map map(visitors);
 
   // train the map in terms of x
@@ -227,7 +227,7 @@ DataFrame inner_join_impl(DataFrame x, DataFrame y,
   check_by(by_x);
 
   typedef VisitorSetIndexMap<DataFrameJoinVisitors, std::vector<int> > Map;
-  DataFrameJoinVisitors visitors(x, y, SymbolVector(by_x), SymbolVector(by_y), true, na_match);
+  DataFrameJoinVisitors visitors(x, y, SymbolVector(by_x), SymbolVector(by_y), false, na_match);
   Map map(visitors);
 
   int n_x = x.nrows(), n_y = y.nrows();
@@ -261,7 +261,7 @@ DataFrame left_join_impl(DataFrame x, DataFrame y,
   check_by(by_x);
 
   typedef VisitorSetIndexMap<DataFrameJoinVisitors, std::vector<int> > Map;
-  DataFrameJoinVisitors visitors(y, x, SymbolVector(by_y), SymbolVector(by_x), true, na_match);
+  DataFrameJoinVisitors visitors(y, x, SymbolVector(by_y), SymbolVector(by_x), false, na_match);
 
   Map map(visitors);
 
@@ -300,7 +300,7 @@ DataFrame right_join_impl(DataFrame x, DataFrame y,
   check_by(by_x);
 
   typedef VisitorSetIndexMap<DataFrameJoinVisitors, std::vector<int> > Map;
-  DataFrameJoinVisitors visitors(x, y, SymbolVector(by_x), SymbolVector(by_y), true, na_match);
+  DataFrameJoinVisitors visitors(x, y, SymbolVector(by_x), SymbolVector(by_y), false, na_match);
   Map map(visitors);
 
   // train the map in terms of x
@@ -337,7 +337,7 @@ DataFrame full_join_impl(DataFrame x, DataFrame y,
   check_by(by_x);
 
   typedef VisitorSetIndexMap<DataFrameJoinVisitors, std::vector<int> > Map;
-  DataFrameJoinVisitors visitors(y, x, SymbolVector(by_y), SymbolVector(by_x), true, na_match);
+  DataFrameJoinVisitors visitors(y, x, SymbolVector(by_y), SymbolVector(by_x), false, na_match);
   Map map(visitors);
 
   // train the map in terms of y

--- a/src/set.cpp
+++ b/src/set.cpp
@@ -58,7 +58,11 @@ dplyr::BoolResult compatible_data_frame_nonames(DataFrame x, DataFrame y, bool c
   if (convert) {
     for (int i = 0; i < n; i++) {
       try {
-        boost::scoped_ptr<JoinVisitor> v(join_visitor(x[i], y[i], SymbolString("x"), SymbolString("x"), true, true));
+        boost::scoped_ptr<JoinVisitor> v(
+          join_visitor(
+            Column(x[i], SymbolString("x")), Column(y[i], SymbolString("y")), true, true
+          )
+        );
       } catch (...) {
         return no_because("incompatible");
       }

--- a/tests/testthat/test-joins.r
+++ b/tests/testthat/test-joins.r
@@ -375,12 +375,20 @@ test_that("JoinStringFactorVisitor and JoinFactorStringVisitor handle NA #688", 
     stringsAsFactors = F
   )
 
-  expect_warning(res <- left_join(x, y, by = "Greek"), "joining character vector")
+  expect_warning(
+    res <- left_join(x, y, by = "Greek"),
+    "Column `Greek` joining factor and character vector, coercing into character vector",
+    fixed = TRUE
+  )
   expect_true(is.na(res$Greek[3]))
   expect_true(is.na(res$Letters[3]))
   expect_equal(res$numbers, 1:3)
 
-  expect_warning(res <- left_join(y, x, by = "Greek"), "joining factor")
+  expect_warning(
+    res <- left_join(y, x, by = "Greek"),
+    "Column `Greek` joining character vector and factor, coercing into character vector",
+    fixed = TRUE
+  )
   expect_equal(res$Greek, y$Greek)
   expect_equal(res$Letters, y$Letters)
   expect_equal(res$numbers[1:2], 1:2)
@@ -674,11 +682,19 @@ test_that("joins work with factors of different levels (#1712)", {
 test_that("anti and semi joins give correct result when by variable is a factor (#1571)", {
   big <- data.frame(letter = rep(c("a", "b"), each = 2), number = 1:2)
   small <- data.frame(letter = "b")
-  expect_warning(aj_result <- anti_join(big, small, by = "letter"), NA)
+  expect_warning(
+    aj_result <- anti_join(big, small, by = "letter"),
+    "Column `letter` joining factors with different levels, coercing to character vector",
+    fixed = TRUE
+  )
   expect_equal(aj_result$number, 1:2)
   expect_equal(aj_result$letter, factor(c("a", "a"), levels = c("a", "b")))
 
-  expect_warning(sj_result <- semi_join(big, small, by = "letter"), NA)
+  expect_warning(
+    sj_result <- semi_join(big, small, by = "letter"),
+    "Column `letter` joining factors with different levels, coercing to character vector",
+    fixed = TRUE
+  )
   expect_equal(sj_result$number, 1:2)
   expect_equal(sj_result$letter, factor(c("b", "b"), levels = c("a", "b")))
 })
@@ -754,15 +770,13 @@ test_that("join handles mix of encodings in data (#1885, #2118, #2271)", {
               expect_equal_df(
                 semi_join(df1, df2, by = "x"),
                 data.frame(x = special, y = 1, stringsAsFactors = factor1)
-              ),
-              msg = NA
+              )
             )
             expect_warning_msg(
               expect_equal_df(
                 anti_join(df1, df2, by = "x"),
                 data.frame(x = special, y = 1, stringsAsFactors = factor1)[0,]
-              ),
-              msg = NA
+              )
             )
           }
         }


### PR DESCRIPTION
- New `Column` class
- Remove duplicate warnings
- Warn about inconsistencies in semi- and anti-joins
- Reverse order of column names in warnings for left join

Closes #2733. Fixes #2739.