### PR TITLE
Wrap ptrdiff_t instead of R_xlen_t

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -178,6 +178,10 @@ test_matches <- function() {
     .Call('dplyr_test_matches', PACKAGE = 'dplyr')
 }
 
+test_length_wrap <- function() {
+    .Call('dplyr_test_length_wrap', PACKAGE = 'dplyr')
+}
+
 assert_all_white_list <- function(data) {
     invisible(.Call('dplyr_assert_all_white_list', PACKAGE = 'dplyr', data))
 }

--- a/inst/include/dplyr/workarounds/xlen.h
+++ b/inst/include/dplyr/workarounds/xlen.h
@@ -5,7 +5,7 @@ namespace Rcpp {
 
 template <>
 inline SEXP wrap(const ptrdiff_t& x) {
-  if (x < -R_SHORT_LEN_MAX || x > R_SHORT_LEN_MAX) {
+  if (x < -R_LEN_T_MAX || x > R_LEN_T_MAX) {
     return Rf_ScalarReal(static_cast<double>(x));
   }
   else {

--- a/inst/include/dplyr/workarounds/xlen.h
+++ b/inst/include/dplyr/workarounds/xlen.h
@@ -1,11 +1,13 @@
 #ifndef DPLYR_WORKAROUND_XLEN_H
 #define DPLYR_WORKAROUND_XLEN_H
 
+#ifdef LONG_VECTOR_SUPPORT
+
 namespace Rcpp {
 
 template <>
-inline SEXP wrap(const ptrdiff_t& x) {
-  if (x < -R_LEN_T_MAX || x > R_LEN_T_MAX) {
+inline SEXP wrap(const R_xlen_t& x) {
+  if (x < -R_SHORT_LEN_MAX || x > R_SHORT_LEN_MAX) {
     return Rf_ScalarReal(static_cast<double>(x));
   }
   else {
@@ -14,5 +16,7 @@ inline SEXP wrap(const ptrdiff_t& x) {
 }
 
 }
+
+#endif
 
 #endif

--- a/inst/include/dplyr/workarounds/xlen.h
+++ b/inst/include/dplyr/workarounds/xlen.h
@@ -5,7 +5,7 @@ namespace Rcpp {
 
 template <>
 inline SEXP wrap(const ptrdiff_t& x) {
-  if (x < -2147483647 || x > 2147483647) {
+  if (x < -R_SHORT_LEN_MAX || x > R_SHORT_LEN_MAX) {
     return Rf_ScalarReal(static_cast<double>(x));
   }
   else {

--- a/inst/include/dplyr/workarounds/xlen.h
+++ b/inst/include/dplyr/workarounds/xlen.h
@@ -4,7 +4,7 @@
 namespace Rcpp {
 
 template <>
-inline SEXP wrap(const R_xlen_t& x) {
+inline SEXP wrap(const ptrdiff_t& x) {
   if (x < -2147483647 || x > 2147483647) {
     return Rf_ScalarReal(static_cast<double>(x));
   }

--- a/inst/include/tools/match.h
+++ b/inst/include/tools/match.h
@@ -10,14 +10,14 @@ inline IntegerVector r_match(SEXP x, SEXP y, SEXP incomparables = R_NilValue) {
     // Work around matching bug in R 3.3.0: #1806
     // https://bugs.r-project.org/bugzilla3/show_bug.cgi?id=16885
     if (Rf_isNull(incomparables)) {
-      return match(x, y, IntegerVector::create(NA_INTEGER), LogicalVector());
+      return match(x, y, NA_INTEGER, LogicalVector());
     }
     else {
-      return match(x, y, IntegerVector::create(NA_INTEGER), incomparables);
+      return match(x, y, NA_INTEGER, incomparables);
     }
   }
   else {
-    return match(x, y, IntegerVector::create(NA_INTEGER), incomparables);
+    return match(x, y, NA_INTEGER, incomparables);
   }
 }
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -582,6 +582,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// test_length_wrap
+LogicalVector test_length_wrap();
+RcppExport SEXP dplyr_test_length_wrap() {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    rcpp_result_gen = Rcpp::wrap(test_length_wrap());
+    return rcpp_result_gen;
+END_RCPP
+}
 // assert_all_white_list
 void assert_all_white_list(const DataFrame& data);
 RcppExport SEXP dplyr_assert_all_white_list(SEXP dataSEXP) {

--- a/src/init_register.c
+++ b/src/init_register.c
@@ -54,6 +54,7 @@ extern SEXP dplyr_strings_addresses(SEXP);
 extern SEXP dplyr_summarise_impl(SEXP, SEXP);
 extern SEXP dplyr_test_comparisons();
 extern SEXP dplyr_test_matches();
+extern SEXP dplyr_test_length_wrap();
 extern SEXP dplyr_ungroup_grouped_df(SEXP);
 extern SEXP dplyr_union_data_frame(SEXP, SEXP);
 
@@ -101,6 +102,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"dplyr_summarise_impl",                  (DL_FUNC) &dplyr_summarise_impl,                  2},
   {"dplyr_test_comparisons",                (DL_FUNC) &dplyr_test_comparisons,                0},
   {"dplyr_test_matches",                    (DL_FUNC) &dplyr_test_matches,                    0},
+  {"dplyr_test_length_wrap",                (DL_FUNC) &dplyr_test_length_wrap,                0},
   {"dplyr_ungroup_grouped_df",              (DL_FUNC) &dplyr_ungroup_grouped_df,              1},
   {"dplyr_union_data_frame",                (DL_FUNC) &dplyr_union_data_frame,                2},
   {NULL, NULL, 0}

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -108,6 +108,8 @@ List test_matches() {
 // [[Rcpp::export]]
 LogicalVector test_length_wrap() {
   R_xlen_t small = R_LEN_T_MAX / 2;
+
+#ifdef LONG_VECTOR_SUPPORT
   R_xlen_t large = (R_xlen_t)(R_LEN_T_MAX * 2.0);
   R_xlen_t missing = NA_INTEGER;
 
@@ -117,4 +119,10 @@ LogicalVector test_length_wrap() {
       as<double>(wrap(large)) == (double)large,
       as<double>(wrap(missing)) == (double)missing
     );
+#else
+  return
+    LogicalVector::create(
+      as<double>(wrap(small)) == (double)small
+    );
+#endif
 }

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -107,12 +107,14 @@ List test_matches() {
 
 // [[Rcpp::export]]
 LogicalVector test_length_wrap() {
-  R_xlen_t small = R_SHORT_LEN_MAX / 2;
-  R_xlen_t large = (R_xlen_t)(R_SHORT_LEN_MAX * 2.0);
+  R_xlen_t small = R_LEN_T_MAX / 2;
+  R_xlen_t large = (R_xlen_t)(R_LEN_T_MAX * 2.0);
+  R_xlen_t missing = NA_INTEGER;
 
   return
     LogicalVector::create(
       as<double>(wrap(small)) == (double)small,
-      as<double>(wrap(large)) == (double)large
+      as<double>(wrap(large)) == (double)large,
+      as<double>(wrap(missing)) == (double)missing
     );
 }

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -104,3 +104,15 @@ List test_matches() {
       )
     );
 }
+
+// [[Rcpp::export]]
+LogicalVector test_length_wrap() {
+  R_xlen_t small = R_SHORT_LEN_MAX / 2;
+  R_xlen_t large = (R_xlen_t)(R_SHORT_LEN_MAX * 2.0);
+
+  return
+    LogicalVector::create(
+      as<double>(wrap(small)) == (double)small,
+      as<double>(wrap(large)) == (double)large
+    );
+}

--- a/tests/testthat/test-internals.r
+++ b/tests/testthat/test-internals.r
@@ -9,3 +9,8 @@ test_that("join_match() works as expected", {
   res <- test_matches()
   expect_true(all(unlist(res)))
 })
+
+test_that("wrapping of length values works as expected", {
+  res <- test_length_wrap()
+  expect_true(all(res))
+})


### PR DESCRIPTION
because `R_xlen_t` is typedef'd to `int`, and our wrapper then takes precedence for *all* `int` values.

Fixes #2736.