### PR TITLE
tbl_df always inherits from tbl

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -353,8 +353,11 @@ and so these functions have been deprecated (but remain around for backward comp
 * The "dim" and "dimnames" attributes are always stripped when copying a 
   vector (#1918, #2049).
 
-* `grouped_df` is registered officially as an S3 class. This makes it 
-  easier to use with S4 (#2276, , @joranE).
+* `grouped_df` and `rowwise` are registered officially as S3 classes.
+  This makes them easier to use with S4 (#2276, @joranE, #2789).
+
+* All operations that return tibbles now include the `"tbl"` class.
+  This is important for correct printing with tibble 1.3.1 (#2789).
 
 * Makeflags uses PKG_CPPFLAGS for defining preprocessor macros.
 

--- a/R/dataframe.R
+++ b/R/dataframe.R
@@ -1,5 +1,3 @@
-methods::setOldClass(c("grouped_df", "tbl_df", "data.frame"))
-
 # Grouping methods ------------------------------------------------------------
 
 #' Convert row names to an explicit variable.

--- a/R/grouped-df.r
+++ b/R/grouped-df.r
@@ -25,7 +25,7 @@ grouped_df <- function(data, vars, drop = TRUE) {
   grouped_df_impl(data, unname(vars), drop)
 }
 
-setOldClass(c("grouped_df", "tbl_df", "data.frame"))
+setOldClass(c("grouped_df", "tbl_df", "tbl", "data.frame"))
 
 #' @rdname grouped_df
 #' @export

--- a/R/rowwise.r
+++ b/R/rowwise.r
@@ -23,6 +23,8 @@ rowwise <- function(data) {
   structure(data, class = c("rowwise_df", "tbl_df", "tbl", "data.frame"))
 }
 
+setOldClass(c("rowwise_df", "tbl_df", "tbl", "data.frame"))
+
 #' @export
 print.rowwise_df <- function(x, ..., n = NULL, width = NULL) {
   cat("Source: local data frame ", dim_desc(x), "\n", sep = "")
@@ -34,7 +36,7 @@ print.rowwise_df <- function(x, ..., n = NULL, width = NULL) {
 
 #' @export
 ungroup.rowwise_df <- function(x, ...) {
-  class(x) <- c("tbl_df", "data.frame")
+  class(x) <- c("tbl_df", "tbl", "data.frame")
   x
 }
 #' @export

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -229,7 +229,7 @@ test_that("group_by keeps attributes", {
 
 test_that("ungroup.rowwise_df gives a tbl_df (#936)", {
   res <- tbl_df(mtcars) %>% rowwise %>% ungroup %>% class
-  expect_equal(res, c("tbl_df", "data.frame"))
+  expect_equal(res, c("tbl_df", "tbl", "data.frame"))
 })
 
 test_that(paste0("group_by handles encodings for native strings (#1507)"), {


### PR DESCRIPTION
Fixes tidyverse/tibble#256.

Ideally, `classes_grouped()` and `classes_not_grouped()` should be exported functions and called throughout, maybe later.