### PR TITLE
Fix common_by() message for many columns

### DIFF
--- a/R/join.r
+++ b/R/join.r
@@ -166,12 +166,22 @@ common_by.NULL <- function(by, x, y) {
   if (length(by) == 0) {
     bad_args("by", "required, because the data sources have no common variables")
   }
-  inform(paste0("Joining, by = ", utils::capture.output(dput(by))))
+  inform(auto_by_msg(by))
 
   list(
     x = by,
     y = by
   )
+}
+
+auto_by_msg <- function(by) {
+  by_quoted <- encodeString(by, quote = '"')
+  if (length(by_quoted) == 1L) {
+    by_code <- by_quoted
+  } else {
+    by_code <- paste0("c(", paste(by_quoted, collapse = ", "), ")")
+  }
+  paste0("Joining, by = ", by_code)
 }
 
 #' @export

--- a/tests/testthat/test-joins.r
+++ b/tests/testthat/test-joins.r
@@ -865,3 +865,25 @@ test_that("join takes LHS with warning if attributes inconsistent", {
   expect_equal(attr(out1$a, "foo"), NULL)
   expect_equal(attr(out2$a, "foo"), "bar")
 })
+
+test_that("common_by() message", {
+  df <- tibble(!!! set_names(letters, letters))
+
+  expect_message(
+    left_join(df, df %>% select(1)),
+    'Joining, by = "a"',
+    fixed = TRUE
+  )
+
+  expect_message(
+    left_join(df, df %>% select(1:3)),
+    'Joining, by = c("a", "b", "c")',
+    fixed = TRUE
+  )
+
+  expect_message(
+    left_join(df, df),
+    paste0("Joining, by = c(", paste0('"', letters, '"', collapse = ", "), ")"),
+    fixed = TRUE
+  )
+})


### PR DESCRIPTION
We need to be careful, the correct substitute for `message()` seems to be `inform(paste0(..., collapse = ""))`.