### PR TITLE
Fix a few out of date things in programming.rmd

### DIFF
--- a/vignettes/programming.Rmd
+++ b/vignettes/programming.Rmd
@@ -418,18 +418,24 @@ x1 <- f(10)
 x2 <- f(100)
 ```
 
-It might look like the expressions are the same if you print them out. But look carefully at the environments --- they're different.
+It might look like the expressions are the same if you print them out.
 
 ```{r}
 x1
 x2
 ```
 
-When we evaluate those formulas using `rlang::eval_tidy()`, we see that they yield different values:
-
+But if you inspect the environments using `rlang::get_env()` --- they're different.
 ```{r, message = FALSE}
 library(rlang)
 
+get_env(x1)
+get_env(x2)
+```
+
+Further, when we evaluate those formulas using `rlang::eval_tidy()`, we see that they yield different values:
+
+```{r}
 eval_tidy(x1)
 eval_tidy(x2)
 ```

--- a/vignettes/programming.Rmd
+++ b/vignettes/programming.Rmd
@@ -150,7 +150,6 @@ mutate_y <- function(df) {
 }
 
 mutate_y(df1)
-# Before dplyr is released, this will give a nice error message
 ```
 
 If this function is in a package, using `.data` also prevents `R CMD check` from giving a NOTE about undefined global variables (provided that you've also imported `rlang::.data` with `@importFrom rlang .data`).
@@ -412,7 +411,7 @@ In practice, the formula is the better of the two options because it captures th
 
 ```{r}
 f <- function(x) {
-  ~ x
+  quo(x)
 }
 
 x1 <- f(10)


### PR DESCRIPTION
- Remove obsolete comment about error message

- `rlang::eval_tidy` doesn't work with base R's formulas (I think this is intentional). Before changing from `~` to `quo`, the output looked like: 
>When we evaluate those formulas using rlang::eval_tidy(), we see that they yield different values:
```
library(rlang)

eval_tidy(x1)
#> ~x
#> <environment: 0x0000000007a12958>
eval_tidy(x2)
#> ~x
#> <environment: 0x000000000c5e48e8>
```