### PR TITLE
Ungrouped mutate() doesn't mark new or overwritten variables as summaries

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 * `top_n()` now executes operations lazily for compatibility with
   database backends (#2848).
 
+* Reuse of new variables created in ungrouped `mutate()` possible again, regression introduced in dplyr 0.7.0 (#2869).
+
 # dplyr 0.7.0
 
 ## New data, functions, and features

--- a/inst/include/dplyr/Result/LazySubsets.h
+++ b/inst/include/dplyr/Result/LazySubsets.h
@@ -58,7 +58,6 @@ public:
     } else {
       data[index.pos] = x;
     }
-    summary_map.insert(symbol);
   }
 
   virtual int size() const {
@@ -67,6 +66,11 @@ public:
 
   virtual int nrows() const {
     return nr;
+  }
+
+  void input_summarised(const SymbolString& symbol, SummarisedVariable x) {
+    input(symbol, x);
+    summary_map.insert(symbol);
   }
 
 public:

--- a/src/summarise.cpp
+++ b/src/summarise.cpp
@@ -145,7 +145,7 @@ DataFrame summarise_not_grouped(DataFrame df, const QuosureList& dots) {
       check_length(Rf_length(result), 1, "a summary value", quosure.name());
     }
     accumulator.set(quosure.name(), result);
-    subsets.input(quosure.name(), result);
+    subsets.input_summarised(quosure.name(), SummarisedVariable(result));
   }
 
   List data = accumulator;

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -756,3 +756,10 @@ test_that("grouped mutate errors on incompatible column type (#1641)", {
     fixed = TRUE
   )
 })
+
+test_that("can reuse new variables", {
+  expect_equal(
+    data.frame(c = 1) %>% mutate(c, gc = mean(c)),
+    data.frame(c = 1, gc = 1)
+  )
+})


### PR DESCRIPTION
Regression introduced in 0.7.0, probably in #2453.

Fixes #2842, fixes #2856.