### PR TITLE
Bump dependency version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Depends:
 Imports:
     assertthat,
     bindrcpp (>= 0.2),
-    glue (>= 1.1),
+    glue (>= 1.1.1),
     magrittr,
     methods,
     pkgconfig,
@@ -57,4 +57,5 @@ License: MIT + file LICENSE
 RoxygenNote: 6.0.1
 Roxygen: list(markdown = TRUE, roclets = c("rd", "namespace", "collate"))
 Remotes:
-    krlmlr/bindrcpp@r-0.2
+    krlmlr/bindrcpp@r-0.2,
+    tidyverse/glue

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Depends:
 Imports:
     assertthat,
     bindrcpp (>= 0.2),
-    glue,
+    glue (>= 1.1),
     magrittr,
     methods,
     pkgconfig,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Depends:
     R (>= 3.1.2)
 Imports:
     assertthat,
-    bindrcpp,
+    bindrcpp (>= 0.1-10),
     glue,
     magrittr,
     methods,
@@ -56,3 +56,5 @@ LazyData: yes
 License: MIT + file LICENSE
 RoxygenNote: 6.0.1
 Roxygen: list(markdown = TRUE, roclets = c("rd", "namespace", "collate"))
+Remotes:
+    krlmlr/bindrcpp

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Depends:
     R (>= 3.1.2)
 Imports:
     assertthat,
-    bindrcpp (>= 0.1-10),
+    bindrcpp (>= 0.2),
     glue,
     magrittr,
     methods,
@@ -57,4 +57,4 @@ License: MIT + file LICENSE
 RoxygenNote: 6.0.1
 Roxygen: list(markdown = TRUE, roclets = c("rd", "namespace", "collate"))
 Remotes:
-    krlmlr/bindrcpp
+    krlmlr/bindrcpp@r-0.2

--- a/inst/include/dplyr_RcppExports.h
+++ b/inst/include/dplyr_RcppExports.h
@@ -73,7 +73,7 @@ namespace dplyr {
         RObject rcpp_result_gen;
         {
             RNGScope RCPP_rngScope_gen;
-            rcpp_result_gen = p_build_index_cpp(Rcpp::wrap(data));
+            rcpp_result_gen = p_build_index_cpp(Shield<SEXP>(Rcpp::wrap(data)));
         }
         if (rcpp_result_gen.inherits("interrupted-error"))
             throw Rcpp::internal::InterruptedException();


### PR DESCRIPTION
for bindrcpp. The upcoming CRAN version will be 0.2.

Fixes #2811.