### PR TITLE
Fix protection error when constructing error messages

### DIFF
--- a/inst/include/dplyr/bad.h
+++ b/inst/include/dplyr/bad.h
@@ -7,7 +7,7 @@ template<class C1>
 void NORET bad_arg(const SymbolString& arg, C1 arg1) {
   static Function bad_fun = Function("bad_args", Environment::namespace_env("dplyr"));
   static Function identity = Function("identity", Environment::base_env());
-  String message = bad_fun(CharacterVector::create(arg.get_string()), wrap(arg1), _[".abort"] = identity);
+  String message = bad_fun(CharacterVector::create(arg.get_string()), arg1, _[".abort"] = identity);
   message.set_encoding(CE_UTF8);
   stop(message.get_cstring());
 }
@@ -16,7 +16,7 @@ template<class C1, class C2>
 void NORET bad_arg(const SymbolString& arg, C1 arg1, C2 arg2) {
   static Function bad_fun = Function("bad_args", Environment::namespace_env("dplyr"));
   static Function identity = Function("identity", Environment::base_env());
-  String message = bad_fun(CharacterVector::create(arg.get_string()), wrap(arg1), arg2, _[".abort"] = identity);
+  String message = bad_fun(CharacterVector::create(arg.get_string()), arg1, arg2, _[".abort"] = identity);
   message.set_encoding(CE_UTF8);
   stop(message.get_cstring());
 }
@@ -25,7 +25,7 @@ template<class C1, class C2, class C3>
 void NORET bad_arg(const SymbolString& arg, C1 arg1, C2 arg2, C3 arg3) {
   static Function bad_fun = Function("bad_args", Environment::namespace_env("dplyr"));
   static Function identity = Function("identity", Environment::base_env());
-  String message = bad_fun(CharacterVector::create(arg.get_string()), wrap(arg1), arg2, arg3, _[".abort"] = identity);
+  String message = bad_fun(CharacterVector::create(arg.get_string()), arg1, arg2, arg3, _[".abort"] = identity);
   message.set_encoding(CE_UTF8);
   stop(message.get_cstring());
 }
@@ -34,7 +34,7 @@ template<class C1>
 void NORET bad_pos_arg(int pos_arg, C1 arg1) {
   static Function bad_fun = Function("bad_pos_args", Environment::namespace_env("dplyr"));
   static Function identity = Function("identity", Environment::base_env());
-  String message = bad_fun(wrap(pos_arg), wrap(arg1), _[".abort"] = identity);
+  String message = bad_fun(pos_arg, arg1, _[".abort"] = identity);
   message.set_encoding(CE_UTF8);
   stop(message.get_cstring());
 }
@@ -43,7 +43,7 @@ template<class C1, class C2>
 void NORET bad_pos_arg(int pos_arg, C1 arg1, C2 arg2) {
   static Function bad_fun = Function("bad_pos_args", Environment::namespace_env("dplyr"));
   static Function identity = Function("identity", Environment::base_env());
-  String message = bad_fun(wrap(pos_arg), wrap(arg1), arg2, _[".abort"] = identity);
+  String message = bad_fun(pos_arg, arg1, arg2, _[".abort"] = identity);
   message.set_encoding(CE_UTF8);
   stop(message.get_cstring());
 }
@@ -52,7 +52,7 @@ template<class C1, class C2, class C3>
 void NORET bad_pos_arg(int pos_arg, C1 arg1, C2 arg2, C3 arg3) {
   static Function bad_fun = Function("bad_pos_args", Environment::namespace_env("dplyr"));
   static Function identity = Function("identity", Environment::base_env());
-  String message = bad_fun(wrap(pos_arg), wrap(arg1), arg2, arg3, _[".abort"] = identity);
+  String message = bad_fun(pos_arg, arg1, arg2, arg3, _[".abort"] = identity);
   message.set_encoding(CE_UTF8);
   stop(message.get_cstring());
 }
@@ -61,7 +61,7 @@ template<class C1>
 void NORET bad_col(const SymbolString& col, C1 arg1) {
   static Function bad_fun = Function("bad_cols", Environment::namespace_env("dplyr"));
   static Function identity = Function("identity", Environment::base_env());
-  String message = bad_fun(CharacterVector::create(col.get_string()), wrap(arg1), _[".abort"] = identity);
+  String message = bad_fun(CharacterVector::create(col.get_string()), arg1, _[".abort"] = identity);
   message.set_encoding(CE_UTF8);
   stop(message.get_cstring());
 }
@@ -70,7 +70,7 @@ template<class C1, class C2>
 void NORET bad_col(const SymbolString& col, C1 arg1, C2 arg2) {
   static Function bad_fun = Function("bad_cols", Environment::namespace_env("dplyr"));
   static Function identity = Function("identity", Environment::base_env());
-  String message = bad_fun(CharacterVector::create(col.get_string()), wrap(arg1), arg2, _[".abort"] = identity);
+  String message = bad_fun(CharacterVector::create(col.get_string()), arg1, arg2, _[".abort"] = identity);
   message.set_encoding(CE_UTF8);
   stop(message.get_cstring());
 }
@@ -79,7 +79,7 @@ template<class C1, class C2, class C3>
 void NORET bad_col(const SymbolString& col, C1 arg1, C2 arg2, C3 arg3) {
   static Function bad_fun = Function("bad_cols", Environment::namespace_env("dplyr"));
   static Function identity = Function("identity", Environment::base_env());
-  String message = bad_fun(CharacterVector::create(col.get_string()), wrap(arg1), arg2, arg3, _[".abort"] = identity);
+  String message = bad_fun(CharacterVector::create(col.get_string()), arg1, arg2, arg3, _[".abort"] = identity);
   message.set_encoding(CE_UTF8);
   stop(message.get_cstring());
 }


### PR DESCRIPTION
I have no idea why I used `wrap()` originally, but this results in a naked `SEXP` which may be destroyed even before the function is called. Tests with gctorture are still running.