### PR TITLE
Auto-disconnect SQLite connection

### DIFF
--- a/R/src_dbi.R
+++ b/R/src_dbi.R
@@ -149,7 +149,7 @@ src_sqlite <- function(path, create = FALSE) {
   con <- DBI::dbConnect(RSQLite::SQLite(), path)
   RSQLite::initExtension(con)
 
-  dbplyr::src_dbi(con)
+  dbplyr::src_dbi(con, auto_disconnect = TRUE)
 }
 
 # S3 methods --------------------------------------------------------------


### PR DESCRIPTION
because DBI specs ask for a warning if a client forgets to disconnect.

I'm aware that RSQLite connections are cheap compared to connections to other DBMS, but I prefer a uniform interface definition.