### PR TITLE
Depend on Rcpp >= 0.12.7

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Imports:
     pkgconfig,
     rlang (>= 0.1),
     R6,
-    Rcpp (>= 0.12.6),
+    Rcpp (>= 0.12.7),
     tibble (>= 1.3.1),
     utils
 Suggests:


### PR DESCRIPTION
This line in dplyr https://github.com/tidyverse/dplyr/blob/master/inst/include/tools/SymbolString.h#L21 uses `Rcpp::String::String(const char*, cetype_t)`, available in Rcpp since this commit https://github.com/RcppCore/Rcpp/commit/0bf8e97e46ff85d02d7f158c6b476369f7912cc1 that was included in 0.12.7.

That's why dplyr needs to depend on Rcpp 0.12.7 instead of 0.12.6.

Closes #2902