### PR TITLE
Show case_when()'s splicing support with arguments in order.

### DIFF
--- a/R/case_when.R
+++ b/R/case_when.R
@@ -49,10 +49,10 @@
 #'
 #' # Dots support splicing:
 #' patterns <- list(
-#'   TRUE ~ as.character(x),
-#'   x %%  5 == 0 ~ "fizz",
-#'   x %%  7 == 0 ~ "buzz",
-#'   x %% 35 == 0 ~ "fizz buzz"
+#'   x %% 35 == 0 ~ "fizz buzz",
+#'   x %% 5 == 0 ~ "fizz",
+#'   x %% 7 == 0 ~ "buzz",
+#'   TRUE ~ as.character(x)
 #' )
 #' case_when(!!! patterns)
 case_when <- function(...) {


### PR DESCRIPTION
Likely a typo resulted from copy-pasting code immediately above. The intent seems to be to show an example that works.