### PR TITLE
Fix protection errors with strings for grouped mutate()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dplyr 0.7.1.9000
 
+* Fix protection error that occurred when creating a character column
+  using grouped `mutate()` (#2971).
+
 # dplyr 0.7.1
 
 * Use new versions of bindrcpp and glue to avoid protection problems.

--- a/inst/include/dplyr/Collecter.h
+++ b/inst/include/dplyr/Collecter.h
@@ -206,20 +206,18 @@ protected:
 private:
 
   void collect_logicalNA(const SlicingIndex& index, LogicalVector) {
-    SEXP* p_data   = Rcpp::internal::r_vector_start<STRSXP>(data);
     int n = index.size();
     for (int i = 0; i < n; i++) {
-      p_data[index[i]] = NA_STRING;
+      SET_STRING_ELT(data, index[i], NA_STRING);
     }
   }
 
   void collect_strings(const SlicingIndex& index, CharacterVector source,
                        int offset = 0) {
     SEXP* p_source = Rcpp::internal::r_vector_start<STRSXP>(source) + offset;
-    SEXP* p_data   = Rcpp::internal::r_vector_start<STRSXP>(data);
     int n = index.size();
     for (int i = 0; i < n; i++) {
-      p_data[index[i]] = p_source[i];
+      SET_STRING_ELT(data, index[i], p_source[i]);
     }
   }
 

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -763,3 +763,13 @@ test_that("can reuse new variables", {
     data.frame(c = 1, gc = 1)
   )
 })
+
+test_that("can use character vectors in grouped mutate (#2971)", {
+  df <-
+    data_frame(x = 1:10000) %>%
+    group_by(x) %>%
+    mutate(y = as.character(runif(1L)),
+           z = as.character(runif(1L)))
+
+  expect_error(df %>% distinct(x, .keep_all = TRUE), NA)
+})


### PR DESCRIPTION
Need `SET_STRING_ELT()` to copy `CHARSXP`.

Fixes #2971.