### PR TITLE
strict parameter for select_vars (related to #2981)

### DIFF
--- a/R/select-vars.R
+++ b/R/select-vars.R
@@ -240,7 +240,7 @@ switch_rename <- function(expr, name) {
 
 
 eval_safely <- function(expr, data = NULL, env = caller_env()) {
-  evl <- purrr::safely(eval_tidy)
-  evl(expr, data = data, env = env)$result
+  tryCatch(eval_tidy(expr, data = data, env = env),
+           error = function(e) NULL)
 }
 

--- a/R/select-vars.R
+++ b/R/select-vars.R
@@ -240,7 +240,7 @@ switch_rename <- function(expr, name) {
 
 
 eval_safely <- function(expr, data = NULL, env = caller_env()) {
-  evl <- safely(eval_tidy)
+  evl <- purrr::safely(eval_tidy)
   evl(expr, data = data, env = env)$result
 }
 


### PR DESCRIPTION
This commit introduces `strict` parameter in `select_vars` function (as discussed in #2981). Instead of using `eval_tidy`, `eval_safely` function is introduced that uses `safely(eval_tidy)` instead of it when `strict = FALSE`. For everything to work, next the `NULL` variables (i.e. nonexistent) are dropped from `ind_list` and `names2(quos)`.