### PR TITLE
Semi- and anti-join maintain sort order of first argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 
 * `distinct()` now throws an error when used on unknown columns (#2867, @foo-bar-baz-qux).
 
-* Semi- and anti-joins now preserve sort order (#3089).
+* Semi- and anti-joins now preserve order of left-hand-side data frame (#3089).
 
 # dplyr 0.7.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
 
 * `distinct()` now throws an error when used on unknown columns (#2867, @foo-bar-baz-qux).
 
+* Semi- and anti-joins now preserve sort order (#3089).
+
 # dplyr 0.7.2
 
 * Move build-time vs. run-time checks out of `.onLoad()` and into `dr_dplyr()`.

--- a/src/join_exports.cpp
+++ b/src/join_exports.cpp
@@ -185,6 +185,8 @@ DataFrame semi_join_impl(DataFrame x, DataFrame y, CharacterVector by_x, Charact
     }
   }
 
+  std::sort(indices.begin(), indices.end());
+
   const DataFrame& out = subset(x, indices, x.names(), get_class(x));
   strip_index(out);
   return out;
@@ -213,6 +215,8 @@ DataFrame anti_join_impl(DataFrame x, DataFrame y, CharacterVector by_x, Charact
   std::vector<int> indices;
   for (Map::iterator it = map.begin(); it != map.end(); ++it)
     push_back(indices, it->second);
+
+  std::sort(indices.begin(), indices.end());
 
   const DataFrame& out = subset(x, indices, x.names(), get_class(x));
   strip_index(out);

--- a/src/join_exports.cpp
+++ b/src/join_exports.cpp
@@ -171,6 +171,7 @@ DataFrame semi_join_impl(DataFrame x, DataFrame y, CharacterVector by_x, Charact
   int n_y = y.nrows();
   // this will collect indices from rows in x that match rows in y
   std::vector<int> indices;
+  indices.reserve(x.nrow());
   for (int i = 0; i < n_y; i++) {
     // find a row in x that matches row i from y
     Map::iterator it = map.find(-i - 1);
@@ -213,6 +214,7 @@ DataFrame anti_join_impl(DataFrame x, DataFrame y, CharacterVector by_x, Charact
 
   // collect what's left
   std::vector<int> indices;
+  indices.reserve(map.size());
   for (Map::iterator it = map.begin(); it != map.end(); ++it)
     push_back(indices, it->second);
 

--- a/tests/testthat/test-joins.r
+++ b/tests/testthat/test-joins.r
@@ -887,3 +887,14 @@ test_that("common_by() message", {
     fixed = TRUE
   )
 })
+
+test_that("semi- and anti-joins preserve order (#2964)", {
+  expect_identical(
+    data_frame(a = 3:1) %>% semi_join(data_frame(a = 1:3)),
+    data_frame(a = 3:1)
+  )
+  expect_identical(
+    data_frame(a = 3:1) %>% anti_join(data_frame(a = 4:6)),
+    data_frame(a = 3:1)
+  )
+})


### PR DESCRIPTION
Closes #2964.