### PR TITLE
Remove typo from README.Rmd

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -49,7 +49,7 @@ install.packages("tidyverse")
 # Alternatively, install just dplyr:
 install.packages("dplyr")
 
-# Or the the development version from GitHub:
+# Or the development version from GitHub:
 # install.packages("devtools")
 devtools::install_github("tidyverse/dplyr")
 ```


### PR DESCRIPTION
The README contains a duplicate "the"