### PR TITLE
Fall back to standard evaluation with non-const default argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@
 
 * `select()`, `rename()` and `summarise()` no longer changes the grouped vars of the original data (#3038).
 
+* `nth(default = var)`, `first(default = var)` and `last(default = var)` fall back to standard evaluation in a grouped operation instead of triggering an error (#3045).
+
 # dplyr 0.7.2
 
 * Move build-time vs. run-time checks out of `.onLoad()` and into `dr_dplyr()`.

--- a/src/hybrid_nth.cpp
+++ b/src/hybrid_nth.cpp
@@ -247,6 +247,7 @@ Result* nth_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
     }
     else if (!has_default && (Rf_isNull(tag) || argmatch("default", CHAR(PRINTNAME(tag))))) {
       def = CAR(p);
+      if (TYPEOF(def) == SYMSXP || TYPEOF(def) == LANGSXP) return 0;
       has_default = true;
     }
     else {

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -274,6 +274,12 @@ test_that("first(), last(), and nth() work", {
     expected = 5L
   )
 
+  default_value <- 6L
+  check_not_hybrid_result(
+    nth(a, 6, default = default_value), a = 1:5,
+    expected = 6L
+  )
+
   expect_equal(
     tibble(a = c(1, 1, 2), b = letters[1:3]) %>%
       group_by(a) %>%


### PR DESCRIPTION
in `nth()`. Closes #2977.