### PR TITLE
Turn off hybrid evaluation for non-summary variables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,8 @@
 
 * `case_when()` accepts `NA` on the LHS (#2927).
 
+* Fixed a rare problem with accessing variable values in `summarise()` when all groups have size one (#3050).
+
 # dplyr 0.7.2
 
 * Move build-time vs. run-time checks out of `.onLoad()` and into `dr_dplyr()`.

--- a/src/hybrid.cpp
+++ b/src/hybrid.cpp
@@ -109,8 +109,7 @@ public:
       // No need to check length since the summary has already been checked
       return subsets.get_variable(name);
     } else {
-      check_length(gdf.max_group_size(), 1, "a summary value", name);
-      return process(*gdf.group_begin());
+      stop("VariableResult::process() needs a summary variable");
     }
   }
 
@@ -166,6 +165,8 @@ Result* get_handler(SEXP call, const ILazySubsets& subsets, const Environment& e
     LOG_VERBOSE << "Searching hybrid handler for symbol " << sym.get_utf8_cstring();
 
     if (subsets.has_variable(sym)) {
+      if (!subsets.is_summary(sym)) return 0;
+
       LOG_VERBOSE << "Using hybrid variable handler";
       return variable_handler(subsets, sym);
     }

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -963,6 +963,16 @@ test_that("can refer to previously summarised symbols", {
   expect_identical(summarise(group_by(mtcars, cyl), x = n(), z = x)[2:3], tibble(x = c(11L, 7L, 14L), z = x))
 })
 
+test_that("can refer to symbols if group size is one overall", {
+  df <- tibble(x = LETTERS[3:1], y = 1:3)
+  expect_identical(
+    df %>%
+      group_by(x) %>%
+      summarise(z = y),
+    tibble(x = LETTERS[1:3], z = 3:1)
+  )
+})
+
 test_that("summarise() supports unquoted values", {
   df <- tibble(g = c(1, 1, 2, 2, 2), x = 1:5)
   expect_identical(summarise(df, out = !! 1), tibble(out = 1))


### PR DESCRIPTION
Fixes #2915 by disabling hybrid evaluation in the problematic (and a few other) cases.