### PR TITLE
Revert unintended API change

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,8 +5,6 @@
 * Fix protection error that occurred when creating a character column
   using grouped `mutate()` (#2971).
 
-* `distinct()` now throws an error when used on unknown columns (#2867, @foo-bar-baz-qux).
-
 * Semi- and anti-joins now preserve order of left-hand-side data frame (#3089).
 
 * `select()`, `rename()` and `summarise()` no longer changes the grouped vars of the original data (#3038).

--- a/R/distinct.R
+++ b/R/distinct.R
@@ -76,15 +76,7 @@ distinct_vars <- function(.data, vars, group_vars = character(), .keep_all = FAL
 
   # Once we've done the mutate, we no longer need lazy objects, and
   # can instead just use their names
-  new_vars <- unique(c(names(vars), group_vars))
-  missing_vars <- setdiff(new_vars, names(.data))
-
-  if (length(missing_vars) > 0) {
-    bad_cols(missing_vars, "not found")
-  }
-
-  # Keep the order of the variables
-  out_vars <- intersect(names(.data), new_vars)
+  out_vars <- intersect(names(.data), c(names(vars), group_vars))
 
   if (.keep_all) {
     keep <- names(.data)

--- a/tests/testthat/test-distinct.R
+++ b/tests/testthat/test-distinct.R
@@ -68,12 +68,6 @@ test_that("empty grouped distinct equivalent to empty ungrouped", {
   expect_equal(df1, df2)
 })
 
-test_that("distinct returns an error when selecting an unknown column", {
-  df <- tibble(g = c(1, 2), x = c(1, 2))
-
-  expect_error(distinct(df, aa))
-})
-
 test_that("distinct on a new, mutated variable is equivalent to mutate followed by distinct", {
   df <- tibble(g = c(1, 2), x = c(1, 2))
 


### PR DESCRIPTION
This reverts #2867 and fixes the regressions found in the "epidata", "fold", and "metaplot" packages (and their downstream dependency "nonmemica").

I've set up a reminder to revert this change later.