### PR TITLE
Fix slice() for negative indices

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Fixed a rare problem with accessing variable values in `summarise()` when all groups have size one (#3050).
 
+* Fixed rare out-of-bounds memory write in `slice()` when negative indices beyond the number of rows were involved (#3073).
+
 * `select()`, `rename()` and `summarise()` no longer change the grouped vars of the original data (#3038).
 
 * `nth(default = var)`, `first(default = var)` and `last(default = var)` fall back to standard evaluation in a grouped operation instead of triggering an error (#3045).

--- a/src/slice.cpp
+++ b/src/slice.cpp
@@ -66,7 +66,7 @@ DataFrame slice_grouped(GroupedDataFrame gdf, const QuosureList& dots) {
   Call call(quosure.expr());
 
   std::vector<int> indx;
-  indx.reserve(1000);
+  indx.reserve(gdf.nrows());
 
   IntegerVector g_test;
   Proxy call_proxy(call, gdf, env);
@@ -162,21 +162,21 @@ DataFrame slice_not_grouped(const DataFrame& df, const QuosureList& dots) {
     if (test[i] != NA_INTEGER)
       drop.insert(-test[i]);
   }
-  int n_drop = drop.size();
-  std::vector<int> indices(nr - n_drop);
+  std::vector<int> indices;
+  indices.reserve(nr);
   std::set<int>::const_iterator drop_it = drop.begin();
 
-  int i = 0, j = 0;
+  int j = 0;
   while (drop_it != drop.end()) {
     int next_drop = *drop_it - 1;
-    while (j < next_drop) {
-      indices[i++] = j++;
+    for (; j < next_drop; ++j) {
+      indices.push_back(j);
     }
     j++;
     ++drop_it;
   }
-  while (i < nr - n_drop) {
-    indices[i++] = j++;
+  for (; j < nr; ++j) {
+    indices.push_back(j);
   }
 
   return subset(df, indices, df.names(), classes_not_grouped());

--- a/src/slice.cpp
+++ b/src/slice.cpp
@@ -66,7 +66,7 @@ DataFrame slice_grouped(GroupedDataFrame gdf, const QuosureList& dots) {
   Call call(quosure.expr());
 
   std::vector<int> indx;
-  indx.reserve(gdf.nrows());
+  indx.reserve(1000);
 
   IntegerVector g_test;
   Proxy call_proxy(call, gdf, env);

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -113,3 +113,8 @@ test_that("slice works under gctorture2", {
   with_gctorture2(999, x2 <- slice(x, 1:10))
   expect_identical(x, x2)
 })
+
+test_that("slice correctly computes the positive indices", {
+  x <- tibble(y = 1:10)
+  expect_identical(slice(x, -10:-30), tibble(y = 1:9))
+})

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -114,7 +114,7 @@ test_that("slice works under gctorture2", {
   expect_identical(x, x2)
 })
 
-test_that("slice correctly computes the positive indices", {
+test_that("slice correctly computes positive indices from negative indices (#3073)", {
   x <- tibble(y = 1:10)
   expect_identical(slice(x, -10:-30), tibble(y = 1:9))
 })


### PR DESCRIPTION
if the range stretches over the number-of-rows boundary.

Fixes downstream problems with waccR.