### PR TITLE
Proper type check for enquoted `call` argument in order_by()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,9 @@
 
 * Grouping by character vectors is now faster (#2204).
 
+* Fixed a crash that occurred when an unexpected input was supplied to
+  the `call` argument of `order_by()` (#3065).
+
 # dplyr 0.7.2
 
 * Move build-time vs. run-time checks out of `.onLoad()` and into `dr_dplyr()`.

--- a/R/order-by.R
+++ b/R/order-by.R
@@ -27,7 +27,10 @@
 #' arrange(right, year)
 order_by <- function(order_by, call) {
   quo <- enquo(call)
-  stopifnot(is_lang(quo))
+  if (!quo_is_lang(quo)) {
+    type <- friendly_type(type_of(get_expr(quo)))
+    bad_args("call", "must be a function call, not { type }")
+  }
 
   fn <- set_expr(quo, node_car(get_expr(quo)))
   args <- node_cdr(get_expr(quo))

--- a/tests/testthat/test-window.R
+++ b/tests/testthat/test-window.R
@@ -58,3 +58,7 @@ test_that("order_by() works in arbitrary envs (#2297)", {
     rev(cumsum(rev(1:5)))
   )
 })
+
+test_that("order_by() fails when not supplied a call (#3065)", {
+  expect_error(order_by(NULL, !! 1L), "`call` must be a function call, not an integer vector")
+})


### PR DESCRIPTION
Part of #3065. This patch fixes the crash.