### PR TITLE
Add warning if any of the selected columns for `distinct()` are of type `list`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -43,13 +43,13 @@
 
 * `select()` and `vars()` now treat `NULL` as empty inputs (#3023).
 
+* Add error for `distinct()` if any of the selected columns are of type `list` (#3088, @foo-bar-baz-qux).
 
 # dplyr 0.7.4
 
 * Fix recent Fedora and ASAN check errors (#3098).
 
 * Avoid dependency on Rcpp 0.12.10 (#3106).
-
 
 # dplyr 0.7.3
 

--- a/R/distinct.R
+++ b/R/distinct.R
@@ -61,6 +61,7 @@ distinct_vars <- function(.data, vars, group_vars = character(), .keep_all = FAL
 
   # If no input, keep all variables
   if (length(vars) == 0) {
+    list_cols_error(.data, names(.data))
     return(list(
       data = .data,
       vars = names(.data),
@@ -84,7 +85,17 @@ distinct_vars <- function(.data, vars, group_vars = character(), .keep_all = FAL
     keep <- unique(out_vars)
   }
 
+  list_cols_error(.data, keep)
   list(data = .data, vars = out_vars, keep = keep)
+}
+
+#' Throw an error if there are tbl columns of type list
+#'
+#' @noRd
+list_cols_error <- function(df, keep_cols) {
+  if(any(map_lgl(df[keep_cols], is.list)))
+    stop("distinct() does not support columns of type `list`",
+            call. = FALSE)
 }
 
 #' Efficiently count the number of unique values in a set of vector

--- a/tests/testthat/test-distinct.R
+++ b/tests/testthat/test-distinct.R
@@ -76,3 +76,12 @@ test_that("distinct on a new, mutated variable is equivalent to mutate followed 
 
   expect_equal(df1, df2)
 })
+
+test_that("distinct on a dataframe or tibble with columns of type list throws an error", {
+  df <- tibble(a = c("1", "1", "2", "2", "3","3"),
+               b = c(list("A"), list("A"), list("B"), list("B"), list("C"), list("C")))
+  df2 <- data.frame(x = 1:5, y=I(list(1:3, 1:3, 1:3, 1:3, 1:3)))
+
+  expect_error(df %>% distinct())
+  expect_error(df2 %>% distinct())
+})


### PR DESCRIPTION
Fixes #3088. Went with a warning so as not to introduce a breaking change, should probably be an error in next version that allows breaking changes (0.9 I'm assuming).

I added a new NEWS section as well as I assume 0.7.3 is already released.