### PR TITLE
Efficient and Adaptive Stratified Sampling

### DIFF
--- a/R/sample.R
+++ b/R/sample.R
@@ -101,7 +101,7 @@ check_weight <- function(x, n) {
 }
 
 check_size <- function(size, n, replace = FALSE) {
-  if (size <= n || replace) return()
+  if (replace || all(size <= n)) return()
 
   bad_args("size", "must be less or equal than {n} (size of data), ",
     "set `replace` = TRUE to use sampling with replacement"
@@ -109,7 +109,7 @@ check_size <- function(size, n, replace = FALSE) {
 }
 
 check_frac <- function(size, replace = FALSE) {
-  if (size <= 1 || replace) return()
+  if (replace || all(size <= 1)) return()
 
   bad_args("size", "of sampled fraction must be less or equal to one, ",
     "set `replace` = TRUE to use sampling with replacement"

--- a/tests/testthat/test-sample.R
+++ b/tests/testthat/test-sample.R
@@ -98,20 +98,6 @@ test_that("can't sample more values than obs (without replacement)", {
   )
 })
 
-test_that("sampling grouped tbl samples each group with different replacement policies", {
-  by_cyl <- mtcars %>% group_by(cyl)
-
-  group_sizes <- group_size(by_cyl)
-  sample_size <- median(group_sizes)
-  with_replacements <- group_sizes < sample_size
-
-  sampled <- by_cyl %>% sample_n(sample_size, with_replacements)
-  expect_is(sampled, "grouped_df")
-  expect_groups(sampled, "cyl")
-  expect_equal(nrow(sampled), sample_size * 3)
-  expect_equal(sampled$cyl, rep(c(4, 6, 8), each = sample_size))
-})
-
 
 df2 <- data.frame(
   x = rep(1:2, 2),

--- a/tests/testthat/test-sample.R
+++ b/tests/testthat/test-sample.R
@@ -78,6 +78,17 @@ test_that("sampling grouped tbl samples each group", {
   expect_equal(sampled$cyl, rep(c(4, 6, 8), each = 2))
 })
 
+test_that("sampling grouped tbl samples each group with different sizes", {
+  # sizes must be 1 or the number of groups (3)
+  expect_error(mtcars %>% group_by(cyl) %>% sample_n(c(1, 2)))
+
+  sampled <- mtcars %>% group_by(cyl) %>% sample_n(c(1, 2, 3))
+  expect_is(sampled, "grouped_df")
+  expect_groups(sampled, "cyl")
+  expect_equal(nrow(sampled), 6)
+  expect_equal(sampled$cyl, rep(c(4, 6, 8), times = c(1, 2, 3)))
+})
+
 test_that("can't sample more values than obs (without replacement)", {
   by_cyl <- mtcars %>% group_by(cyl)
   expect_error(
@@ -86,6 +97,21 @@ test_that("can't sample more values than obs (without replacement)", {
     fixed = TRUE
   )
 })
+
+test_that("sampling grouped tbl samples each group with different replacement policies", {
+  by_cyl <- mtcars %>% group_by(cyl)
+
+  group_sizes <- group_size(by_cyl)
+  sample_size <- median(group_sizes)
+  with_replacements <- group_sizes < sample_size
+
+  sampled <- by_cyl %>% sample_n(sample_size, with_replacements)
+  expect_is(sampled, "grouped_df")
+  expect_groups(sampled, "cyl")
+  expect_equal(nrow(sampled), sample_size * 3)
+  expect_equal(sampled$cyl, rep(c(4, 6, 8), each = sample_size))
+})
+
 
 df2 <- data.frame(
   x = rep(1:2, 2),


### PR DESCRIPTION
Improves `df %>% group_by(...) %>% sample_*(...)` performance by 10-100x for dataset with large number of groups.

Also allows sample size and replacement policy to be customizable for each group.

The motivation is that when performing stratified sampling using `group_by %>% sample_n` on 100k+ strata, it can take minutes or longer. A toy example shows every 1k groups increases runtime by ~2s. A quick profiling shows most of time is spent in `eval_tidy(weight, ...)` for each group. This PR performs the weight calculation using `mutate` instead to preserve the semantics but eliminates the repeated overscope lookup across groups.

In addition, `size, frac, replace` arguments now accepts a vector for all groups in addition to a constant value. Unit tests have been added for this new feature.

cc: @lemioneta

``` r
library(dplyr)
#>
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#>
#>     filter, lag
#> The following objects are masked from 'package:base':
#>
#>     intersect, setdiff, setequal, union

n_strata <- 1000
# number of original observations in each strata (follows normal distribution)
n_per_strata_mean <- 100
n_per_strata_sd <- 10

# how many to sample from each strata
n_sample <- 10

source_df <-
  data_frame(group = 1:n_strata) %>%
  group_by(group) %>%
  do(sample_n(iris, round(rnorm(1, n_per_strata_mean, n_per_strata_sd)), replace = TRUE)) %>%
  ungroup() %>%
  # shuffle
  sample_frac(1)

source_df
#> # A tibble: 100,151 x 6
#>    group Sepal.Length Sepal.Width Petal.Length Petal.Width    Species
#>    <int>        <dbl>       <dbl>        <dbl>       <dbl>     <fctr>
#>  1   406          5.0         3.6          1.4         0.2     setosa
#>  2   998          5.5         2.4          3.8         1.1 versicolor
#>  3   101          6.4         2.8          5.6         2.2  virginica
#>  4   803          5.6         2.7          4.2         1.3 versicolor
#>  5   897          6.7         3.3          5.7         2.5  virginica
#>  6   743          4.9         3.1          1.5         0.2     setosa
#>  7   885          6.2         2.2          4.5         1.5 versicolor
#>  8    37          5.0         3.6          1.4         0.2     setosa
#>  9   276          5.2         4.1          1.5         0.1     setosa
#> 10   225          6.9         3.2          5.7         2.3  virginica
#> # ... with 100,141 more rows

# dplyr master ###########################
## sample without replacement no weights
system.time({
  source_df %>%
    group_by(group) %>%
    sample_n(n_sample)
})
#>    user  system elapsed
#>   1.677   0.006   1.687
## sample without replacement with weights
system.time({
  source_df %>%
    group_by(group) %>%
    sample_n(n_sample, weight = Petal.Length)
})
#>    user  system elapsed
#>   1.827   0.017   1.857
# sample with replacement
system.time({
  source_df %>%
    group_by(group) %>%
    sample_n(n_sample, replace = TRUE)
})
#>    user  system elapsed
#>   1.860   0.015   1.895

# dplyr dev ##################################
devtools::load_all("~/workspace/dplyr")
#> Loading dplyr
## sample without replacement no weights
system.time({
  source_df %>%
    group_by(group) %>%
    sample_n(n_sample)
})
#>    user  system elapsed
#>   0.019   0.000   0.023
## sample without replacement with weights
system.time({
  source_df %>%
    group_by(group) %>%
    sample_n(n_sample, weight = Petal.Length)
})
#>    user  system elapsed
#>   0.065   0.002   0.070
# sample with replacement
system.time({
  source_df %>%
    group_by(group) %>%
    sample_n(n_sample, replace = TRUE)
})
#>    user  system elapsed
#>   0.017   0.000   0.018
```

Before (dplyr master)

![image](https://user-images.githubusercontent.com/4317392/32302198-b6fd7924-bf1e-11e7-9018-21e4e3650e1a.png)

After

![image](https://user-images.githubusercontent.com/4317392/32302262-ff0edff0-bf1e-11e7-8e8b-2979769a6891.png)

