### PR TITLE
distinct() retains ordering of variables provided by the user

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -44,6 +44,7 @@
 * `select()` and `vars()` now treat `NULL` as empty inputs (#3023).
 
 * Add error for `distinct()` if any of the selected columns are of type `list` (#3088, @foo-bar-baz-qux).
+* `distinct()` now retains the ordering of variables provided by the user (#3195, @foo-bar-baz-qux)
 
 # dplyr 0.7.4
 

--- a/R/distinct.R
+++ b/R/distinct.R
@@ -77,7 +77,7 @@ distinct_vars <- function(.data, vars, group_vars = character(), .keep_all = FAL
 
   # Once we've done the mutate, we no longer need lazy objects, and
   # can instead just use their names
-  out_vars <- intersect(names(.data), c(names(vars), group_vars))
+  out_vars <- intersect(c(names(vars), group_vars), names(.data))
 
   if (.keep_all) {
     keep <- names(.data)

--- a/tests/testthat/test-distinct.R
+++ b/tests/testthat/test-distinct.R
@@ -85,3 +85,12 @@ test_that("distinct on a dataframe or tibble with columns of type list throws an
   expect_error(df %>% distinct())
   expect_error(df2 %>% distinct())
 })
+
+test_that("distinct retains the variable ordering specified by the user", {
+  df <- tibble(g = c(1, 2, 1), x = c(1, 2, 1))
+
+  expect_equal(colnames(distinct(df, g, x)), c("g", "x"))
+  expect_equal(colnames(distinct(df, x, g)), c("x", "g"))
+  expect_equal(colnames(distinct(df, y = x + 1, g)), c("y", "g"))
+  expect_equal(colnames(distinct(df, g, y = x + 1)), c("g", "y"))
+})


### PR DESCRIPTION
Fixes #3195.

- If `.keep_all = TRUE` then the data frame variable ordering is used.
- Works for mutated variables made in the function call.
- Grouped variables appear after (i.e. to the right) the user-specified variables based on the previous behavior/code. Perhaps also worth changing so grouped variables are first, then the user-specified variables?