### PR TITLE
add example in case_when about consistent RHS

### DIFF
--- a/R/case_when.R
+++ b/R/case_when.R
@@ -49,6 +49,15 @@
 #'   x %% 7 == 0 ~ 7,
 #'   TRUE ~ NA_real_
 #' )
+#' # This throws an error as NA is logical not numeric
+#' \dontrun{
+#' case_when(
+#'   x %% 35 == 0 ~ 35,
+#'   x %% 5 == 0 ~ 5,
+#'   x %% 7 == 0 ~ 7,
+#'   TRUE ~ NA
+#' )
+#' }
 #'
 #' # case_when is particularly useful inside mutate when you want to
 #' # create a new variable that relies on a complex combination of existing

--- a/R/case_when.R
+++ b/R/case_when.R
@@ -34,6 +34,22 @@
 #'   x %% 35 == 0 ~ "fizz buzz"
 #' )
 #'
+#' # All RHS needs to be the same type. Inconsitent types will throw an error.
+#' # This applies also to NA values used in RHS - NA is logical so you must use other
+#' # typed value like NA_real_, NA_complex, NA_character_, NA_integer_ in other cases
+#' case_when(
+#'   x %% 35 == 0 ~ NA_character_,
+#'   x %% 5 == 0 ~ "fizz",
+#'   x %% 7 == 0 ~ "buzz",
+#'   TRUE ~ as.character(x)
+#' )
+#' case_when(
+#'   x %% 35 == 0 ~ 35,
+#'   x %% 5 == 0 ~ 5,
+#'   x %% 7 == 0 ~ 7,
+#'   TRUE ~ NA_real_
+#' )
+#'
 #' # case_when is particularly useful inside mutate when you want to
 #' # create a new variable that relies on a complex combination of existing
 #' # variables

--- a/man/case_when.Rd
+++ b/man/case_when.Rd
@@ -44,6 +44,31 @@ case_when(
   x \%\% 35 == 0 ~ "fizz buzz"
 )
 
+# All RHS needs to be the same type. Inconsitent types will throw an error.
+# This applies also to NA values used in RHS - NA is logical so you must use other
+# typed value like NA_real_, NA_complex, NA_character_, NA_integer_ in other cases
+case_when(
+  x \%\% 35 == 0 ~ NA_character_,
+  x \%\% 5 == 0 ~ "fizz",
+  x \%\% 7 == 0 ~ "buzz",
+  TRUE ~ as.character(x)
+)
+case_when(
+  x \%\% 35 == 0 ~ 35,
+  x \%\% 5 == 0 ~ 5,
+  x \%\% 7 == 0 ~ 7,
+  TRUE ~ NA_real_
+)
+# This throws an error as NA is logical not numeric
+\dontrun{
+case_when(
+  x \%\% 35 == 0 ~ 35,
+  x \%\% 5 == 0 ~ 5,
+  x \%\% 7 == 0 ~ 7,
+  TRUE ~ NA
+)
+}
+
 # case_when is particularly useful inside mutate when you want to
 # create a new variable that relies on a complex combination of existing
 # variables


### PR DESCRIPTION
closes #3202 

I added some examples in the documentation to show how consistent RHS works when using `NA` value. 

I think just adding example is enough but I can add precisions in documentation text also. 

Question : Can we add a sample of code that throws an error in a doc example ? 
something like
```r
x <- 1:50
case_when(
  x %% 35 == 0 ~ 35,
  x %% 5 == 0 ~ 5,
  x %% 7 == 0 ~ 7,
  TRUE ~ NA
)
```

I did not generate `Rd` file as you may prefer to do it on your side. Tell me if I had to.