### PR TITLE
Add contributor code of conduct

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -28,3 +28,4 @@ demo/pandas
 ^docs$
 ^_pkgdown\.yml$
 ^issues$
+^CONDUCT\.md$

--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -1,0 +1,25 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, we pledge to respect all people who 
+contribute through reporting issues, posting feature requests, updating documentation,
+submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for
+everyone, regardless of level of experience, gender, gender identity and expression,
+sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.
+
+Examples of unacceptable behavior by participants include the use of sexual language or
+imagery, derogatory comments or personal attacks, trolling, public or private harassment,
+insults, or other unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments,
+commits, code, wiki edits, issues, and other contributions that are not aligned to this 
+Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed 
+from the project team.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by 
+opening an issue or contacting one or more of the project maintainers.
+
+This Code of Conduct is adapted from the Contributor Covenant 
+(http://contributor-covenant.org), version 1.0.0, available at 
+http://contributor-covenant.org/version/1/0/0/

--- a/README.Rmd
+++ b/README.Rmd
@@ -83,3 +83,8 @@ starwars %>%
   filter(n > 1)
 ```
 
+
+
+---
+Please note that this project is released with a [Contributor Code of Conduct](CONDUCT.md).
+By participating in this project you agree to abide by its terms.

--- a/README.md
+++ b/README.md
@@ -111,3 +111,6 @@ starwars %>%
 #> 5 Mirialan     2  53.1
 #> # ... with 4 more rows
 ```
+---
+Please note that this project is released with a [Contributor Code of Conduct](CONDUCT.md).
+By participating in this project you agree to abide by its terms.


### PR DESCRIPTION
Adds contributor code of conduct from `usethis::use_code_of_conduct()`