### PR TITLE
Modify tally and friends to be consistent

### DIFF
--- a/tests/testthat/test-count-tally.r
+++ b/tests/testthat/test-count-tally.r
@@ -51,11 +51,11 @@ test_that("can add counts of a variable called n", {
 test_that("add_count respects and preserves existing groups", {
   df <- data.frame(g = c(1, 2, 2, 2), val = c("b", "b", "b", "c"))
   res <- df %>% add_count(val)
-  expect_equal(res$n, c(3, 3, 3, 1))
+  expect_equal(res$nn, c(3, 3, 3, 1))
   expect_no_groups(res)
 
   res <- df %>% group_by(g) %>% add_count(val)
-  expect_equal(res$n, c(1, 2, 2, 1))
+  expect_equal(res$nn, c(1, 2, 2, 1))
   expect_groups(res, "g")
 })
 
@@ -76,22 +76,22 @@ test_that("can add tallies of a variable", {
   df <- data.frame(a = c(1, 1, 2, 2, 2))
 
   out <- df %>% group_by(a) %>% add_tally()
-  expect_equal(names(out), c("a", "n"))
+  expect_equal(names(out), c("a", "nn"))
   expect_equal(out$a, df$a)
-  expect_equal(out$n, c(2, 2, 3, 3, 3))
+  expect_equal(out$nn, c(2, 2, 3, 3, 3))
 
   out <- df %>% group_by(a) %>% add_tally(sort = TRUE)
-  expect_equal(out$n, c(3, 3, 3, 2, 2))
+  expect_equal(out$nn, c(3, 3, 3, 2, 2))
 })
 
 test_that("add_tally respects and preserves existing groups", {
   df <- data.frame(g = c(1, 2, 2, 2), val = c("b", "b", "b", "c"))
   res <- df %>% group_by(val) %>% add_tally()
-  expect_equal(res$n, c(3, 3, 3, 1))
+  expect_equal(res$nn, c(3, 3, 3, 1))
   expect_groups(res, "val")
 
   res <- df %>% group_by(g, val) %>% add_tally()
-  expect_equal(res$n, c(1, 2, 2, 1))
+  expect_equal(res$nn, c(1, 2, 2, 1))
   expect_groups(res, c("g", "val"))
 })
 
@@ -99,9 +99,9 @@ test_that("add_tally can be given a weighting variable", {
   df <- data.frame(a = c(1, 1, 2, 2, 2), w = c(1, 1, 2, 3, 4))
 
   out <- df %>% group_by(a) %>% add_tally(wt = w)
-  expect_equal(out$n, c(2, 2, 9, 9, 9))
+  expect_equal(out$nn, c(2, 2, 9, 9, 9))
 
   out <- df %>% group_by(a) %>% add_tally(wt = w + 1)
-  expect_equal(out$n, c(4, 4, 12, 12, 12))
+  expect_equal(out$nn, c(4, 4, 12, 12, 12))
 })
 


### PR DESCRIPTION
Hi,

I've noticed that tally and their firends were not consistent. You could not apply consistently tally more than two times. The third time the count variable `nn` is not interpreted as a count anymore.

I suggest to use `n` only as a count for rows. Thus `tally` should (almost) always use this name `n` to store the counts. To be consistent, I suggest to use `nn` (and the `nnn` and so on) when using `add_tally` whether or not it exists a column `n`.

The only exception is when using `tally` when `n` is a grouping variable. In that case, I suggest using `nn` for the count with a warning message.

This modifies slightly the behavior of `add_tally` but I hope this may be acceptable.

Erwan