### PR TITLE
Joins give better error message with duplicate column names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -55,6 +55,8 @@
 
 *  Fix `row_number()` and `ntile()` ordering to use the locale-dependent ordering functions in R when dealing with character vectors, rather than always using the C-locale ordering function in C (#2792, @foo-bar-baz-qux).
 
+* Better error message when joining data frames with duplicate column names. Joining such data frames with a semi- or anti-join now gives a warning, which may be converted to an error in future versions (#3243).
+
 # dplyr 0.7.4
 
 * Fix recent Fedora and ASAN check errors (#3098).

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -186,6 +186,10 @@ test_length_wrap <- function() {
     .Call(`_dplyr_test_length_wrap`)
 }
 
+check_valid_colnames <- function(df, warn_only = FALSE) {
+    invisible(.Call(`_dplyr_check_valid_colnames_export`, df, warn_only))
+}
+
 assert_all_white_list <- function(data) {
     invisible(.Call(`_dplyr_assert_all_white_list`, data))
 }

--- a/R/tbl-df.r
+++ b/R/tbl-df.r
@@ -152,6 +152,9 @@ check_na_matches <- function(na_matches) {
 inner_join.tbl_df <- function(x, y, by = NULL, copy = FALSE,
                               suffix = c(".x", ".y"), ...,
                               na_matches = pkgconfig::get_config("dplyr::na_matches")) {
+  check_valid_colnames(x)
+  check_valid_colnames(y)
+
   by <- common_by(by, x, y)
   suffix <- check_suffix(suffix)
 
@@ -165,6 +168,9 @@ inner_join.tbl_df <- function(x, y, by = NULL, copy = FALSE,
 left_join.tbl_df <- function(x, y, by = NULL, copy = FALSE,
                              suffix = c(".x", ".y"), ...,
                              na_matches = pkgconfig::get_config("dplyr::na_matches")) {
+  check_valid_colnames(x)
+  check_valid_colnames(y)
+
   by <- common_by(by, x, y)
   suffix <- check_suffix(suffix)
 
@@ -178,6 +184,9 @@ left_join.tbl_df <- function(x, y, by = NULL, copy = FALSE,
 right_join.tbl_df <- function(x, y, by = NULL, copy = FALSE,
                               suffix = c(".x", ".y"), ...,
                               na_matches = pkgconfig::get_config("dplyr::na_matches")) {
+  check_valid_colnames(x)
+  check_valid_colnames(y)
+
   by <- common_by(by, x, y)
   suffix <- check_suffix(suffix)
 
@@ -190,6 +199,9 @@ right_join.tbl_df <- function(x, y, by = NULL, copy = FALSE,
 full_join.tbl_df <- function(x, y, by = NULL, copy = FALSE,
                              suffix = c(".x", ".y"), ...,
                              na_matches = pkgconfig::get_config("dplyr::na_matches")) {
+  check_valid_colnames(x)
+  check_valid_colnames(y)
+
   by <- common_by(by, x, y)
   suffix <- check_suffix(suffix)
 
@@ -201,6 +213,9 @@ full_join.tbl_df <- function(x, y, by = NULL, copy = FALSE,
 #' @rdname join.tbl_df
 semi_join.tbl_df <- function(x, y, by = NULL, copy = FALSE, ...,
                              na_matches = pkgconfig::get_config("dplyr::na_matches")) {
+  check_valid_colnames(x, warn_only = TRUE)
+  check_valid_colnames(y, warn_only = TRUE)
+
   by <- common_by(by, x, y)
   y <- auto_copy(x, y, copy = copy)
   semi_join_impl(x, y, by$x, by$y, check_na_matches(na_matches))
@@ -210,6 +225,9 @@ semi_join.tbl_df <- function(x, y, by = NULL, copy = FALSE, ...,
 #' @rdname join.tbl_df
 anti_join.tbl_df <- function(x, y, by = NULL, copy = FALSE, ...,
                              na_matches = pkgconfig::get_config("dplyr::na_matches")) {
+  check_valid_colnames(x, warn_only = TRUE)
+  check_valid_colnames(y, warn_only = TRUE)
+
   by <- common_by(by, x, y)
   y <- auto_copy(x, y, copy = copy)
   anti_join_impl(x, y, by$x, by$y, check_na_matches(na_matches))

--- a/inst/include/dplyr/GroupedDataFrame.h
+++ b/inst/include/dplyr/GroupedDataFrame.h
@@ -13,29 +13,6 @@
 
 namespace dplyr {
 
-inline void check_valid_colnames(const DataFrame& df) {
-  if (df.size()) {
-    CharacterVector names(df.names());
-    LogicalVector dup = duplicated(names);
-    if (any(dup).is_true()) {
-      std::stringstream s;
-      s << "found duplicated column name: ";
-      bool first = true;
-      for (int i = 0; i < df.size(); i++) {
-        if (dup[i] == TRUE) {
-          if (first) {
-            first = false;
-          } else {
-            s << ", ";
-          }
-          s << names[i];
-        }
-      }
-      stop(s.str());
-    }
-  }
-}
-
 class GroupedDataFrame;
 
 class GroupedDataFrameIndexIterator {

--- a/inst/include/dplyr/bad.h
+++ b/inst/include/dplyr/bad.h
@@ -1,6 +1,9 @@
 #ifndef DPLYR_DPLYR_BAD_H
 #define DPLYR_DPLYR_BAD_H
 
+#include <tools/SymbolString.h>
+#include <tools/SymbolVector.h>
+
 namespace dplyr {
 
 template<class C1>
@@ -82,6 +85,33 @@ void NORET bad_col(const SymbolString& col, C1 arg1, C2 arg2, C3 arg3) {
   String message = bad_fun(CharacterVector::create(col.get_string()), arg1, arg2, arg3, _[".abort"] = identity);
   message.set_encoding(CE_UTF8);
   stop(message.get_cstring());
+}
+
+template<class C1>
+String msg_bad_cols(const SymbolVector& cols, C1 arg1) {
+  static Function bad_fun = Function("bad_cols", Environment::namespace_env("dplyr"));
+  static Function identity = Function("identity", Environment::base_env());
+  String message = bad_fun(cols.get_vector(), arg1, _[".abort"] = identity);
+  message.set_encoding(CE_UTF8);
+  return message;
+}
+
+template<class C1, class C2>
+String msg_bad_cols(const SymbolVector& cols, C1 arg1, C2 arg2) {
+  static Function bad_fun = Function("bad_cols", Environment::namespace_env("dplyr"));
+  static Function identity = Function("identity", Environment::base_env());
+  String message = bad_fun(cols.get_vector(), arg1, arg2, _[".abort"] = identity);
+  message.set_encoding(CE_UTF8);
+  return message;
+}
+
+template<class C1, class C2, class C3>
+String msg_bad_cols(const SymbolVector& cols, C1 arg1, C2 arg2, C3 arg3) {
+  static Function bad_fun = Function("bad_cols", Environment::namespace_env("dplyr"));
+  static Function identity = Function("identity", Environment::base_env());
+  String message = bad_fun(cols.get_vector(), arg1, arg2, arg3, _[".abort"] = identity);
+  message.set_encoding(CE_UTF8);
+  return message;
 }
 
 }

--- a/inst/include/tools/utils.h
+++ b/inst/include/tools/utils.h
@@ -3,6 +3,7 @@
 
 #include <tools/SymbolVector.h>
 
+void check_valid_colnames(const DataFrame& df, bool warn_only = false);
 void assert_all_white_list(const DataFrame&);
 SEXP shared_SEXP(SEXP x);
 SEXP shallow_copy(const List& data);

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -603,6 +603,17 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// check_valid_colnames_export
+void check_valid_colnames_export(const DataFrame& df, bool warn_only);
+RcppExport SEXP _dplyr_check_valid_colnames_export(SEXP dfSEXP, SEXP warn_onlySEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const DataFrame& >::type df(dfSEXP);
+    Rcpp::traits::input_parameter< bool >::type warn_only(warn_onlySEXP);
+    check_valid_colnames_export(df, warn_only);
+    return R_NilValue;
+END_RCPP
+}
 // assert_all_white_list
 void assert_all_white_list(const DataFrame& data);
 RcppExport SEXP _dplyr_assert_all_white_list(SEXP dataSEXP) {
@@ -723,6 +734,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dplyr_test_comparisons", (DL_FUNC) &_dplyr_test_comparisons, 0},
     {"_dplyr_test_matches", (DL_FUNC) &_dplyr_test_matches, 0},
     {"_dplyr_test_length_wrap", (DL_FUNC) &_dplyr_test_length_wrap, 0},
+    {"_dplyr_check_valid_colnames_export", (DL_FUNC) &_dplyr_check_valid_colnames_export, 2},
     {"_dplyr_assert_all_white_list", (DL_FUNC) &_dplyr_assert_all_white_list, 1},
     {"_dplyr_shallow_copy", (DL_FUNC) &_dplyr_shallow_copy, 1},
     {"_dplyr_cumall", (DL_FUNC) &_dplyr_cumall, 1},

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -68,7 +68,7 @@ DataFrame filter_grouped(const SlicedTibble& gdf, const NamedQuosure& quo) {
   }
 
   // Subset the grouped data frame
-  DataFrame res = subset(data, test, data.names(), classes_grouped<SlicedTibble>());
+  DataFrame res = subset(data, test, classes_grouped<SlicedTibble>());
   copy_vars(res, data);
   strip_index(res);
   return SlicedTibble(res).data();

--- a/src/join_exports.cpp
+++ b/src/join_exports.cpp
@@ -188,7 +188,7 @@ DataFrame semi_join_impl(DataFrame x, DataFrame y, CharacterVector by_x, Charact
 
   std::sort(indices.begin(), indices.end());
 
-  const DataFrame& out = subset(x, indices, x.names(), get_class(x));
+  const DataFrame& out = subset(x, indices, get_class(x));
   strip_index(out);
   return out;
 }
@@ -220,7 +220,7 @@ DataFrame anti_join_impl(DataFrame x, DataFrame y, CharacterVector by_x, Charact
 
   std::sort(indices.begin(), indices.end());
 
-  const DataFrame& out = subset(x, indices, x.names(), get_class(x));
+  const DataFrame& out = subset(x, indices, get_class(x));
   strip_index(out);
   return out;
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -10,9 +10,6 @@ using namespace Rcpp;
 
 // [[Rcpp::export(name = "check_valid_colnames")]]
 void check_valid_colnames_export(const DataFrame& df, bool warn_only = false) {
-  if (df.size() == 0)
-    return;
-
   CharacterVector names(df.names());
   LogicalVector dup = duplicated(names);
   if (any(dup).is_true()) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -8,6 +8,26 @@
 
 using namespace Rcpp;
 
+// [[Rcpp::export(name = "check_valid_colnames")]]
+void check_valid_colnames_export(const DataFrame& df, bool warn_only = false) {
+  if (df.size()) {
+    CharacterVector names(df.names());
+    LogicalVector dup = duplicated(names);
+    if (any(dup).is_true()) {
+      String msg = msg_bad_cols(SymbolVector(static_cast<SEXP>(names[dup])), "must have a unique name");
+      if (warn_only)
+        warning(msg.get_cstring());
+      else
+        stop(msg.get_cstring());
+    }
+  }
+}
+
+// Need forwarder to avoid compilation warning for default argument
+void check_valid_colnames(const DataFrame& df, bool warn_only) {
+  check_valid_colnames_export(df, warn_only);
+}
+
 // [[Rcpp::export]]
 void assert_all_white_list(const DataFrame& data) {
   // checking variables are on the white list
@@ -240,6 +260,7 @@ bool is_vector(SEXP x) {
     return false;
   }
 }
+
 bool is_atomic(SEXP x) {
   switch (TYPEOF(x)) {
   case LGLSXP:
@@ -257,14 +278,17 @@ bool is_atomic(SEXP x) {
 SEXP vec_names(SEXP x) {
   return Rf_getAttrib(x, R_NamesSymbol);
 }
+
 bool is_str_empty(SEXP str) {
   const char* c_str = CHAR(str);
   return strcmp(c_str, "") == 0;
 }
+
 bool has_name_at(SEXP x, R_len_t i) {
   SEXP nms = vec_names(x);
   return TYPEOF(nms) == STRSXP && !is_str_empty(STRING_ELT(nms, i));
 }
+
 SEXP name_at(SEXP x, size_t i) {
   SEXP names = vec_names(x);
   if (Rf_isNull(names))
@@ -276,12 +300,14 @@ SEXP name_at(SEXP x, size_t i) {
 SEXP f_env(SEXP x) {
   return Rf_getAttrib(x, Rf_install(".Environment"));
 }
+
 bool is_quosure(SEXP x) {
   return TYPEOF(x) == LANGSXP
          && Rf_length(x) == 2
          && Rf_inherits(x, "quosure")
          && TYPEOF(f_env(x)) == ENVSXP;
 }
+
 SEXP maybe_rhs(SEXP x) {
   if (is_quosure(x))
     return CADR(x);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -10,16 +10,17 @@ using namespace Rcpp;
 
 // [[Rcpp::export(name = "check_valid_colnames")]]
 void check_valid_colnames_export(const DataFrame& df, bool warn_only = false) {
-  if (df.size()) {
-    CharacterVector names(df.names());
-    LogicalVector dup = duplicated(names);
-    if (any(dup).is_true()) {
-      String msg = msg_bad_cols(SymbolVector(static_cast<SEXP>(names[dup])), "must have a unique name");
-      if (warn_only)
-        warning(msg.get_cstring());
-      else
-        stop(msg.get_cstring());
-    }
+  if (df.size() == 0)
+    return;
+
+  CharacterVector names(df.names());
+  LogicalVector dup = duplicated(names);
+  if (any(dup).is_true()) {
+    String msg = msg_bad_cols(SymbolVector(static_cast<SEXP>(names[dup])), "must have a unique name");
+    if (warn_only)
+      warning(msg.get_cstring());
+    else
+      stop(msg.get_cstring());
   }
 }
 

--- a/tests/testthat/test-joins.r
+++ b/tests/testthat/test-joins.r
@@ -319,7 +319,7 @@ test_that("left_join by different variable names (#617)", {
   expect_equal(res$y2, c("foo", "bar", "foo"))
 })
 
-test_that("joins support comple vectors", {
+test_that("joins support complex vectors", {
   a <- data.frame(x = c(1, 1, 2, 3) * 1i, y = 1:4)
   b <- data.frame(x = c(1, 2, 2, 4) * 1i, z = 1:4)
   j <- inner_join(a, b, "x")
@@ -921,5 +921,91 @@ test_that("join handles raw vectors", {
   expect_identical(
     inner_join(df1, df2, by = "r"),
     data_frame(r = as.raw(3:4), x = c(3:4), y = c(3:4))
+  )
+})
+
+test_that("joins reject data frames with duplicate columns (#3243)", {
+  df1 <- data.frame(x1 = 1:3, x2 = 1:3, y = 1:3)
+  names(df1)[1:2] <- "x"
+  df2 <- data.frame(x = 2:4, y = 2:4)
+
+  expect_error(
+    left_join(df1, df2, by = c("x", "y")),
+    "Column `x` must have a unique name",
+    fixed = TRUE
+  )
+
+  expect_error(
+    left_join(df2, df1, by = c("x", "y")),
+    "Column `x` must have a unique name",
+    fixed = TRUE
+  )
+
+  expect_error(
+    right_join(df1, df2, by = c("x", "y")),
+    "Column `x` must have a unique name",
+    fixed = TRUE
+  )
+
+  expect_error(
+    right_join(df2, df1, by = c("x", "y")),
+    "Column `x` must have a unique name",
+    fixed = TRUE
+  )
+
+  expect_error(
+    inner_join(df1, df2, by = c("x", "y")),
+    "Column `x` must have a unique name",
+    fixed = TRUE
+  )
+
+  expect_error(
+    inner_join(df2, df1, by = c("x", "y")),
+    "Column `x` must have a unique name",
+    fixed = TRUE
+  )
+
+  expect_error(
+    full_join(df1, df2, by = c("x", "y")),
+    "Column `x` must have a unique name",
+    fixed = TRUE
+  )
+
+  expect_error(
+    full_join(df2, df1, by = c("x", "y")),
+    "Column `x` must have a unique name",
+    fixed = TRUE
+  )
+
+  expect_error(
+    semi_join(df1, df2, by = c("x", "y")),
+    "Column `x` must have a unique name",
+    fixed = TRUE
+  )
+
+  # FIXME: Compatibility, should throw an error eventually
+  expect_warning(
+    expect_equal(
+      semi_join(df2, df1, by = c("x", "y")),
+      data.frame(x = 2:3, y = 2:3)
+    ),
+    "Column `x` must have a unique name",
+    fixed = TRUE
+  )
+
+  expect_error(
+    anti_join(df1, df2, by = c("x", "y")),
+    "Column `x` must have a unique name",
+    fixed = TRUE
+  )
+
+  # FIXME: Compatibility, should throw an error eventually
+  expect_warning(
+    expect_equal(
+      anti_join(df2, df1, by = c("x", "y")),
+      data.frame(x = 4L, y = 4L)
+    ),
+    "Column `x` must have a unique name",
+    fixed = TRUE
   )
 })

--- a/tic.R
+++ b/tic.R
@@ -1,10 +1,1 @@
 add_package_checks()
-
-get_stage("before_script") %>%
-  add_code_step({
-    dir.create("~/.R", showWarnings = FALSE)
-    writeLines(
-      "PKG_CXXFLAGS := ${PKG_CXXFLAGS} $${TRAVIS_CXXFLAGS}",
-      "~/.R/Makevars"
-    )
-  })


### PR DESCRIPTION
- semi- and anti-joins give a warning if RHS has dupes

Fixes #3243.

I have no idea why the build fails when `~/.R/Makevars` is created on Travis.