### PR TITLE
Use MARK_NOT_MUTABLE() instead of SET_NAMED()

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -31,7 +31,7 @@ void assert_all_white_list(const DataFrame& data) {
 }
 
 SEXP shared_SEXP(SEXP x) {
-  SET_NAMED(x, 2);
+  MARK_NOT_MUTABLE(x);
   return x;
 }
 


### PR DESCRIPTION
Just checked, `MARK_NOT_MUTABLE` has been around for at least four years now.

Fixes #3258.