### PR TITLE
Add Rcpp dependencies

### DIFF
--- a/vignettes/internals/hybrid-evaluation.Rmd
+++ b/vignettes/internals/hybrid-evaluation.Rmd
@@ -254,7 +254,7 @@ The code below is suitable to run through `sourceCpp`.
 
 ```cpp
 #include <dplyr.h>
-// [[Rcpp::depends(dplyr,BH)]]
+// [[Rcpp::depends(dplyr,BH,plogr)]]
 
 using namespace dplyr ;
 using namespace Rcpp ;


### PR DESCRIPTION
Receive this error if `depends()` doesn't include `plogr`

```C++
> Rcpp::sourceCpp('test1.cpp')
In file included from test1.cpp:1:
In file included from /Users/jakobelben/Library/R/3.4/library/dplyr/include/dplyr.h:4:
/Users/jakobelben/Library/R/3.4/library/dplyr/include/dplyr/main.h:11:10: fatal error: 'plogr.h' file not found
#include <plogr.h>
         ^~~~~~~~~
1 error generated.
make: *** [test1.o] Error 1
/usr/local/clang4/bin/clang++ -I/Library/Frameworks/R.framework/Resources/include -DNDEBUG   -I"/Users/jakobelben/Library/R/3.4/library/Rcpp/include" -I"/Users/jakobelben/Library/R/3.4/library/BH/include" -I"/Users/jakobelben/Library/R/3.4/library/dplyr/include" -I"/Users/jakobelben/Desktop/c++" -I/usr/local/include   -fPIC  -Wall -g -O2  -c test1.cpp -o test1.o
Error in Rcpp::sourceCpp("test1.cpp") : 
  Error 1 occurred building shared library.
```