### PR TITLE
Documentation and errors for slice() with negative indices

### DIFF
--- a/R/manip.r
+++ b/R/manip.r
@@ -67,6 +67,9 @@ filter_ <- function(.data, ..., .dots = list()) {
 #' intrinsic notion of row order. If you want to perform the equivalent
 #' operation, use [filter()] and [row_number()].
 #'
+#' Positive values select rows to keep; negative values drop rows. The
+#' values provided must be either all positive or all negative.
+#'
 #' @family single table verbs
 #' @param .data A tbl.
 #' @param ... Integer row values.
@@ -83,6 +86,10 @@ filter_ <- function(.data, ..., .dots = list()) {
 #' slice(mtcars, 1L)
 #' slice(mtcars, n())
 #' slice(mtcars, 5:n())
+#' # Rows can be dropped with negative indices:
+#' slice(mtcars, -5:-n())
+#' # In this case, the result will be equivalent to:
+#' slice(mtcars, 1:4)
 #'
 #' by_cyl <- group_by(mtcars, cyl)
 #' slice(by_cyl, 1:2)

--- a/src/slice.cpp
+++ b/src/slice.cpp
@@ -32,7 +32,7 @@ public:
     }
 
     if (n_neg > 0 && n_pos > 0) {
-      stop("Found %d positive indices and %d negative indices", n_pos, n_neg);
+      stop("Indices must be either all positive or all negative, not a mix of both. Found %d positive indices and %d negative indices", n_pos, n_neg);
     }
 
   }


### PR DESCRIPTION
Related to discussion on Issue 3309. I have added some documentation on using negative indices, and also updated the slice() error message that is triggered if a mix of positive and negative indices are used.

https://github.com/tidyverse/dplyr/issues/3309