### PR TITLE
Grammar tweak

### DIFF
--- a/vignettes/dplyr.Rmd
+++ b/vignettes/dplyr.Rmd
@@ -272,7 +272,7 @@ However you need to be careful when progressively rolling up summaries like this
 
 One of the appealing features of dplyr is that you can refer to
 columns from the tibble as if they were regular variables. However,
-the syntactic uniformity of referring to bare column names hide
+the syntactic uniformity of referring to bare column names hides
 semantical differences across the verbs. A column symbol supplied to
 `select()` does not have the same meaning as the same symbol supplied
 to `mutate()`.


### PR DESCRIPTION
“Syntactic uniformity” is a singular noun, so the verb hide should be changed to hides.