### PR TITLE
resets plyr attach hook when detaching dplyr

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -67,6 +67,8 @@
 
 * Better error message when joining data frames with duplicate column names. Joining such data frames with a semi- or anti-join now gives a warning, which may be converted to an error in future versions (#3243).
 
+* Added an `.onDetach()` hook that allows for plyr to be loaded and attached without the warning message that says functions in dplyr will be masked, since dplyr is no longer attached (#3359).
+
 # dplyr 0.7.4
 
 * Fix recent Fedora and ASAN check errors (#3098).

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -19,6 +19,10 @@
   })
 }
 
+.onDetach <- function(libname, pkgname) {
+  setHook(packageEvent("plyr", "attach"), NULL, "replace")
+}
+
 when_attached <- function(pkg, action) {
   if (is_attached(pkg)) {
     action


### PR DESCRIPTION
When loading and attaching plyr after dplyr, certain functions in dplyr are masked by some in plyr, which can create problems (hence the "You have loaded plyr after dplyr..." message). But when you detach and unload both packages and then load and attach plyr by itself, the message is still printed even though dplyr is not attached nor loaded.

This PR adds an `.onDetach()` hook which replaces the plyr attach hook function with NULL so that the message isn't given when plyr is safely loaded and attached.

I tested this with @lgbarrett4 by rebuilding dplyr with the `.onDetach` function and made sure the loading and attaching of plyr by itself worked without a warning message.