### PR TITLE
Fix rename_all() on grouped data

### DIFF
--- a/R/colwise-select.R
+++ b/R/colwise-select.R
@@ -95,6 +95,8 @@ vars_select_syms <- function(vars, funs, tbl, strict = FALSE) {
     bad_args(".funs", "must specify a renaming function")
   }
 
-  group_syms <- base::setdiff(syms(group_vars(tbl)), syms)
+  group_vars <- group_vars(tbl)
+  group_syms <- base::setdiff(syms(group_vars), syms)
+  group_syms <- set_names(group_syms, group_vars)
   c(group_syms, syms)
 }

--- a/R/grouped-df.r
+++ b/R/grouped-df.r
@@ -148,7 +148,7 @@ ensure_group_vars <- function(vars, data, notify = TRUE) {
 
 #' @export
 rename.grouped_df <- function(.data, ...) {
-  vars <- tidyselect::vars_rename(names(.data), !!! quos(...))
+  vars <- tidyselect::vars_rename(names(.data), ...)
   select_impl(.data, vars)
 }
 #' @export

--- a/tests/testthat/test-colwise-select.R
+++ b/tests/testthat/test-colwise-select.R
@@ -71,3 +71,9 @@ test_that("select_if() handles quoted predicates", {
   expect_identical(select_if(mtcars, "is_integerish"), expected)
   expect_identical(select_if(mtcars, ~is_integerish(.x)), expected)
 })
+
+test_that("rename_all() works with grouped data", {
+  df <- data.frame(a = 1, b = 2)
+  out <- df %>% group_by(a) %>% rename_all(toupper)
+  expect_identical(out, group_by(data.frame(a = 1, B = 2), a))
+})


### PR DESCRIPTION
Closes #2947.

@hadley currently `rename_all()` does not rename the grouping variables. This is consistent with `mutate_all()` and `summarise_all()` but it seems that in the case of names it'd make sense to operate on the grouping vars as well. What do you think?