### PR TITLE
slice does not enforce tibble when input is a raw data.frame. closes …

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -69,6 +69,8 @@
 
 * Added an `.onDetach()` hook that allows for plyr to be loaded and attached without the warning message that says functions in dplyr will be masked, since dplyr is no longer attached (#3359, @jwnorman).
 
+* `slice()` no longer enforce tibble classes when input is a simple `data.frame` (#3297). 
+
 # dplyr 0.7.4
 
 * Fix recent Fedora and ASAN check errors (#3098).

--- a/src/slice.cpp
+++ b/src/slice.cpp
@@ -124,6 +124,7 @@ DataFrame slice_grouped(GroupedDataFrame gdf, const QuosureList& dots) {
 
 DataFrame slice_not_grouped(const DataFrame& df, const QuosureList& dots) {
   CharacterVector names = df.names();
+  CharacterVector classes = Rf_getAttrib(df, R_ClassSymbol) ;
 
   const NamedQuosure& quosure = dots[0];
   Call call(quosure.expr());
@@ -147,13 +148,13 @@ DataFrame slice_not_grouped(const DataFrame& df, const QuosureList& dots) {
       idx[i] = test[j++] - 1;
     }
 
-    return subset(df, idx, df.names(), classes_not_grouped());
+    return subset(df, idx, df.names(), classes);
   }
 
   // special case where only NA
   if (counter.get_n_negative() == 0) {
     std::vector<int> indices;
-    return subset(df, indices, df.names(), classes_not_grouped());
+    return subset(df, indices, df.names(), classes);
   }
 
   // just negatives (out of range is dealt with early in CountIndices).
@@ -179,7 +180,7 @@ DataFrame slice_not_grouped(const DataFrame& df, const QuosureList& dots) {
     indices.push_back(j);
   }
 
-  return subset(df, indices, df.names(), classes_not_grouped());
+  return subset(df, indices, df.names(), classes);
 }
 
 // [[Rcpp::export]]

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -128,3 +128,9 @@ test_that("slice handles raw matrices", {
     matrix(as.raw(c(1, 2, 5, 6)), ncol = 2)
   )
 })
+
+test_that("slice on ungrouped data.frame (not tibble) does not enforce tibble", {
+  expect_equal( class(slice(mtcars, 2)), "data.frame")
+  expect_equal( class(slice(mtcars, -2)), "data.frame")
+  expect_equal( class(slice(mtcars, NA)), "data.frame")
+})


### PR DESCRIPTION
closes #3297

I would say this is pretty straightforward. We just use the classes from the input data frame instead of 
forcing tibble via `classes_not_grouped`. 

```
inline Rcpp::CharacterVector classes_not_grouped() {
  return Rcpp::CharacterVector::create("tbl_df", "tbl", "data.frame");
}
```
