### PR TITLE
Fix arguments of `.onDetach`.

### DIFF
--- a/R/zzz.r
+++ b/R/zzz.r
@@ -19,7 +19,7 @@
   })
 }
 
-.onDetach <- function(libname, pkgname) {
+.onDetach <- function(libpath) {
   setHook(packageEvent("plyr", "attach"), NULL, "replace")
 }
 


### PR DESCRIPTION
This is fairly trivial, and inline with `?.onDetach` expects. 

```
  File ‘dplyr/R/zzz.r’:
     .onDetach has wrong argument list ‘libname, pkgname’

   Package detach functions should have one argument with name starting
     with ‘lib’.
   Package detach functions should not call ‘library.dynam.unload’.
   See section ‘Good practice’ in '?.Last.lib'.
```