### PR TITLE
slice handles 0 in positive and negative indices. closes #3313

### DIFF
--- a/src/slice.cpp
+++ b/src/slice.cpp
@@ -83,7 +83,9 @@ DataFrame slice_grouped(GroupedDataFrame gdf, const QuosureList& dots) {
       // positive indexing
       int ntest = g_test.size();
       for (int j = 0; j < ntest; j++) {
-        if (!(g_test[j] > nr || g_test[j] < 1)) {
+        // only keep things inside inside 1:nr
+        // this skips 0 and NA (which is negative (-2^31) for INTSXP)
+        if (g_test[j] >=1 && g_test[j] <= nr) {
           indx.push_back(indices[g_test[j] - 1]);
         }
       }
@@ -144,6 +146,8 @@ DataFrame slice_not_grouped(const DataFrame& df, const QuosureList& dots) {
     std::vector<int> idx(n_pos);
     int j = 0;
     for (int i = 0; i < n_pos; i++) {
+      // skip until we are inside 1:nr
+      // this skips 0 and NA (which is negative (-2^31) for INTSXP)
       while (test[j] > nr || test[j] < 1) j++;
       idx[i] = test[j++] - 1;
     }

--- a/src/slice.cpp
+++ b/src/slice.cpp
@@ -83,7 +83,7 @@ DataFrame slice_grouped(GroupedDataFrame gdf, const QuosureList& dots) {
       // positive indexing
       int ntest = g_test.size();
       for (int j = 0; j < ntest; j++) {
-        if (!(g_test[j] > nr || g_test[j] == NA_INTEGER)) {
+        if (!(g_test[j] > nr || g_test[j] < 1)) {
           indx.push_back(indices[g_test[j] - 1]);
         }
       }
@@ -92,7 +92,7 @@ DataFrame slice_grouped(GroupedDataFrame gdf, const QuosureList& dots) {
       std::set<int> drop;
       int n = g_test.size();
       for (int j = 0; j < n; j++) {
-        if (g_test[j] != NA_INTEGER)
+        if (g_test[j] != NA_INTEGER && g_test[j] != 0)
           drop.insert(-g_test[j]);
       }
       int n_drop = drop.size();

--- a/src/slice.cpp
+++ b/src/slice.cpp
@@ -144,7 +144,7 @@ DataFrame slice_not_grouped(const DataFrame& df, const QuosureList& dots) {
     std::vector<int> idx(n_pos);
     int j = 0;
     for (int i = 0; i < n_pos; i++) {
-      while (test[j] > nr || test[j] == NA_INTEGER) j++;
+      while (test[j] > nr || test[j] < 1) j++;
       idx[i] = test[j++] - 1;
     }
 

--- a/src/slice.cpp
+++ b/src/slice.cpp
@@ -160,7 +160,7 @@ DataFrame slice_not_grouped(const DataFrame& df, const QuosureList& dots) {
   // just negatives (out of range is dealt with early in CountIndices).
   std::set<int> drop;
   for (int i = 0; i < n; i++) {
-    if (test[i] != NA_INTEGER)
+    if (test[i] != NA_INTEGER && test[i] != 0)
       drop.insert(-test[i]);
   }
   std::vector<int> indices;

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -134,3 +134,10 @@ test_that("slice on ungrouped data.frame (not tibble) does not enforce tibble", 
   expect_equal( class(slice(mtcars, -2)), "data.frame")
   expect_equal( class(slice(mtcars, NA)), "data.frame")
 })
+
+test_that("slice skips 0 (#)",{
+  d <- tibble(x = 1:5, y = LETTERS[1:5])
+  expect_identical(slice(d, 0), slice(d, integer(0)))
+  expect_identical(slice(d, c(0, 1)), slice(d, 1))
+  expect_identical(slice(d, c(0, 1, 2)), slice(d, c(1,2)))
+})

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -136,7 +136,15 @@ test_that("slice on ungrouped data.frame (not tibble) does not enforce tibble", 
 })
 
 test_that("slice skips 0 (#3313)",{
-  d <- tibble(x = 1:5, y = LETTERS[1:5])
+  d <- tibble(x = 1:5, y = LETTERS[1:5], g=1)
+  expect_identical(slice(d, 0), slice(d, integer(0)))
+  expect_identical(slice(d, c(0, 1)), slice(d, 1))
+  expect_identical(slice(d, c(0, 1, 2)), slice(d, c(1,2)))
+
+  expect_identical(slice(d, c(-1, 0)), slice(d, -1))
+  expect_identical(slice(d, c(0, -1)), slice(d, -1))
+
+  d <- group_by(d,g)
   expect_identical(slice(d, 0), slice(d, integer(0)))
   expect_identical(slice(d, c(0, 1)), slice(d, 1))
   expect_identical(slice(d, c(0, 1, 2)), slice(d, c(1,2)))

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -135,9 +135,12 @@ test_that("slice on ungrouped data.frame (not tibble) does not enforce tibble", 
   expect_equal( class(slice(mtcars, NA)), "data.frame")
 })
 
-test_that("slice skips 0 (#)",{
+test_that("slice skips 0 (#3313)",{
   d <- tibble(x = 1:5, y = LETTERS[1:5])
   expect_identical(slice(d, 0), slice(d, integer(0)))
   expect_identical(slice(d, c(0, 1)), slice(d, 1))
   expect_identical(slice(d, c(0, 1, 2)), slice(d, c(1,2)))
+
+  expect_identical(slice(d, c(-1, 0)), slice(d, -1))
+  expect_identical(slice(d, c(0, -1)), slice(d, -1))
 })


### PR DESCRIPTION
- slice handles 0 in positive and negative indices (#3313)

--- 

See #3313 for details, this fixes it but I wonder if instead of skipping the 0 we should make them illegal here, as `slice` should expect either strictly positive (to keep) or strictly negative (to drop). 

```
slice( d, c(0,1) )
```

But there seems to be some tolerance for it in R: 

```
> x <- 1:10
> x[0]
integer(0)
> x[c(0,1)]
[1] 1
```
