### PR TITLE
bind_cols handles unnamed list. closes #3402

### DIFF
--- a/inst/include/tools/utils.h
+++ b/inst/include/tools/utils.h
@@ -16,6 +16,7 @@ bool is_vector(SEXP x);
 bool is_atomic(SEXP x);
 
 SEXP vec_names(SEXP x);
+SEXP vec_names_or_empty(SEXP x);
 bool is_str_empty(SEXP str);
 bool has_name_at(SEXP x, R_len_t i);
 SEXP name_at(SEXP x, size_t i);

--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -368,7 +368,8 @@ List cbind_all(List dots) {
       continue;
 
     if (TYPEOF(current) == VECSXP) {
-      CharacterVector current_names = vec_names(current);
+      CharacterVector current_names = vec_names_or_empty(current);
+
       int nc = Rf_length(current);
       for (int j = 0; j < nc; j++, k++) {
         out[k] = shared_SEXP(VECTOR_ELT(current, j));

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -277,6 +277,14 @@ SEXP vec_names(SEXP x) {
   return Rf_getAttrib(x, R_NamesSymbol);
 }
 
+SEXP vec_names_or_empty(SEXP x) {
+  SEXP nms = Rf_getAttrib(x, R_NamesSymbol);
+  if (Rf_isNull(nms)) {
+    return Rf_allocVector(STRSXP, LENGTH(x)) ;
+  }
+  return nms ;
+}
+
 bool is_str_empty(SEXP str) {
   const char* c_str = CHAR(str);
   return strcmp(c_str, "") == 0;

--- a/tests/testthat/test-binds.R
+++ b/tests/testthat/test-binds.R
@@ -625,6 +625,7 @@ test_that("supports NULL values", {
 
 test_that("bind_cols handles unnamed list (#3402)", {
   expect_identical(
-    bind_cols(list(1, 2))
+    bind_cols(list(1, 2)),
+    bind_cols(list(V1=1, V2=2))
   )
 })

--- a/tests/testthat/test-binds.R
+++ b/tests/testthat/test-binds.R
@@ -622,3 +622,9 @@ test_that("unnamed vectors fail", {
 test_that("supports NULL values", {
   expect_identical(bind_cols(a = 1, NULL, b = 2, NULL), tibble(a = 1, b = 2))
 })
+
+test_that("bind_cols handles unnamed list (#3402)", {
+  expect_identical(
+    bind_cols(list(1, 2))
+  )
+})


### PR DESCRIPTION
- bind_cols handles unnamed list. (#3402)

--- 

I made it so that 
 
```
> bind_cols(list(1, 2))
# A tibble: 1 x 2
     V1    V2
  <dbl> <dbl>
1    1.    2.
> bind_cols(list(1, x=2))
# A tibble: 1 x 2
     V1     x
  <dbl> <dbl>
1    1.    2.
> bind_cols(list(x=1, 2))
# A tibble: 1 x 2
      x    V1
  <dbl> <dbl>
1    1.    2.
```

but if it's better I can make it fail with a better error message. 