### PR TITLE
hybrid evaluation simplifies dplyr::foo to foo. closes #3309

### DIFF
--- a/src/hybrid.cpp
+++ b/src/hybrid.cpp
@@ -147,7 +147,7 @@ Result* get_handler(SEXP call, const ILazySubsets& subsets, const Environment& e
     // interpret dplyr::fun() as fun(). #3309
     SEXP fun_symbol = CAR(call);
     if (TYPEOF(fun_symbol) == LANGSXP &&
-        CAR(fun_symbol) == Rf_install("::") &&
+        CAR(fun_symbol) == R_DoubleColonSymbol &&
         CADR(fun_symbol) == Rf_install("dplyr")
        ) {
       fun_symbol = CADDR(fun_symbol) ;

--- a/src/hybrid.cpp
+++ b/src/hybrid.cpp
@@ -141,8 +141,18 @@ Result* get_handler(SEXP call, const ILazySubsets& subsets, const Environment& e
 
   if (TYPEOF(call) == LANGSXP) {
     int depth = Rf_length(call);
+
     HybridHandlerMap& handlers = get_handlers();
+
+    // interpret dplyr::fun() as fun(). #3309
     SEXP fun_symbol = CAR(call);
+    if (TYPEOF(fun_symbol) == LANGSXP &&
+        CAR(fun_symbol) == Rf_install("::") &&
+        CADR(fun_symbol) == Rf_install("dplyr")
+       ) {
+      fun_symbol = CADDR(fun_symbol) ;
+    }
+
     if (TYPEOF(fun_symbol) != SYMSXP) {
       LOG_VERBOSE << "Not a function: " << type2name(fun_symbol);
       return 0;

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -691,6 +691,19 @@ test_that("hybrid handlers don't nest", {
   )
 })
 
+test_that("row_number() is equivalent to dplyr::row_number() (#3309)", {
+  check_hybrid_result(
+    list(dplyr::row_number()),
+    a = 1:5,
+    expected = list(1:5),
+    test_eval = FALSE
+  )
+  expect_identical(
+    filter(mtcars, dplyr::row_number() == 6L),
+    filter(mtcars, row_number() == 6L)
+  )
+})
+
 test_that("constant folding and argument matching in hybrid evaluator (#2299)", {
   skip("Currently failing")
   skip("Currently failing (external var)")


### PR DESCRIPTION
 - hybrid evaluation simplifies calls prefixed with the dplyr namespace (#3309)
