### PR TITLE
Fix lookup of .funs

### DIFF
--- a/R/funs.R
+++ b/R/funs.R
@@ -93,7 +93,7 @@ as_fun <- function(.x, .env, .args) {
 }
 
 quo_as_function <- function(quo) {
-  new_function(exprs(. = ), quo_get_expr(quo))
+  new_function(exprs(. = ), quo_get_expr(quo), quo_get_env(quo))
 }
 
 fun_env <- function(quo, default_env) {

--- a/tests/testthat/test-colwise-select.R
+++ b/tests/testthat/test-colwise-select.R
@@ -77,3 +77,18 @@ test_that("rename_all() works with grouped data (#3363)", {
   out <- df %>% group_by(a) %>% rename_all(toupper)
   expect_identical(out, group_by(data.frame(a = 1, B = 2), a))
 })
+
+test_that("scoping (#3426)", {
+  interface <- function(.tbl, .funs = list()) {
+    impl(.tbl, .funs = .funs)
+  }
+
+  impl <- function(.tbl, ...) {
+    select_all(.tbl, ...)
+  }
+
+  expect_identical(
+    interface(mtcars, .funs = toupper),
+    select_all(mtcars, .funs = list(toupper))
+  )
+})


### PR DESCRIPTION
Fixes check failures in the keyholder package.

Reprex with 842b1fe4:

``` r
library(dplyr)
library(tidyselect)
interface <- function(.tbl, .funs = list()) {
  impl(.tbl, .funs = .funs)
}

impl <- function(.tbl, ...) {
  select_all(.tbl, ...)
}

interface(iris, .funs = toupper)
```

> Created on 2018-03-14 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).