### PR TITLE
turn off hybrid evaluation by masking the function. #3255

### DIFF
--- a/inst/include/dplyr/HybridHandler.h
+++ b/inst/include/dplyr/HybridHandler.h
@@ -4,8 +4,24 @@
 namespace dplyr {
 class ILazySubsets;
 class Result;
-}
 
-typedef dplyr::Result* (*HybridHandler)(SEXP, const dplyr::ILazySubsets&, int);
+typedef dplyr::Result* (*HybridHandlerFun)(SEXP, const dplyr::ILazySubsets&, int);
+
+struct HybridHandler {
+  HybridHandlerFun handler ;
+  SEXP reference ;
+
+  HybridHandler():
+    handler(0),
+    reference(R_NilValue)
+  {}
+
+  HybridHandler(HybridHandlerFun handler_, SEXP reference_):
+    handler(handler_), reference(reference_)
+  {}
+
+};
+
+}
 
 #endif // dplyr_dplyr_HybridHandlerMap_H

--- a/inst/include/dplyr/HybridHandler.h
+++ b/inst/include/dplyr/HybridHandler.h
@@ -5,9 +5,9 @@ namespace dplyr {
 class ILazySubsets;
 class Result;
 
-typedef dplyr::Result* (*HybridHandlerFun)(SEXP, const dplyr::ILazySubsets&, int);
-
 struct HybridHandler {
+  typedef dplyr::Result* (*HybridHandlerFun)(SEXP, const dplyr::ILazySubsets&, int);
+
   HybridHandlerFun handler ;
   SEXP reference ;
 

--- a/inst/include/dplyr/HybridHandlerMap.h
+++ b/inst/include/dplyr/HybridHandlerMap.h
@@ -4,7 +4,7 @@
 #include <tools/hash.h>
 #include <dplyr/HybridHandler.h>
 
-typedef dplyr_hash_map<SEXP, HybridHandler> HybridHandlerMap;
+typedef dplyr_hash_map<SEXP, dplyr::HybridHandler> HybridHandlerMap;
 
 void install_simple_handlers(HybridHandlerMap& handlers);
 void install_minmax_handlers(HybridHandlerMap& handlers);

--- a/inst/include/dplyr/registration.h
+++ b/inst/include/dplyr/registration.h
@@ -6,7 +6,7 @@
 #if defined(COMPILING_DPLYR)
 
 DataFrame build_index_cpp(DataFrame data);
-void registerHybridHandler(const char*, HybridHandler);
+void registerHybridHandler(const char*, dplyr::HybridHandler);
 SEXP get_time_classes();
 SEXP get_date_classes();
 

--- a/src/hybrid.cpp
+++ b/src/hybrid.cpp
@@ -178,7 +178,7 @@ Result* get_handler(SEXP call, const ILazySubsets& subsets, const Environment& e
     // mutate( x = mean(x) )
     // if `mean` evaluates to something other than `base::mean` then no hybrid.
     RObject fun = Rf_eval(fun_symbol, env) ;
-    if( fun != it->second.reference ) return 0 ;
+    if (check && fun != it->second.reference) return 0 ;
 
     LOG_INFO << "Using hybrid handler for " << CHAR(PRINTNAME(fun_symbol));
 

--- a/src/hybrid.cpp
+++ b/src/hybrid.cpp
@@ -178,7 +178,7 @@ Result* get_handler(SEXP call, const ILazySubsets& subsets, const Environment& e
     // mutate( x = mean(x) )
     // if `mean` evaluates to something other than `base::mean` then no hybrid.
     RObject fun = Rf_findFun(fun_symbol, env) ;
-    if (check && !Rf_isNull(it->second.reference) && fun != it->second.reference) return 0 ;
+    if (check && fun != it->second.reference) return 0 ;
 
     LOG_INFO << "Using hybrid handler for " << CHAR(PRINTNAME(fun_symbol));
 

--- a/src/hybrid.cpp
+++ b/src/hybrid.cpp
@@ -59,9 +59,9 @@ HybridHandlerMap& get_handlers() {
   static HybridHandlerMap handlers;
   if (!handlers.size()) {
     /*
-    handlers[ Rf_install( "cumsum")      ] = cumfun_prototype<CumSum>;
-    handlers[ Rf_install( "cummin")      ] = cumfun_prototype<CumMin>;
-    handlers[ Rf_install( "cummax")      ] = cumfun_prototype<CumMax>;
+    handlers[ Rf_install( "cumsum")      ] = HybridHandler( cumfun_prototype<CumSum>, R_NilValue );
+    handlers[ Rf_install( "cummin")      ] = HybridHandler( cumfun_prototype<CumMin>, R_NilValue );
+    handlers[ Rf_install( "cummax")      ] = HybridHandler( cumfun_prototype<CumMax>, R_NilValue );
     */
 
     install_simple_handlers(handlers);
@@ -173,7 +173,7 @@ Result* get_handler(SEXP call, const ILazySubsets& subsets, const Environment& e
 
     LOG_INFO << "Using hybrid handler for " << CHAR(PRINTNAME(fun_symbol));
 
-    return it->second(call, subsets, depth - 1);
+    return it->second.handler(call, subsets, depth - 1);
   } else if (TYPEOF(call) == SYMSXP) {
     SymbolString sym = SymbolString(Symbol(call));
 

--- a/src/hybrid.cpp
+++ b/src/hybrid.cpp
@@ -177,8 +177,8 @@ Result* get_handler(SEXP call, const ILazySubsets& subsets, const Environment& e
     // is expected. This would happen if e.g. the mean function has been shadowed
     // mutate( x = mean(x) )
     // if `mean` evaluates to something other than `base::mean` then no hybrid.
-    RObject fun = Rf_eval(fun_symbol, env) ;
-    if (check && fun != it->second.reference) return 0 ;
+    RObject fun = Rf_findFun(fun_symbol, env) ;
+    if (check && !Rf_isNull(it->second.reference) && fun != it->second.reference) return 0 ;
 
     LOG_INFO << "Using hybrid handler for " << CHAR(PRINTNAME(fun_symbol));
 

--- a/src/hybrid_count.cpp
+++ b/src/hybrid_count.cpp
@@ -51,6 +51,6 @@ Result* count_distinct_prototype(SEXP call, const ILazySubsets& subsets, int) {
 }
 
 void install_count_handlers(HybridHandlerMap& handlers) {
-  handlers[ Rf_install("n") ] = count_prototype;
-  handlers[ Rf_install("n_distinct") ] = count_distinct_prototype;
+  handlers[ Rf_install("n") ] = HybridHandler(count_prototype, R_NilValue) ;
+  handlers[ Rf_install("n_distinct") ] = HybridHandler(count_distinct_prototype, R_NilValue) ;
 }

--- a/src/hybrid_count.cpp
+++ b/src/hybrid_count.cpp
@@ -51,6 +51,7 @@ Result* count_distinct_prototype(SEXP call, const ILazySubsets& subsets, int) {
 }
 
 void install_count_handlers(HybridHandlerMap& handlers) {
-  handlers[ Rf_install("n") ] = HybridHandler(count_prototype, R_NilValue) ;
-  handlers[ Rf_install("n_distinct") ] = HybridHandler(count_distinct_prototype, R_NilValue) ;
+  Environment ns_dplyr = Environment::namespace_env("dplyr") ;
+  handlers[ Rf_install("n") ] = HybridHandler(count_prototype, ns_dplyr["n"]) ;
+  handlers[ Rf_install("n_distinct") ] = HybridHandler(count_distinct_prototype, ns_dplyr["n_distinct"]) ;
 }

--- a/src/hybrid_debug.cpp
+++ b/src/hybrid_debug.cpp
@@ -89,7 +89,6 @@ Result* verify_not_hybrid_prototype(SEXP call, const ILazySubsets&, int nargs) {
 
 void install_debug_handlers(HybridHandlerMap& handlers) {
   Environment ns_dplyr = Environment::namespace_env("dplyr") ;
-  // these are handled differently than the real hybrids
-  handlers[ Rf_install("verify_hybrid") ] = HybridHandler(verify_hybrid_prototype, R_NilValue) ;
-  handlers[ Rf_install("verify_not_hybrid") ] = HybridHandler(verify_not_hybrid_prototype, R_NilValue);
+  handlers[ Rf_install("verify_hybrid") ] = HybridHandler(verify_hybrid_prototype, ns_dplyr["verify_hybrid"]) ;
+  handlers[ Rf_install("verify_not_hybrid") ] = HybridHandler(verify_not_hybrid_prototype, ns_dplyr["verify_not_hybrid"]);
 }

--- a/src/hybrid_debug.cpp
+++ b/src/hybrid_debug.cpp
@@ -88,6 +88,6 @@ Result* verify_not_hybrid_prototype(SEXP call, const ILazySubsets&, int nargs) {
 }
 
 void install_debug_handlers(HybridHandlerMap& handlers) {
-  handlers[ Rf_install("verify_hybrid") ] = verify_hybrid_prototype;
-  handlers[ Rf_install("verify_not_hybrid") ] = verify_not_hybrid_prototype;
+  handlers[ Rf_install("verify_hybrid") ] = HybridHandler(verify_hybrid_prototype, R_NilValue) ;
+  handlers[ Rf_install("verify_not_hybrid") ] = HybridHandler(verify_not_hybrid_prototype, R_NilValue);
 }

--- a/src/hybrid_debug.cpp
+++ b/src/hybrid_debug.cpp
@@ -88,6 +88,8 @@ Result* verify_not_hybrid_prototype(SEXP call, const ILazySubsets&, int nargs) {
 }
 
 void install_debug_handlers(HybridHandlerMap& handlers) {
+  Environment ns_dplyr = Environment::namespace_env("dplyr") ;
+  // these are handled differently than the real hybrids
   handlers[ Rf_install("verify_hybrid") ] = HybridHandler(verify_hybrid_prototype, R_NilValue) ;
   handlers[ Rf_install("verify_not_hybrid") ] = HybridHandler(verify_not_hybrid_prototype, R_NilValue);
 }

--- a/src/hybrid_in.cpp
+++ b/src/hybrid_in.cpp
@@ -48,5 +48,5 @@ Result* in_prototype(SEXP call, const ILazySubsets& subsets, int) {
 }
 
 void install_in_handlers(HybridHandlerMap& handlers) {
-  handlers[ Rf_install("%in%") ] = HybridHandler(in_prototype, R_NilValue);
+  handlers[ Rf_install("%in%") ] = HybridHandler(in_prototype, Environment::base_namespace()["%in%"]);
 }

--- a/src/hybrid_in.cpp
+++ b/src/hybrid_in.cpp
@@ -48,5 +48,5 @@ Result* in_prototype(SEXP call, const ILazySubsets& subsets, int) {
 }
 
 void install_in_handlers(HybridHandlerMap& handlers) {
-  handlers[ Rf_install("%in%") ] = in_prototype;
+  handlers[ Rf_install("%in%") ] = HybridHandler(in_prototype, R_NilValue);
 }

--- a/src/hybrid_minmax.cpp
+++ b/src/hybrid_minmax.cpp
@@ -67,6 +67,6 @@ Result* minmax_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
 }
 
 void install_minmax_handlers(HybridHandlerMap& handlers) {
-  handlers[Rf_install("min")] = minmax_prototype<true>;
-  handlers[Rf_install("max")] = minmax_prototype<false>;
+  handlers[Rf_install("min")] = HybridHandler(minmax_prototype<true>, R_NilValue);
+  handlers[Rf_install("max")] = HybridHandler(minmax_prototype<false>, R_NilValue);
 }

--- a/src/hybrid_minmax.cpp
+++ b/src/hybrid_minmax.cpp
@@ -67,6 +67,7 @@ Result* minmax_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
 }
 
 void install_minmax_handlers(HybridHandlerMap& handlers) {
-  handlers[Rf_install("min")] = HybridHandler(minmax_prototype<true>, R_NilValue);
-  handlers[Rf_install("max")] = HybridHandler(minmax_prototype<false>, R_NilValue);
+  Environment ns_base = Environment::base_namespace() ;
+  handlers[Rf_install("min")] = HybridHandler(minmax_prototype<true>, ns_base["min"]);
+  handlers[Rf_install("max")] = HybridHandler(minmax_prototype<false>, ns_base["max"]);
 }

--- a/src/hybrid_nth.cpp
+++ b/src/hybrid_nth.cpp
@@ -329,7 +329,7 @@ Result* last_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
 }
 
 void install_nth_handlers(HybridHandlerMap& handlers) {
-  handlers[ Rf_install("first") ] = first_prototype;
-  handlers[ Rf_install("last") ] = last_prototype;
-  handlers[ Rf_install("nth") ] = nth_prototype;
+  handlers[ Rf_install("first") ] = HybridHandler(first_prototype, R_NilValue) ;
+  handlers[ Rf_install("last") ] = HybridHandler(last_prototype, R_NilValue) ;
+  handlers[ Rf_install("nth") ] = HybridHandler(nth_prototype, R_NilValue);
 }

--- a/src/hybrid_nth.cpp
+++ b/src/hybrid_nth.cpp
@@ -329,7 +329,8 @@ Result* last_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
 }
 
 void install_nth_handlers(HybridHandlerMap& handlers) {
-  handlers[ Rf_install("first") ] = HybridHandler(first_prototype, R_NilValue) ;
-  handlers[ Rf_install("last") ] = HybridHandler(last_prototype, R_NilValue) ;
-  handlers[ Rf_install("nth") ] = HybridHandler(nth_prototype, R_NilValue);
+  Environment ns_dplyr = Environment::namespace_env("dplyr") ;
+  handlers[ Rf_install("first") ] = HybridHandler(first_prototype, ns_dplyr["first"]) ;
+  handlers[ Rf_install("last") ] = HybridHandler(last_prototype, ns_dplyr["last"]) ;
+  handlers[ Rf_install("nth") ] = HybridHandler(nth_prototype, ns_dplyr["nth"]);
 }

--- a/src/hybrid_offset.cpp
+++ b/src/hybrid_offset.cpp
@@ -93,6 +93,6 @@ Result* leadlag_prototype(SEXP call, const ILazySubsets& subsets, int) {
 }
 
 void install_offset_handlers(HybridHandlerMap& handlers) {
-  handlers[ Rf_install("lead") ] = leadlag_prototype<Lead>;
-  handlers[ Rf_install("lag") ] = leadlag_prototype<Lag>;
+  handlers[ Rf_install("lead") ] = HybridHandler(leadlag_prototype<Lead>, R_NilValue);
+  handlers[ Rf_install("lag") ] = HybridHandler(leadlag_prototype<Lag>, R_NilValue);
 }

--- a/src/hybrid_offset.cpp
+++ b/src/hybrid_offset.cpp
@@ -93,6 +93,8 @@ Result* leadlag_prototype(SEXP call, const ILazySubsets& subsets, int) {
 }
 
 void install_offset_handlers(HybridHandlerMap& handlers) {
-  handlers[ Rf_install("lead") ] = HybridHandler(leadlag_prototype<Lead>, R_NilValue);
-  handlers[ Rf_install("lag") ] = HybridHandler(leadlag_prototype<Lag>, R_NilValue);
+  Environment ns_dplyr = Environment::namespace_env("dplyr") ;
+
+  handlers[ Rf_install("lead") ] = HybridHandler(leadlag_prototype<Lead>, ns_dplyr["lead"]);
+  handlers[ Rf_install("lag") ] = HybridHandler(leadlag_prototype<Lag>, ns_dplyr["lag"]);
 }

--- a/src/hybrid_simple.cpp
+++ b/src/hybrid_simple.cpp
@@ -74,8 +74,8 @@ Result* simple_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
 }
 
 void install_simple_handlers(HybridHandlerMap& handlers) {
-  handlers[ Rf_install("mean") ] = simple_prototype<dplyr::Mean>;
-  handlers[ Rf_install("var") ] = simple_prototype<dplyr::Var>;
-  handlers[ Rf_install("sd") ] = simple_prototype<dplyr::Sd>;
-  handlers[ Rf_install("sum") ] = simple_prototype<dplyr::Sum>;
+  handlers[ Rf_install("mean") ] = HybridHandler(simple_prototype<dplyr::Mean>, R_NilValue);
+  handlers[ Rf_install("var") ] = HybridHandler(simple_prototype<dplyr::Var>, R_NilValue);
+  handlers[ Rf_install("sd") ] = HybridHandler(simple_prototype<dplyr::Sd>, R_NilValue);
+  handlers[ Rf_install("sum") ] = HybridHandler(simple_prototype<dplyr::Sum>, R_NilValue);
 }

--- a/src/hybrid_simple.cpp
+++ b/src/hybrid_simple.cpp
@@ -74,8 +74,11 @@ Result* simple_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
 }
 
 void install_simple_handlers(HybridHandlerMap& handlers) {
-  handlers[ Rf_install("mean") ] = HybridHandler(simple_prototype<dplyr::Mean>, R_NilValue);
-  handlers[ Rf_install("var") ] = HybridHandler(simple_prototype<dplyr::Var>, R_NilValue);
-  handlers[ Rf_install("sd") ] = HybridHandler(simple_prototype<dplyr::Sd>, R_NilValue);
-  handlers[ Rf_install("sum") ] = HybridHandler(simple_prototype<dplyr::Sum>, R_NilValue);
+  Environment ns_stats = Environment::namespace_env("stats") ;
+  Environment ns_base = Environment::base_namespace() ;
+
+  handlers[ Rf_install("mean") ] = HybridHandler(simple_prototype<dplyr::Mean>, ns_base["mean"]);
+  handlers[ Rf_install("var") ] = HybridHandler(simple_prototype<dplyr::Var>, ns_stats["var"]);
+  handlers[ Rf_install("sd") ] = HybridHandler(simple_prototype<dplyr::Sd>, ns_stats["sd"]);
+  handlers[ Rf_install("sum") ] = HybridHandler(simple_prototype<dplyr::Sum>, ns_base["sum"]);
 }

--- a/src/hybrid_window.cpp
+++ b/src/hybrid_window.cpp
@@ -157,10 +157,10 @@ Result* rank_impl_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
 }
 
 void install_window_handlers(HybridHandlerMap& handlers) {
-  handlers[ Rf_install("row_number") ] = row_number_prototype;
-  handlers[ Rf_install("ntile") ] = ntile_prototype;
-  handlers[ Rf_install("min_rank") ] = rank_impl_prototype<dplyr::internal::min_rank_increment>;
-  handlers[ Rf_install("percent_rank") ] = rank_impl_prototype<dplyr::internal::percent_rank_increment>;
-  handlers[ Rf_install("dense_rank") ] = rank_impl_prototype<dplyr::internal::dense_rank_increment>;
-  handlers[ Rf_install("cume_dist") ] = rank_impl_prototype<dplyr::internal::cume_dist_increment>;
+  handlers[ Rf_install("row_number") ] = HybridHandler(row_number_prototype, R_NilValue);
+  handlers[ Rf_install("ntile") ] = HybridHandler(ntile_prototype, R_NilValue);
+  handlers[ Rf_install("min_rank") ] = HybridHandler(rank_impl_prototype<dplyr::internal::min_rank_increment>, R_NilValue);
+  handlers[ Rf_install("percent_rank") ] = HybridHandler(rank_impl_prototype<dplyr::internal::percent_rank_increment>, R_NilValue);
+  handlers[ Rf_install("dense_rank") ] = HybridHandler(rank_impl_prototype<dplyr::internal::dense_rank_increment>, R_NilValue);
+  handlers[ Rf_install("cume_dist") ] = HybridHandler(rank_impl_prototype<dplyr::internal::cume_dist_increment>, R_NilValue);
 }

--- a/src/hybrid_window.cpp
+++ b/src/hybrid_window.cpp
@@ -159,7 +159,7 @@ Result* rank_impl_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
 void install_window_handlers(HybridHandlerMap& handlers) {
   Environment ns_dplyr = Environment::namespace_env("dplyr") ;
 
-  handlers[ Rf_install("row_number") ] = HybridHandler(row_number_prototype, ns_dplyr["row_numner"]);
+  handlers[ Rf_install("row_number") ] = HybridHandler(row_number_prototype, ns_dplyr["row_number"]);
   handlers[ Rf_install("ntile") ] = HybridHandler(ntile_prototype, ns_dplyr["ntile"]);
   handlers[ Rf_install("min_rank") ] = HybridHandler(rank_impl_prototype<dplyr::internal::min_rank_increment>, ns_dplyr["min_rank"]);
   handlers[ Rf_install("percent_rank") ] = HybridHandler(rank_impl_prototype<dplyr::internal::percent_rank_increment>, ns_dplyr["percent_rank"]);

--- a/src/hybrid_window.cpp
+++ b/src/hybrid_window.cpp
@@ -157,10 +157,12 @@ Result* rank_impl_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
 }
 
 void install_window_handlers(HybridHandlerMap& handlers) {
-  handlers[ Rf_install("row_number") ] = HybridHandler(row_number_prototype, R_NilValue);
-  handlers[ Rf_install("ntile") ] = HybridHandler(ntile_prototype, R_NilValue);
-  handlers[ Rf_install("min_rank") ] = HybridHandler(rank_impl_prototype<dplyr::internal::min_rank_increment>, R_NilValue);
-  handlers[ Rf_install("percent_rank") ] = HybridHandler(rank_impl_prototype<dplyr::internal::percent_rank_increment>, R_NilValue);
-  handlers[ Rf_install("dense_rank") ] = HybridHandler(rank_impl_prototype<dplyr::internal::dense_rank_increment>, R_NilValue);
-  handlers[ Rf_install("cume_dist") ] = HybridHandler(rank_impl_prototype<dplyr::internal::cume_dist_increment>, R_NilValue);
+  Environment ns_dplyr = Environment::namespace_env("dplyr") ;
+
+  handlers[ Rf_install("row_number") ] = HybridHandler(row_number_prototype, ns_dplyr["row_numner"]);
+  handlers[ Rf_install("ntile") ] = HybridHandler(ntile_prototype, ns_dplyr["ntile"]);
+  handlers[ Rf_install("min_rank") ] = HybridHandler(rank_impl_prototype<dplyr::internal::min_rank_increment>, ns_dplyr["min_rank"]);
+  handlers[ Rf_install("percent_rank") ] = HybridHandler(rank_impl_prototype<dplyr::internal::percent_rank_increment>, ns_dplyr["percent_rank"]);
+  handlers[ Rf_install("dense_rank") ] = HybridHandler(rank_impl_prototype<dplyr::internal::dense_rank_increment>, ns_dplyr["dense_rank"]);
+  handlers[ Rf_install("cume_dist") ] = HybridHandler(rank_impl_prototype<dplyr::internal::cume_dist_increment>, ns_dplyr["cume_dist"]);
 }

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -1121,7 +1121,7 @@ test_that("top_n() is hybridised (#2822)", {
 })
 
 test_that( "hybrid evaluation can be disabled locally (#3255)", {
-  tbl <- data.frame( x = 1:10)
+  tbl <- data.frame(x = 1:10)
 
   first <- function(...) 42
   expect_equal( summarise( tbl, y = first(x) )$y, 42 )

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -1133,3 +1133,86 @@ test_that("top_n() is hybridised (#2822)", {
   min_rank <- bad_hybrid_handler
   expect_error(top_n(mtcars, 1, cyl), NA)
 })
+
+test_that( "hybrid evaluation can be disabled locally (#3255)", {
+  tbl <- data.frame( x = 1:10)
+
+  first <- function(...) 42
+  expect_equal( summarise( tbl, y = first(x) )$y, 42 )
+  expect_equal( summarise( tbl, y = dplyr::first(x) )$y, 1 )
+
+  last <- function(...) 42
+  expect_equal( summarise( tbl, y = last(x) )$y, 42 )
+  expect_equal( summarise( tbl, y = dplyr::last(x) )$y, 10 )
+
+  nth <- function(...) 42
+  expect_equal( summarise( tbl, y = nth(x, 2L) )$y, 42 )
+  expect_equal( summarise( tbl, y = dplyr::nth(x, 2) )$y, 2 )
+
+  mean <- function(...) 42
+  tbl <- data.frame( x = 1:10)
+  expect_equal( summarise( tbl, y = mean(x) )$y, 42 )
+  expect_equal( summarise( tbl, y = base::mean(x) )$y, 5.5 )
+
+  var <- function(...) 42
+  expect_equal( summarise( tbl, y = var(x) )$y, 42 )
+  expect_equal( summarise( tbl, y = stats::var(x) )$y, stats::var(tbl$x) )
+
+  sd <- function(...) 42
+  expect_equal( summarise( tbl, y = sd(x) )$y, 42 )
+  expect_equal( summarise( tbl, y = stats::sd(x) )$y, stats::sd(tbl$x) )
+
+  row_number <- function() 42
+  expect_equal( mutate( tbl, y = row_number() )$y, rep(42, 10) )
+  expect_equal( mutate( tbl, y = dplyr::row_number() )$y, 1:10 )
+
+  ntile <- function(x, n) 42
+  expect_equal( mutate( tbl, y = ntile(x, 2) )$y, rep(42, 10) )
+  expect_equal( mutate( tbl, y = dplyr::ntile(x,2) )$y, rep(1:2, each = 5) )
+
+  min_rank <- function(x) 42
+  expect_equal( mutate( tbl, y = min_rank(x) )$y, rep(42, 10) )
+  expect_equal( mutate( tbl, y = dplyr::min_rank(x) )$y, 1:10 )
+
+  percent_rank <- function(x) 42
+  expect_equal( mutate( tbl, y = percent_rank(x) )$y, rep(42, 10) )
+  expect_equal( mutate( tbl, y = dplyr::percent_rank(x) )$y, dplyr::percent_rank(1:10) )
+
+  dense_rank <- function(x) 42
+  expect_equal( mutate( tbl, y = dense_rank(x) )$y, rep(42, 10) )
+  expect_equal( mutate( tbl, y = dplyr::dense_rank(x) )$y, dplyr::dense_rank(1:10) )
+
+  cume_dist <- function(x) 42
+  expect_equal( mutate( tbl, y = cume_dist(x) )$y, rep(42, 10) )
+  expect_equal( mutate( tbl, y = dplyr::cume_dist(x) )$y, dplyr::cume_dist(1:10) )
+
+  lead <- function(x) 42
+  expect_equal( mutate( tbl, y = lead(x) )$y, rep(42, 10) )
+  expect_equal( mutate( tbl, y = dplyr::lead(x) )$y, dplyr::lead(1:10) )
+
+  lag <- function(x) 42
+  expect_equal( mutate( tbl, y = lag(x) )$y, rep(42, 10) )
+  expect_equal( mutate( tbl, y = dplyr::lag(x) )$y, dplyr::lag(1:10) )
+
+  `%in%` <- function(x, y) TRUE
+  expect_identical( filter( tbl, x %in% 3 ), tbl )
+
+  min <- function(x) 42
+  expect_equal( mutate( tbl, y = min(x) )$y, rep(42, 10) )
+  expect_equal( mutate( tbl, y = base::min(x) )$y, 1L )
+
+  max <- function(x) 42
+  expect_equal( mutate( tbl, y = max(x) )$y, rep(42, 10) )
+  expect_equal( mutate( tbl, y = base::max(x) )$y, 10L )
+
+  n <- function() 42
+  expect_equal( summarise( tbl, y = n() )$y, 42 )
+  expect_equal( summarise( tbl, y = dplyr::n() )$y, 10L )
+
+  n_distinct <- function(x) 42
+  expect_equal( summarise( tbl, y = n_distinct(x) )$y, 42 )
+  expect_equal( summarise( tbl, y = dplyr::n_distinct(x) )$y, 10L )
+
+
+})
+

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -1024,8 +1024,6 @@ test_that("constant folding and argument matching in hybrid evaluator (#2299)", 
 })
 
 test_that("simple handlers supports quosured symbols", {
-  mean <- sum <- var <- sd <- bad_hybrid_handler
-
   expect_identical(
     pull(summarise(mtcars, mean(!!quo(cyl)))),
     base::mean(mtcars$cyl)
@@ -1045,7 +1043,6 @@ test_that("simple handlers supports quosured symbols", {
 })
 
 test_that("%in% handler supports quosured symbols", {
-  `%in%` <- bad_hybrid_handler
   expect_identical(
     pull(mutate(mtcars, !!quo(cyl) %in% 4)),
     base::`%in%`(mtcars$cyl, 4)
@@ -1053,8 +1050,6 @@ test_that("%in% handler supports quosured symbols", {
 })
 
 test_that("min() and max() handlers supports quosured symbols", {
-  min <- max <- bad_hybrid_handler
-
   expect_identical(
     pull(summarise(mtcars, min(!!quo(cyl)))),
     base::min(mtcars$cyl)
@@ -1066,8 +1061,6 @@ test_that("min() and max() handlers supports quosured symbols", {
 })
 
 test_that("lead/lag handlers support quosured symbols", {
-  lead <- lag <- bad_hybrid_handler
-
   expect_identical(
     pull(mutate(mtcars, lead(!!quo(cyl)))),
     dplyr::lead(mtcars$cyl)
@@ -1079,8 +1072,6 @@ test_that("lead/lag handlers support quosured symbols", {
 })
 
 test_that("window handlers supports quosured symbols", {
-  ntile <- min_rank <- percent_rank <- dense_rank <- cume_dist <- bad_hybrid_handler
-
   expect_identical(
     pull(mutate(mtcars, ntile(!!quo(disp), 2))),
     dplyr::ntile(mtcars$disp, 2)
@@ -1104,8 +1095,6 @@ test_that("window handlers supports quosured symbols", {
 })
 
 test_that("n_distinct() handler supports quosured symbols", {
-  n_distinct <- bad_hybrid_handler
-
   expect_identical(
     pull(summarise(mtcars, n_distinct(!!quo(cyl)))),
     dplyr::n_distinct(mtcars$cyl)
@@ -1113,8 +1102,6 @@ test_that("n_distinct() handler supports quosured symbols", {
 })
 
 test_that("nth handlers support quosured symbols", {
-  first <- last <- nth <- bad_hybrid_handler
-
   expect_identical(
     pull(summarise(mtcars, first(!!quo(cyl)))),
     dplyr::first(mtcars$cyl)
@@ -1130,7 +1117,6 @@ test_that("nth handlers support quosured symbols", {
 })
 
 test_that("top_n() is hybridised (#2822)", {
-  min_rank <- bad_hybrid_handler
   expect_error(top_n(mtcars, 1, cyl), NA)
 })
 
@@ -1198,12 +1184,12 @@ test_that( "hybrid evaluation can be disabled locally (#3255)", {
   expect_identical( filter( tbl, x %in% 3 ), tbl )
 
   min <- function(x) 42
-  expect_equal( mutate( tbl, y = min(x) )$y, rep(42, 10) )
-  expect_equal( mutate( tbl, y = base::min(x) )$y, 1L )
+  expect_equal( summarise( tbl, y = min(x) )$y, 42 )
+  expect_equal( summarise( tbl, y = base::min(x) )$y, 1L )
 
   max <- function(x) 42
-  expect_equal( mutate( tbl, y = max(x) )$y, rep(42, 10) )
-  expect_equal( mutate( tbl, y = base::max(x) )$y, 10L )
+  expect_equal( summarise( tbl, y = max(x) )$y, 42 )
+  expect_equal( summarise( tbl, y = base::max(x) )$y, 10L )
 
   n <- function() 42
   expect_equal( summarise( tbl, y = n() )$y, 42 )


### PR DESCRIPTION
 - hybrid functions can now be masked by regular R functions to turn hybrid evaluation off (#3255). 

--- 

closes #3255 

@lionel- @krlmlr this follows the discussion in #3255. Some of the tests in `test-hybrid.R` had to change because they were based on the previous behavior. 


```
test_that("nth handlers support quosured symbols", {
  first <- last <- nth <- bad_hybrid_handler

  expect_identical(
    pull(summarise(mtcars, first(!!quo(cyl)))),
    dplyr::first(mtcars$cyl)
  )
  expect_identical(
    pull(summarise(mtcars, last(!!quo(cyl)))),
    dplyr::last(mtcars$cyl)
  )
  expect_identical(
    pull(summarise(mtcars, nth(!!quo(cyl), 2))),
    dplyr::nth(mtcars$cyl, 2)
  )
})

```

is now: 

```
test_that("nth handlers support quosured symbols", {
  expect_identical(
    pull(summarise(mtcars, first(!!quo(cyl)))),
    dplyr::first(mtcars$cyl)
  )
  expect_identical(
    pull(summarise(mtcars, last(!!quo(cyl)))),
    dplyr::last(mtcars$cyl)
  )
  expect_identical(
    pull(summarise(mtcars, nth(!!quo(cyl), 2))),
    dplyr::nth(mtcars$cyl, 2)
  )
})

```

otherwise, by design this calls the redefined functions `first`, `last` ...

Maybe we would need to revisit so that hybridness is tested