### PR TITLE
row_number is hybridifyed on empty indices set. closes #3454

### DIFF
--- a/src/hybrid_window.cpp
+++ b/src/hybrid_window.cpp
@@ -35,9 +35,9 @@ Result* row_number(const RObject& data, const bool ascending) {
 }
 
 Result* row_number_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
-  if (nargs > 1 || subsets.size() == 0) return 0;
-
   if (nargs == 0) return new RowNumber_0();
+
+  if (nargs > 1) return 0;
 
   RObject data(CADR(call));
   bool ascending = true;

--- a/tests/testthat/test-filter.r
+++ b/tests/testthat/test-filter.r
@@ -220,6 +220,13 @@ test_that("row_number does not segfault with example from #781", {
   expect_equal(nrow(res), 0L)
 })
 
+test_that("row_number works on 0 length columns (#3454)", {
+  expect_identical(
+    mutate( tibble(), a = row_number()),
+    tibble(a=integer())
+  )
+})
+
 test_that("filter does not alter expression (#971)", {
   my_filter <- ~ am == 1
   expect_equal(my_filter[[2]][[2]], as.name("am"))


### PR DESCRIPTION
 - `row_number()` works on empty subsets (#3454)