### PR TITLE
ntile with only one argument in dplyr expressions

### DIFF
--- a/inst/include/dplyr/Result/Rank.h
+++ b/inst/include/dplyr/Result/Rank.h
@@ -390,6 +390,19 @@ private:
   double ntiles;
 };
 
+class Ntile_1 : public Result {
+public:
+  Ntile_1(int ntiles_)  ;
+
+  virtual SEXP process(const GroupedDataFrame& gdf) ;
+  virtual SEXP process(const RowwiseDataFrame& gdf) ;
+  virtual SEXP process(const FullDataFrame& df)  ;
+  virtual SEXP process(const SlicingIndex& index) ;
+
+private:
+  int ntiles;
+};
+
 class RowNumber_0 : public Result {
 public:
 

--- a/src/hybrid_window.cpp
+++ b/src/hybrid_window.cpp
@@ -83,7 +83,10 @@ Result* ntile(const RObject& data, const int number_tiles, const bool ascending)
 Result* ntile_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
 
   if (nargs == 1) {
-    // handle 2nd arg
+    // only one arg. We only accept if it is named "n"
+    SEXP cdr = CDR(call);
+    if (TAG(cdr) != Rf_install("n")) return 0;
+
     SEXP ntiles = maybe_rhs(CADR(call));
     if (TYPEOF(ntiles) != INTSXP && TYPEOF(ntiles) != REALSXP) return 0;
     int number_tiles = as<int>(ntiles);
@@ -223,5 +226,3 @@ SEXP Ntile_1::process(const SlicingIndex& index) {
 }
 
 }
-
-

--- a/src/hybrid_window.cpp
+++ b/src/hybrid_window.cpp
@@ -181,6 +181,7 @@ void install_window_handlers(HybridHandlerMap& handlers) {
 }
 
 namespace dplyr {
+
 Ntile_1::Ntile_1(int ntiles_) : ntiles(ntiles_) {}
 
 SEXP Ntile_1::process(const GroupedDataFrame& gdf) {
@@ -188,6 +189,7 @@ SEXP Ntile_1::process(const GroupedDataFrame& gdf) {
   if (n == 0) return IntegerVector(0);
 
   int ng = gdf.ngroups();
+
   GroupedDataFrame::group_iterator git = gdf.group_begin();
   IntegerVector out = no_init(n);
   for (int i = 0; i < ng; i++, ++git) {
@@ -215,10 +217,11 @@ SEXP Ntile_1::process(const SlicingIndex& index) {
 
   IntegerVector out = no_init(nrows);
   for (int i = nrows - 1; i >= 0; i--) {
-    out[ index[i] ] = (int)floor(ntiles * i / nrows) + 1;
+    out[ i ] = (int)floor(ntiles * i / nrows) + 1;
   }
   return out;
 }
+
 }
 
 

--- a/src/hybrid_window.cpp
+++ b/src/hybrid_window.cpp
@@ -81,30 +81,43 @@ Result* ntile(const RObject& data, const int number_tiles, const bool ascending)
 }
 
 Result* ntile_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
-  if (nargs != 2) return 0;
 
-  // handle 2nd arg
-  SEXP ntiles = maybe_rhs(CADDR(call));
-  if (TYPEOF(ntiles) != INTSXP && TYPEOF(ntiles) != REALSXP) return 0;
-  int number_tiles = as<int>(ntiles);
-  if (number_tiles == NA_INTEGER) return 0;
+  if (nargs == 1) {
+    // handle 2nd arg
+    SEXP ntiles = maybe_rhs(CADR(call));
+    if (TYPEOF(ntiles) != INTSXP && TYPEOF(ntiles) != REALSXP) return 0;
+    int number_tiles = as<int>(ntiles);
+    if (number_tiles == NA_INTEGER) return 0;
 
-  RObject data(maybe_rhs(CADR(call)));
-  bool ascending = true;
-  if (TYPEOF(data) == LANGSXP && CAR(data) == Rf_install("desc")) {
-    data = CADR(data);
-    ascending = false;
+    return new Ntile_1(number_tiles);
   }
 
-  if (TYPEOF(data) == SYMSXP) {
-    SymbolString name = SymbolString(Symbol(data));
-    if (subsets.has_non_summary_variable(name)) data = subsets.get_variable(name);
-    else return 0;
+  if (nargs == 2) {
+    // handle 2nd arg
+    SEXP ntiles = maybe_rhs(CADDR(call));
+    if (TYPEOF(ntiles) != INTSXP && TYPEOF(ntiles) != REALSXP) return 0;
+    int number_tiles = as<int>(ntiles);
+    if (number_tiles == NA_INTEGER) return 0;
+
+    RObject data(maybe_rhs(CADR(call)));
+    bool ascending = true;
+    if (TYPEOF(data) == LANGSXP && CAR(data) == Rf_install("desc")) {
+      data = CADR(data);
+      ascending = false;
+    }
+
+    if (TYPEOF(data) == SYMSXP) {
+      SymbolString name = SymbolString(Symbol(data));
+      if (subsets.has_non_summary_variable(name)) data = subsets.get_variable(name);
+      else return 0;
+    }
+
+    if (subsets.nrows() != Rf_length(data)) return 0;
+
+    return ntile(data, number_tiles, ascending);
   }
 
-  if (subsets.nrows() != Rf_length(data)) return 0;
-
-  return ntile(data, number_tiles, ascending);
+  return 0;
 }
 
 template <typename Increment, bool ascending>
@@ -166,3 +179,46 @@ void install_window_handlers(HybridHandlerMap& handlers) {
   handlers[ Rf_install("dense_rank") ] = HybridHandler(rank_impl_prototype<dplyr::internal::dense_rank_increment>, ns_dplyr["dense_rank"]);
   handlers[ Rf_install("cume_dist") ] = HybridHandler(rank_impl_prototype<dplyr::internal::cume_dist_increment>, ns_dplyr["cume_dist"]);
 }
+
+namespace dplyr {
+Ntile_1::Ntile_1(int ntiles_) : ntiles(ntiles_) {}
+
+SEXP Ntile_1::process(const GroupedDataFrame& gdf) {
+  int n  = gdf.nrows();
+  if (n == 0) return IntegerVector(0);
+
+  int ng = gdf.ngroups();
+  GroupedDataFrame::group_iterator git = gdf.group_begin();
+  IntegerVector out = no_init(n);
+  for (int i = 0; i < ng; i++, ++git) {
+    const SlicingIndex& index = *git;
+    int m = index.size();
+
+    for (int j = m - 1; j >= 0; j--) {
+      out[ index[j] ] = (int)floor((ntiles * j) / m) + 1;
+    }
+  }
+  return out;
+}
+
+SEXP Ntile_1::process(const RowwiseDataFrame& gdf) {
+  return IntegerVector(gdf.nrows(), 1);
+}
+
+SEXP Ntile_1::process(const FullDataFrame& df) {
+  return process(df.get_index());
+}
+
+SEXP Ntile_1::process(const SlicingIndex& index) {
+  int nrows = index.size();
+  if (nrows == 0) return IntegerVector(0);
+
+  IntegerVector out = no_init(nrows);
+  for (int i = nrows - 1; i >= 0; i--) {
+    out[ index[i] ] = (int)floor(ntiles * i / nrows) + 1;
+  }
+  return out;
+}
+}
+
+

--- a/tests/testthat/test-mutate-windowed.R
+++ b/tests/testthat/test-mutate-windowed.R
@@ -133,16 +133,15 @@ test_that("min_rank handles columns full of NaN (#726)", {
 test_that("ntile works with one argument (#3418)", {
   df <- data.frame(x=1:42)
   expect_identical(
-    mutate( df, nt = ntile(9)),
-    mutate( df, nt = ntile(row_number(), 9))
+    mutate( df, nt = ntile(n = 9)),
+    mutate( df, nt = ntile(row_number(), n = 9))
   )
 
   df <- group_by( data.frame(x=1:42, g = rep(1:7, each=6)), g )
   expect_identical(
-    mutate( df, nt = ntile(4)),
-    mutate( df, nt = ntile(row_number(), 4))
+    mutate( df, nt = ntile(n = 4)),
+    mutate( df, nt = ntile(row_number(), n = 4))
   )
-
 })
 
 test_that("rank functions deal correctly with NA (#774)", {

--- a/tests/testthat/test-mutate-windowed.R
+++ b/tests/testthat/test-mutate-windowed.R
@@ -136,6 +136,13 @@ test_that("ntile works with one argument (#3418)", {
     mutate( df, nt = ntile(9)),
     mutate( df, nt = ntile(row_number(), 9))
   )
+
+  df <- group_by( data.frame(x=1:42, g = rep(1:7, each=6)), g )
+  expect_identical(
+    mutate( df, nt = ntile(4)),
+    mutate( df, nt = ntile(row_number(), 4))
+  )
+
 })
 
 test_that("rank functions deal correctly with NA (#774)", {

--- a/tests/testthat/test-mutate-windowed.R
+++ b/tests/testthat/test-mutate-windowed.R
@@ -130,6 +130,14 @@ test_that("min_rank handles columns full of NaN (#726)", {
   expect_true(all(is.na(data$rank)))
 })
 
+test_that("ntile works with one argument (#3418)", {
+  df <- data.frame(x=1:42)
+  expect_identical(
+    mutate( df, nt = ntile(9)),
+    mutate( df, nt = ntile(row_number(), 9))
+  )
+})
+
 test_that("rank functions deal correctly with NA (#774)", {
   data <- data_frame(x = c(1, 2, NA, 1, 0, NA))
   res <- data %>% mutate(


### PR DESCRIPTION
```
> df <- tibble(x=1:42)
> mutate( df, nt = ntile(9))
# A tibble: 42 x 2
       x    nt
   <int> <int>
 1     1     1
 2     2     1
 3     3     1
 4     4     1
 5     5     1
 6     6     2
 7     7     2
 8     8     2
 9     9     2
10    10     2
# ... with 32 more rows
```

on the example from #3418 :

```r
> library(tidyr)
>  mtcars %>%
+   as_tibble() %>% 
+   mutate(ntile = ntile(7)) %>%
+   nest(-ntile)
# A tibble: 7 x 2
  ntile data             
  <int> <list>           
1     1 <tibble [5 × 11]>
2     2 <tibble [5 × 11]>
3     3 <tibble [4 × 11]>
4     4 <tibble [5 × 11]>
5     5 <tibble [4 × 11]>
6     6 <tibble [5 × 11]>
7     7 <tibble [4 × 11]>
```

I have not touched the non hybrid version, so at the moment these are confusing

```
> ntile(4)
Error in ntile(4) : argument "n" is missing, with no default
> ntile(n=4)
Error in ntile(n = 4) : argument "x" is missing, with no default
```
