### PR TITLE
tally works correctly on tbl_sql (#3075)

### DIFF
--- a/R/count-tally.R
+++ b/R/count-tally.R
@@ -63,7 +63,7 @@
 tally <- function(x, wt, sort = FALSE) {
   wt <- enquo(wt)
 
-  if (quo_is_missing(wt) && "n" %in% names(x)) {
+  if (quo_is_missing(wt) && "n" %in% tbl_vars(x)) {
     inform("Using `n` as weighting variable")
     wt <- quo(n)
   }

--- a/tests/testthat/test-count-tally.r
+++ b/tests/testthat/test-count-tally.r
@@ -104,3 +104,14 @@ test_that("add_tally can be given a weighting variable", {
   out <- df %>% group_by(a) %>% add_tally(wt = w + 1)
   expect_equal(out$n, c(4, 4, 12, 12, 12))
 })
+
+test_that("tally works on tbl_sql (#3075)", {
+  db <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+
+  dLocal <- data.frame(n = 1:3)
+  expect_message(tally_local <- tally(dLocal), "Using `n` as weighting variable")
+
+  dRemote <- dplyr::copy_to(db, dLocal)
+  expect_message(tally_remote <- tally(dRemote), "Using `n` as weighting variable" )
+  expect_equal(pull(tally_remote, nn), 6)
+})

--- a/tests/testthat/test-count-tally.r
+++ b/tests/testthat/test-count-tally.r
@@ -104,14 +104,3 @@ test_that("add_tally can be given a weighting variable", {
   out <- df %>% group_by(a) %>% add_tally(wt = w + 1)
   expect_equal(out$n, c(4, 4, 12, 12, 12))
 })
-
-test_that("tally works on tbl_sql (#3075)", {
-  db <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
-
-  dLocal <- data.frame(n = 1:3)
-  expect_message(tally_local <- tally(dLocal), "Using `n` as weighting variable")
-
-  dRemote <- dplyr::copy_to(db, dLocal)
-  expect_message(tally_remote <- tally(dRemote), "Using `n` as weighting variable" )
-  expect_equal(pull(tally_remote, nn), 6)
-})


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)

db <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")

dLocal <- data.frame(n = 1:3)
tally(dLocal)
#> Using `n` as weighting variable
#>   nn
#> 1  6

dRemote <- dplyr::copy_to(db, dLocal)
tally(dRemote)
#> Using `n` as weighting variable
#> # Source:   lazy query [?? x 1]
#> # Database: sqlite 3.22.0 [:memory:]
#>      nn
#>   <int>
#> 1     6
```

Created on 2018-04-23 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).