### PR TITLE
faster hybrid sum, mean, var and sd for logical vectors. closes #3189

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -125,6 +125,8 @@
 
 * Improved performance for wide tibbles (#3335). 
 
+* Faster hybrid `sum()` on logical vectors (#3189). 
+
 ## Internal
 
 * Compute variable names for joins in R (#3430).

--- a/inst/include/dplyr/Result/Mean.h
+++ b/inst/include/dplyr/Result/Mean.h
@@ -22,8 +22,8 @@ struct Mean_internal {
       // if there are NA, we could return quicker as in the version for
       // INTSXP, but we would penalize the most common case
       //
-      // INTSXP: no shortcut, need to test
-      if (NA_RM || RTYPE == INTSXP) {
+      // INTSXP, LGLSXP: no shortcut, need to test
+      if (NA_RM || RTYPE == INTSXP || RTYPE == LGLSXP) {
         if (Rcpp::traits::is_na<RTYPE>(value)) {
           if (!NA_RM) {
             return NA_REAL;

--- a/inst/include/dplyr/Result/Sum.h
+++ b/inst/include/dplyr/Result/Sum.h
@@ -64,9 +64,9 @@ struct Sum<REALSXP, NA_RM, Index> {
 } // namespace internal
 
 template <int RTYPE, bool NA_RM>
-class Sum : public Processor < RTYPE == REALSXP ? REALSXP : INTSXP, Sum<RTYPE, NA_RM> > {
+class Sum : public Processor < RTYPE == LGLSXP ? INTSXP : RTYPE, Sum<RTYPE, NA_RM> > {
 public :
-  typedef Processor < RTYPE == REALSXP ? REALSXP : INTSXP, Sum<RTYPE, NA_RM> > Base;
+  typedef Processor < RTYPE == LGLSXP ? INTSXP : RTYPE, Sum<RTYPE, NA_RM> > Base;
   typedef typename Rcpp::traits::storage_type<RTYPE>::type STORAGE;
 
   Sum(SEXP x) :

--- a/inst/include/dplyr/Result/Sum.h
+++ b/inst/include/dplyr/Result/Sum.h
@@ -15,7 +15,7 @@ struct Sum {
     long double res = 0;
     int n = indices.size();
     for (int i = 0; i < n; i++) {
-      double value = ptr[indices[i]];
+      STORAGE value = ptr[indices[i]];
 
       if (Rcpp::traits::is_na<RTYPE>(value)) {
         if (NA_RM) {
@@ -64,9 +64,9 @@ struct Sum<REALSXP, NA_RM, Index> {
 } // namespace internal
 
 template <int RTYPE, bool NA_RM>
-class Sum : public Processor< RTYPE, Sum<RTYPE, NA_RM> > {
-public:
-  typedef Processor< RTYPE, Sum<RTYPE, NA_RM> > Base;
+class Sum : public Processor < RTYPE == REALSXP ? REALSXP : INTSXP, Sum<RTYPE, NA_RM> > {
+public :
+  typedef Processor < RTYPE == REALSXP ? REALSXP : INTSXP, Sum<RTYPE, NA_RM> > Base;
   typedef typename Rcpp::traits::storage_type<RTYPE>::type STORAGE;
 
   Sum(SEXP x) :

--- a/src/hybrid_simple.cpp
+++ b/src/hybrid_simple.cpp
@@ -23,6 +23,8 @@ Result* simple_prototype_impl(SEXP arg) {
     return new Fun<INTSXP, narm>(arg);
   case REALSXP:
     return new Fun<REALSXP, narm>(arg);
+  case LGLSXP:
+    return new Fun<LGLSXP, narm>(arg);
   default:
     break;
   }

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -1032,3 +1032,17 @@ test_that("first() and last() can be called without dplyr loaded (#3498)", {
   expect_equal(df$y, 3L)
   expect_equal(df$z, 1L)
 })
+
+test_that("hybrid sum handles NA correctly (#3528)",{
+  d <- tibble(x = c(1L,2L,NA) )
+
+  expect_equal( summarise(d, x = sum(x, na.rm = TRUE)), tibble(x = 3L))
+  expect_equal( summarise(d, x = sum(x, na.rm = FALSE)), tibble(x = NA_integer_))
+  expect_equal( summarise(d, x = sum(x)), tibble(x = NA_integer_))
+
+  d <- tibble(x = c(TRUE, FALSE, NA) )
+  expect_equal( summarise(d, x = sum(x, na.rm = TRUE)), tibble(x = 1L))
+  expect_equal( summarise(d, x = sum(x, na.rm = FALSE)), tibble(x = NA_integer_))
+  expect_equal( summarise(d, x = sum(x)), tibble(x = NA_integer_))
+
+})


### PR DESCRIPTION
Now getting this with the `microbenchmark` from #3189 

```r
> microbenchmark(
+   # summarizing double variable
+   testTibble %>% summarise(s = sum(a)),
+   # summarizing logical variable <- ISSUE IS HERE
+   testTibble %>% summarise(s = sum(b)),
+   # summarizing integer variable
+   testTibble %>% summarise(s = sum(c)),
+   # compare with simple sums without grouping
+   testTibble %>% pull(a) %>% sum(),
+   testTibble %>% pull(b) %>% sum(),
+   testTibble %>% pull(c) %>% sum()
+ )
Unit: microseconds
                                 expr     min        lq      mean   median        uq      max neval
 testTibble %>% summarise(s = sum(a)) 887.793  963.7880 1113.9784 1009.477 1113.3875 3213.814   100
 testTibble %>% summarise(s = sum(b)) 914.653 1026.2770 1246.6117 1105.180 1254.5270 3613.427   100
 testTibble %>% summarise(s = sum(c)) 910.163 1050.9785 1292.7114 1121.504 1289.3445 3761.196   100
     testTibble %>% pull(a) %>% sum() 234.278  261.6915  313.4974  290.272  338.3865  594.999   100
     testTibble %>% pull(b) %>% sum() 244.330  272.5560  324.5580  300.282  344.5930  676.081   100
     testTibble %>% pull(c) %>% sum() 248.123  273.9390  352.3891  296.661  360.1785 1834.551   100
```