### PR TITLE
initial internal code for a between for strings #2995

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -38,6 +38,10 @@ arrange_impl <- function(data, quosures) {
     .Call(`_dplyr_arrange_impl`, data, quosures)
 }
 
+between_string <- function(x, left, right) {
+    .Call(`_dplyr_between_string`, x, left, right)
+}
+
 #' Do values in a numeric vector fall in specified range?
 #'
 #' This is a shortcut for `x >= left & x <= right`, implemented

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -86,6 +86,19 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// between_string
+LogicalVector between_string(CharacterVector x, String left, String right);
+RcppExport SEXP _dplyr_between_string(SEXP xSEXP, SEXP leftSEXP, SEXP rightSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< CharacterVector >::type x(xSEXP);
+    Rcpp::traits::input_parameter< String >::type left(leftSEXP);
+    Rcpp::traits::input_parameter< String >::type right(rightSEXP);
+    rcpp_result_gen = Rcpp::wrap(between_string(x, left, right));
+    return rcpp_result_gen;
+END_RCPP
+}
 // between
 LogicalVector between(NumericVector x, double left, double right);
 RcppExport SEXP _dplyr_between(SEXP xSEXP, SEXP leftSEXP, SEXP rightSEXP) {
@@ -697,6 +710,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dplyr_gp", (DL_FUNC) &_dplyr_gp, 1},
     {"_dplyr_init_logging", (DL_FUNC) &_dplyr_init_logging, 1},
     {"_dplyr_arrange_impl", (DL_FUNC) &_dplyr_arrange_impl, 2},
+    {"_dplyr_between_string", (DL_FUNC) &_dplyr_between_string, 3},
     {"_dplyr_between", (DL_FUNC) &_dplyr_between, 3},
     {"_dplyr_flatten_bindable", (DL_FUNC) &_dplyr_flatten_bindable, 1},
     {"_dplyr_bind_rows_", (DL_FUNC) &_dplyr_bind_rows_, 2},

--- a/src/between.cpp
+++ b/src/between.cpp
@@ -2,6 +2,40 @@
 #include <Rcpp.h>
 using namespace Rcpp;
 
+#include <dplyr/VectorVisitorImpl.h>
+
+// [[Rcpp::export]]
+LogicalVector between_string(CharacterVector x, String left, String right) {
+  int n = x.size();
+
+  LogicalVector out = no_init(n) ;
+  if (left == NA || right == NA) {
+    for (int i = 0; i < n; ++i)
+      out[i] = NA_LOGICAL;
+    return out;
+  }
+
+  CharacterVector y(n + 2) ;
+  for (int i = 0; i < n; i++) {
+    y[i] = x[i];
+  }
+  y[n] = left;
+  y[n + 1] = right;
+
+  dplyr::VectorVisitorImpl<STRSXP> v(y);
+
+  for (int i = 0; i < n; i++) {
+    if (v.is_na(i)) {
+      out[i] = NA_INTEGER;
+    } else {
+      out[i] = v.greater(i, n) && v.less(i, n + 1);
+    }
+
+  }
+  return out;
+}
+
+
 //' Do values in a numeric vector fall in specified range?
 //'
 //' This is a shortcut for `x >= left & x <= right`, implemented


### PR DESCRIPTION
for now this is a separate function internally but I feel like `between` should dispatch and deal with at least `REALSXP`, `STRSXP`, `INTSXP` and `RAWSXP`. 

The string version uses a `VectorVisitorImpl<STRSXP>` so that it can take advantage of its `greater` and `less` methods. 

Wondering however if we could take advantage that the `vec` in `VectorVisitorImpl<STRSXP>` is forced to be utf8, would we not have a way to compare two utf8 strings without having to go through the hoops of `CharacterVectorOrderer`