### PR TITLE
Performance fixes for wide data frames

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -114,6 +114,8 @@
 
 * `sample_n()` and `sample_frac()` on grouped data frame are now faster especially for those with large number of groups (#3193, @saurfang).
 
+* Improved performance for wide tibbles (#3335). 
+
 ## Internal
 
 * Compute variable names for joins in R (#3430).

--- a/inst/include/dplyr/Result/LazySubsets.h
+++ b/inst/include/dplyr/Result/LazySubsets.h
@@ -9,7 +9,7 @@ namespace dplyr {
 
 class LazySubsets : public ILazySubsets {
 public:
-  LazySubsets(const DataFrame& df) : nr(df.nrows()) {
+  LazySubsets(const DataFrame& df) : symbol_map(df.size(), df.names()), summary_map(), data(df.size()), nr(df.nrows()) {
     int nvars = df.size();
     if (nvars) {
       CharacterVector names = df.names();
@@ -18,8 +18,7 @@ public:
         if (Rf_inherits(column, "matrix")) {
           stop("matrix as column is not supported");
         }
-        symbol_map.insert(names[i]);
-        data.push_back(df[i]);
+        data[i] = df[i];
       }
     }
   }

--- a/inst/include/tools/SymbolMap.h
+++ b/inst/include/tools/SymbolMap.h
@@ -25,6 +25,12 @@ private:
 public:
   SymbolMap(): lookup(), names() {}
 
+  SymbolMap(int n, const CharacterVector& names_): lookup(n), names((SEXP)names_) {
+    for (int i = 0; i < n; i++) {
+      lookup.insert(std::make_pair(names_[i], i));
+    }
+  }
+
   SymbolMap(const SymbolVector& names_): lookup(), names(names_) {}
 
   SymbolMapIndex insert(const SymbolString& name) {


### PR DESCRIPTION
This was going through the `SymbolVector::push_back` method. 

```
void push_back(const SymbolString& s) {
    v.push_back(s.get_string());
  }
```

and `v` is a `CharacterVector` 😱 

This is still expensive e.g. compared to `[`, I'll look for other bottlenecks.

``` r
library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
library(purrr)

n_samples <- 500
n_features <- 100000

df <- bind_cols(
  tibble(sample_id = paste0("sample_", 1:n_samples)),
  1:n_features %>%
    map(rnorm, n = n_samples) %>%
    map(as_tibble) %>%
    bind_cols()
)

system.time(fetched_sample <- filter(df, sample_id == "sample_1"))
#>    user  system elapsed 
#>   1.720   0.029   1.755
system.time(fetched_sample <- df[which(df$sample_id == "sample_1"),])
#>    user  system elapsed 
#>   0.048   0.001   0.048
```

For reference in the original issue, these were the timings: 

```r
> system.time(fetched_sample <- filter(df, sample_id == "sample_1"))
#>.   user  system elapsed
#> 165.060   0.110 165.446
```