### PR TITLE
train child slicers in VectorSlicer::train()

### DIFF
--- a/src/group_indices.cpp
+++ b/src/group_indices.cpp
@@ -343,6 +343,14 @@ private:
     } else {
       train_impl(index_range);
     }
+
+    // ---- for each level, train child slicers
+    int n = indices.size();
+    slicers.reserve(n);
+    for (int i = 0; i < n; i++) {
+      slicers.push_back(slicer(indices[i], depth + 1, data, visitors));
+      slicer_size += slicers[i]->size();
+    }
   }
 
   template <typename Indices>
@@ -353,9 +361,6 @@ private:
 
       agents.push_back(NA_INTEGER);         // NA is used as a placeholder
       indices.push_back(std::vector<int>()); // empty indices
-
-      slicers.push_back(slicer(indices[0], depth + 1, data, visitors));
-      slicer_size = slicers[0]->size();
 
     } else {
       Map map(visitor, n);
@@ -380,12 +385,10 @@ private:
       agents.reserve(nlevels);
       slicers.reserve(nlevels);
 
-      // ---- for each case, train child slicers
+      // ---- for each case, create indices
       for (int i = 0; i < nlevels; i++) {
         agents.push_back(map_collect[i].first);
         indices.push_back(MOVE(*map_collect[i].second));
-        slicers.push_back(slicer(indices[i], depth + 1, data, visitors));
-        slicer_size += slicers[i]->size();
       }
 
     }

--- a/tests/testthat/test-empty-groups.R
+++ b/tests/testthat/test-empty-groups.R
@@ -1,11 +1,39 @@
 context("empty groups")
 
-df <- data_frame(f = factor( c(1,1,2,2), levels = 1:3), x = c(1,2,1,4)) %>%
-  group_by(f)
+df <- data_frame(
+  e = 1,
+  f = factor(c(1, 1, 2, 2), levels = 1:3),
+  g = c(1, 1, 2, 2),
+  x = c(1, 2, 1, 4)) %>%
+  group_by(e, f, g)
 
 test_that("filter and slice keep zero length groups", {
   expect_equal( group_size(filter(df, f == 1)), c(2, 0, 0) )
   expect_equal( group_size(slice(df, 1)), c(1, 1, 0) )
+})
+
+test_that("filtering and slicing retains labels for zero length groups", {
+  expect_equal(
+    count(filter(df, f == 1)),
+    tibble(
+      e = 1,
+      f = factor(1:3),
+      g = c(1, NA, NA),
+      n = c(2L, 0L, 0L)
+    ) %>%
+      group_by(e, f)
+
+  )
+  expect_equal(
+    count(slice(df, 1)),
+    tibble(
+      e = 1,
+      f = factor(1:3),
+      g = c(1, 2, NA),
+      n = c(1L, 1L, 0L)
+    ) %>%
+      group_by(e, f)
+  )
 })
 
 test_that("mutate keeps zero length groups", {
@@ -18,13 +46,11 @@ test_that("summarise returns a row for zero length groups", {
 
 test_that("arrange keeps zero length groups",{
   expect_equal( group_size(arrange(df)), c(2, 2, 0) )
+  expect_equal( group_size(arrange(df, x)), c(2, 2, 0) )
 })
 
 test_that("bind_rows respect the drop attribute of grouped df",{
-  df <- data_frame(f = factor( c(1,1,2,2), levels = 1:3), x = c(1,2,1,4))
-  g <- group_by(df, f)
-
-  gg <- bind_rows(g,g)
+  gg <- bind_rows(df, df)
   expect_equal(group_size(gg), c(4L,4L,0L))
 })
 


### PR DESCRIPTION
When reviewing the code I was puzzled why there were calls to `slicer()` in `FactorSlicer::train()` but not in `VectorSlicer::train()`.