### PR TITLE
mutate keeps attributes of the data. closes #3558.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 
 * Faster hybrid `sum()`, `mean()`, `var()` and `sd()` for logical vectors (#3189).
 
+* `mutate()` keeps arbitrary attributes of the data frame (#3558). 
 
 # dplyr 0.7.5.9000 (2018-05-02)
 

--- a/src/mutate.cpp
+++ b/src/mutate.cpp
@@ -21,25 +21,10 @@
 using namespace Rcpp;
 using namespace dplyr;
 
-template <typename Data>
-SEXP structure_mutate(const NamedListAccumulator<Data>& accumulator,
-                      const DataFrame& df,
-                      CharacterVector classes,
-                      bool grouped = true) {
-  List res = accumulator;
+SEXP structure_mutate(List res, const DataFrame& df, CharacterVector classes) {
   set_class(res, classes);
-  set_rownames(res, df.nrows());
-
-  if (grouped) {
-    copy_vars(res, df);
-    res.attr("labels")  = df.attr("labels");
-    res.attr("index")  = df.attr("index");
-    res.attr("indices") = df.attr("indices");
-    res.attr("drop") = df.attr("drop");
-    res.attr("group_sizes") = df.attr("group_sizes");
-    res.attr("biggest_group_size") = df.attr("biggest_group_size");
-  }
-
+  copy_most_attributes(res, df);
+  // set_rownames(res, df.nrows());
   return res;
 }
 
@@ -129,7 +114,7 @@ DataFrame mutate_not_grouped(DataFrame df, const QuosureList& dots) {
     call_proxy.input(name, variable);
     accumulator.set(name, variable);
   }
-  List res = structure_mutate(accumulator, df, classes_not_grouped(), false);
+  List res = structure_mutate(accumulator, df, classes_not_grouped());
 
   return res;
 }

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -798,3 +798,9 @@ test_that("mutate() to UTF-8 column names", {
 
   expect_equal(colnames(df), c("a", "\u5e78"))
 })
+
+test_that("mutate() keeps arbitrary attributes of the data frame (#3558)",{
+  d <- structure(data.frame(a=1:3), foo = "bar") %>%
+    mutate(a = a/2)
+  expect_equal(attr(d, "foo"), "bar")
+})


### PR DESCRIPTION
Not sure we want to open that Pandora's box. Propagating attributes might be more difficult for other verbs. 

Maybe attribute specific handling should be dedicated to a class that inherits from tbl_df or something. 