### PR TITLE
fix first and last when used without argument inside dplyr expression…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 - The grouping metadata of grouped data frame has been reorganized in a single tidy tibble (#3489). 
 - new function `group_data()` to extract the grouping structure (#3489).
 - new function `group_rows()` to get a list of row indices for each group (#3489).
+- `first()` and `last()` hybrid functions fall back to R evaluation when given no arguments (#3589). 
 
 # dplyr 0.7.5.9001
 

--- a/src/hybrid_nth.cpp
+++ b/src/hybrid_nth.cpp
@@ -304,6 +304,10 @@ Result* nth_prototype(SEXP call, const ILazySubsets& subsets, int nargs) {
 }
 
 Result* firstlast_prototype(SEXP call, const ILazySubsets& subsets, int nargs, int pos) {
+  // only accept first(x) and last(x)
+  // otherwise fall back to R evaluation
+  if (Rf_length(call) < 2) return 0;
+
   SEXP tail = CDDR(call);
 
   // replacing `first` or `last` by `dplyr::nth`

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -1228,6 +1228,10 @@ test_that("hybrid evaluation can be disabled locally (#3255)", {
   n_distinct <- function(x) 42
   expect_equal(summarise(tbl, y = n_distinct(x))$y, 42)
   expect_equal(summarise(tbl, y = dplyr::n_distinct(x))$y, 10L)
+})
 
-
+test_that("hybrid first and last fall back to R eval when no argument (#3589)", {
+  res <- mutate(tibble(v1 = 5:6), v2 = 1:4 %>% first(), v3 = 1:4 %>% last())
+  expect_equal(res$v2, rep(1L, 2))
+  expect_equal(res$v3, rep(4L, 2))
 })


### PR DESCRIPTION
…s. closes #3589

This addresses the problem from #3589, until we have something better as part of #3526. 