### PR TITLE
handling of empty or NA in names in select

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Imports:
     Rcpp (>= 0.12.15),
     rlang (>= 0.2.0),
     tibble (>= 1.3.1),
-    tidyselect (>= 0.2.3),
+    tidyselect (>= 0.2.4.9000),
     utils
 Suggests: 
     bit64 (>= 0.9.7),
@@ -60,3 +60,5 @@ Encoding: UTF-8
 LazyData: yes
 Roxygen: list(markdown = TRUE, roclets = c("rd", "namespace", "collate"))
 RoxygenNote: 6.0.1.9000
+Remotes: 
+    tidyverse/tidyselect

--- a/tests/testthat/test-select.r
+++ b/tests/testthat/test-select.r
@@ -134,3 +134,22 @@ test_that("can select() or rename() with strings and character vectors", {
   expect_identical(rename(mtcars, !!!vars), rename(mtcars, foo = cyl, bar = am))
   expect_identical(rename(mtcars, !!vars), rename(mtcars, foo = cyl, bar = am))
 })
+
+test_that("select works on empty names (#3601)", {
+  df <- data.frame(x=1, y=2, z=3)
+  colnames(df) <- c("x","y","")
+  expect_identical(select(df, x)$x, 1)
+
+  colnames(df) <- c("","y","z")
+  expect_identical(select(df, y)$y, 2)
+})
+
+test_that("select works on NA names (#3601)", {
+  skip("to be discussed")
+  df <- data.frame(x=1, y=2, z=3)
+  colnames(df) <- c("x","y",NA)
+  expect_identical(select(df, x)$x, 1)
+
+  colnames(df) <- c(NA,"y","z")
+  expect_identical(select(df, y)$y, 2)
+})


### PR DESCRIPTION
``` r
library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
df <- data.frame(x=1, y=2, z=3)
colnames(df) <- c("x","y","")
select(df, x)
#>   x
#> 1 1

df <- data.frame(x=1, y=2, z=3)
colnames(df) <- c("", "y","z")
select(df, y)
#>   y
#> 1 2
```

Created on 2018-05-28 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).