### PR TITLE
mutate_at quotes the ... closes #3437

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 - joins no longer make lazy grouped data (#3566). 
 - new `nest_join()` function. `nest_join()` creates a list column of the matching rows. `nest_join()` + `tidyr::unnest()` is equivalent to `inner_join`  (#3570). 
 - `last_col()` is re-exported from tidyselect (#3584)
+- `mutate_at()` quotes the `...` (#3437). 
 
 # dplyr 0.7.5.9001
 

--- a/R/funs.R
+++ b/R/funs.R
@@ -62,7 +62,7 @@ as_fun_list <- function(.x, .quo, .env, ...) {
   force(.quo)
 
   # If a fun_list, update args
-  args <- list2(...)
+  args <- exprs(...)
   if (is_fun_list(.x)) {
     if (!is_empty(args)) {
       .x[] <- map(.x, lang_modify, !!!args)


### PR DESCRIPTION
The change is fairly trivial in `as_fun_list`, i.e. using `exprs` instead of `list2`,  but this way we can splice things into `...`. 

This potentially affects other users of `as_fun_list` but not in a way that breaks the tests ... 🙈 

``` r
library(tidyverse)

gear_levels <- c(tri = "3", quad = "4", sex = "6", `NA` = "8")

mtcars %>% 
  mutate_at("gear", parse_factor, levels = gear_levels) %>% 
  mutate_at("gear", fct_recode, !!!gear_levels)
#> Warning: 5 parsing failures.
#> row # A tibble: 5 x 4 col     row   col expected           actual expected   <int> <int> <chr>              <chr>  actual 1    27    NA value in level set 5      row 2    28    NA value in level set 5      col 3    29    NA value in level set 5      expected 4    30    NA value in level set 5      actual 5    31    NA value in level set 5
#>     mpg cyl  disp  hp drat    wt  qsec vs am gear carb
#> 1  21.0   6 160.0 110 3.90 2.620 16.46  0  1 quad    4
#> 2  21.0   6 160.0 110 3.90 2.875 17.02  0  1 quad    4
#> 3  22.8   4 108.0  93 3.85 2.320 18.61  1  1 quad    1
#> 4  21.4   6 258.0 110 3.08 3.215 19.44  1  0  tri    1
#> 5  18.7   8 360.0 175 3.15 3.440 17.02  0  0  tri    2
#> 6  18.1   6 225.0 105 2.76 3.460 20.22  1  0  tri    1
#> 7  14.3   8 360.0 245 3.21 3.570 15.84  0  0  tri    4
#> 8  24.4   4 146.7  62 3.69 3.190 20.00  1  0 quad    2
#> 9  22.8   4 140.8  95 3.92 3.150 22.90  1  0 quad    2
#> 10 19.2   6 167.6 123 3.92 3.440 18.30  1  0 quad    4
#> 11 17.8   6 167.6 123 3.92 3.440 18.90  1  0 quad    4
#> 12 16.4   8 275.8 180 3.07 4.070 17.40  0  0  tri    3
#> 13 17.3   8 275.8 180 3.07 3.730 17.60  0  0  tri    3
#> 14 15.2   8 275.8 180 3.07 3.780 18.00  0  0  tri    3
#> 15 10.4   8 472.0 205 2.93 5.250 17.98  0  0  tri    4
#> 16 10.4   8 460.0 215 3.00 5.424 17.82  0  0  tri    4
#> 17 14.7   8 440.0 230 3.23 5.345 17.42  0  0  tri    4
#> 18 32.4   4  78.7  66 4.08 2.200 19.47  1  1 quad    1
#> 19 30.4   4  75.7  52 4.93 1.615 18.52  1  1 quad    2
#> 20 33.9   4  71.1  65 4.22 1.835 19.90  1  1 quad    1
#> 21 21.5   4 120.1  97 3.70 2.465 20.01  1  0  tri    1
#> 22 15.5   8 318.0 150 2.76 3.520 16.87  0  0  tri    2
#> 23 15.2   8 304.0 150 3.15 3.435 17.30  0  0  tri    2
#> 24 13.3   8 350.0 245 3.73 3.840 15.41  0  0  tri    4
#> 25 19.2   8 400.0 175 3.08 3.845 17.05  0  0  tri    2
#> 26 27.3   4  79.0  66 4.08 1.935 18.90  1  1 quad    1
#> 27 26.0   4 120.3  91 4.43 2.140 16.70  0  1 <NA>    2
#> 28 30.4   4  95.1 113 3.77 1.513 16.90  1  1 <NA>    2
#> 29 15.8   8 351.0 264 4.22 3.170 14.50  0  1 <NA>    4
#> 30 19.7   6 145.0 175 3.62 2.770 15.50  0  1 <NA>    6
#> 31 15.0   8 301.0 335 3.54 3.570 14.60  0  1 <NA>    8
#> 32 21.4   4 121.0 109 4.11 2.780 18.60  1  1 quad    2
```

Created on 2018-05-29 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).