### PR TITLE
mutate( x = some_expression() -> NULL ) removes column x

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@
 - new `nest_join()` function. `nest_join()` creates a list column of the matching rows. `nest_join()` + `tidyr::unnest()` is equivalent to `inner_join`  (#3570). 
 - `last_col()` is re-exported from tidyselect (#3584). 
 - hybrid version of `sum(na.rm = FALSE)` exits early when there are missing values. This considerably improves performance when there are missing values early in the vector (#3288). 
+- `mutate()` removes a column when the expression evaluates to `NULL` for all groups (#2945).
 
 # dplyr 0.7.5.9001
 

--- a/src/mutate.cpp
+++ b/src/mutate.cpp
@@ -82,6 +82,10 @@ DataFrame mutate_grouped(const DataFrame& df, const QuosureList& dots) {
       proxy.set_call(call);
       boost::scoped_ptr<Gatherer> gather(gatherer<Data, Subsets>(proxy, gdf, name));
       variable = gather->collect();
+      if (Rf_isNull(variable)) {
+        accumulator.rm(name);
+        continue;
+      }
     } else if (Rf_length(call) == 1) {
       boost::scoped_ptr<Gatherer> gather(constant_gatherer(call, gdf.nrows(), name));
       variable = gather->collect();


### PR DESCRIPTION
```r
> data_frame(a = 1:3, b=4:6) %>% group_by(a) %>%  mutate( b = identity(NULL))
# A tibble: 3 x 1
# Groups:   a [3]
      a
  <int>
1     1
2     2
3     3
```

When it's not always NULL, it's treated as NA when NA is supported, otherwise as NULL: 

```r
> data_frame(a = 1:3, b=4:6) %>% group_by(a) %>%  mutate( b = if(a==1) NULL else b )
# A tibble: 3 x 2
# Groups:   a [3]
      a     b
  <int> <int>
1     1    NA
2     2     5
3     3     6
> data_frame(a = 1:3, b=4:6) %>% group_by(a) %>%  mutate( b = if(a==1) NULL else list(b) )
# A tibble: 3 x 2
# Groups:   a [3]
      a b        
  <int> <list>   
1     1 <NULL>   
2     2 <int [1]>
3     3 <int [1]>
```

