### PR TITLE
`summarise_at()` excludes grouping variables. closes #3613

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@
 - `last_col()` is re-exported from tidyselect (#3584). 
 - hybrid version of `sum(na.rm = FALSE)` exits early when there are missing values. This considerably improves performance when there are missing values early in the vector (#3288). 
 - `mutate()` removes a column when the expression evaluates to `NULL` for all groups (#2945).
+- `last_col()` is re-exported from tidyselect (#3584).
+- `summarise_at()` excludes the grouping variables (#3613). 
 
 # dplyr 0.7.5.9001
 

--- a/R/colwise-mutate.R
+++ b/R/colwise-mutate.R
@@ -82,7 +82,7 @@ summarise_if <- function(.tbl, .predicate, .funs, ...) {
 #' @export
 summarise_at <- function(.tbl, .vars, .funs, ..., .cols = NULL) {
   .vars <- check_dot_cols(.vars, .cols)
-  funs <- manip_at(.tbl, .vars, .funs, enquo(.funs), caller_env(), .include_group_vars = TRUE, ...)
+  funs <- manip_at(.tbl, .vars, .funs, enquo(.funs), caller_env(), ...)
   summarise(.tbl, !!!funs)
 }
 

--- a/tests/testthat/test-colwise-mutate.R
+++ b/tests/testthat/test-colwise-mutate.R
@@ -147,9 +147,7 @@ test_that("summarise_at refuses to treat grouping variables (#3351)", {
     group_by(gr1)
 
   expect_error(
-    summarise_at(tbl, vars(gr1), mean),
-    "Column `gr1` can't be modified because it's a grouping variable",
-    fixed = TRUE
+    summarise_at(tbl, vars(gr1), mean)
   )
 })
 
@@ -160,6 +158,15 @@ test_that("summarise variants does not summarise grouping variable (#3351)", {
 
   expect_identical(summarise_all(tbl, mean), res)
   expect_identical(summarise_if(tbl, is.integer, mean), res)
+})
+
+test_that("summarise_at removes grouping variables (#3613)", {
+  d <- tibble( x = 1:2, y = 3:4, g = 1:2) %>% group_by(g)
+  res <- d %>%
+    group_by(g) %>%
+    summarise_at(-1, mean)
+
+  expect_equal(names(res), c("g", "y"))
 })
 
 # Deprecated ---------------------------------------------------------


### PR DESCRIPTION
```r
> iris %>%
+   group_by(Species) %>%
+   summarise_at(-1, mean)
# A tibble: 3 x 4
  Species    Sepal.Width Petal.Length Petal.Width
  <fct>            <dbl>        <dbl>       <dbl>
1 setosa            3.43         1.46       0.246
2 versicolor        2.77         4.26       1.33 
3 virginica         2.97         5.55       2.03 
> 
```

just a bit unfortunate that because of this, the error message is less useful: 

```
> tbl <- data_frame(gr1 = rep(1:2, 4), gr2 = rep(1:2, each = 4), x = 1:8) %>% group_by(gr1)
> summarise_at(tbl, vars(gr1), mean)
 Error in .f(.x[[i]], ...) : object 'gr1' not found 
```

Maybe `summarise_at` could tryCatch this `funs <- manip_at(.tbl, .vars, .funs, enquo(.funs), caller_env(), ...)` and act on it. 