### PR TITLE
GroupedDataFrame are compatible with older style grouped_df. 

### DIFF
--- a/src/group_indices.cpp
+++ b/src/group_indices.cpp
@@ -484,8 +484,16 @@ SEXP build_index_cpp(const DataFrame& data, const SymbolVector& vars) {
 
 namespace dplyr {
 
-SEXP check_grouped(SEXP data) {
+SEXP check_grouped(RObject data) {
   static SEXP groups_symbol = Rf_install("groups");
+  static SEXP vars_symbol = Rf_install("vars");
+
+  // compat with old style grouped data frames
+  SEXP vars = Rf_getAttrib(data, vars_symbol);
+  if (!Rf_isNull(vars)) {
+    DataFrame groups = build_index_cpp(data, SymbolVector(vars));
+    data.attr("groups") = groups;
+  }
 
   // get the groups attribute and check for consistency
   SEXP groups = Rf_getAttrib(data, groups_symbol);

--- a/tests/testthat/test-group_data.R
+++ b/tests/testthat/test-group_data.R
@@ -56,3 +56,10 @@ test_that("GroupDataFrame checks the structure of the groups attribute", {
   attr(df, "groups") <- NA
   expect_error(group_data(df), "is a corrupt grouped_df")
 })
+
+test_that("GroupedDataFrame is compatible with older style grouped_df (#3604)", {
+  df <- tibble(x = 1:4, g = rep(1:2, each = 2))
+  attr(df, "vars") <- "g"
+  attr(df, "class") <- c("grouped_df", "tbl_df", "tbl", "data.frame")
+  expect_equal(group_rows(df), list(1:2, 3:4))
+})


### PR DESCRIPTION
```r
> df <- tibble(x = 1:4, g = rep(1:2, each = 2))
>   attr(df, "vars") <- "g"
>   attr(df, "class") <- c("grouped_df", "tbl_df", "tbl", "data.frame")
> group_rows(df)
[[1]]
[1] 1 2

[[2]]
[1] 3 4
```