### PR TITLE
nest_join() handles the case when multiple rows in x match rows in y.…

### DIFF
--- a/src/join_exports.cpp
+++ b/src/join_exports.cpp
@@ -205,20 +205,34 @@ List nest_join_impl(DataFrame x, DataFrame y,
 
   int n_x = x.nrows(), n_y = y.nrows();
 
-  std::vector<int> indices_x;
-  std::vector<int> indices_y;
-
   train_push_back_right(map, n_y);
 
   List list_col(n_x) ;
 
   DataFrameSubsetVisitors y_subset_visitors(y, aux_y);
 
+  // to deal with the case where multiple rows of x match rows in y
+  dplyr_hash_map<int,SEXP> resolved_map(y_subset_visitors.size());
+
   for (int i = 0; i < n_x; i++) {
+
+    // check if the i row of x matches rows in y
     Map::iterator it = map.find(i);
     if (it != map.end()) {
-      std::transform(it->second.begin(), it->second.end(), it->second.begin(), reverse_index);
-      list_col[i] = y_subset_visitors.subset(it->second, Rf_getAttrib(y, R_ClassSymbol));
+
+      // then check if we have already seen that match
+      dplyr_hash_map<int,SEXP>::iterator rit = resolved_map.find(it->first);
+      if (rit == resolved_map.end()) {
+        // first time we see the match, so transform the indices that were collected
+        // so that they are on the 0-based positive space, then subset y
+        std::transform(it->second.begin(), it->second.end(), it->second.begin(), reverse_index);
+        resolved_map[it->first] = list_col[i] = y_subset_visitors.subset(it->second, Rf_getAttrib(y, R_ClassSymbol));
+      } else {
+        // we have seen that match already, just lazy duplicate the tibble that is
+        // stored in the resolved map
+        list_col[i] = Rf_lazy_duplicate(rit->second);
+      }
+
     } else {
       list_col[i] = y_subset_visitors.subset(EmptySubset(), Rf_getAttrib(y, R_ClassSymbol));
     }
@@ -239,7 +253,6 @@ List nest_join_impl(DataFrame x, DataFrame y,
   GroupedDataFrame::copy_groups(out, x) ;
 
   return out;
-
 }
 
 

--- a/tests/testthat/test-joins.r
+++ b/tests/testthat/test-joins.r
@@ -1006,6 +1006,17 @@ test_that("nest_join works (#3570)",{
   expect_identical(res$data[[2]], tibble(z = double()))
 })
 
+test_that("nest_join handles multiple matches in x (#3642)", {
+  df1 <- tibble(x = c(1, 1))
+  df2 <- tibble(x = 1, y = 1:2)
+
+  tbls <- df1 %>%
+    nest_join(df2) %>%
+    pull()
+
+  expect_identical(tbls[[1]], tbls[[2]])
+})
+
 test_that("joins reject data frames with duplicate columns (#3243)", {
   df1 <- data.frame(x1 = 1:3, x2 = 1:3, y = 1:3)
   names(df1)[1:2] <- "x"


### PR DESCRIPTION
```r
>   df1 <- tibble(x = c(1, 1))
>   df2 <- tibble(x = 1, y = 1:2)
> 
>   df1 %>%
+     nest_join(df2) %>%
+     pull()
Joining, by = "x"
[[1]]
# A tibble: 2 x 1
      y
  <int>
1     1
2     2

[[2]]
# A tibble: 2 x 1
      y
  <int>
1     1
2     2
```

