### PR TITLE
arrange.data.frame recognizes the .by_group argument, closes #3546

### DIFF
--- a/R/dataframe.R
+++ b/R/dataframe.R
@@ -98,13 +98,13 @@ mutate_.data.frame <- function(.data, ..., .dots = list()) {
 }
 
 #' @export
-arrange.data.frame <- function(.data, ...) {
-  as.data.frame(arrange(tbl_df(.data), ...))
+arrange.data.frame <- function(.data, ..., .by_group = FALSE) {
+  as.data.frame(arrange(tbl_df(.data), ..., .by_group = .by_group))
 }
 #' @export
-arrange_.data.frame <- function(.data, ..., .dots = list()) {
+arrange_.data.frame <- function(.data, ..., .dots = list(), .by_group = FALSE) {
   dots <- compat_lazy_dots(.dots, caller_env(), ...)
-  arrange(.data, !!!dots)
+  arrange(.data, !!!dots, .by_group = .by_group)
 }
 
 #' @export

--- a/tests/testthat/test-arrange.r
+++ b/tests/testthat/test-arrange.r
@@ -179,6 +179,13 @@ test_that("arrange fails gracefully on data.frame input (#3153)", {
   expect_error(arrange(df, iris), "Argument 1 is of unsupported type data.frame")
 })
 
+test_that("arrange.data.frame recognizes the .by_group argument (#3546)", {
+  df <- data.frame(foo=1:2, bar=2)
+  res <- df %>%
+    arrange(foo, .by_group=TRUE)
+  expect_identical(res, df)
+})
+
 # grouped_df --------------------------------------------------------------
 
 test_that("can choose to include grouping vars", {


### PR DESCRIPTION
```
> df <- data.frame(foo=1:2, bar=2) 
> df %>%                                              
+     arrange(foo, .by_group=TRUE)                                                
  foo bar
1   1   2
2   2   2
```

This replaces #3607