### PR TITLE
Make a few doc sections more explicit

### DIFF
--- a/R/manip.r
+++ b/R/manip.r
@@ -31,7 +31,7 @@
 #'   Multiple conditions are combined with `&`. Only rows where the
 #'   condition evaluates to `TRUE` are kept.
 #'
-#'   These arguments are automatically [quoted][rlang::quo] and
+#'   The arguments in `...` are automatically [quoted][rlang::quo] and
 #'   [evaluated][rlang::eval_tidy] in the context of the data
 #'   frame. They support [unquoting][rlang::quasiquotation] and
 #'   splicing. See `vignette("programming")` for an introduction to
@@ -64,9 +64,9 @@ filter_ <- function(.data, ..., .dots = list(), .preserve = TRUE) {
   UseMethod("filter_")
 }
 
-#' Select rows by position
+#' Choose rows by position
 #'
-#' Select rows by their ordinal position in the tbl.  Grouped tbls use
+#' Choose rows by their ordinal position in the tbl.  Grouped tbls use
 #' the ordinal position within the group.
 #'
 #' Slice does not work with relational databases because they have no
@@ -77,9 +77,10 @@ filter_ <- function(.data, ..., .dots = list(), .preserve = TRUE) {
 #' @param .data A tbl.
 #' @param ... Integer row values.  Provide either positive values to keep,
 #'   or negative values to drop. The values provided must be either all
-#'   positive or all negative.
+#'   positive or all negative.  Indices beyond the number of rows in the
+#'   input are silently ignored.
 #'
-#'   These arguments are automatically [quoted][rlang::quo] and
+#'   The arguments in `...` are automatically [quoted][rlang::quo] and
 #'   [evaluated][rlang::eval_tidy] in the context of the data
 #'   frame. They support [unquoting][rlang::quasiquotation] and
 #'   splicing. See `vignette("programming")` for an introduction to
@@ -121,10 +122,9 @@ slice_ <- function(.data, ..., .dots = list()) {
 
 #' Reduce multiple values down to a single value
 #'
-#' Create one or more scalar variables summarizing the variables of an existing tbl.
-#'
-#' When `summarise()` is used on grouped data created by [group_by()],
-#' the output will have one row for each group.
+#' Create one or more scalar variables summarizing the variables of an
+#' existing tbl. Tbls with groups created by [group_by()] will result in one
+#' row in the output for each group.  Tbls with no groups will result in one row.
 #'
 #' `summarise()` and `summarize()` are synonyms.
 #'
@@ -149,7 +149,7 @@ slice_ <- function(.data, ..., .dots = list()) {
 #'   name of the variable in the result. The value should be an expression
 #'   that returns a single value like `min(x)`, `n()`, or `sum(is.na(y))`.
 #'
-#'   These arguments are automatically [quoted][rlang::quo] and
+#'   The arguments in `...` are automatically [quoted][rlang::quo] and
 #'   [evaluated][rlang::eval_tidy] in the context of the data
 #'   frame. They support [unquoting][rlang::quasiquotation] and
 #'   splicing. See `vignette("programming")` for an introduction to
@@ -209,11 +209,12 @@ summarize_ <- summarise_
 #' Create or transform variables
 #'
 #' `mutate()` adds new variables and preserves existing ones;
-#' `transmute()` adds new variables and drops existing ones.
+#' `transmute()` adds new variables and drops existing ones.  Both
+#' functions preserve the number of rows of the input.
 #'
 #' @section Useful functions available in calculations of variables:
 #'
-#' * [`+`], [`-`], [log()], etc., for their usual arithmetic meanings
+#' * [`+`], [`-`], [log()], etc., for their usual mathematical meanings
 #'
 #' * [lead()], [lag()]
 #'
@@ -237,10 +238,13 @@ summarize_ <- summarise_
 #' @export
 #' @inheritParams filter
 #' @inheritSection filter Tidy data
-#' @param ... Name-value pairs of expressions. Use `NULL` to drop
-#'   a variable in `mutate`.
+#' @param ... Name-value pairs of expressions, each with length 1 or the same
+#'   length as the number of rows in the group (if using [group_by()]) or in the entire
+#'   input (if not using groups). The name of each argument will be the name of
+#'   a new variable, and the value will be its corresponding value.  Use a `NULL`
+#'   value in `mutate` to drop a variable.
 #'
-#'   These arguments are automatically [quoted][rlang::quo] and
+#'   The arguments in `...` are automatically [quoted][rlang::quo] and
 #'   [evaluated][rlang::eval_tidy] in the context of the data
 #'   frame. They support [unquoting][rlang::quasiquotation] and
 #'   splicing. See `vignette("programming")` for an introduction to
@@ -392,13 +396,19 @@ arrange.grouped_df <- function(.data, ..., .by_group = FALSE) {
 
 #' Select/rename variables by name
 #'
-#' Choose variables from a tbl, optionally renaming them.
+#' Choose or rename variables from a tbl.
 #' `select()` keeps only the variables you mention; `rename()`
 #' keeps all variables.
 #'
+#' These functions work by column index, not value; thus, an expression
+#' like `select(data.frame(x = 1:5, y = 10), z = x+1)` does not create a variable
+#' with values `2:6`. (In the current implementation, the expression `z = x+1`
+#' wouldn't do anything useful.)  To calculate using column values, see
+#' [mutate()]/[transmute()].
+#'
 #' @section Useful functions:
 #' As well as using existing functions like `:` and `c()`, there are
-#' a number of special functions that only work inside `select`:
+#' a number of special functions that only work inside `select()`:
 #'
 #' * [starts_with()], [ends_with()], [contains()]
 #' * [matches()]
@@ -430,7 +440,7 @@ arrange.grouped_df <- function(.data, ..., .by_group = FALSE) {
 #'   If the first expression is negative, `select()` will automatically
 #'   start with all variables.
 #'
-#'   Use named arguments, e.g. `new_name=old_name`, to rename selected variables.
+#'   Use named arguments, e.g. `new_name = old_name`, to rename selected variables.
 #'
 #'   The arguments in `...` are automatically [quoted][rlang::quo] and
 #'   [evaluated][rlang::eval_tidy] in a context where column names

--- a/R/manip.r
+++ b/R/manip.r
@@ -1,6 +1,6 @@
 #' Return rows with matching conditions
 #'
-#' Use `filter()` find rows/cases where conditions are true. Unlike
+#' Use `filter()` to choose rows/cases where conditions are true. Unlike
 #' base subsetting with `[`, rows where the condition evaluates to `NA` are
 #' dropped.
 #'
@@ -66,16 +66,18 @@ filter_ <- function(.data, ..., .dots = list(), .preserve = TRUE) {
 
 #' Select rows by position
 #'
+#' Select rows by their ordinal position in the tbl.  Grouped tbls use
+#' the ordinal position within the group.
+#'
 #' Slice does not work with relational databases because they have no
 #' intrinsic notion of row order. If you want to perform the equivalent
 #' operation, use [filter()] and [row_number()].
 #'
-#' Positive values select rows to keep; negative values drop rows. The
-#' values provided must be either all positive or all negative.
-#'
 #' @family single table verbs
 #' @param .data A tbl.
-#' @param ... Integer row values.
+#' @param ... Integer row values.  Provide either positive values to keep,
+#'   or negative values to drop. The values provided must be either all
+#'   positive or all negative.
 #'
 #'   These arguments are automatically [quoted][rlang::quo] and
 #'   [evaluated][rlang::eval_tidy] in the context of the data
@@ -87,6 +89,7 @@ filter_ <- function(.data, ..., .dots = list(), .preserve = TRUE) {
 #' @export
 #' @examples
 #' slice(mtcars, 1L)
+#' # Similar to tail(mtcars, 1):
 #' slice(mtcars, n())
 #' slice(mtcars, 5:n())
 #' # Rows can be dropped with negative indices:
@@ -116,10 +119,14 @@ slice_ <- function(.data, ..., .dots = list()) {
   UseMethod("slice_")
 }
 
-#' Reduces multiple values down to a single value
+#' Reduce multiple values down to a single value
 #'
-#' `summarise()` is typically used on grouped data created by [group_by()].
-#' The output will have one row for each group.
+#' Create one or more scalar variables summarizing the variables of an existing tbl.
+#'
+#' When `summarise()` is used on grouped data created by [group_by()],
+#' the output will have one row for each group.
+#'
+#' `summarise()` and `summarize()` are synonyms.
 #'
 #' @section Useful functions:
 #'
@@ -199,16 +206,14 @@ summarize <- summarise
 summarize_ <- summarise_
 
 
-#' Add new variables
+#' Create or transform variables
 #'
-#' `mutate()` adds new variables and preserves existing;
-#' `transmute()` drops existing variables.
+#' `mutate()` adds new variables and preserves existing ones;
+#' `transmute()` adds new variables and drops existing ones.
 #'
-#' @section Useful functions:
+#' @section Useful functions available in calculations of variables:
 #'
-#' * [`+`], [`-`] etc
-#'
-#' * [log()]
+#' * [`+`], [`-`], [log()], etc., for their usual arithmetic meanings
 #'
 #' * [lead()], [lag()]
 #'
@@ -233,7 +238,7 @@ summarize_ <- summarise_
 #' @inheritParams filter
 #' @inheritSection filter Tidy data
 #' @param ... Name-value pairs of expressions. Use `NULL` to drop
-#'   a variable.
+#'   a variable in `mutate`.
 #'
 #'   These arguments are automatically [quoted][rlang::quo] and
 #'   [evaluated][rlang::eval_tidy] in the context of the data
@@ -335,7 +340,7 @@ transmute_.grouped_df <- function(.data, ..., .dots = list()) {
 
 #' Arrange rows by variables
 #'
-#' Use [desc()] to sort a variable in descending order.
+#' Order tbl rows by an expression involving its variables.
 #'
 #' @section Locales:
 #' The sort order for character vectors will depend on the collating sequence
@@ -344,13 +349,14 @@ transmute_.grouped_df <- function(.data, ..., .dots = list()) {
 #' @export
 #' @inheritParams filter
 #' @inheritSection filter Tidy data
-#' @param ... Comma separated list of unquoted variable names. Use
-#'   [desc()] to sort a variable in descending order.
+#' @param ... Comma separated list of unquoted variable names, or expressions
+#'   involving variable names. Use [desc()] to sort a variable in descending order.
 #' @family single table verbs
 #' @return An object of the same class as `.data`.
 #' @examples
 #' arrange(mtcars, cyl, disp)
 #' arrange(mtcars, desc(disp))
+#' arrange(mtcars, (disp-150)^2)
 #'
 #' # grouped arrange ignores groups
 #' by_cyl <- mtcars %>% group_by(cyl)
@@ -386,12 +392,13 @@ arrange.grouped_df <- function(.data, ..., .by_group = FALSE) {
 
 #' Select/rename variables by name
 #'
+#' Choose variables from a tbl, optionally renaming them.
 #' `select()` keeps only the variables you mention; `rename()`
 #' keeps all variables.
 #'
 #' @section Useful functions:
 #' As well as using existing functions like `:` and `c()`, there are
-#' a number of special functions that only work inside `select`
+#' a number of special functions that only work inside `select`:
 #'
 #' * [starts_with()], [ends_with()], [contains()]
 #' * [matches()]
@@ -416,17 +423,18 @@ arrange.grouped_df <- function(.data, ..., .by_group = FALSE) {
 #' @inheritParams filter
 #' @inheritSection filter Tidy data
 #' @param ... One or more unquoted expressions separated by commas.
-#'   You can treat variable names like they are positions.
+#'   You can treat variable names like they are positions, so you can
+#'   use expressions like `x:y` to select ranges of variables.
 #'
-#'   Positive values select variables; negative values to drop variables.
+#'   Positive values select variables; negative values drop variables.
 #'   If the first expression is negative, `select()` will automatically
 #'   start with all variables.
 #'
-#'   Use named arguments to rename selected variables.
+#'   Use named arguments, e.g. `new_name=old_name`, to rename selected variables.
 #'
-#'   These arguments are automatically [quoted][rlang::quo] and
+#'   The arguments in `...` are automatically [quoted][rlang::quo] and
 #'   [evaluated][rlang::eval_tidy] in a context where column names
-#'   represent column positions. They support
+#'   represent column positions. They also support
 #'   [unquoting][rlang::quasiquotation] and splicing. See
 #'   `vignette("programming")` for an introduction to these concepts.
 #'

--- a/man/arrange.Rd
+++ b/man/arrange.Rd
@@ -13,8 +13,8 @@ arrange(.data, ...)
 \item{.data}{A tbl. All main verbs are S3 generics and provide methods
 for \code{\link[=tbl_df]{tbl_df()}}, \code{\link[dtplyr:tbl_dt]{dtplyr::tbl_dt()}} and \code{\link[dbplyr:tbl_dbi]{dbplyr::tbl_dbi()}}.}
 
-\item{...}{Comma separated list of unquoted variable names. Use
-\code{\link[=desc]{desc()}} to sort a variable in descending order.}
+\item{...}{Comma separated list of unquoted variable names, or expressions
+involving variable names. Use \code{\link[=desc]{desc()}} to sort a variable in descending order.}
 
 \item{.by_group}{If \code{TRUE}, will sort first by grouping variable. Applies to
 grouped data frames only.}
@@ -23,7 +23,7 @@ grouped data frames only.}
 An object of the same class as \code{.data}.
 }
 \description{
-Use \code{\link[=desc]{desc()}} to sort a variable in descending order.
+Order tbl rows by an expression involving its variables.
 }
 \section{Locales}{
 
@@ -40,6 +40,7 @@ convert to an explicit variable with \code{\link[tibble:rownames_to_column]{tibb
 \examples{
 arrange(mtcars, cyl, disp)
 arrange(mtcars, desc(disp))
+arrange(mtcars, (disp-150)^2)
 
 # grouped arrange ignores groups
 by_cyl <- mtcars \%>\% group_by(cyl)

--- a/man/filter.Rd
+++ b/man/filter.Rd
@@ -27,7 +27,7 @@ is preserved, otherwise it is recalculated based on the resulting data.}
 An object of the same class as \code{.data}.
 }
 \description{
-Use \code{filter()} find rows/cases where conditions are true. Unlike
+Use \code{filter()} to choose rows/cases where conditions are true. Unlike
 base subsetting with \code{[}, rows where the condition evaluates to \code{NA} are
 dropped.
 }

--- a/man/mutate.Rd
+++ b/man/mutate.Rd
@@ -3,7 +3,7 @@
 \name{mutate}
 \alias{mutate}
 \alias{transmute}
-\title{Add new variables}
+\title{Create or transform variables}
 \usage{
 mutate(.data, ...)
 
@@ -14,7 +14,7 @@ transmute(.data, ...)
 for \code{\link[=tbl_df]{tbl_df()}}, \code{\link[dtplyr:tbl_dt]{dtplyr::tbl_dt()}} and \code{\link[dbplyr:tbl_dbi]{dbplyr::tbl_dbi()}}.}
 
 \item{...}{Name-value pairs of expressions. Use \code{NULL} to drop
-a variable.
+a variable in \code{mutate}.
 
 These arguments are automatically \link[rlang:quo]{quoted} and
 \link[rlang:eval_tidy]{evaluated} in the context of the data
@@ -26,14 +26,13 @@ these concepts.}
 An object of the same class as \code{.data}.
 }
 \description{
-\code{mutate()} adds new variables and preserves existing;
-\code{transmute()} drops existing variables.
+\code{mutate()} adds new variables and preserves existing ones;
+\code{transmute()} adds new variables and drops existing ones.
 }
-\section{Useful functions}{
+\section{Useful functions available in calculations of variables}{
 
 \itemize{
-\item \code{\link{+}}, \code{\link{-}} etc
-\item \code{\link[=log]{log()}}
+\item \code{\link{+}}, \code{\link{-}}, \code{\link[=log]{log()}}, etc., for their usual arithmetic meanings
 \item \code{\link[=lead]{lead()}}, \code{\link[=lag]{lag()}}
 \item \code{\link[=dense_rank]{dense_rank()}}, \code{\link[=min_rank]{min_rank()}}, \code{\link[=percent_rank]{percent_rank()}}, \code{\link[=row_number]{row_number()}},
 \code{\link[=cume_dist]{cume_dist()}}, \code{\link[=ntile]{ntile()}}

--- a/man/select.Rd
+++ b/man/select.Rd
@@ -14,17 +14,18 @@ rename(.data, ...)
 for \code{\link[=tbl_df]{tbl_df()}}, \code{\link[dtplyr:tbl_dt]{dtplyr::tbl_dt()}} and \code{\link[dbplyr:tbl_dbi]{dbplyr::tbl_dbi()}}.}
 
 \item{...}{One or more unquoted expressions separated by commas.
-You can treat variable names like they are positions.
+You can treat variable names like they are positions, so you can
+use expressions like \code{x:y} to select ranges of variables.
 
-Positive values select variables; negative values to drop variables.
+Positive values select variables; negative values drop variables.
 If the first expression is negative, \code{select()} will automatically
 start with all variables.
 
-Use named arguments to rename selected variables.
+Use named arguments, e.g. \code{new_name=old_name}, to rename selected variables.
 
-These arguments are automatically \link[rlang:quo]{quoted} and
+The arguments in \code{...} are automatically \link[rlang:quo]{quoted} and
 \link[rlang:eval_tidy]{evaluated} in a context where column names
-represent column positions. They support
+represent column positions. They also support
 \link[rlang:quasiquotation]{unquoting} and splicing. See
 \code{vignette("programming")} for an introduction to these concepts.
 
@@ -35,13 +36,14 @@ examples about tidyselect helpers such as \code{starts_with()}, \code{everything
 An object of the same class as \code{.data}.
 }
 \description{
+Choose variables from a tbl, optionally renaming them.
 \code{select()} keeps only the variables you mention; \code{rename()}
 keeps all variables.
 }
 \section{Useful functions}{
 
 As well as using existing functions like \code{:} and \code{c()}, there are
-a number of special functions that only work inside \code{select}
+a number of special functions that only work inside \code{select}:
 \itemize{
 \item \code{\link[=starts_with]{starts_with()}}, \code{\link[=ends_with]{ends_with()}}, \code{\link[=contains]{contains()}}
 \item \code{\link[=matches]{matches()}}

--- a/man/slice.Rd
+++ b/man/slice.Rd
@@ -9,7 +9,9 @@ slice(.data, ...)
 \arguments{
 \item{.data}{A tbl.}
 
-\item{...}{Integer row values.
+\item{...}{Integer row values.  Provide either positive values to keep,
+or negative values to drop. The values provided must be either all
+positive or all negative.
 
 These arguments are automatically \link[rlang:quo]{quoted} and
 \link[rlang:eval_tidy]{evaluated} in the context of the data
@@ -18,13 +20,13 @@ splicing. See \code{vignette("programming")} for an introduction to
 these concepts.}
 }
 \description{
+Select rows by their ordinal position in the tbl.  Grouped tbls use
+the ordinal position within the group.
+}
+\details{
 Slice does not work with relational databases because they have no
 intrinsic notion of row order. If you want to perform the equivalent
 operation, use \code{\link[=filter]{filter()}} and \code{\link[=row_number]{row_number()}}.
-}
-\details{
-Positive values select rows to keep; negative values drop rows. The
-values provided must be either all positive or all negative.
 }
 \section{Tidy data}{
 
@@ -34,6 +36,7 @@ convert to an explicit variable with \code{\link[tibble:rownames_to_column]{tibb
 
 \examples{
 slice(mtcars, 1L)
+# Similar to tail(mtcars, 1):
 slice(mtcars, n())
 slice(mtcars, 5:n())
 # Rows can be dropped with negative indices:

--- a/man/summarise.Rd
+++ b/man/summarise.Rd
@@ -3,7 +3,7 @@
 \name{summarise}
 \alias{summarise}
 \alias{summarize}
-\title{Reduces multiple values down to a single value}
+\title{Reduce multiple values down to a single value}
 \usage{
 summarise(.data, ...)
 
@@ -28,8 +28,13 @@ An object of the same class as \code{.data}. One grouping level will
 be dropped.
 }
 \description{
-\code{summarise()} is typically used on grouped data created by \code{\link[=group_by]{group_by()}}.
-The output will have one row for each group.
+Create one or more scalar variables summarizing the variables of an existing tbl.
+}
+\details{
+When \code{summarise()} is used on grouped data created by \code{\link[=group_by]{group_by()}},
+the output will have one row for each group.
+
+\code{summarise()} and \code{summarize()} are synonyms.
 }
 \section{Useful functions}{
 


### PR DESCRIPTION
In general, if a Description section jumped right into exceptions or special cases without first saying what the function does, I added something briefly describing what the function does.  

The rest of what's here is mostly small clarifications or corrections.