### PR TITLE
count-tally doc - adding rename option

### DIFF
--- a/R/count-tally.R
+++ b/R/count-tally.R
@@ -21,7 +21,7 @@
 #' then the column returned will be `nnn`, and so on.
 #'
 #' There is currently no way to control the output variable name - if you
-#' need to change the default, you'll have to write the [summarise()]
+#' need to change the default, you can call [rename()] afterwards or you'll have to write the [summarise()]
 #' yourself.
 #'
 #' @param x a [tbl()] to tally/count.


### PR DESCRIPTION
Not a typo or grammatical errors, but a suggestion to add to the documentation for add_count/tally.

The current documentation suggests to summarise yourself if you want another variable name than n, but there is an even easier option which is to call dplyr::rename() afterwards. 