### PR TITLE
regression test for handling of utf8 characters in mutate_all

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -112,6 +112,8 @@ To be released as 0.8.0
 
 * grouped data frames support `[, drop = TRUE]` (#3714). 
 
+* `mutate_all()`, `mutate_at()`, `summarise_all()` and `summarise_at()` handle utf-8 names (#2967).
+
 # dplyr 0.7.6
 
 * `exprs()` is no longer exported to avoid conflicts with `Biobase::exprs()`

--- a/tests/testthat/test-colwise-mutate.R
+++ b/tests/testthat/test-colwise-mutate.R
@@ -196,7 +196,7 @@ test_that("specific directions are given for _all() and _at() versions", {
   mutate_each(mtcars, funs(mean), cyl)
 })
 
-test_that("group_by_(at,all) handle utf-8 names (#2967)", {
+test_that("group_by_(at,all) handle utf-8 names (#3829)", {
   withr::with_locale( c(LC_CTYPE = "C"), {
     name <- "\u4e2d"
     tbl <- tibble(a = 1) %>%
@@ -207,7 +207,6 @@ test_that("group_by_(at,all) handle utf-8 names (#2967)", {
 
     res <- group_by_at(tbl, name) %>% groups()
     expect_equal(res[[1]], sym(name))
-
   })
 })
 
@@ -239,6 +238,5 @@ test_that("*_(all,at) handle utf-8 names (#2967)", {
 
     res <- select_at(tbl, name) %>% names()
     expect_equal(res, name)
-
   })
 })

--- a/tests/testthat/test-colwise-mutate.R
+++ b/tests/testthat/test-colwise-mutate.R
@@ -211,12 +211,34 @@ test_that("group_by_(at,all) handle utf-8 names (#2967)", {
   })
 })
 
-test_that("mutate_all handles utf-8 names (#2967)", {
+test_that("*_(all,at) handle utf-8 names (#2967)", {
   withr::with_locale( c(LC_CTYPE = "C"), {
-    res <- tibble(a = 1) %>%
-      setNames("\u4e2d") %>%
+    name <- "\u4e2d"
+    tbl <- tibble(a = 1) %>%
+      setNames(name)
+
+    res <- tbl %>%
       mutate_all(funs(as.character)) %>%
       names()
-    expect_equal(res, "\u4e2d")
+    expect_equal(res, name)
+
+    res <- tbl %>%
+      mutate_at(name, funs(as.character)) %>%
+      names()
+    expect_equal(res, name)
+
+    res <- tbl %>%
+      summarise_all(funs(as.character)) %>%
+      names()
+    expect_equal(res, name)
+
+    res <- tbl %>%
+      summarise_at(name, funs(as.character)) %>%
+      names()
+    expect_equal(res, name)
+
+    res <- select_at(tbl, name) %>% names()
+    expect_equal(res, name)
+
   })
 })

--- a/tests/testthat/test-colwise-mutate.R
+++ b/tests/testthat/test-colwise-mutate.R
@@ -210,3 +210,13 @@ test_that("group_by_(at,all) handle utf-8 names (#2967)", {
 
   })
 })
+
+test_that("mutate_all handles utf-8 names (#2967)", {
+  withr::with_locale( c(LC_CTYPE = "C"), {
+    res <- tibble(a = 1) %>%
+      setNames("\u4e2d") %>%
+      mutate_all(funs(as.character)) %>%
+      names()
+    expect_equal(res, "\u4e2d")
+  })
+})


### PR DESCRIPTION
This just adds this test which now passes: 

```r
test_that("mutate_all handles utf-8 names (#2967)", {
  withr::with_locale( c(LC_CTYPE = "C"), {
    res <- tibble(a = 1) %>%
      setNames("\u4e2d") %>%
      mutate_all(funs(as.character)) %>%
      names()
    expect_equal(res, "\u4e2d")
  })
})
```