### PR TITLE
Avoid initializing context in R

### DIFF
--- a/R/context.R
+++ b/R/context.R
@@ -1,7 +1,4 @@
-
 context_env <- new_environment()
-context_env[[".group_size"]] <- NULL
-context_env[[".group_index"]] <- NULL
 
 from_context <- function(what){
   context_env[[what]] %||% abort(glue("{expr} should only be called in a data context", expr = deparse(sys.call(-1))))


### PR DESCRIPTION
The variable names are called differently in C++, yet it still works. I guess we don't need to initialize at all.