### PR TITLE
Provide a hash function of Rcomplex for Windows

### DIFF
--- a/inst/include/tools/hash.h
+++ b/inst/include/tools/hash.h
@@ -21,6 +21,37 @@
 #endif
 #endif // #ifndef dplyr_hash_set
 
+// FIXME: remove this when Rcpp provides a hash function for Rcomplex
+#if defined(_WIN32)
+#if __cplusplus >= 201103L
+namespace std {
+  template<>
+  struct hash<Rcomplex> {
+    std::size_t operator()(const Rcomplex& cx) const {
+      std::hash<double> hasher;
+      size_t seed = hasher(cx.r);
+      boost::hash_combine(seed, hasher(cx.i));
+      return seed;
+    }
+  };
+}
+#elif defined(HAS_TR1_UNORDERED_SET)
+namespace std {
+  namespace tr1 {
+    template<>
+    struct hash<Rcomplex> {
+      std::size_t operator()(const Rcomplex& cx) const {
+	std::tr1::hash<double> hasher;
+	size_t seed = hasher(cx.r);
+	boost::hash_combine(seed, hasher(cx.i));
+	return seed;
+      }
+    };
+  }
+}
+#endif
+#endif
+
 inline std::size_t hash_value(const Rcomplex& cx) {
   boost::hash<double> hasher;
   size_t seed = hasher(cx.r);


### PR DESCRIPTION
Fixes #3825 

Rcpp doesn't seem to provide a hash function of `Rcomplex`, so we need to define by ourselves for now.

c.f. https://github.com/RcppCore/Rcpp/blob/f3c5a34e06e774532227470b01c63a8f08ce4313/inst/include/Rcpp/sugar/sets.h#L25-L59