### PR TITLE
tidier tidy_text

### DIFF
--- a/R/utils-expr.R
+++ b/R/utils-expr.R
@@ -35,6 +35,8 @@ tidy_text <- function(quo, width = 60L) {
   expr <- quo_get_expr(quo)
   if (is_data_pronoun(expr)) {
     as_string(node_cadr(node_cdr(expr)))
+  } else if (is_symbol(expr)) {
+    as_string(expr)
   } else {
     quo_text(quo, width = width)
   }

--- a/tests/testthat/test-colwise-mutate.R
+++ b/tests/testthat/test-colwise-mutate.R
@@ -195,3 +195,18 @@ test_that("specific directions are given for _all() and _at() versions", {
   mutate_each(mtcars, funs(mean))
   mutate_each(mtcars, funs(mean), cyl)
 })
+
+test_that("group_by_(at,all) handle utf-8 names (#2967)", {
+  withr::with_locale( c(LC_CTYPE = "C"), {
+    name <- "\u4e2d"
+    tbl <- tibble(a = 1) %>%
+      setNames(name)
+
+    res <- group_by_all(tbl) %>% groups()
+    expect_equal(res[[1]], sym(name))
+
+    res <- group_by_at(tbl, name) %>% groups()
+    expect_equal(res[[1]], sym(name))
+
+  })
+})


### PR DESCRIPTION
Skip using quo_text with bare symbols so that we can borrow `rlang::as_string` magic with encoding.

```r
tidy_text <- function(quo, width = 60L) {
  expr <- quo_get_expr(quo)
  if (is_data_pronoun(expr)) {
    as_string(node_cadr(node_cdr(expr)))
  } else if (is_symbol(expr)) {
    as_string(expr)
  } else {
    quo_text(quo, width = width)
  }
}
```

The alternative would be that `rlang::expr_text` handle bare symbols:

```r
expr_text <- function(expr, width = 60L, nlines = Inf) {
  if (is_symbol(expr)) {
    return(as_string(expr))
  }
  str <- deparse(expr, width.cutoff = width)

  if (length(str) > nlines) {
    str <- c(str[seq_len(nlines - 1)], "...")
  }

  paste0(str, collapse = "\n")
}
```

