### PR TITLE
Centralize static Rf_install calls.

### DIFF
--- a/inst/include/dplyr/Collecter.h
+++ b/inst/include/dplyr/Collecter.h
@@ -8,6 +8,8 @@
 #include <tools/vector_class.h>
 #include <tools/collapse.h>
 
+#include <dplyr/symbols.h>
+
 namespace dplyr {
 
 static inline bool inherits_from(SEXP x, const std::set<std::string>& classes) {
@@ -379,7 +381,7 @@ public:
 
 private:
   void update_tz(SEXP v) {
-    RObject v_tz(Rf_getAttrib(v, Rf_install("tzone")));
+    RObject v_tz(Rf_getAttrib(v, symbols().tzone));
     // if the new tz is NULL, keep previous value
     if (v_tz.isNULL()) return;
 
@@ -627,7 +629,7 @@ inline Collecter* collecter(SEXP model, int n) {
   switch (TYPEOF(model)) {
   case INTSXP:
     if (Rf_inherits(model, "POSIXct"))
-      return new POSIXctCollecter(n, Rf_getAttrib(model, Rf_install("tzone")));
+      return new POSIXctCollecter(n, Rf_getAttrib(model, symbols().tzone));
     if (Rf_inherits(model, "factor"))
       return new FactorCollecter(n, model);
     if (Rf_inherits(model, "Date"))
@@ -635,12 +637,12 @@ inline Collecter* collecter(SEXP model, int n) {
     return new Collecter_Impl<INTSXP>(n);
   case REALSXP:
     if (Rf_inherits(model, "POSIXct"))
-      return new POSIXctCollecter(n, Rf_getAttrib(model, Rf_install("tzone")));
+      return new POSIXctCollecter(n, Rf_getAttrib(model, symbols().tzone));
     if (Rf_inherits(model, "difftime"))
       return
         new DifftimeCollecter(
           n,
-          Rcpp::as<std::string>(Rf_getAttrib(model, Rf_install("units"))),
+          Rcpp::as<std::string>(Rf_getAttrib(model, symbols().units)),
           Rf_getAttrib(model, R_ClassSymbol));
     if (Rf_inherits(model, "Date"))
       return new TypedCollecter<REALSXP>(n, get_date_classes());
@@ -694,7 +696,7 @@ inline Collecter* promote_collecter(SEXP model, int n, Collecter* previous) {
     return new Collecter_Impl<INTSXP>(n);
   case REALSXP:
     if (Rf_inherits(model, "POSIXct"))
-      return new POSIXctCollecter(n, Rf_getAttrib(model, Rf_install("tzone")));
+      return new POSIXctCollecter(n, Rf_getAttrib(model, symbols().tzone));
     if (Rf_inherits(model, "Date"))
       return new TypedCollecter<REALSXP>(n, get_date_classes());
     if (Rf_inherits(model, "integer64"))

--- a/inst/include/dplyr/Collecter.h
+++ b/inst/include/dplyr/Collecter.h
@@ -381,7 +381,7 @@ public:
 
 private:
   void update_tz(SEXP v) {
-    RObject v_tz(Rf_getAttrib(v, symbols().tzone));
+    RObject v_tz(Rf_getAttrib(v, symbols::tzone));
     // if the new tz is NULL, keep previous value
     if (v_tz.isNULL()) return;
 
@@ -629,7 +629,7 @@ inline Collecter* collecter(SEXP model, int n) {
   switch (TYPEOF(model)) {
   case INTSXP:
     if (Rf_inherits(model, "POSIXct"))
-      return new POSIXctCollecter(n, Rf_getAttrib(model, symbols().tzone));
+      return new POSIXctCollecter(n, Rf_getAttrib(model, symbols::tzone));
     if (Rf_inherits(model, "factor"))
       return new FactorCollecter(n, model);
     if (Rf_inherits(model, "Date"))
@@ -637,12 +637,12 @@ inline Collecter* collecter(SEXP model, int n) {
     return new Collecter_Impl<INTSXP>(n);
   case REALSXP:
     if (Rf_inherits(model, "POSIXct"))
-      return new POSIXctCollecter(n, Rf_getAttrib(model, symbols().tzone));
+      return new POSIXctCollecter(n, Rf_getAttrib(model, symbols::tzone));
     if (Rf_inherits(model, "difftime"))
       return
         new DifftimeCollecter(
           n,
-          Rcpp::as<std::string>(Rf_getAttrib(model, symbols().units)),
+          Rcpp::as<std::string>(Rf_getAttrib(model, symbols::units)),
           Rf_getAttrib(model, R_ClassSymbol));
     if (Rf_inherits(model, "Date"))
       return new TypedCollecter<REALSXP>(n, get_date_classes());
@@ -696,7 +696,7 @@ inline Collecter* promote_collecter(SEXP model, int n, Collecter* previous) {
     return new Collecter_Impl<INTSXP>(n);
   case REALSXP:
     if (Rf_inherits(model, "POSIXct"))
-      return new POSIXctCollecter(n, Rf_getAttrib(model, symbols().tzone));
+      return new POSIXctCollecter(n, Rf_getAttrib(model, symbols::tzone));
     if (Rf_inherits(model, "Date"))
       return new TypedCollecter<REALSXP>(n, get_date_classes());
     if (Rf_inherits(model, "integer64"))

--- a/inst/include/dplyr/data/DataMask.h
+++ b/inst/include/dplyr/data/DataMask.h
@@ -393,9 +393,6 @@ public:
   // this is why the setup if the environments is lazy,
   // as we might not need them at all
   void rechain(SEXP env) {
-    static SEXP s_dot_env = Rf_install(".env");
-    static SEXP s_dot_data = Rf_install(".data");
-
     if (!active_bindings_ready) {
       // the active bindings have not been used at all
       // so setup the environments ...
@@ -422,7 +419,7 @@ public:
                   );
 
       // install the pronoun
-      Rf_defineVar(s_dot_data, rlang::as_data_pronoun(mask_active), data_mask);
+      Rf_defineVar(symbols().dot_data, rlang::as_data_pronoun(mask_active), data_mask);
 
       active_bindings_ready = true;
     } else {
@@ -438,7 +435,7 @@ public:
 
     // change the parent environment of mask_active
     SET_ENCLOS(mask_active, env);
-    Rf_defineVar(s_dot_env, env, data_mask);
+    Rf_defineVar(symbols().dot_env, env, data_mask);
   }
 
   // get ready to evaluate an R expression for a given group

--- a/inst/include/dplyr/data/DataMask.h
+++ b/inst/include/dplyr/data/DataMask.h
@@ -419,7 +419,7 @@ public:
                   );
 
       // install the pronoun
-      Rf_defineVar(symbols().dot_data, rlang::as_data_pronoun(mask_active), data_mask);
+      Rf_defineVar(symbols::dot_data, rlang::as_data_pronoun(mask_active), data_mask);
 
       active_bindings_ready = true;
     } else {
@@ -435,7 +435,7 @@ public:
 
     // change the parent environment of mask_active
     SET_ENCLOS(mask_active, env);
-    Rf_defineVar(symbols().dot_env, env, data_mask);
+    Rf_defineVar(symbols::dot_env, env, data_mask);
   }
 
   // get ready to evaluate an R expression for a given group

--- a/inst/include/dplyr/hybrid/Expression.h
+++ b/inst/include/dplyr/hybrid/Expression.h
@@ -87,14 +87,14 @@ public:
       // a symbol
       valid = true;
       func = head;
-    } else if (TYPEOF(head) == LANGSXP && Rf_length(head) == 3 && CAR(head) == symbols().double_colon && TYPEOF(CADR(head)) == SYMSXP && TYPEOF(CADDR(head)) == SYMSXP) {
+    } else if (TYPEOF(head) == LANGSXP && Rf_length(head) == 3 && CAR(head) == symbols::double_colon && TYPEOF(CADR(head)) == SYMSXP && TYPEOF(CADDR(head)) == SYMSXP) {
       // a call of the `::` function
       func = CADDR(head);
       package = CADR(head);
 
       // give up on pkg::fun if pkg is not one of dplyr, stats or base
       // because we only hybrid functions from those
-      valid = package == symbols().dplyr || package == symbols().stats || package == symbols().base;
+      valid = package == symbols::dplyr || package == symbols::stats || package == symbols::base;
     }
 
     // the arguments
@@ -238,7 +238,7 @@ public:
     if (is_column_impl(val, column, false)) {
       return true;
     }
-    if (TYPEOF(val) == LANGSXP && Rf_length(val) == 1 && CAR(val) == symbols().desc && is_column_impl(CADR(val), column, true)) {
+    if (TYPEOF(val) == LANGSXP && Rf_length(val) == 1 && CAR(val) == symbols::desc && is_column_impl(CADR(val), column, true)) {
       return true;
     }
     return false;
@@ -263,7 +263,7 @@ private:
       return test_is_column(val, column, desc);
     }
 
-    if (TYPEOF(val) == LANGSXP && Rf_length(val) == 3 && CADR(val) == symbols().dot_data) {
+    if (TYPEOF(val) == LANGSXP && Rf_length(val) == 3 && CADR(val) == symbols::dot_data) {
       SEXP fun = CAR(val);
       SEXP rhs = CADDR(val);
 

--- a/inst/include/dplyr/hybrid/Expression.h
+++ b/inst/include/dplyr/hybrid/Expression.h
@@ -4,6 +4,7 @@
 #include <dplyr/hybrid/Column.h>
 #include <tools/SymbolString.h>
 #include <dplyr/data/DataMask.h>
+#include <dplyr/symbols.h>
 
 namespace dplyr {
 namespace hybrid {
@@ -80,25 +81,20 @@ public:
     data_mask(data_mask_),
     n(0)
   {
-    static SEXP R_DoubleColonSymbol = Rf_install("::");
-    static SEXP s_dplyr = Rf_install("dplyr");
-    static SEXP s_stats = Rf_install("stats");
-    static SEXP s_base  = Rf_install("base");
-
     // the function called, e.g. n, or dplyr::n
     SEXP head = CAR(expr);
     if (TYPEOF(head) == SYMSXP) {
       // a symbol
       valid = true;
       func = head;
-    } else if (TYPEOF(head) == LANGSXP && Rf_length(head) == 3 && CAR(head) == R_DoubleColonSymbol && TYPEOF(CADR(head)) == SYMSXP && TYPEOF(CADDR(head)) == SYMSXP) {
+    } else if (TYPEOF(head) == LANGSXP && Rf_length(head) == 3 && CAR(head) == symbols().double_colon && TYPEOF(CADR(head)) == SYMSXP && TYPEOF(CADDR(head)) == SYMSXP) {
       // a call of the `::` function
       func = CADDR(head);
       package = CADR(head);
 
       // give up on pkg::fun if pkg is not one of dplyr, stats or base
       // because we only hybrid functions from those
-      valid = package == s_dplyr || package == s_stats || package == s_base;
+      valid = package == symbols().dplyr || package == symbols().stats || package == symbols().base;
     }
 
     // the arguments
@@ -242,9 +238,7 @@ public:
     if (is_column_impl(val, column, false)) {
       return true;
     }
-
-    LOG_VERBOSE << "is_column_impl(true)";
-    if (TYPEOF(val) == LANGSXP && Rf_length(val) == 1 && CAR(val) == Rf_install("desc") && is_column_impl(CADR(val), column, true)) {
+    if (TYPEOF(val) == LANGSXP && Rf_length(val) == 1 && CAR(val) == symbols().desc && is_column_impl(CADR(val), column, true)) {
       return true;
     }
     return false;
@@ -269,7 +263,7 @@ private:
       return test_is_column(val, column, desc);
     }
 
-    if (TYPEOF(val) == LANGSXP && Rf_length(val) == 3 && CADR(val) == Rf_install(".data")) {
+    if (TYPEOF(val) == LANGSXP && Rf_length(val) == 3 && CADR(val) == symbols().dot_data) {
       SEXP fun = CAR(val);
       SEXP rhs = CADDR(val);
 

--- a/inst/include/dplyr/hybrid/hybrid.h
+++ b/inst/include/dplyr/hybrid/hybrid.h
@@ -19,41 +19,14 @@
 #include <dplyr/hybrid/vector_result/lead_lag.h>
 #include <dplyr/hybrid/vector_result/in.h>
 
+#include <dplyr/symbols.h>
+
 namespace dplyr {
 namespace hybrid {
 
 template <typename SlicedTibble, typename Operation>
 SEXP hybrid_do(SEXP expr, const SlicedTibble& data, const DataMask<SlicedTibble>& mask, SEXP env, const Operation& op) {
   if (TYPEOF(expr) != LANGSXP) return R_UnboundValue;
-
-  static SEXP s_n = Rf_install("n");
-  static SEXP s_sum = Rf_install("sum");
-  static SEXP s_mean = Rf_install("mean");
-  static SEXP s_var = Rf_install("var");
-  static SEXP s_sd = Rf_install("sd");
-  static SEXP s_n_distinct = Rf_install("n_distinct");
-  static SEXP s_first = Rf_install("first");
-  static SEXP s_last = Rf_install("last");
-  static SEXP s_nth = Rf_install("nth");
-  static SEXP s_group_indices = Rf_install("group_indices");
-  static SEXP s_min = Rf_install("min");
-  static SEXP s_max = Rf_install("max");
-  static SEXP s_row_number = Rf_install("row_number");
-  static SEXP s_ntile = Rf_install("ntile");
-  static SEXP s_min_rank = Rf_install("min_rank");
-  static SEXP s_percent_rank = Rf_install("percent_rank");
-  static SEXP s_dense_rank = Rf_install("dense_rank");
-  static SEXP s_cume_dist = Rf_install("cume_dist");
-  static SEXP s_lead = Rf_install("lead");
-  static SEXP s_lag = Rf_install("lag");
-  static SEXP s_in = Rf_install("%in%");
-
-  static SEXP s_narm = Rf_install("na.rm");
-  static SEXP s_default = Rf_install("default");
-
-  static SEXP s_dplyr = Rf_install("dplyr");
-  static SEXP s_base = Rf_install("base");
-  static SEXP s_stats = Rf_install("stats");
 
   Environment ns_base  = Environment::base_env();
   Environment ns_dplyr = Environment::namespace_env("dplyr");
@@ -63,7 +36,7 @@ SEXP hybrid_do(SEXP expr, const SlicedTibble& data, const DataMask<SlicedTibble>
   if (!expression.is_valid()) return R_UnboundValue;
 
   // functions that take variadic number of arguments
-  if (expression.is_fun(s_n_distinct, s_dplyr, ns_dplyr)) {
+  if (expression.is_fun(symbols().n_distinct, symbols().dplyr, ns_dplyr)) {
     return n_distinct_(data, expression, op);
   }
 
@@ -71,128 +44,128 @@ SEXP hybrid_do(SEXP expr, const SlicedTibble& data, const DataMask<SlicedTibble>
   switch (expression.size()) {
   case 0:
     // n()
-    if (expression.is_fun(s_n, s_dplyr, ns_dplyr)) {
+    if (expression.is_fun(symbols().n, symbols().dplyr, ns_dplyr)) {
       return op(n_(data));
     }
 
     // group_indices()
-    if (expression.is_fun(s_group_indices, s_dplyr, ns_dplyr)) {
+    if (expression.is_fun(symbols().group_indices, symbols().dplyr, ns_dplyr)) {
       return op(group_indices_(data));
     }
 
     // row_number()
-    if (expression.is_fun(s_row_number, s_dplyr, ns_dplyr)) {
+    if (expression.is_fun(symbols().row_number, symbols().dplyr, ns_dplyr)) {
       return op(row_number_(data));
     }
 
     break;
 
   case 1:
-    if (expression.is_fun(s_sum, s_base, ns_base)) {
+    if (expression.is_fun(symbols().sum, symbols().base, ns_base)) {
       // sum( <column> ) and base::sum( <column> )
       Column x;
       if (expression.is_unnamed(0) && expression.is_column(0, x)) {
         return sum_(data, x, /* na.rm = */ false, op);
       }
-    } else if (expression.is_fun(s_mean, s_base, ns_base)) {
+    } else if (expression.is_fun(symbols().mean, symbols().base, ns_base)) {
       // mean( <column> ) and base::mean( <column> )
 
       Column x;
       if (expression.is_unnamed(0) && expression.is_column(0, x)) {
         return mean_(data, x, false, op);
       }
-    } else if (expression.is_fun(s_var, s_stats, ns_stats)) {
+    } else if (expression.is_fun(symbols().var, symbols().stats, ns_stats)) {
       // var( <column> ) and stats::var( <column> )
 
       Column x;
       if (expression.is_unnamed(0) && expression.is_column(0, x)) {
         return var_(data, x, false, op);
       }
-    } else if (expression.is_fun(s_sd, s_stats, ns_stats)) {
+    } else if (expression.is_fun(symbols().sd, symbols().stats, ns_stats)) {
       // sd( <column> ) and stats::sd( <column> )
 
       Column x;
       if (expression.is_unnamed(0) && expression.is_column(0, x)) {
         return sd_(data, x, false, op);
       }
-    } else if (expression.is_fun(s_first, s_dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols().first, symbols().dplyr, ns_dplyr)) {
       // first( <column> )
 
       Column x;
       if (expression.is_unnamed(0) && expression.is_column(0, x)) {
         return first1_(data, x, op);
       }
-    } else if (expression.is_fun(s_last, s_dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols().last, symbols().dplyr, ns_dplyr)) {
       // last( <column> )
 
       Column x;
       if (expression.is_unnamed(0) && expression.is_column(0, x)) {
         return last1_(data, x, op);
       }
-    } else if (expression.is_fun(s_min, s_base, ns_base)) {
+    } else if (expression.is_fun(symbols().min, symbols().base, ns_base)) {
       // min( <column> )
 
       Column x;
       if (expression.is_unnamed(0) && expression.is_column(0, x)) {
         return min_(data, x, false, op);
       }
-    } else if (expression.is_fun(s_max, s_base, ns_base)) {
+    } else if (expression.is_fun(symbols().max, symbols().base, ns_base)) {
       // max( <column> )
 
       Column x;
       if (expression.is_unnamed(0) && expression.is_column(0, x)) {
         return max_(data, x, false, op);
       }
-    } else if (expression.is_fun(s_row_number, s_dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols().row_number, symbols().dplyr, ns_dplyr)) {
       // row_number( <column> )
 
       Column x;
       if (expression.is_unnamed(0) && expression.is_column(0, x)) {
         return row_number_1(data, x, op);
       }
-    } else if (expression.is_fun(s_ntile, s_dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols().ntile, symbols().dplyr, ns_dplyr)) {
       // ntile( n = <int> )
 
       int n;
-      if (expression.is_named(0, s_n) && expression.is_scalar_int(0, n)) {
+      if (expression.is_named(0, symbols().n) && expression.is_scalar_int(0, n)) {
         return op(ntile_1(data, n));
       }
-    } else if (expression.is_fun(s_min_rank, s_dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols().min_rank, symbols().dplyr, ns_dplyr)) {
       // min_rank( <column> )
 
       Column x;
       if (expression.is_unnamed(0) && expression.is_column(0, x)) {
         return min_rank_(data, x, op);
       }
-    } else if (expression.is_fun(s_percent_rank, s_dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols().percent_rank, symbols().dplyr, ns_dplyr)) {
       // percent_rank( <column> )
 
       Column x;
       if (expression.is_unnamed(0) && expression.is_column(0, x)) {
         return percent_rank_(data, x, op);
       }
-    } else if (expression.is_fun(s_dense_rank, s_dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols().dense_rank, symbols().dplyr, ns_dplyr)) {
       // dense_rank( <column> )
 
       Column x;
       if (expression.is_unnamed(0) && expression.is_column(0, x)) {
         return dense_rank_(data, x, op);
       }
-    } else if (expression.is_fun(s_cume_dist, s_dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols().cume_dist, symbols().dplyr, ns_dplyr)) {
       // cume_dist( <column> )
 
       Column x;
       if (expression.is_unnamed(0) && expression.is_column(0, x)) {
         return cume_dist_(data, x, op);
       }
-    } else if (expression.is_fun(s_lead, s_dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols().lead, symbols().dplyr, ns_dplyr)) {
       // lead( <column> )
 
       Column x;
       if (expression.is_unnamed(0) && expression.is_column(0, x)) {
         return lead_1(data, x, 1, op);
       }
-    } else if (expression.is_fun(s_lag, s_dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols().lag, symbols().dplyr, ns_dplyr)) {
       // lag( <column> )
 
       Column x;
@@ -205,29 +178,29 @@ SEXP hybrid_do(SEXP expr, const SlicedTibble& data, const DataMask<SlicedTibble>
     return R_UnboundValue;
 
   case 2:
-    if (expression.is_fun(s_sum, s_base, ns_base)) {
+    if (expression.is_fun(symbols().sum, symbols().base, ns_base)) {
       // sum( <column>, na.rm = <bool> )
       // base::sum( <column>, na.rm = <bool> )
 
       Column x;
       bool test;
       if (expression.is_unnamed(0) && expression.is_column(0, x) &&
-          expression.is_named(1, s_narm) && expression.is_scalar_logical(1, test)
+          expression.is_named(1, symbols().narm) && expression.is_scalar_logical(1, test)
          ) {
         return sum_(data, x, test, op);
       }
-    } else if (expression.is_fun(s_mean, s_base, ns_base)) {
+    } else if (expression.is_fun(symbols().mean, symbols().base, ns_base)) {
       // mean( <column>, na.rm = <bool> )
       // base::mean( <column>, na.rm = <bool> )
       Column x;
       bool test;
 
       if (expression.is_unnamed(0) && expression.is_column(0, x) &&
-          expression.is_named(1, s_narm) && expression.is_scalar_logical(1, test)
+          expression.is_named(1, symbols().narm) && expression.is_scalar_logical(1, test)
          ) {
         return mean_(data, x, test, op);
       }
-    } else if (expression.is_fun(s_var, s_stats, ns_stats)) {
+    } else if (expression.is_fun(symbols().var, symbols().stats, ns_stats)) {
       // var( <column>, na.rm = <bool> )
       // stats::var( <column>, na.rm = <bool> )
 
@@ -236,12 +209,12 @@ SEXP hybrid_do(SEXP expr, const SlicedTibble& data, const DataMask<SlicedTibble>
 
       if (
         expression.is_unnamed(0) && expression.is_column(0, x) &&
-        expression.is_named(1, s_narm) && expression.is_scalar_logical(1, test)
+        expression.is_named(1, symbols().narm) && expression.is_scalar_logical(1, test)
       ) {
         return var_(data, x, test, op);
       }
 
-    } else if (expression.is_fun(s_sd, s_stats, ns_stats)) {
+    } else if (expression.is_fun(symbols().sd, symbols().stats, ns_stats)) {
       // sd( <column>, na.rm = <bool> )
       // stats::sd( <column>, na.rm = <bool> )
 
@@ -250,90 +223,90 @@ SEXP hybrid_do(SEXP expr, const SlicedTibble& data, const DataMask<SlicedTibble>
 
       if (
         expression.is_unnamed(0) && expression.is_column(0, x) &&
-        expression.is_named(1, s_narm) && expression.is_scalar_logical(1, test)
+        expression.is_named(1, symbols().narm) && expression.is_scalar_logical(1, test)
       ) {
         return sd_(data, x, test, op);
       }
 
-    } else if (expression.is_fun(s_first, s_dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols().first, symbols().dplyr, ns_dplyr)) {
       // first( <column>, default = <scalar> )
 
       Column x;
-      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, s_default)) {
+      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols().default_)) {
         return first2_(data, x, /* default = */ expression.value(1), op);
       }
 
-    } else if (expression.is_fun(s_last, s_dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols().last, symbols().dplyr, ns_dplyr)) {
       // last( <column>, default = <scalar> )
 
       Column x;
 
-      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, s_default)) {
+      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols().default_)) {
         return last2_(data, x, /* default = */ expression.value(1), op);
       }
 
-    } else if (expression.is_fun(s_nth, s_dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols().nth, symbols().dplyr, ns_dplyr)) {
       // nth( <column>, n = <int> )
 
       Column x;
       int n;
 
-      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, s_n) && expression.is_scalar_int(1, n)) {
+      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols().n) && expression.is_scalar_int(1, n)) {
         return nth2_(data, x, n, op);
       }
 
-    } else if (expression.is_fun(s_min, s_base, ns_base)) {
+    } else if (expression.is_fun(symbols().min, symbols().base, ns_base)) {
       // min( <column>, na.rm = <bool> )
 
       Column x;
       bool test;
 
-      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, s_narm) && expression.is_scalar_logical(1, test)) {
+      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols().narm) && expression.is_scalar_logical(1, test)) {
         return min_(data, x, /* na.rm = */ test, op);
       }
 
-    } else if (expression.is_fun(s_max, s_base, ns_base)) {
+    } else if (expression.is_fun(symbols().max, symbols().base, ns_base)) {
       // max( <column>, na.rm = <bool> )
 
       Column x;
       bool test;
 
-      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, s_narm) && expression.is_scalar_logical(1, test)) {
+      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols().narm) && expression.is_scalar_logical(1, test)) {
         return max_(data, x, /* na.rm = */ test, op);
       }
 
-    } else if (expression.is_fun(s_ntile, s_dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols().ntile, symbols().dplyr, ns_dplyr)) {
       // ntile( <column>, n = <int> )
 
       Column x;
       int n;
 
-      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, s_n) && expression.is_scalar_int(1, n)) {
+      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols().n) && expression.is_scalar_int(1, n)) {
         return ntile_2(data, x, n, op);
       } else {
         return R_UnboundValue;
       }
-    } else if (expression.is_fun(s_lead, s_dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols().lead, symbols().dplyr, ns_dplyr)) {
       // lead( <column>, n = <int> )
 
       Column x;
       int n;
 
-      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, s_n) && expression.is_scalar_int(1, n) && n >= 0) {
+      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols().n) && expression.is_scalar_int(1, n) && n >= 0) {
         return lead_1(data, x, n, op);
       }
 
-    } else if (expression.is_fun(s_lag, s_dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols().lag, symbols().dplyr, ns_dplyr)) {
       // lag( <column>, n = <int> )
 
       Column x;
       int n;
 
-      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, s_n) && expression.is_scalar_int(1, n) && n >= 0) {
+      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols().n) && expression.is_scalar_int(1, n) && n >= 0) {
         return lag_1(data, x, n, op);
       }
 
-    } else if (expression.is_fun(s_in, s_base, ns_base)) {
+    } else if (expression.is_fun(symbols().in, symbols().base, ns_base)) {
       // <column> %in% <column>
 
       Column lhs;
@@ -351,10 +324,10 @@ SEXP hybrid_do(SEXP expr, const SlicedTibble& data, const DataMask<SlicedTibble>
   case 3:
 
     // nth( <column>, n = <int>, default = <scalar> )
-    if (expression.is_fun(s_nth, s_dplyr, ns_dplyr)) {
+    if (expression.is_fun(symbols().nth, symbols().dplyr, ns_dplyr)) {
       Column x;
       int n;
-      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, s_n) && expression.is_scalar_int(1, n) && expression.is_named(2, s_default)) {
+      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols().n) && expression.is_scalar_int(1, n) && expression.is_named(2, symbols().default_)) {
         return nth3_default(data, x, n, expression.value(2), op);
       }
     }

--- a/inst/include/dplyr/hybrid/hybrid.h
+++ b/inst/include/dplyr/hybrid/hybrid.h
@@ -36,7 +36,7 @@ SEXP hybrid_do(SEXP expr, const SlicedTibble& data, const DataMask<SlicedTibble>
   if (!expression.is_valid()) return R_UnboundValue;
 
   // functions that take variadic number of arguments
-  if (expression.is_fun(symbols().n_distinct, symbols().dplyr, ns_dplyr)) {
+  if (expression.is_fun(symbols::n_distinct, symbols::dplyr, ns_dplyr)) {
     return n_distinct_(data, expression, op);
   }
 
@@ -44,128 +44,128 @@ SEXP hybrid_do(SEXP expr, const SlicedTibble& data, const DataMask<SlicedTibble>
   switch (expression.size()) {
   case 0:
     // n()
-    if (expression.is_fun(symbols().n, symbols().dplyr, ns_dplyr)) {
+    if (expression.is_fun(symbols::n, symbols::dplyr, ns_dplyr)) {
       return op(n_(data));
     }
 
     // group_indices()
-    if (expression.is_fun(symbols().group_indices, symbols().dplyr, ns_dplyr)) {
+    if (expression.is_fun(symbols::group_indices, symbols::dplyr, ns_dplyr)) {
       return op(group_indices_(data));
     }
 
     // row_number()
-    if (expression.is_fun(symbols().row_number, symbols().dplyr, ns_dplyr)) {
+    if (expression.is_fun(symbols::row_number, symbols::dplyr, ns_dplyr)) {
       return op(row_number_(data));
     }
 
     break;
 
   case 1:
-    if (expression.is_fun(symbols().sum, symbols().base, ns_base)) {
+    if (expression.is_fun(symbols::sum, symbols::base, ns_base)) {
       // sum( <column> ) and base::sum( <column> )
       Column x;
       if (expression.is_unnamed(0) && expression.is_column(0, x)) {
         return sum_(data, x, /* na.rm = */ false, op);
       }
-    } else if (expression.is_fun(symbols().mean, symbols().base, ns_base)) {
+    } else if (expression.is_fun(symbols::mean, symbols::base, ns_base)) {
       // mean( <column> ) and base::mean( <column> )
 
       Column x;
       if (expression.is_unnamed(0) && expression.is_column(0, x)) {
         return mean_(data, x, false, op);
       }
-    } else if (expression.is_fun(symbols().var, symbols().stats, ns_stats)) {
+    } else if (expression.is_fun(symbols::var, symbols::stats, ns_stats)) {
       // var( <column> ) and stats::var( <column> )
 
       Column x;
       if (expression.is_unnamed(0) && expression.is_column(0, x)) {
         return var_(data, x, false, op);
       }
-    } else if (expression.is_fun(symbols().sd, symbols().stats, ns_stats)) {
+    } else if (expression.is_fun(symbols::sd, symbols::stats, ns_stats)) {
       // sd( <column> ) and stats::sd( <column> )
 
       Column x;
       if (expression.is_unnamed(0) && expression.is_column(0, x)) {
         return sd_(data, x, false, op);
       }
-    } else if (expression.is_fun(symbols().first, symbols().dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols::first, symbols::dplyr, ns_dplyr)) {
       // first( <column> )
 
       Column x;
       if (expression.is_unnamed(0) && expression.is_column(0, x)) {
         return first1_(data, x, op);
       }
-    } else if (expression.is_fun(symbols().last, symbols().dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols::last, symbols::dplyr, ns_dplyr)) {
       // last( <column> )
 
       Column x;
       if (expression.is_unnamed(0) && expression.is_column(0, x)) {
         return last1_(data, x, op);
       }
-    } else if (expression.is_fun(symbols().min, symbols().base, ns_base)) {
+    } else if (expression.is_fun(symbols::min, symbols::base, ns_base)) {
       // min( <column> )
 
       Column x;
       if (expression.is_unnamed(0) && expression.is_column(0, x)) {
         return min_(data, x, false, op);
       }
-    } else if (expression.is_fun(symbols().max, symbols().base, ns_base)) {
+    } else if (expression.is_fun(symbols::max, symbols::base, ns_base)) {
       // max( <column> )
 
       Column x;
       if (expression.is_unnamed(0) && expression.is_column(0, x)) {
         return max_(data, x, false, op);
       }
-    } else if (expression.is_fun(symbols().row_number, symbols().dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols::row_number, symbols::dplyr, ns_dplyr)) {
       // row_number( <column> )
 
       Column x;
       if (expression.is_unnamed(0) && expression.is_column(0, x)) {
         return row_number_1(data, x, op);
       }
-    } else if (expression.is_fun(symbols().ntile, symbols().dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols::ntile, symbols::dplyr, ns_dplyr)) {
       // ntile( n = <int> )
 
       int n;
-      if (expression.is_named(0, symbols().n) && expression.is_scalar_int(0, n)) {
+      if (expression.is_named(0, symbols::n) && expression.is_scalar_int(0, n)) {
         return op(ntile_1(data, n));
       }
-    } else if (expression.is_fun(symbols().min_rank, symbols().dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols::min_rank, symbols::dplyr, ns_dplyr)) {
       // min_rank( <column> )
 
       Column x;
       if (expression.is_unnamed(0) && expression.is_column(0, x)) {
         return min_rank_(data, x, op);
       }
-    } else if (expression.is_fun(symbols().percent_rank, symbols().dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols::percent_rank, symbols::dplyr, ns_dplyr)) {
       // percent_rank( <column> )
 
       Column x;
       if (expression.is_unnamed(0) && expression.is_column(0, x)) {
         return percent_rank_(data, x, op);
       }
-    } else if (expression.is_fun(symbols().dense_rank, symbols().dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols::dense_rank, symbols::dplyr, ns_dplyr)) {
       // dense_rank( <column> )
 
       Column x;
       if (expression.is_unnamed(0) && expression.is_column(0, x)) {
         return dense_rank_(data, x, op);
       }
-    } else if (expression.is_fun(symbols().cume_dist, symbols().dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols::cume_dist, symbols::dplyr, ns_dplyr)) {
       // cume_dist( <column> )
 
       Column x;
       if (expression.is_unnamed(0) && expression.is_column(0, x)) {
         return cume_dist_(data, x, op);
       }
-    } else if (expression.is_fun(symbols().lead, symbols().dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols::lead, symbols::dplyr, ns_dplyr)) {
       // lead( <column> )
 
       Column x;
       if (expression.is_unnamed(0) && expression.is_column(0, x)) {
         return lead_1(data, x, 1, op);
       }
-    } else if (expression.is_fun(symbols().lag, symbols().dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols::lag, symbols::dplyr, ns_dplyr)) {
       // lag( <column> )
 
       Column x;
@@ -178,29 +178,29 @@ SEXP hybrid_do(SEXP expr, const SlicedTibble& data, const DataMask<SlicedTibble>
     return R_UnboundValue;
 
   case 2:
-    if (expression.is_fun(symbols().sum, symbols().base, ns_base)) {
+    if (expression.is_fun(symbols::sum, symbols::base, ns_base)) {
       // sum( <column>, na.rm = <bool> )
       // base::sum( <column>, na.rm = <bool> )
 
       Column x;
       bool test;
       if (expression.is_unnamed(0) && expression.is_column(0, x) &&
-          expression.is_named(1, symbols().narm) && expression.is_scalar_logical(1, test)
+          expression.is_named(1, symbols::narm) && expression.is_scalar_logical(1, test)
          ) {
         return sum_(data, x, test, op);
       }
-    } else if (expression.is_fun(symbols().mean, symbols().base, ns_base)) {
+    } else if (expression.is_fun(symbols::mean, symbols::base, ns_base)) {
       // mean( <column>, na.rm = <bool> )
       // base::mean( <column>, na.rm = <bool> )
       Column x;
       bool test;
 
       if (expression.is_unnamed(0) && expression.is_column(0, x) &&
-          expression.is_named(1, symbols().narm) && expression.is_scalar_logical(1, test)
+          expression.is_named(1, symbols::narm) && expression.is_scalar_logical(1, test)
          ) {
         return mean_(data, x, test, op);
       }
-    } else if (expression.is_fun(symbols().var, symbols().stats, ns_stats)) {
+    } else if (expression.is_fun(symbols::var, symbols::stats, ns_stats)) {
       // var( <column>, na.rm = <bool> )
       // stats::var( <column>, na.rm = <bool> )
 
@@ -209,12 +209,12 @@ SEXP hybrid_do(SEXP expr, const SlicedTibble& data, const DataMask<SlicedTibble>
 
       if (
         expression.is_unnamed(0) && expression.is_column(0, x) &&
-        expression.is_named(1, symbols().narm) && expression.is_scalar_logical(1, test)
+        expression.is_named(1, symbols::narm) && expression.is_scalar_logical(1, test)
       ) {
         return var_(data, x, test, op);
       }
 
-    } else if (expression.is_fun(symbols().sd, symbols().stats, ns_stats)) {
+    } else if (expression.is_fun(symbols::sd, symbols::stats, ns_stats)) {
       // sd( <column>, na.rm = <bool> )
       // stats::sd( <column>, na.rm = <bool> )
 
@@ -223,90 +223,90 @@ SEXP hybrid_do(SEXP expr, const SlicedTibble& data, const DataMask<SlicedTibble>
 
       if (
         expression.is_unnamed(0) && expression.is_column(0, x) &&
-        expression.is_named(1, symbols().narm) && expression.is_scalar_logical(1, test)
+        expression.is_named(1, symbols::narm) && expression.is_scalar_logical(1, test)
       ) {
         return sd_(data, x, test, op);
       }
 
-    } else if (expression.is_fun(symbols().first, symbols().dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols::first, symbols::dplyr, ns_dplyr)) {
       // first( <column>, default = <scalar> )
 
       Column x;
-      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols().default_)) {
+      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols::default_)) {
         return first2_(data, x, /* default = */ expression.value(1), op);
       }
 
-    } else if (expression.is_fun(symbols().last, symbols().dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols::last, symbols::dplyr, ns_dplyr)) {
       // last( <column>, default = <scalar> )
 
       Column x;
 
-      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols().default_)) {
+      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols::default_)) {
         return last2_(data, x, /* default = */ expression.value(1), op);
       }
 
-    } else if (expression.is_fun(symbols().nth, symbols().dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols::nth, symbols::dplyr, ns_dplyr)) {
       // nth( <column>, n = <int> )
 
       Column x;
       int n;
 
-      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols().n) && expression.is_scalar_int(1, n)) {
+      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols::n) && expression.is_scalar_int(1, n)) {
         return nth2_(data, x, n, op);
       }
 
-    } else if (expression.is_fun(symbols().min, symbols().base, ns_base)) {
+    } else if (expression.is_fun(symbols::min, symbols::base, ns_base)) {
       // min( <column>, na.rm = <bool> )
 
       Column x;
       bool test;
 
-      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols().narm) && expression.is_scalar_logical(1, test)) {
+      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols::narm) && expression.is_scalar_logical(1, test)) {
         return min_(data, x, /* na.rm = */ test, op);
       }
 
-    } else if (expression.is_fun(symbols().max, symbols().base, ns_base)) {
+    } else if (expression.is_fun(symbols::max, symbols::base, ns_base)) {
       // max( <column>, na.rm = <bool> )
 
       Column x;
       bool test;
 
-      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols().narm) && expression.is_scalar_logical(1, test)) {
+      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols::narm) && expression.is_scalar_logical(1, test)) {
         return max_(data, x, /* na.rm = */ test, op);
       }
 
-    } else if (expression.is_fun(symbols().ntile, symbols().dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols::ntile, symbols::dplyr, ns_dplyr)) {
       // ntile( <column>, n = <int> )
 
       Column x;
       int n;
 
-      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols().n) && expression.is_scalar_int(1, n)) {
+      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols::n) && expression.is_scalar_int(1, n)) {
         return ntile_2(data, x, n, op);
       } else {
         return R_UnboundValue;
       }
-    } else if (expression.is_fun(symbols().lead, symbols().dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols::lead, symbols::dplyr, ns_dplyr)) {
       // lead( <column>, n = <int> )
 
       Column x;
       int n;
 
-      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols().n) && expression.is_scalar_int(1, n) && n >= 0) {
+      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols::n) && expression.is_scalar_int(1, n) && n >= 0) {
         return lead_1(data, x, n, op);
       }
 
-    } else if (expression.is_fun(symbols().lag, symbols().dplyr, ns_dplyr)) {
+    } else if (expression.is_fun(symbols::lag, symbols::dplyr, ns_dplyr)) {
       // lag( <column>, n = <int> )
 
       Column x;
       int n;
 
-      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols().n) && expression.is_scalar_int(1, n) && n >= 0) {
+      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols::n) && expression.is_scalar_int(1, n) && n >= 0) {
         return lag_1(data, x, n, op);
       }
 
-    } else if (expression.is_fun(symbols().in, symbols().base, ns_base)) {
+    } else if (expression.is_fun(symbols::in, symbols::base, ns_base)) {
       // <column> %in% <column>
 
       Column lhs;
@@ -324,10 +324,10 @@ SEXP hybrid_do(SEXP expr, const SlicedTibble& data, const DataMask<SlicedTibble>
   case 3:
 
     // nth( <column>, n = <int>, default = <scalar> )
-    if (expression.is_fun(symbols().nth, symbols().dplyr, ns_dplyr)) {
+    if (expression.is_fun(symbols::nth, symbols::dplyr, ns_dplyr)) {
       Column x;
       int n;
-      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols().n) && expression.is_scalar_int(1, n) && expression.is_named(2, symbols().default_)) {
+      if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols::n) && expression.is_scalar_int(1, n) && expression.is_named(2, symbols::default_)) {
         return nth3_default(data, x, n, expression.value(2), op);
       }
     }

--- a/inst/include/dplyr/hybrid/scalar_result/n_distinct.h
+++ b/inst/include/dplyr/hybrid/scalar_result/n_distinct.h
@@ -58,7 +58,7 @@ SEXP n_distinct_(const SlicedTibble& data, const Expression& expression, const O
   for (int i = 0; i < n; i++) {
     Column column;
 
-    if (expression.is_named(i, symbols().narm)) {
+    if (expression.is_named(i, symbols::narm)) {
       bool test ;
       // if we have na.rm= TRUE, or na.rm = FALSE, we can handle it
       if (expression.is_scalar_logical(i, test)) {

--- a/inst/include/dplyr/hybrid/scalar_result/n_distinct.h
+++ b/inst/include/dplyr/hybrid/scalar_result/n_distinct.h
@@ -51,7 +51,6 @@ private:
 
 template <typename SlicedTibble, typename Expression, typename Operation>
 SEXP n_distinct_(const SlicedTibble& data, const Expression& expression, const Operation& op) {
-  SEXP s_narm = Rf_install("na.rm");
   std::vector<SEXP> columns;
   bool narm = false;
 
@@ -59,7 +58,7 @@ SEXP n_distinct_(const SlicedTibble& data, const Expression& expression, const O
   for (int i = 0; i < n; i++) {
     Column column;
 
-    if (expression.is_named(i, s_narm)) {
+    if (expression.is_named(i, symbols().narm)) {
       bool test ;
       // if we have na.rm= TRUE, or na.rm = FALSE, we can handle it
       if (expression.is_scalar_logical(i, test)) {

--- a/inst/include/dplyr/symbols.h
+++ b/inst/include/dplyr/symbols.h
@@ -3,98 +3,50 @@
 
 namespace dplyr {
 
-struct symbols_t {
-  SEXP package;
-  SEXP n;
-  SEXP tzone;
-  SEXP units;
-  SEXP dot_env;
-  SEXP dot_data;
+struct symbols {
+  static SEXP package;
+  static SEXP n;
+  static SEXP tzone;
+  static SEXP units;
+  static SEXP dot_env;
+  static SEXP dot_data;
 
-  SEXP sum;
-  SEXP mean;
-  SEXP var;
-  SEXP sd;
-  SEXP n_distinct;
-  SEXP first;
-  SEXP last;
-  SEXP nth;
-  SEXP group_indices;
-  SEXP min;
-  SEXP max;
-  SEXP row_number;
-  SEXP ntile;
-  SEXP min_rank;
-  SEXP percent_rank;
-  SEXP dense_rank;
-  SEXP cume_dist;
-  SEXP lead;
-  SEXP lag;
-  SEXP in;
+  static SEXP sum;
+  static SEXP mean;
+  static SEXP var;
+  static SEXP sd;
+  static SEXP n_distinct;
+  static SEXP first;
+  static SEXP last;
+  static SEXP nth;
+  static SEXP group_indices;
+  static SEXP min;
+  static SEXP max;
+  static SEXP row_number;
+  static SEXP ntile;
+  static SEXP min_rank;
+  static SEXP percent_rank;
+  static SEXP dense_rank;
+  static SEXP cume_dist;
+  static SEXP lead;
+  static SEXP lag;
+  static SEXP in;
 
-  SEXP narm;
-  SEXP default_;
+  static SEXP narm;
+  static SEXP default_;
 
-  SEXP dplyr;
-  SEXP base;
-  SEXP stats;
+  static SEXP dplyr;
+  static SEXP base;
+  static SEXP stats;
 
-  SEXP desc;
-  SEXP double_colon;
-  SEXP na_rm;
-  SEXP new_env;
-  SEXP comment;
-  SEXP groups;
-  SEXP vars;
-
-  symbols_t() {
-    package = Rf_install("package");
-    n = Rf_install("n");
-    tzone = Rf_install("tzone");
-    units = Rf_install("units");
-    dot_env = Rf_install(".env");
-    dot_data = Rf_install(".data");
-
-    sum = Rf_install("sum");
-    mean = Rf_install("mean");
-    var = Rf_install("var");
-    sd = Rf_install("sd");
-    n_distinct = Rf_install("n_distinct");
-    first = Rf_install("first");
-    last = Rf_install("last");
-    nth = Rf_install("nth");
-    group_indices = Rf_install("group_indices");
-    min = Rf_install("min");
-    max = Rf_install("max");
-    row_number = Rf_install("row_number");
-    ntile = Rf_install("ntile");
-    min_rank = Rf_install("min_rank");
-    percent_rank = Rf_install("percent_rank");
-    dense_rank = Rf_install("dense_rank");
-    cume_dist = Rf_install("cume_dist");
-    lead = Rf_install("lead");
-    lag = Rf_install("lag");
-    in = Rf_install("%in%");
-
-    narm = Rf_install("na.rm");
-    default_ = Rf_install("default");
-
-    dplyr = Rf_install("dplyr");
-    base = Rf_install("base");
-    stats = Rf_install("stats");
-
-    desc = Rf_install("desc");
-    double_colon = Rf_install("::");
-    na_rm = Rf_install("na.rm");
-    new_env = Rf_install("new.env");
-    comment = Rf_install("comment");
-    groups = Rf_install("groups");
-    vars = Rf_install("vars");
-  }
-
+  static SEXP desc;
+  static SEXP double_colon;
+  static SEXP na_rm;
+  static SEXP new_env;
+  static SEXP comment;
+  static SEXP groups;
+  static SEXP vars;
 };
-
-symbols_t& symbols();
 
 }
 

--- a/inst/include/dplyr/symbols.h
+++ b/inst/include/dplyr/symbols.h
@@ -1,0 +1,102 @@
+#ifndef DPLYR_SYMBOLS_H
+#define DPLYR_SYMBOLS_H
+
+namespace dplyr {
+
+struct symbols_t {
+  SEXP package;
+  SEXP n;
+  SEXP tzone;
+  SEXP units;
+  SEXP dot_env;
+  SEXP dot_data;
+
+  SEXP sum;
+  SEXP mean;
+  SEXP var;
+  SEXP sd;
+  SEXP n_distinct;
+  SEXP first;
+  SEXP last;
+  SEXP nth;
+  SEXP group_indices;
+  SEXP min;
+  SEXP max;
+  SEXP row_number;
+  SEXP ntile;
+  SEXP min_rank;
+  SEXP percent_rank;
+  SEXP dense_rank;
+  SEXP cume_dist;
+  SEXP lead;
+  SEXP lag;
+  SEXP in;
+
+  SEXP narm;
+  SEXP default_;
+
+  SEXP dplyr;
+  SEXP base;
+  SEXP stats;
+
+  SEXP desc;
+  SEXP double_colon;
+  SEXP na_rm;
+  SEXP new_env;
+  SEXP comment;
+  SEXP groups;
+  SEXP vars;
+
+  symbols_t() {
+    package = Rf_install("package");
+    n = Rf_install("n");
+    tzone = Rf_install("tzone");
+    units = Rf_install("units");
+    dot_env = Rf_install(".env");
+    dot_data = Rf_install(".data");
+
+    sum = Rf_install("sum");
+    mean = Rf_install("mean");
+    var = Rf_install("var");
+    sd = Rf_install("sd");
+    n_distinct = Rf_install("n_distinct");
+    first = Rf_install("first");
+    last = Rf_install("last");
+    nth = Rf_install("nth");
+    group_indices = Rf_install("group_indices");
+    min = Rf_install("min");
+    max = Rf_install("max");
+    row_number = Rf_install("row_number");
+    ntile = Rf_install("ntile");
+    min_rank = Rf_install("min_rank");
+    percent_rank = Rf_install("percent_rank");
+    dense_rank = Rf_install("dense_rank");
+    cume_dist = Rf_install("cume_dist");
+    lead = Rf_install("lead");
+    lag = Rf_install("lag");
+    in = Rf_install("%in%");
+
+    narm = Rf_install("na.rm");
+    default_ = Rf_install("default");
+
+    dplyr = Rf_install("dplyr");
+    base = Rf_install("base");
+    stats = Rf_install("stats");
+
+    desc = Rf_install("desc");
+    double_colon = Rf_install("::");
+    na_rm = Rf_install("na.rm");
+    new_env = Rf_install("new.env");
+    comment = Rf_install("comment");
+    groups = Rf_install("groups");
+    vars = Rf_install("vars");
+  }
+
+};
+
+symbols_t& symbols();
+
+}
+
+
+#endif

--- a/inst/include/tools/is_lubridate_unsupported.h
+++ b/inst/include/tools/is_lubridate_unsupported.h
@@ -1,13 +1,19 @@
 #ifndef dplyr_tools_is_lubridate_unsupported_h
 #define dplyr_tools_is_lubridate_unsupported_h
 
+#include <dplyr/symbols.h>
+
+namespace dplyr {
+
 inline bool is_lubridate_unsupported(SEXP x) {
   if (!Rf_inherits(x, "Period") && !Rf_inherits(x, "Interval")) return false ;
   SEXP cl = Rf_getAttrib(x, R_ClassSymbol) ;
   if (Rf_isNull(cl)) return false ;
-  SEXP pkg = Rf_getAttrib(cl, Rf_install("package")) ;
+  SEXP pkg = Rf_getAttrib(cl, symbols().package) ;
   if (Rf_isNull(pkg)) return false ;
   return STRING_ELT(pkg, 0) == Rf_mkChar("lubridate");
+}
+
 }
 
 #endif

--- a/inst/include/tools/is_lubridate_unsupported.h
+++ b/inst/include/tools/is_lubridate_unsupported.h
@@ -9,7 +9,7 @@ inline bool is_lubridate_unsupported(SEXP x) {
   if (!Rf_inherits(x, "Period") && !Rf_inherits(x, "Interval")) return false ;
   SEXP cl = Rf_getAttrib(x, R_ClassSymbol) ;
   if (Rf_isNull(cl)) return false ;
-  SEXP pkg = Rf_getAttrib(cl, symbols().package) ;
+  SEXP pkg = Rf_getAttrib(cl, symbols::package) ;
   if (Rf_isNull(pkg)) return false ;
   return STRING_ELT(pkg, 0) == Rf_mkChar("lubridate");
 }

--- a/src/arrange.cpp
+++ b/src/arrange.cpp
@@ -13,6 +13,7 @@
 #include <tools/bad.h>
 
 #include <dplyr/data/DataMask.h>
+#include <dplyr/symbols.h>
 
 using namespace Rcpp;
 using namespace dplyr;
@@ -21,8 +22,6 @@ using namespace dplyr;
 
 template <typename SlicedTibble>
 SEXP arrange_template(const SlicedTibble& gdf, const QuosureList& quosures) {
-  static SEXP symb_desc = Rf_install("desc");
-
   const DataFrame& data = gdf.data();
   if (data.size() == 0 || data.nrows() == 0)
     return data;
@@ -43,7 +42,7 @@ SEXP arrange_template(const SlicedTibble& gdf, const QuosureList& quosures) {
   for (int i = 0; i < nargs; i++) {
     const NamedQuosure& quosure = quosures[i];
     SEXP expr = quosure.expr();
-    bool is_desc = TYPEOF(expr) == LANGSXP && symb_desc == CAR(expr);
+    bool is_desc = TYPEOF(expr) == LANGSXP && symbols().desc == CAR(expr);
     expr = is_desc ? CADR(expr) : expr ;
 
     mask.rechain(quosure.env());

--- a/src/arrange.cpp
+++ b/src/arrange.cpp
@@ -42,7 +42,7 @@ SEXP arrange_template(const SlicedTibble& gdf, const QuosureList& quosures) {
   for (int i = 0; i < nargs; i++) {
     const NamedQuosure& quosure = quosures[i];
     SEXP expr = quosure.expr();
-    bool is_desc = TYPEOF(expr) == LANGSXP && symbols().desc == CAR(expr);
+    bool is_desc = TYPEOF(expr) == LANGSXP && symbols::desc == CAR(expr);
     expr = is_desc ? CADR(expr) : expr ;
 
     mask.rechain(quosure.env());

--- a/src/group_indices.cpp
+++ b/src/group_indices.cpp
@@ -17,6 +17,7 @@
 #include <tools/utils.h>
 
 #include <dplyr/hybrid/scalar_result/n.h>
+#include <dplyr/symbols.h>
 
 using namespace Rcpp;
 using namespace dplyr;
@@ -485,18 +486,16 @@ SEXP build_index_cpp(const DataFrame& data, const SymbolVector& vars) {
 namespace dplyr {
 
 SEXP check_grouped(RObject data) {
-  static SEXP groups_symbol = Rf_install("groups");
-  static SEXP vars_symbol = Rf_install("vars");
-
   // compat with old style grouped data frames
-  SEXP vars = Rf_getAttrib(data, vars_symbol);
+  SEXP vars = Rf_getAttrib(data, symbols().vars);
+
   if (!Rf_isNull(vars)) {
     DataFrame groups = build_index_cpp(data, SymbolVector(vars));
     data.attr("groups") = groups;
   }
 
   // get the groups attribute and check for consistency
-  SEXP groups = Rf_getAttrib(data, groups_symbol);
+  SEXP groups = Rf_getAttrib(data, symbols().groups);
 
   // groups must be a data frame
   if (!is<DataFrame>(groups)) {
@@ -548,8 +547,7 @@ GroupedDataFrame::GroupedDataFrame(DataFrame x, const GroupedDataFrame& model):
 SymbolVector GroupedDataFrame::group_vars(SEXP x) {
   check_grouped(x);
 
-  static SEXP groups_symbol = Rf_install("groups");
-  SEXP groups = Rf_getAttrib(x, groups_symbol);
+  SEXP groups = Rf_getAttrib(x, dplyr::symbols().groups);
 
   int n = Rf_length(groups) - 1;
   CharacterVector vars = Rf_getAttrib(groups, R_NamesSymbol);

--- a/src/group_indices.cpp
+++ b/src/group_indices.cpp
@@ -487,7 +487,7 @@ namespace dplyr {
 
 SEXP check_grouped(RObject data) {
   // compat with old style grouped data frames
-  SEXP vars = Rf_getAttrib(data, symbols().vars);
+  SEXP vars = Rf_getAttrib(data, symbols::vars);
 
   if (!Rf_isNull(vars)) {
     DataFrame groups = build_index_cpp(data, SymbolVector(vars));
@@ -495,7 +495,7 @@ SEXP check_grouped(RObject data) {
   }
 
   // get the groups attribute and check for consistency
-  SEXP groups = Rf_getAttrib(data, symbols().groups);
+  SEXP groups = Rf_getAttrib(data, symbols::groups);
 
   // groups must be a data frame
   if (!is<DataFrame>(groups)) {
@@ -547,7 +547,7 @@ GroupedDataFrame::GroupedDataFrame(DataFrame x, const GroupedDataFrame& model):
 SymbolVector GroupedDataFrame::group_vars(SEXP x) {
   check_grouped(x);
 
-  SEXP groups = Rf_getAttrib(x, dplyr::symbols().groups);
+  SEXP groups = Rf_getAttrib(x, dplyr::symbols::groups);
 
   int n = Rf_length(groups) - 1;
   CharacterVector vars = Rf_getAttrib(groups, R_NamesSymbol);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2,6 +2,7 @@
 #include <dplyr/main.h>
 
 #include <dplyr/registration.h>
+#include <dplyr/symbols.h>
 
 using namespace Rcpp;
 
@@ -30,4 +31,11 @@ SEXP get_date_classes() {
 // [[Rcpp::export]]
 SEXP get_time_classes() {
   return VECTOR_ELT(get_cache(), 1);
+}
+
+namespace dplyr {
+symbols_t& symbols() {
+  static symbols_t dplyr_symbols;
+  return dplyr_symbols;
+}
 }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -34,8 +34,48 @@ SEXP get_time_classes() {
 }
 
 namespace dplyr {
-symbols_t& symbols() {
-  static symbols_t dplyr_symbols;
-  return dplyr_symbols;
-}
+
+SEXP symbols::package = Rf_install("package");
+SEXP symbols::n = Rf_install("n");
+SEXP symbols::tzone = Rf_install("tzone");
+SEXP symbols::units = Rf_install("units");
+SEXP symbols::dot_env = Rf_install(".env");
+SEXP symbols::dot_data = Rf_install(".data");
+
+SEXP symbols::sum = Rf_install("sum");
+SEXP symbols::mean = Rf_install("mean");
+SEXP symbols::var = Rf_install("var");
+SEXP symbols::sd = Rf_install("sd");
+SEXP symbols::n_distinct = Rf_install("n_distinct");
+SEXP symbols::first = Rf_install("first");
+SEXP symbols::last = Rf_install("last");
+SEXP symbols::nth = Rf_install("nth");
+SEXP symbols::group_indices = Rf_install("group_indices");
+SEXP symbols::min = Rf_install("min");
+SEXP symbols::max = Rf_install("max");
+SEXP symbols::row_number = Rf_install("row_number");
+SEXP symbols::ntile = Rf_install("ntile");
+SEXP symbols::min_rank = Rf_install("min_rank");
+SEXP symbols::percent_rank = Rf_install("percent_rank");
+SEXP symbols::dense_rank = Rf_install("dense_rank");
+SEXP symbols::cume_dist = Rf_install("cume_dist");
+SEXP symbols::lead = Rf_install("lead");
+SEXP symbols::lag = Rf_install("lag");
+SEXP symbols::in = Rf_install("%in%");
+
+SEXP symbols::narm = Rf_install("na.rm");
+SEXP symbols::default_ = Rf_install("default");
+
+SEXP symbols::dplyr = Rf_install("dplyr");
+SEXP symbols::base = Rf_install("base");
+SEXP symbols::stats = Rf_install("stats");
+
+SEXP symbols::desc = Rf_install("desc");
+SEXP symbols::double_colon = Rf_install("::");
+SEXP symbols::na_rm = Rf_install("na.rm");
+SEXP symbols::new_env = Rf_install("new.env");
+SEXP symbols::comment = Rf_install("comment");
+SEXP symbols::groups = Rf_install("groups");
+SEXP symbols::vars = Rf_install("vars");
+
 }

--- a/src/join.cpp
+++ b/src/join.cpp
@@ -5,6 +5,7 @@
 #include <tools/SymbolString.h>
 
 #include <dplyr/visitors/join/JoinVisitorImpl.h>
+#include <dplyr/symbols.h>
 
 namespace dplyr {
 
@@ -14,7 +15,7 @@ inline bool is_bare_vector(SEXP x) {
   // only allow R_Names. as in R's do_isvector
   while (att != R_NilValue) {
     SEXP tag = TAG(att);
-    if (!(tag == R_NamesSymbol || tag == Rf_install("comment"))) return false;
+    if (!(tag == R_NamesSymbol || tag == symbols().comment)) return false;
     att = CDR(att);
   }
 

--- a/src/join.cpp
+++ b/src/join.cpp
@@ -15,7 +15,7 @@ inline bool is_bare_vector(SEXP x) {
   // only allow R_Names. as in R's do_isvector
   while (att != R_NilValue) {
     SEXP tag = TAG(att);
-    if (!(tag == R_NamesSymbol || tag == symbols().comment)) return false;
+    if (!(tag == R_NamesSymbol || tag == symbols::comment)) return false;
     att = CDR(att);
   }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -6,12 +6,12 @@
 #include <tools/collapse.h>
 #include <tools/bad.h>
 #include <dplyr/data/GroupedDataFrame.h>
+#include <dplyr/symbols.h>
 
 using namespace Rcpp;
 
 SEXP child_env(SEXP parent) {
-  static SEXP s_new_env = Rf_install("new.env");
-  return Rf_eval(Rf_lang3(s_new_env, Rf_ScalarLogical(TRUE), parent), R_BaseEnv);
+  return Rf_eval(Rf_lang3(symbols().new_env, Rf_ScalarLogical(TRUE), parent), R_BaseEnv);
 }
 
 // [[Rcpp::export]]
@@ -164,8 +164,7 @@ std::string get_single_class(SEXP x) {
   }
 
   // just call R to deal with other cases
-  // we could call R_data_class directly but we might get a "this is not part of the api"
-  RObject class_call(Rf_lang2(Rf_install("class"), x));
+  RObject class_call(Rf_lang2(R_ClassSymbol, x));
   klass = Rf_eval(class_call, R_GlobalEnv);
   return CHAR(STRING_ELT(klass, 0));
 }
@@ -325,7 +324,7 @@ bool is_data_pronoun(SEXP expr) {
     return false;
 
   SEXP first = CADR(expr);
-  if (first != Rf_install(".data"))
+  if (first != symbols().dot_data)
     return false;
 
   SEXP second = CADDR(expr);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -11,7 +11,7 @@
 using namespace Rcpp;
 
 SEXP child_env(SEXP parent) {
-  return Rf_eval(Rf_lang3(symbols().new_env, Rf_ScalarLogical(TRUE), parent), R_BaseEnv);
+  return Rf_eval(Rf_lang3(symbols::new_env, Rf_ScalarLogical(TRUE), parent), R_BaseEnv);
 }
 
 // [[Rcpp::export]]
@@ -324,7 +324,7 @@ bool is_data_pronoun(SEXP expr) {
     return false;
 
   SEXP first = CADR(expr);
-  if (first != symbols().dot_data)
+  if (first != symbols::dot_data)
     return false;
 
   SEXP second = CADDR(expr);


### PR DESCRIPTION
So that symbols that are statically used, e.g. `Rf_install("n")` are initialized only once, and we get top them by `symbols().n`

I tried to rather have the syntax `symbols::n` but could not get it to work. 
