### PR TITLE
use of no_init

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,4 +60,6 @@ LazyData: yes
 Roxygen: list(markdown = TRUE, roclets = c("rd", "namespace", "collate"))
 RoxygenNote: 6.1.0.9000
 Remotes:
-    tidyverse/rlang
+    tidyverse/rlang, 
+    RcppCode/Rcpp
+

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     methods,
     pkgconfig (>= 2.0.1),
     R6 (>= 2.2.2),
-    Rcpp (>= 0.12.18),
+    Rcpp (>= 0.12.19.1),
     rlang (>= 0.2.2),
     tibble (>= 1.3.1),
     tidyselect (>= 0.2.3),
@@ -53,7 +53,7 @@ Suggests:
 LinkingTo: 
     BH (>= 1.58.0-1),
     plogr (>= 0.1.10),
-    Rcpp (>= 0.12.18)
+    Rcpp (>= 0.12.19.1)
 VignetteBuilder: knitr
 Encoding: UTF-8
 LazyData: yes

--- a/inst/include/dplyr/visitors/subset/column_subset.h
+++ b/inst/include/dplyr/visitors/subset/column_subset.h
@@ -67,8 +67,7 @@ template <int RTYPE, typename Index>
 SEXP column_subset_matrix_impl(const Rcpp::Matrix<RTYPE>& x, const Index& index, Rcpp::traits::true_type) {
   int n = index.size();
   int nc = x.ncol();
-  Shield<SEXP> mat(Rf_allocMatrix(RTYPE, n, nc));
-  Rcpp::Matrix<RTYPE> res(mat);
+  Rcpp::Matrix<RTYPE> res(no_init(n, nc));
   for (int i = 0; i < n; i++) {
     if (index[i] >= 0) {
       res.row(i) = x.row(index[i]);
@@ -84,8 +83,7 @@ template <int RTYPE, typename Index>
 SEXP column_subset_matrix_impl(const Rcpp::Matrix<RTYPE>& x, const Index& index, Rcpp::traits::false_type) {
   int n = index.size();
   int nc = x.ncol();
-  Shield<SEXP> mat(Rf_allocMatrix(RTYPE, n, nc));
-  Rcpp::Matrix<RTYPE> res(mat);
+  Rcpp::Matrix<RTYPE> res(no_init(n, nc));
   for (int i = 0; i < n; i++) {
     res.row(i) = x.row(index[i]);
   }

--- a/inst/include/dplyr/visitors/subset/column_subset.h
+++ b/inst/include/dplyr/visitors/subset/column_subset.h
@@ -67,7 +67,8 @@ template <int RTYPE, typename Index>
 SEXP column_subset_matrix_impl(const Rcpp::Matrix<RTYPE>& x, const Index& index, Rcpp::traits::true_type) {
   int n = index.size();
   int nc = x.ncol();
-  Rcpp::Matrix<RTYPE> res = no_init(n, nc);
+  Shield<SEXP> mat(Rf_allocMatrix(RTYPE, n, nc));
+  Rcpp::Matrix<RTYPE> res(mat);
   for (int i = 0; i < n; i++) {
     if (index[i] >= 0) {
       res.row(i) = x.row(index[i]);
@@ -83,7 +84,8 @@ template <int RTYPE, typename Index>
 SEXP column_subset_matrix_impl(const Rcpp::Matrix<RTYPE>& x, const Index& index, Rcpp::traits::false_type) {
   int n = index.size();
   int nc = x.ncol();
-  Rcpp::Matrix<RTYPE> res = no_init(n, nc);
+  Shield<SEXP> mat(Rf_allocMatrix(RTYPE, n, nc));
+  Rcpp::Matrix<RTYPE> res(mat);
   for (int i = 0; i < n; i++) {
     res.row(i) = x.row(index[i]);
   }

--- a/src/summarise.cpp
+++ b/src/summarise.cpp
@@ -41,7 +41,7 @@ public:
 
   virtual SEXP extract(const std::vector<IntegerVector>& new_indices) {
     int n = new_indices.size();
-    Vec out = no_init(n);
+    Vec out(no_init(n));
     copy_most_attributes(out, origin);
     for (int i = 0; i < n; i++) {
       int new_index = new_indices[i][0];


### PR DESCRIPTION
This does not work: 

```cpp
Rcpp::Matrix<RTYPE> res(no_init(n, nc));
```

and gives: 

```cpp
In file included from arrange.cpp:1:
In file included from ./pch.h:1:
In file included from /Library/Frameworks/R.framework/Versions/3.5/Resources/library/Rcpp/include/Rcpp.h:40:
In file included from /Library/Frameworks/R.framework/Versions/3.5/Resources/library/Rcpp/include/Rcpp/Vector.h:58:
/Library/Frameworks/R.framework/Versions/3.5/Resources/library/Rcpp/include/Rcpp/vector/Matrix.h:93:18: error: call to non-static member function without an object argument
        Storage::set__( Rf_allocMatrix( RTYPE, obj.nrow(), obj.ncol() ) );
        ~~~~~~~~~^~~~~
../inst/include/dplyr/visitors/subset/column_subset.h:71:23: note: in instantiation of member function 'Rcpp::Matrix<13, PreserveStorage>::Matrix' requested here
  Rcpp::Matrix<RTYPE> res(no_init(n, nc));
```

This line https://github.com/RcppCore/Rcpp/blob/master/inst/include/Rcpp/vector/Matrix.h#L93 should use `VECTOR::set__` instead. 

