### PR TITLE
- old debugging function `gp`

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -17,10 +17,6 @@ strings_addresses <- function(s) {
     .Call(`_dplyr_strings_addresses`, s)
 }
 
-gp <- function(x) {
-    .Call(`_dplyr_gp`, x)
-}
-
 #' Enable internal logging
 #'
 #' Log entries, depending on the log level, will be printed to the standard

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -53,17 +53,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// gp
-unsigned short gp(SEXP x);
-RcppExport SEXP _dplyr_gp(SEXP xSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< SEXP >::type x(xSEXP);
-    rcpp_result_gen = Rcpp::wrap(gp(x));
-    return rcpp_result_gen;
-END_RCPP
-}
 // init_logging
 void init_logging(const std::string& log_level);
 RcppExport SEXP _dplyr_init_logging(SEXP log_levelSEXP) {
@@ -730,7 +719,6 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dplyr_dfloc", (DL_FUNC) &_dplyr_dfloc, 1},
     {"_dplyr_plfloc", (DL_FUNC) &_dplyr_plfloc, 1},
     {"_dplyr_strings_addresses", (DL_FUNC) &_dplyr_strings_addresses, 1},
-    {"_dplyr_gp", (DL_FUNC) &_dplyr_gp, 1},
     {"_dplyr_init_logging", (DL_FUNC) &_dplyr_init_logging, 1},
     {"_dplyr_arrange_impl", (DL_FUNC) &_dplyr_arrange_impl, 2},
     {"_dplyr_between", (DL_FUNC) &_dplyr_between, 3},

--- a/src/address.cpp
+++ b/src/address.cpp
@@ -61,15 +61,6 @@ CharacterVector strings_addresses(CharacterVector s) {
   return res;
 }
 
-// simple internal debugging function to access the gp part of the SEXP
-// only meant for internal use in dplyr debugging
-
-// [[Rcpp::export]]
-unsigned short gp(SEXP x) {
-  return reinterpret_cast<sxpinfo_struct*>(x)->gp;
-}
-
-
 //' Enable internal logging
 //'
 //' Log entries, depending on the log level, will be printed to the standard

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -555,16 +555,10 @@ test_that("summarise handles list output columns (#832)", {
   res <- df %>% group_by(g) %>% summarise(y = list(x))
   expect_equal(res$y[[1]], 1:5)
   expect_equal(res$y[[2]], 6:10)
-  # just checking objects are not messed up internally
-  expect_equal(gp(res$y[[1]]), 0L)
-  expect_equal(gp(res$y[[2]]), 0L)
 
   res <- df %>% group_by(g) %>% summarise(y = list(x + 1))
   expect_equal(res$y[[1]], 1:5 + 1)
   expect_equal(res$y[[2]], 6:10 + 1)
-  # just checking objects are not messed up internally
-  expect_equal(gp(res$y[[1]]), 0L)
-  expect_equal(gp(res$y[[2]]), 0L)
 
   df <- data_frame(x = 1:10, g = rep(1:2, each = 5))
   res <- df %>% summarise(y = list(x))


### PR DESCRIPTION
This was needed when we used the Shinkrable vectors thing. We no longer do, and this is causing issues on #3853. closes #3853.