### PR TITLE
+ virtual destructor to SlicingIndex

### DIFF
--- a/inst/include/tools/SlicingIndex.h
+++ b/inst/include/tools/SlicingIndex.h
@@ -6,6 +6,7 @@
 // Important special cases can be implemented without materializing the map.
 class SlicingIndex {
 public:
+  virtual ~SlicingIndex(){};
   virtual int size() const = 0;
   virtual int operator[](int i) const = 0;
   virtual int group() const = 0;


### PR DESCRIPTION
Although part of the work on the hybrid refactor got rid of the need of the base class `SlicingIndex` because the index class is directly used as a template parameter. But there are still some places taking a `const SlicingIndex&` (Collecter and bind). 