### PR TITLE
Bug/3868 first last nth

### DIFF
--- a/inst/include/dplyr/hybrid/scalar_result/first_last.h
+++ b/inst/include/dplyr/hybrid/scalar_result/first_last.h
@@ -35,9 +35,9 @@ public:
     if (n == 0) return def ;
 
     if (pos > 0 && pos <= n) {
-      return column[pos - 1];
+      return column[indices[pos - 1]];
     } else if (pos < 0 && pos >= -n) {
-      return column[n + pos];
+      return column[indices[n + pos]];
     }
 
     return def;

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -604,3 +604,21 @@ test_that("verbs can nest with well defined behavior (#2080)", {
   expect_equal(res$n1, res$n4)
   expect_equal(res$n1, res$n5)
 })
+
+test_that("hybrid first, last and nth operate within groups (#3868)", {
+  first_ <- function(x) x[1]
+  last_  <- function(x) tail(x, 1L)
+  nth_   <- function(x, n) x[n]
+  expect_identical(
+    iris %>% group_by(Species) %>% summarise(Sepal.Length = first(Sepal.Length)),
+    iris %>% group_by(Species) %>% summarise(Sepal.Length = first_(Sepal.Length))
+  )
+  expect_identical(
+    iris %>% group_by(Species) %>% summarise(Sepal.Length = last(Sepal.Length)),
+    iris %>% group_by(Species) %>% summarise(Sepal.Length = last_(Sepal.Length))
+  )
+  expect_identical(
+    iris %>% group_by(Species) %>% summarise(Sepal.Length = nth(Sepal.Length, n = 2L)),
+    iris %>% group_by(Species) %>% summarise(Sepal.Length = nth_(Sepal.Length, n = 2L))
+  )
+})


### PR DESCRIPTION
```
> iris %>%
+   group_by(Species) %>%
+   summarise(Sepal.Length = first(Sepal.Length))
# A tibble: 3 x 2
  Species    Sepal.Length
  <fct>             <dbl>
1 setosa              5.1
2 versicolor          7  
3 virginica           6.3
> 
> iris %>%
+   group_by(Species) %>%
+   summarise(Sepal.Length = last(Sepal.Length))
# A tibble: 3 x 2
  Species    Sepal.Length
  <fct>             <dbl>
1 setosa              5  
2 versicolor          5.7
3 virginica           5.9
```