### PR TITLE
Feature/3888 rlang lambda

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     pkgconfig (>= 2.0.1),
     R6 (>= 2.2.2),
     Rcpp (>= 0.12.19.1),
-    rlang (>= 0.2.2.9002),
+    rlang (>= 0.2.2.9004),
     tibble (>= 1.3.1),
     tidyselect (>= 0.2.3),
     utils

--- a/inst/include/dplyr/hybrid/Expression.h
+++ b/inst/include/dplyr/hybrid/Expression.h
@@ -99,17 +99,24 @@ public:
     package(R_NilValue),
     data_mask(data_mask_),
     n(0),
-    id(NOMATCH)
+    id(NOMATCH),
+    dot_alias(R_NilValue)
   {
     // the function called, e.g. n, or dplyr::n
     SEXP head = CAR(expr);
+
     if (TYPEOF(head) == SYMSXP) {
       // the head is a symbol, so we lookup what it resolves to
       // then match that against the hash map
       FindFunData finder(head, env);
       if (finder.findFun()) {
-        SEXP f = finder.res;
-        dplyr_hash_map<SEXP, hybrid_function>::const_iterator it = get_hybrid_inline_map().find(finder.res);
+
+        // The function resolves to finder.res
+        // If this happens to be a rlang_lambda_function we need to look further
+        SEXP f = resolve_rlang_lambda(finder.res);
+
+        // this also may update expr
+        dplyr_hash_map<SEXP, hybrid_function>::const_iterator it = get_hybrid_inline_map().find(f);
         if (it != get_hybrid_inline_map().end()) {
           func = it->second.name;
           package = it->second.package;
@@ -118,8 +125,10 @@ public:
       }
 
     } else if (TYPEOF(head) == CLOSXP || TYPEOF(head) == BUILTINSXP || TYPEOF(head) == SPECIALSXP) {
-      // directly a function (an inlined function) so we can match that directly
-      dplyr_hash_map<SEXP, hybrid_function>::const_iterator it = get_hybrid_inline_map().find(head);
+      // head is an inlined function. if it is an rlang_lambda_function, we need to look inside
+      SEXP f = resolve_rlang_lambda(head);
+
+      dplyr_hash_map<SEXP, hybrid_function>::const_iterator it = get_hybrid_inline_map().find(f);
       if (it != get_hybrid_inline_map().end()) {
         func = it->second.name;
         package = it->second.package;
@@ -280,6 +289,30 @@ private:
 
   hybrid_id id;
 
+  SEXP dot_alias;
+
+  SEXP resolve_rlang_lambda(SEXP f) {
+    if (Rf_inherits(f, "rlang_lambda_function") && Rf_length(expr) == 2 && TYPEOF(CADR(expr)) == SYMSXP) {
+      dot_alias =  CADR(expr);
+
+      // look again:
+      SEXP body = BODY(f);
+
+      if (TYPEOF(body) == BCODESXP) {
+        body = VECTOR_ELT(BODY_EXPR(body), 0);
+      }
+
+      if (TYPEOF(body) == LANGSXP && TYPEOF(CAR(body)) == SYMSXP) {
+        FindFunData finder_lambda(CAR(body), CLOENV(f));
+        if (finder_lambda.findFun()) {
+          f = finder_lambda.res;
+          expr = body;
+        }
+      }
+    }
+    return f;
+  }
+
   inline bool is_column_impl(SEXP val, Column& column, bool desc) const {
     if (TYPEOF(val) == SYMSXP) {
       return test_is_column(val, column, desc);
@@ -304,7 +337,11 @@ private:
   }
 
   inline bool test_is_column(Rcpp::Symbol s, Column& column, bool desc) const {
+    if (!Rf_isNull(dot_alias) && (s == symbols::dot || s == symbols::dot_x)) {
+      s = dot_alias;
+    }
     SymbolString symbol(s);
+
     // does the data mask have this symbol, and if so is it a real column (not a summarised)
     const ColumnBinding<SlicedTibble>* subset = data_mask.maybe_get_subset_binding(symbol);
     if (!subset || subset->is_summary()) return false;
@@ -317,7 +354,6 @@ private:
     column.is_desc = desc;
     return true;
   }
-
 
 };
 

--- a/inst/include/dplyr/hybrid/Expression.h
+++ b/inst/include/dplyr/hybrid/Expression.h
@@ -302,11 +302,20 @@ private:
         body = VECTOR_ELT(BODY_EXPR(body), 0);
       }
 
-      if (TYPEOF(body) == LANGSXP && TYPEOF(CAR(body)) == SYMSXP) {
-        FindFunData finder_lambda(CAR(body), CLOENV(f));
-        if (finder_lambda.findFun()) {
-          f = finder_lambda.res;
-          expr = body;
+      if (TYPEOF(body) == LANGSXP) {
+        SEXP head = CAR(body);
+
+        if (TYPEOF(head) == SYMSXP) {
+          // the body's car of the lambda is a symbol
+          // need to resolve it
+          FindFunData finder_lambda(head, CLOENV(f));
+          if (finder_lambda.findFun()) {
+            f = finder_lambda.res;
+            expr = body;
+          }
+        } else if (TYPEOF(head) == CLOSXP || TYPEOF(head) == BUILTINSXP || TYPEOF(head) == SPECIALSXP) {
+          // already a function, just use that
+          f = head;
         }
       }
     }

--- a/inst/include/dplyr/hybrid/scalar_result/mean_sd_var.h
+++ b/inst/include/dplyr/hybrid/scalar_result/mean_sd_var.h
@@ -176,12 +176,12 @@ SEXP meansdvar_dispatch(const SlicedTibble& data, const Expression<SlicedTibble>
 
   switch (expression.size()) {
   case 1:
-    // sd( <column> )
+    // fun( <column> )
     if (expression.is_unnamed(0) && expression.is_column(0, x)) {
       return internal::SimpleDispatch<SlicedTibble, Impl, Operation>(data, x, na_rm, op).get();
     }
   case 2:
-    // sd( <column>, na.rm = <bool> )
+    // fun( <column>, na.rm = <bool> )
     if (expression.is_unnamed(0) && expression.is_column(0, x) &&
         expression.is_named(1, symbols::narm) && expression.is_scalar_logical(1, na_rm)
        ) {

--- a/inst/include/dplyr/symbols.h
+++ b/inst/include/dplyr/symbols.h
@@ -51,6 +51,8 @@ struct symbols {
   static SEXP str;
   static SEXP dot_Internal;
   static SEXP inspect;
+  static SEXP dot;
+  static SEXP dot_x;
 };
 
 }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -86,4 +86,6 @@ SEXP symbols::op_minus = Rf_install("-");
 SEXP symbols::str = Rf_install("str");
 SEXP symbols::dot_Internal = Rf_install(".Internal");
 SEXP symbols::inspect = Rf_install("inspect");
+SEXP symbols::dot = Rf_install(".");
+SEXP symbols::dot_x = Rf_install(".x");
 }


### PR DESCRIPTION
``` r
library(dplyr)
library(rlang)

m <- as_function(~mean(.))

m2 <- m
body(m2)[[1]] <- mean
attr(m2, "class") <- "rlang_lambda_function"

summarise(iris, 
  fun_symbol = mean(Sepal.Length),
  lambda = m(Sepal.Length), 
  inlined_lambda = (!!m)(Sepal.Length), 
  inlined_function = (!!mean)(Sepal.Length), 
  inlinde_lambda_function = (!!m2)(Sepal.Length)
)
#>   fun_symbol   lambda inlined_lambda inlined_function
#> 1   5.843333 5.843333       5.843333         5.843333
#>   inlinde_lambda_function
#> 1                5.843333

# all use hybrid 
hybrid_call(iris, mean(Sepal.Length))
#> <hybrid evaluation>
#>   call      : base::mean(Sepal.Length)
#>   C++ class : dplyr::hybrid::internal::SimpleDispatchImpl<14, false, dplyr::NaturalDataFrame, dplyr::hybrid::internal::MeanImpl>
hybrid_call(iris, m(Sepal.Length))
#> <hybrid evaluation>
#>   call      : base::mean(Sepal.Length)
#>   C++ class : dplyr::hybrid::internal::SimpleDispatchImpl<14, false, dplyr::NaturalDataFrame, dplyr::hybrid::internal::MeanImpl>
hybrid_call(iris, (!!m)(Sepal.Length))
#> <hybrid evaluation>
#>   call      : base::mean(Sepal.Length)
#>   C++ class : dplyr::hybrid::internal::SimpleDispatchImpl<14, false, dplyr::NaturalDataFrame, dplyr::hybrid::internal::MeanImpl>
hybrid_call(iris, (!!mean)(Sepal.Length))
#> <hybrid evaluation>
#>   call      : base::mean(Sepal.Length)
#>   C++ class : dplyr::hybrid::internal::SimpleDispatchImpl<14, false, dplyr::NaturalDataFrame, dplyr::hybrid::internal::MeanImpl>
hybrid_call(iris, (!!m2)(Sepal.Length))
#> <hybrid evaluation>
#>   call      : base::mean(Sepal.Length)
#>   C++ class : dplyr::hybrid::internal::SimpleDispatchImpl<14, false, dplyr::NaturalDataFrame, dplyr::hybrid::internal::MeanImpl>
```

Created on 2018-10-10 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)