### PR TITLE
Revise filter internals to use less Rcpp protection

### DIFF
--- a/inst/include/dplyr/data/GroupedDataFrame.h
+++ b/inst/include/dplyr/data/GroupedDataFrame.h
@@ -3,6 +3,7 @@
 
 #include <dplyr/registration.h>
 #include <tools/SlicingIndex.h>
+#include <tools/VectorView.h>
 
 #include <tools/SymbolVector.h>
 #include <tools/SymbolMap.h>
@@ -22,7 +23,7 @@ public:
 
   int i;
   const GroupedDataFrame& gdf;
-  List indices;
+  ListView indices;
 };
 
 class GroupedDataFrame {
@@ -72,7 +73,7 @@ public:
     return symbols.has(g);
   }
 
-  inline List indices() const {
+  inline SEXP indices() const {
     return groups[groups.size() - 1] ;
   }
 
@@ -92,7 +93,7 @@ public:
   }
 
   template <typename Data>
-  static void set_groups(Data& x, DataFrame groups) {
+  static void set_groups(Data& x, SEXP groups) {
     x.attr("groups") = groups;
   }
 
@@ -123,7 +124,7 @@ inline GroupedDataFrameIndexIterator& GroupedDataFrameIndexIterator::operator++(
 }
 
 inline GroupedSlicingIndex GroupedDataFrameIndexIterator::operator*() const {
-  return GroupedSlicingIndex(IntegerVector(indices[i]), i);
+  return GroupedSlicingIndex(indices[i], i);
 }
 
 }

--- a/inst/include/dplyr/data/RowwiseDataFrame.h
+++ b/inst/include/dplyr/data/RowwiseDataFrame.h
@@ -74,7 +74,7 @@ public:
   }
 
   static inline CharacterVector classes() {
-    return Rcpp::CharacterVector::create("tbl_df", "tbl", "data.frame");
+    return Rcpp::CharacterVector::create("rowwise_df", "tbl_df", "tbl", "data.frame");
   }
 
 private:

--- a/inst/include/tools/SlicingIndex.h
+++ b/inst/include/tools/SlicingIndex.h
@@ -1,6 +1,8 @@
 #ifndef dplyr_tools_SlicingIndex_H
 #define dplyr_tools_SlicingIndex_H
 
+#include <tools/VectorView.h>
+
 // A SlicingIndex allows specifying which rows of a data frame are selected in which order, basically a 0:n -> 0:m map.
 // It also can be used to split a data frame in groups.
 // Important special cases can be implemented without materializing the map.
@@ -19,8 +21,8 @@ public:
 class GroupedSlicingIndex : public SlicingIndex {
 public:
   GroupedSlicingIndex(): data(), group_index(-1) {}
-  GroupedSlicingIndex(IntegerVector data_) : data(data_), group_index(-1) {}
-  GroupedSlicingIndex(IntegerVector data_, int group_) : data(data_), group_index(group_) {}
+
+  GroupedSlicingIndex(SEXP data_, int group_) : data(data_), group_index(group_) {}
 
   virtual int size() const {
     return data.size();
@@ -39,7 +41,7 @@ public:
   }
 
 private:
-  IntegerVector data;
+  Rcpp::IntegerVectorView data;
   int group_index;
 };
 

--- a/inst/include/tools/VectorView.h
+++ b/inst/include/tools/VectorView.h
@@ -1,0 +1,12 @@
+#ifndef dplyr_tools_VectorView_H
+#define dplyr_tools_VectorView_H
+
+namespace Rcpp {
+
+typedef Vector<INTSXP, NoProtectStorage> IntegerVectorView;
+typedef Vector<VECSXP, NoProtectStorage> ListView;
+typedef DataFrame_Impl<NoProtectStorage> DataFrameView;
+
+}
+
+#endif

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -141,11 +141,6 @@ public:
     return Rf_length(new_indices[i]);
   }
 
-  // is the group i dense
-  inline bool is_dense(int i) const {
-    return dense[i];
-  }
-
   // after this has been trained, materialize
   // a 1-based integer vector
   IntegerVector get(const SlicedTibble& df) const {
@@ -163,7 +158,7 @@ public:
 
         // the new indices
         const IntegerVector& new_idx = new_indices[i];
-        if (is_dense(i)) {
+        if (dense[i]) {
           // in that case we can just copy all the data
           for (int j = 0; j < chunk_size; j++, ii++) {
             out[ii] = old_idx[j] + 1;
@@ -208,8 +203,11 @@ public:
 private:
 
   void add_group(int i, int n) {
+    // the new grouped indices
     new_indices[i] = Rcpp::seq(k + 1, k + n);
-    k += n ;
+
+    // increase the size of indices subset vector
+    k += n;
   }
 
 };


### PR DESCRIPTION
`GroupedSlicingIndex` does not need to protect its `data`, it is already protected. 

`GroupedFilterIndices` does not need to hold a `std::vector<slicing_index>`