### PR TITLE
ignore empty quosures in group_by

### DIFF
--- a/R/group-by.r
+++ b/R/group-by.r
@@ -107,6 +107,7 @@ ungroup <- function(x, ...) {
 #' @keywords internal
 group_by_prepare <- function(.data, ..., .dots = list(), add = FALSE) {
   new_groups <- c(quos(...), compat_lazy_dots(.dots, caller_env()))
+  new_groups <- new_groups[!map_lgl(new_groups, quo_is_missing)]
 
   # If any calls, use mutate to add new columns, then group by those
   .data <- add_computed_columns(.data, new_groups)
@@ -119,11 +120,11 @@ group_by_prepare <- function(.data, ..., .dots = list(), add = FALSE) {
     group_names <- c(group_vars(.data), group_names)
   }
   group_names <- unique(group_names)
-  ok <- group_names != "<empty>"
+
   list(
     data = .data,
-    groups = syms(group_names[ok]),
-    group_names = group_names[ok]
+    groups = syms(group_names),
+    group_names = group_names
   )
 }
 

--- a/R/group-by.r
+++ b/R/group-by.r
@@ -119,11 +119,11 @@ group_by_prepare <- function(.data, ..., .dots = list(), add = FALSE) {
     group_names <- c(group_vars(.data), group_names)
   }
   group_names <- unique(group_names)
-
+  ok <- group_names != "<empty>"
   list(
     data = .data,
-    groups = syms(group_names),
-    group_names = group_names
+    groups = syms(group_names[ok]),
+    group_names = group_names[ok]
   )
 }
 

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -328,6 +328,8 @@ test_that("grouped data frames support drop=TRUE (#3714)", {
 })
 
 test_that("group_by ignores empty quosures (3780)", {
-
+  empty <- quo()
+  expect_equal(group_by(mtcars, cyl), group_by(mtcars, cyl, !!empty))
 })
+
 

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -326,3 +326,8 @@ test_that("grouped data frames support drop=TRUE (#3714)", {
 
   expect_is(group_by(iris, Species)[ , c("Species", "Sepal.Width"), drop=TRUE], "grouped_df")
 })
+
+test_that("group_by ignores empty quosures (3780)", {
+
+})
+


### PR DESCRIPTION
closes #3780 

```r
> group_by(mtcars, cyl, !!quo())
# A tibble: 32 x 11
# Groups:   cyl [3]
     mpg   cyl  disp    hp  drat    wt  qsec    vs    am  gear  carb
 * <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
 1  21       6  160    110  3.9   2.62  16.5     0     1     4     4
 2  21       6  160    110  3.9   2.88  17.0     0     1     4     4
 3  22.8     4  108     93  3.85  2.32  18.6     1     1     4     1
 4  21.4     6  258    110  3.08  3.22  19.4     1     0     3     1
 5  18.7     8  360    175  3.15  3.44  17.0     0     0     3     2
 6  18.1     6  225    105  2.76  3.46  20.2     1     0     3     1
 7  14.3     8  360    245  3.21  3.57  15.8     0     0     3     4
 8  24.4     4  147.    62  3.69  3.19  20       1     0     4     2
 9  22.8     4  141.    95  3.92  3.15  22.9     1     0     4     2
10  19.2     6  168.   123  3.92  3.44  18.3     1     0     4     4
# ... with 22 more rows
```