### PR TITLE
slice does nothing on empty groups. 

### DIFF
--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -163,3 +163,18 @@ test_that("slice accepts ... (#3804)", {
   g <- mtcars %>% group_by(cyl)
   expect_equal(slice(g, 1, n()), slice(g, c(1, n())))
 })
+
+test_that("slice does not evaluate the expression in empty groups (#1438)", {
+  res <- mtcars %>%
+    group_by(cyl) %>%
+    filter(cyl==6) %>%
+    slice(1:2)
+  expect_equal(nrow(res), 2L)
+
+  expect_condition(
+    res <- mtcars %>% group_by(cyl) %>% filter(cyl==6) %>% sample_n(size=3),
+    NA
+  )
+  expect_equal(nrow(res), 3L)
+})
+


### PR DESCRIPTION
```r
> mtcars %>%
+     group_by(cyl) %>%
+     filter(cyl==6) %>%
+     slice(1:2)
# A tibble: 2 x 11
# Groups:   cyl [3]
    mpg   cyl  disp    hp  drat    wt  qsec    vs    am  gear  carb
  <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
1    21     6   160   110   3.9  2.62  16.5     0     1     4     4
2    21     6   160   110   3.9  2.88  17.0     0     1     4     4
> mtcars %>%
+     group_by(cyl) %>%
+     filter(cyl==6) %>%
+     sample_n(size = 3)
# A tibble: 3 x 11
# Groups:   cyl [3]
    mpg   cyl  disp    hp  drat    wt  qsec    vs    am  gear  carb
  <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
1  19.2     6  168.   123  3.92  3.44  18.3     1     0     4     4
2  19.7     6  145    175  3.62  2.77  15.5     0     1     5     6
3  21       6  160    110  3.9   2.62  16.5     0     1     4     4
```