### PR TITLE
flatten_bindable() allows typed lists

### DIFF
--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -152,8 +152,8 @@ bool dplyr_is_bind_spliceable(SEXP x) {
   if (TYPEOF(x) != VECSXP)
     return false;
 
-  if (OBJECT(x))
-    return Rf_inherits(x, "spliced");
+  if (Rf_inherits(x, "spliced")) return true;
+  if (Rf_inherits(x, "data.frame")) return false;
 
   for (R_xlen_t i = 0; i != Rf_xlength(x); ++i) {
     if (is_atomic(VECTOR_ELT(x, i)))

--- a/tests/testthat/test-binds.R
+++ b/tests/testthat/test-binds.R
@@ -629,3 +629,9 @@ test_that("bind_cols handles unnamed list (#3402)", {
     bind_cols(list(V1 = 1, V2 = 2))
   )
 })
+
+test_that("bind_rows handles typed lists (#3924)", {
+  df <- data.frame(x = 1, y = 2)
+  lst <- structure(list(df, df, df), class = "special_lst")
+  expect_equal(bind_rows(lst), bind_rows(df,df,df))
+})


### PR DESCRIPTION
``` r
library(dplyr)
df <- data.frame(x = 1, y = 2)
lst <- structure(list(df, df, df), class = "special_lst")
bind_rows(lst)
#>   x y
#> 1 1 2
#> 2 1 2
#> 3 1 2
```

Created on 2018-10-18 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)