### PR TITLE
Fix group_by with 0 groups

### DIFF
--- a/R/nest_by.R
+++ b/R/nest_by.R
@@ -7,7 +7,7 @@ nest_by_impl <- function(.data, key_var){
     mutate(!!key_var := map(.data$.rows, function(.x) to_nest[.x,, drop = FALSE])) %>%
     select(-".rows")
 
-  attr(out[[key_var]], "model") <- to_nest[integer(), , drop = FALSE]
+  attr(out[[key_var]], "ptype") <- to_nest[integer(), , drop = FALSE]
   out
 }
 

--- a/R/nest_by.R
+++ b/R/nest_by.R
@@ -2,10 +2,13 @@
 nest_by_impl <- function(.data, key_var){
   to_nest <- select(ungroup(.data), setdiff(tbl_vars(.data), group_vars(.data)))
 
-  .data %>%
+  out <- .data %>%
     group_data() %>%
     mutate(!!key_var := map(.data$.rows, function(.x) to_nest[.x,, drop = FALSE])) %>%
     select(-".rows")
+
+  attr(out[[key_var]], "model") <- to_nest[integer(), , drop = FALSE]
+  out
 }
 
 #' Nest by one or more variables

--- a/inst/include/dplyr/standard/GroupedCallReducer.h
+++ b/inst/include/dplyr/standard/GroupedCallReducer.h
@@ -402,8 +402,13 @@ private:
     return processor->get();
   }
 
-  static SEXP get_processed_empty() {
-    return LogicalVector(0, NA_LOGICAL);
+  SEXP get_processed_empty() {
+    SEXP res = PROTECT(chunk_source.process_chunk(typename SlicedTibble::slicing_index()));
+    // recycle res 0 times
+    SEXP out = PROTECT(Rf_allocVector(TYPEOF(res), 0));
+    copy_attributes(out, res);
+    UNPROTECT(2);
+    return out;
   }
 
 private:

--- a/inst/include/tools/SlicingIndex.h
+++ b/inst/include/tools/SlicingIndex.h
@@ -20,7 +20,15 @@ public:
 // It is used in grouped operations (group_by()).
 class GroupedSlicingIndex : public SlicingIndex {
 public:
-  GroupedSlicingIndex(): data(), group_index(-1) {}
+  GroupedSlicingIndex(): data(), group_index(-1) {
+    R_PreserveObject(data);
+  }
+
+  ~GroupedSlicingIndex() {
+    if (group_index == -1) {
+      R_ReleaseObject(data);
+    }
+  }
 
   GroupedSlicingIndex(SEXP data_, int group_) : data(data_), group_index(group_) {}
 
@@ -41,7 +49,13 @@ public:
   }
 
 private:
+  // in general we don't need to protect data because
+  // it is already protected by the .rows column of the grouped_df
+  //
+  // but we do when using the default constructor, hence the
+  // R_PreserveObject / R_ReleaseObject above
   Rcpp::IntegerVectorView data;
+
   int group_index;
 };
 

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -357,9 +357,7 @@ test_that("summarise handles grouped tibble with 0 groups (#3935)", {
   expect_equal(nrow(res), 0L)
   expect_equal(res$y, double())
   expect_equal(res$n, integer())
-
-  # TODO:
-  # expect_equal(res$z, double())
+  expect_equal(res$z, double())
 })
 
 test_that("filter handles grouped tibble with 0 groups (#3935)", {

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -337,3 +337,45 @@ test_that("group_cols() selects grouping variables", {
   expect_identical(select(group_by(mtcars, cyl, am), group_cols()), group_by_all(select(mtcars, cyl, am)))
   expect_identical(mutate_at(group_by(iris, Species), vars(-group_cols()), `/`, 100), mutate_all(group_by(iris, Species), `/`, 100))
 })
+
+# Zero groups ---------------------------------------------------
+
+test_that("mutate handles grouped tibble with 0 groups (#3935)", {
+  df <- tibble(x=integer()) %>% group_by(x)
+  res <- mutate(df, y = mean(x), z = +mean(x), n = n())
+  expect_equal(names(res), c("x", "y", "z", "n"))
+  expect_equal(nrow(res), 0L)
+  expect_equal(res$y, double())
+  expect_equal(res$z, double())
+  expect_equal(res$n, integer())
+})
+
+test_that("summarise handles grouped tibble with 0 groups (#3935)", {
+  df <- tibble(x=integer()) %>% group_by(x)
+  res <- summarise(df, y = mean(x), z = +mean(x), n = n())
+  expect_equal(names(res), c("x", "y", "z", "n"))
+  expect_equal(nrow(res), 0L)
+  expect_equal(res$y, double())
+  expect_equal(res$n, integer())
+
+  # TODO:
+  # expect_equal(res$z, double())
+})
+
+test_that("filter handles grouped tibble with 0 groups (#3935)", {
+  df <- tibble(x=integer()) %>% group_by(x)
+  res <- filter(df, x > 3L)
+  expect_identical(df, res)
+})
+
+test_that("select handles grouped tibble with 0 groups (#3935)", {
+  df <- tibble(x=integer()) %>% group_by(x)
+  res <- select(df, x)
+  expect_identical(df, res)
+})
+
+test_that("arrange handles grouped tibble with 0 groups (#3935)", {
+  df <- tibble(x=integer()) %>% group_by(x)
+  res <- arrange(df, x)
+  expect_identical(df, res)
+})

--- a/tests/testthat/test-group_data.R
+++ b/tests/testthat/test-group_data.R
@@ -30,11 +30,11 @@ test_that("group_rows and group_data work with 0 rows data frames (#3489)", {
   df <- tibble(x=integer())
   expect_identical(group_rows(df), list(integer()))
   expect_identical(group_rows(rowwise(df)), list())
-  expect_identical(group_rows(group_by(df, x)), list(integer()))
+  expect_identical(group_rows(group_by(df, x)), list())
 
   expect_identical(group_data(df), tibble(.rows = list(integer())))
   expect_identical(group_data(rowwise(df)), tibble(.rows =list()))
-  expect_identical(group_data(group_by(df, x)), tibble(x = NA_integer_, .rows = list(integer())))
+  expect_identical(group_data(group_by(df, x)), tibble(x = integer(), .rows = list()))
 })
 
 test_that("GroupDataFrame checks the structure of the groups attribute", {


### PR DESCRIPTION
closes #3935. 

```
> tibble(x = integer()) %>% group_by(x) %>% group_data()
# A tibble: 0 x 2
# ... with 2 variables: x <int>, .rows <list>
```