### PR TITLE
Fix Travis errors on R 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ jobs:
     warnings_are_errors: false
   - r: 3.1
     warnings_are_errors: false
+    env: R_REMOTES_NO_ERRORS_FROM_WARNINGS=true
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Currently, builds on R 3.1 fail due to this error. devtools 2.0 now raises error if there are missing packages unless `R_REMOTES_NO_ERRORS_FROM_WARNINGS=true` is set.

```
Error: (converted from warning) package ‘dbplyr’ is not available (for R version 3.1.3)
```

c.f. https://github.com/travis-ci/travis-ci/issues/10285#issuecomment-432251006
