### PR TITLE
Better compat with old grouped_df format. closes #3719

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 dist: trusty
 cache: packages
 latex: false
-fortran:false
+fortran: false
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: false
 dist: trusty
 cache: packages
 latex: false
+fortran:false
 
 jobs:
   include:

--- a/inst/include/tools/debug.h
+++ b/inst/include/tools/debug.h
@@ -1,6 +1,8 @@
 #ifndef dplyr_tools_debug_H
 #define dplyr_tools_debug_H
 
+#include <dplyr/symbols.h>
+
 // borrowed from Rcpp11
 #ifndef RCPP_DEBUG_OBJECT
 #define RCPP_DEBUG_OBJECT(OBJ) Rf_PrintValue( Rf_eval( Rf_lang2( dplyr::symbols::str, OBJ ), R_GlobalEnv ) );

--- a/src/group_indices.cpp
+++ b/src/group_indices.cpp
@@ -501,8 +501,12 @@ SEXP check_grouped(RObject data) {
   SEXP vars = Rf_getAttrib(data, symbols::vars);
 
   if (!Rf_isNull(vars)) {
+    Rcpp::warning("Detecting old grouped_df format, replacing `vars` attribute by `groups`");
     DataFrame groups = build_index_cpp(data, SymbolVector(vars));
     data.attr("groups") = groups;
+    data.attr("vars") = R_NilValue;
+    data.attr("indices") = R_NilValue;
+    data.attr("labels") = R_NilValue;
   }
 
   // get the groups attribute and check for consistency

--- a/tests/testthat/test-group_data.R
+++ b/tests/testthat/test-group_data.R
@@ -62,4 +62,14 @@ test_that("GroupedDataFrame is compatible with older style grouped_df (#3604)", 
   attr(df, "vars") <- "g"
   attr(df, "class") <- c("grouped_df", "tbl_df", "tbl", "data.frame")
   expect_equal(group_rows(df), list(1:2, 3:4))
+
+  df <- structure(
+    data.frame(x=1),
+    class = c("grouped_df", "tbl_df", "tbl", "data.frame"),
+    vars = list(sym("x"))
+  )
+  g <- expect_warning(group_data(df))
+  expect_identical(g, tibble(x = 1, .rows = list(1L)))
+  expect_null(attr(df, "vars"))
 })
+


### PR DESCRIPTION
``` r
library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
library(ggplot2)

df <- structure(
  data.frame(x=1),
  class = c("grouped_df", "tbl_df", "tbl", "data.frame"),
  vars = list(sym("x"))
)
# attributes are replaced here
df
#> Warning in group_data_grouped_df(.data): Detecting old grouped_df format,
#> replacing `vars` attribute by `groups`
#> # A tibble: 1 x 1
#> # Groups:   x [1]
#>       x
#> * <dbl>
#> 1     1

# so here it's fine
df
#> # A tibble: 1 x 1
#> # Groups:   x [1]
#>       x
#> * <dbl>
#> 1     1

ggplot(economics_long, aes(date, value01)) +
  geom_line(aes(linetype = variable))
#> Warning in grouped_indices_grouped_df_impl(.data): Detecting old grouped_df
#> format, replacing `vars` attribute by `groups`
```

![](https://i.imgur.com/jYD4mVm.png)

Created on 2018-10-25 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)