### PR TITLE
only allow all NA logical vectors. closes #3970

### DIFF
--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -12,6 +12,7 @@
 
 #include <tools/bad.h>
 #include <tools/set_rownames.h>
+#include <tools/all_na.h>
 
 using namespace Rcpp;
 using namespace dplyr;
@@ -31,10 +32,17 @@ SEXP check_result_lgl_type(SEXP tmp) {
   return tmp;
 }
 
-inline SEXP check_filter_integer_result(SEXP tmp) {
-  if (TYPEOF(tmp) != INTSXP && TYPEOF(tmp) != REALSXP && TYPEOF(tmp) != LGLSXP) {
+inline SEXP check_slice_result(SEXP tmp) {
+  switch (TYPEOF(tmp)) {
+  case INTSXP:
+  case REALSXP:
+    break;
+  case LGLSXP:
+    if (all_na(tmp)) break;
+  default:
     stop("slice condition does not evaluate to an integer or numeric vector. ");
   }
+
   return tmp;
 }
 
@@ -415,7 +423,7 @@ DataFrame slice_template(const SlicedTibble& gdf, const Quosure& quo) {
     }
 
     // evaluate the expression in the data mask
-    IntegerVector g_test = check_filter_integer_result(mask.eval(quo.expr(), indices));
+    IntegerVector g_test = check_slice_result(mask.eval(quo.expr(), indices));
 
     // scan the results to see if all >= 1 or all <= -1
     CountIndices counter(indices.size(), g_test);

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -75,9 +75,15 @@ test_that("slice handles NA (#1235)", {
   expect_equal(nrow(slice(df, c(-1L, NA_integer_))), 2L)
 
   df <- data_frame(x = 1:4, g = rep(1:2, 2)) %>% group_by(g)
-  expect_equal(nrow(slice(df, NA)), 0L)
   expect_equal(nrow(slice(df, c(1, NA))), 2)
   expect_equal(nrow(slice(df, c(-1, NA))), 2)
+})
+
+test_that("slice handles logical NA (#3970)", {
+  df <- data_frame(x = 1:3)
+  expect_equal(nrow(slice(df, NA)), 0L)
+  expect_error(slice(df, TRUE))
+  expect_error(slice(df, FALSE))
 })
 
 test_that("slice handles empty data frames (#1219)", {


### PR DESCRIPTION
ping @earowang

the reason why we allowed logical was the `NA`, so I've changed it to only support all NA logical vectors: 

``` r
library(dplyr, warn.conflicts = FALSE)
df <- tibble(x = 1:3)
slice(df, NA)
#> # A tibble: 0 x 1
#> # … with 1 variable: x <int>
slice(df, TRUE)
#> Error: slice condition does not evaluate to an integer or numeric vector.
slice(df, FALSE)
#> Error: slice condition does not evaluate to an integer or numeric vector.
```

<sup>Created on 2018-11-16 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)</sup>