### PR TITLE
make rlang lambdas inherit from the data mask.

### DIFF
--- a/inst/include/dplyr/data/DataMask.h
+++ b/inst/include/dplyr/data/DataMask.h
@@ -507,6 +507,10 @@ public:
     get_context_env()["..group_size"] = indices.size();
     get_context_env()["..group_number"] = indices.group() + 1;
 
+    if (TYPEOF(expr) == LANGSXP && Rf_inherits(CAR(expr), "rlang_lambda_function")) {
+      SET_CLOENV(CAR(expr), mask_resolved) ;
+    }
+
     // evaluate the call in the data mask
     SEXP res = Rcpp_fast_eval(expr, data_mask);
 

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -851,3 +851,31 @@ test_that("columns are no longer available when set to NULL on mutate (#3799)", 
   expect_error(mutate(tbl, y = NULL, a = +sum(y)))
   expect_error(mutate(tbl, y = NULL, a = sum(y)))
 })
+
+test_that("rlang lambda inherit from the data mask (#3843)", {
+  res <- iris %>%
+    mutate_at(
+      vars(starts_with("Petal")),
+      ~ ifelse(Species == "setosa" & . < 1.5, NA, .)
+    )
+  expected <- iris %>%
+    mutate(
+      Petal.Length = ifelse(Species == "setosa" & Petal.Length < 1.5, NA, Petal.Length),
+      Petal.Width  = ifelse(Species == "setosa" & Petal.Width  < 1.5, NA, Petal.Width)
+    )
+  expect_equal(res, expected)
+
+  res <- iris %>%
+    group_by(Species) %>%
+    mutate_at(
+      vars(starts_with("Petal")),
+      ~ ifelse(Species == "setosa" & . < 1.5, NA, .)
+    )
+  expected <- iris %>%
+    group_by(Species) %>%
+    mutate(
+      Petal.Length = ifelse(Species == "setosa" & Petal.Length < 1.5, NA, Petal.Length),
+      Petal.Width  = ifelse(Species == "setosa" & Petal.Width  < 1.5, NA, Petal.Width)
+    )
+  expect_equal(res, expected)
+})


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)

iris %>% 
  as_tibble() %>% 
  mutate_at(
    vars(starts_with("Petal")),
    ~ ifelse(Species == "setosa" & . < 1.5, NA, .)
  )
#> # A tibble: 150 x 5
#>    Sepal.Length Sepal.Width Petal.Length Petal.Width Species
#>           <dbl>       <dbl>        <dbl>       <dbl> <fct>  
#>  1          5.1         3.5         NA            NA setosa 
#>  2          4.9         3           NA            NA setosa 
#>  3          4.7         3.2         NA            NA setosa 
#>  4          4.6         3.1          1.5          NA setosa 
#>  5          5           3.6         NA            NA setosa 
#>  6          5.4         3.9          1.7          NA setosa 
#>  7          4.6         3.4         NA            NA setosa 
#>  8          5           3.4          1.5          NA setosa 
#>  9          4.4         2.9         NA            NA setosa 
#> 10          4.9         3.1          1.5          NA setosa 
#> # … with 140 more rows
```

This only works for rlamg lambdas, e.g. this does not work. Should it @lionel- ?

``` r
library(dplyr, warn.conflicts = FALSE)

iris %>% 
  as_tibble() %>% 
  mutate_at(
    vars(starts_with("Petal")),
    function(.) ifelse(Species == "setosa" & . < 1.5, NA, .)
  )
#> Error in ifelse(Species == "setosa" & . < 1.5, NA, .): object 'Species' not found
```

<sup>Created on 2018-11-20 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)</sup>