### PR TITLE
Use friendly_type_of()

### DIFF
--- a/R/bind.r
+++ b/R/bind.r
@@ -119,7 +119,7 @@ bind_rows <- function(..., .id = NULL) {
   if (!is_null(.id)) {
     if (!(is_string(.id))) {
       bad_args(".id", "must be a scalar string, ",
-        "not {type_of(.id)} of length {length(.id)}"
+        "not {friendly_type_of(.id)} of length {length(.id)}"
       )
     }
     if (!all(have_name(x) | map_lgl(x, is_empty))) {

--- a/R/case_when.R
+++ b/R/case_when.R
@@ -107,7 +107,7 @@ case_when <- function(...) {
     if (!inherits(f, "formula") || length(f) != 3) {
       non_formula_arg <- substitute(list(...))[[i + 1]]
       header <- glue("Case {i} ({deparsed})", deparsed = fmt_obj1(deparse_trunc(non_formula_arg)))
-      glubort(header, "must be a two-sided formula, not a {type_of(f)}")
+      glubort(header, "must be a two-sided formula, not {friendly_type_of(f)}")
     }
 
     env <- environment(f)
@@ -115,7 +115,7 @@ case_when <- function(...) {
     query[[i]] <- eval_bare(f[[2]], env)
     if (!is.logical(query[[i]])) {
       header <- glue("LHS of case {i} ({deparsed})", deparsed = fmt_obj1(deparse_trunc(f_lhs(f))))
-      glubort(header, "must be a logical, not {type_of(query[[i]])}")
+      glubort(header, "must be a logical, not {friendly_type_of(query[[i]])}")
     }
 
     value[[i]] <- eval_bare(f[[3]], env)

--- a/R/colwise-filter.R
+++ b/R/colwise-filter.R
@@ -70,7 +70,7 @@ apply_filter_syms <- function(pred, syms, tbl) {
     joiner <- any_exprs
   } else {
     bad_args(".vars_predicate", "must be a call to `all_vars()` or `any_vars()`, ",
-      "not {type_of(pred)}"
+      "not {friendly_type_of(pred)}"
     )
   }
 

--- a/R/colwise.R
+++ b/R/colwise.R
@@ -163,7 +163,7 @@ tbl_at_vars <- function(tbl, vars, .include_group_vars = FALSE) {
     out
   } else {
     bad_args(".vars", "must be a character/numeric vector or a `vars()` object, ",
-      "not {type_of(vars)}"
+      "not {friendly_type_of(vars)}"
     )
   }
 }

--- a/R/compat-purrr.R
+++ b/R/compat-purrr.R
@@ -1,4 +1,4 @@
-# nocov - compat-purrr (last updated: rlang 0.0.0.9007)
+# nocov start - compat-purrr (last updated: rlang 0.3.0.9000)
 
 # This file serves as a reference for compatibility functions for
 # purrr. They are not drop-in replacements but allow a similar style
@@ -11,7 +11,8 @@ map <- function(.x, .f, ...) {
 }
 map_mold <- function(.x, .f, .mold, ...) {
   out <- vapply(.x, .f, .mold, ..., USE.NAMES = FALSE)
-  rlang::set_names(out, names(.x))
+  names(out) <- names(.x)
+  out
 }
 map_lgl <- function(.x, .f, ...) {
   map_mold(.x, .f, logical(1), ...)
@@ -49,7 +50,12 @@ pluck_cpl <- function(.x, .f) {
 }
 
 map2 <- function(.x, .y, .f, ...) {
-  Map(.f, .x, .y, ...)
+  out <- mapply(.f, .x, .y, MoreArgs = list(...), SIMPLIFY = FALSE)
+  if (length(out) == length(.x)) {
+    set_names(out, names(.x))
+  } else {
+    set_names(out, NULL)
+  }
 }
 map2_lgl <- function(.x, .y, .f, ...) {
   as.vector(map2(.x, .y, .f, ...), "logical")
@@ -157,5 +163,37 @@ accumulate_right <- function(.x, .f, ..., .init) {
   f <- function(x, y) .f(y, x, ...)
   Reduce(f, .x, init = .init, right = TRUE, accumulate = TRUE)
 }
+
+detect <- function(.x, .f, ..., .right = FALSE, .p = is_true) {
+  for (i in index(.x, .right)) {
+    if (.p(.f(.x[[i]], ...))) {
+      return(.x[[i]])
+    }
+  }
+  NULL
+}
+detect_index <- function(.x, .f, ..., .right = FALSE, .p = is_true) {
+  for (i in index(.x, .right)) {
+    if (.p(.f(.x[[i]], ...))) {
+      return(i)
+    }
+  }
+  0L
+}
+index <- function(x, right = FALSE) {
+  idx <- seq_along(x)
+  if (right) {
+    idx <- rev(idx)
+  }
+  idx
+}
+
+imap <- function(.x, .f, ...) {
+  map2(.x, vec_index(.x), .f, ...)
+}
+vec_index <- function(x) {
+  names(x) %||% seq_along(x)
+}
+
 
 # nocov end

--- a/R/error.R
+++ b/R/error.R
@@ -139,3 +139,53 @@ parse_args <- function(x) {
 parse_named_call <- function(x) {
   map_chr(x, quo_text)
 }
+
+
+# From rlang
+friendly_type_of <- function(x) {
+  if (is.object(x)) {
+    sprintf("a `%s` object", class(x)[[1]])
+  } else {
+    as_friendly_type(typeof(x))
+  }
+}
+as_friendly_type <- function(type) {
+  switch(type,
+    logical = "a logical vector",
+    integer = "an integer vector",
+    numeric = ,
+    double = "a double vector",
+    complex = "a complex vector",
+    character = "a character vector",
+    raw = "a raw vector",
+    string = "a string",
+    list = "a list",
+
+    NULL = "NULL",
+    environment = "an environment",
+    externalptr = "a pointer",
+    weakref = "a weak reference",
+    S4 = "an S4 object",
+
+    name = ,
+    symbol = "a symbol",
+    language = "a call",
+    pairlist = "a pairlist node",
+    expression = "an expression vector",
+    quosure = "a quosure",
+    formula = "a formula",
+
+    char = "an internal string",
+    promise = "an internal promise",
+    ... = "an internal dots object",
+    any = "an internal `any` object",
+    bytecode = "an internal bytecode object",
+
+    primitive = ,
+    builtin = ,
+    special = "a primitive function",
+    closure = "a function",
+
+    type
+  )
+}

--- a/R/error.R
+++ b/R/error.R
@@ -144,7 +144,7 @@ parse_named_call <- function(x) {
 # From rlang
 friendly_type_of <- function(x) {
   if (is.object(x)) {
-    sprintf("a `%s` object", class(x)[[1]])
+    sprintf("a `%s` object", fmt_classes(x))
   } else {
     as_friendly_type(typeof(x))
   }

--- a/R/if_else.R
+++ b/R/if_else.R
@@ -29,7 +29,7 @@
 #' # Attributes are taken from the `true` vector,
 if_else <- function(condition, true, false, missing = NULL) {
   if (!is.logical(condition)) {
-    bad_args("condition", "must be a logical, not {type_of(condition)}")
+    bad_args("condition", "must be a logical vector, not {friendly_type_of(condition)}")
   }
 
   out <- true[rep(NA_integer_, length(condition))]

--- a/R/join.r
+++ b/R/join.r
@@ -223,14 +223,14 @@ auto_by_msg <- function(by) {
 #' @export
 common_by.default <- function(by, x, y) {
   bad_args("by", "must be a (named) character vector, list, or NULL for ",
-    "natural joins (not recommended in production code), not {type_of(by)}"
+    "natural joins (not recommended in production code), not {friendly_type_of(by)}"
   )
 }
 
 check_suffix <- function(x) {
   if (!is.character(x) || length(x) != 2) {
     bad_args("suffix", "must be a character vector of length 2, ",
-      "not {type_of(x)} of length {length(x)}"
+      "not {friendly_type_of(x)} of length {length(x)}"
     )
   }
 

--- a/R/lead-lag.R
+++ b/R/lead-lag.R
@@ -41,7 +41,7 @@ lead <- function(x, n = 1L, default = NA, order_by = NULL, ...) {
 
   if (length(n) != 1 || !is.numeric(n) || n < 0) {
     bad_args("n", "must be a nonnegative integer scalar, ",
-      "not {type_of(n)} of length {length(n)}"
+      "not {friendly_type_of(n)} of length {length(n)}"
     )
   }
   if (n == 0) return(x)
@@ -67,7 +67,7 @@ lag <- function(x, n = 1L, default = NA, order_by = NULL, ...) {
 
   if (length(n) != 1 || !is.numeric(n) || n < 0) {
     bad_args("n", "must be a nonnegative integer scalar, ",
-      "not {type_of(n)} of length {length(n)}"
+      "not {friendly_type_of(n)} of length {length(n)}"
     )
   }
   if (n == 0) return(x)

--- a/R/order-by.R
+++ b/R/order-by.R
@@ -27,17 +27,18 @@
 #' arrange(right, year)
 order_by <- function(order_by, call) {
   quo <- enquo(call)
-  if (!quo_is_call(quo)) {
-    type <- friendly_type(type_of(get_expr(quo)))
+  expr <- quo_get_expr(quo)
+  if (!is_call(expr)) {
+    type <- friendly_type_of(expr)
     bad_args("call", "must be a function call, not { type }")
   }
 
-  fn <- set_expr(quo, node_car(get_expr(quo)))
-  args <- node_cdr(get_expr(quo))
+  fn <- set_expr(quo, node_car(expr))
+  args <- node_cdr(expr)
   args <- map(args, new_quosure, quo_get_env(quo))
 
-  quo <- quo(with_order(!!order_by, !!fn, !!!args))
-  eval_tidy(quo)
+  expr <- expr(with_order(!!order_by, !!fn, !!!args))
+  eval_tidy(expr)
 }
 
 #' Run a function with one order, translating result back to original order

--- a/R/sample.R
+++ b/R/sample.R
@@ -84,7 +84,7 @@ check_weight <- function(x, n) {
   if (is.null(x)) return()
 
   if (!is.numeric(x)) {
-    bad_args("weight", "must be a numeric, not {type_of(x)}")
+    bad_args("weight", "must be a numeric, not {friendly_type_of(x)}")
   }
   if (any(x < 0)) {
     bad_args("weight", "must be a vector with all values nonnegative, ",

--- a/R/sample.R
+++ b/R/sample.R
@@ -67,15 +67,13 @@ sample_frac <- function(tbl, size = 1, replace = FALSE, weight = NULL, .env = NU
 #' @export
 sample_n.default <- function(tbl, size, replace = FALSE, weight = NULL,
                              .env = parent.frame()) {
-
-  bad_args("tbl", "must be a data frame, not {fmt_classes(tbl)}")
+  bad_args("tbl", "must be a data frame, not {friendly_type_of(tbl)}")
 }
 
 #' @export
 sample_frac.default <- function(tbl, size = 1, replace = FALSE, weight = NULL,
                                 .env = parent.frame()) {
-
-  bad_args("tbl", "must be a data frame, not {fmt_classes(tbl)}")
+  bad_args("tbl", "must be a data frame, not {friendly_type_of(tbl)}")
 }
 
 # Helper functions -------------------------------------------------------------

--- a/R/tbl-cube.r
+++ b/R/tbl-cube.r
@@ -87,14 +87,14 @@ tbl_cube <- function(dimensions, measures) {
   if (!is.list(dimensions) || any_apply(dimensions, Negate(is.atomic)) ||
     is.null(names(dimensions))) {
     bad_args("dimensions", "must be a named list of vectors, ",
-      "not {type_of(dimensions)}"
+      "not {friendly_type_of(dimensions)}"
     )
   }
 
   if (!is.list(measures) || any_apply(measures, Negate(is.array)) ||
     is.null(names(measures))) {
     bad_args("measures", "must be a named list of arrays, ",
-      "not {type_of(measures)}"
+      "not {friendly_type_of(measures)}"
     )
   }
 

--- a/R/utils-replace-with.R
+++ b/R/utils-replace-with.R
@@ -49,7 +49,7 @@ check_type <- function(x, template, header) {
     return()
   }
 
-  glubort(header, "must be type {type_of(template)}, not {typeof(x)}")
+  glubort(header, "must be {friendly_type_of(template)}, not {friendly_type_of(x)}")
 }
 
 check_class <- function(x, template, header) {
@@ -61,5 +61,7 @@ check_class <- function(x, template, header) {
     return()
   }
 
-  glubort(header, "must be {fmt_classes(template)}, not {fmt_classes(x)}")
+  exp_classes <- fmt_classes(template)
+  out_classes <- fmt_classes(x)
+  glubort(header, "must have class `{exp_classes}`, not class `{out_classes}`")
 }

--- a/tests/testthat/test-binds.R
+++ b/tests/testthat/test-binds.R
@@ -25,7 +25,7 @@ test_that("bind_rows() err for invalid ID", {
 
   expect_error(
     bind_rows(df1, df2, .id = 5),
-    "`.id` must be a scalar string, not double of length 1",
+    "`.id` must be a scalar string, not a double vector of length 1",
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-case-when.R
+++ b/tests/testthat/test-case-when.R
@@ -13,7 +13,7 @@ test_that("error messages", {
     case_when(
       paste(50)
     ),
-    "Case 1 (`paste(50)`) must be a two-sided formula, not a string",
+    "Case 1 (`paste(50)`) must be a two-sided formula, not a character vector",
     fixed = TRUE
   )
 
@@ -21,7 +21,7 @@ test_that("error messages", {
     case_when(
       50 ~ 1:3
     ),
-    "LHS of case 1 (`50`) must be a logical, not double",
+    "LHS of case 1 (`50`) must be a logical, not a double vector",
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-colwise-filter.R
+++ b/tests/testthat/test-colwise-filter.R
@@ -26,12 +26,12 @@ test_that("aborts on empty selection", {
 test_that("aborts when supplied funs() or list", {
   expect_error(
     filter_all(mtcars, list(~. > 0)),
-    "`.vars_predicate` must be a call to `all_vars()` or `any_vars()`, not list",
+    "`.vars_predicate` must be a call to `all_vars()` or `any_vars()`, not a list",
     fixed = TRUE
   )
   expect_error(
     filter_all(mtcars, funs(. > 0)),
-    "`.vars_predicate` must be a call to `all_vars()` or `any_vars()`, not list",
+    "`.vars_predicate` must be a call to `all_vars()` or `any_vars()`, not a `fun_list` object",
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-colwise.R
+++ b/tests/testthat/test-colwise.R
@@ -3,7 +3,7 @@ context("colwise utils")
 test_that("tbl_at_vars() errs on bad input", {
   expect_error(
     tbl_at_vars(iris, raw(3)),
-    "`.vars` must be a character/numeric vector or a `vars()` object, not raw",
+    "`.vars` must be a character/numeric vector or a `vars()` object, not a raw vector",
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-if-else.R
+++ b/tests/testthat/test-if-else.R
@@ -3,7 +3,7 @@ context("if_else")
 test_that("first argument must be logical", {
   expect_error(
     if_else(1:10, 1, 2),
-    "`condition` must be a logical, not integer",
+    "`condition` must be a logical vector, not an integer vector",
     fixed = TRUE
   )
 })
@@ -24,7 +24,7 @@ test_that("true and false must be same length as condition (or length 1)", {
 test_that("true and false must be same type and same class", {
   expect_error(
     if_else(1:3 < 2, 1, 1L),
-    "`false` must be type double, not integer",
+    "`false` must be a double vector, not an integer vector",
     fixed = TRUE
   )
 
@@ -32,7 +32,7 @@ test_that("true and false must be same type and same class", {
   y <- ordered("x")
   expect_error(
     if_else(1:3 < 2, x, y),
-    "`false` must be factor, not ordered/factor",
+    "`false` must have class `factor`, not class `ordered/factor`",
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-joins.r
+++ b/tests/testthat/test-joins.r
@@ -265,17 +265,17 @@ test_that("can handle 'by' columns with suffix, reverse (#3266)", {
 test_that("check suffix input", {
   expect_error(
     inner_join(e, f, "x", suffix = letters[1:3]),
-    "`suffix` must be a character vector of length 2, not character of length 3",
+    "`suffix` must be a character vector of length 2, not a character vector of length 3",
     fixed = TRUE
   )
   expect_error(
     inner_join(e, f, "x", suffix = letters[1]),
-    "`suffix` must be a character vector of length 2, not string of length 1",
+    "`suffix` must be a character vector of length 2, not a character vector of length 1",
     fixed = TRUE
   )
   expect_error(
     inner_join(e, f, "x", suffix = 1:2),
-    "`suffix` must be a character vector of length 2, not integer of length 2",
+    "`suffix` must be a character vector of length 2, not an integer vector of length 2",
     fixed = TRUE
   )
 })
@@ -343,7 +343,7 @@ test_that("join functions error on column not found #371", {
 
   expect_error(
     left_join(data.frame(x = 1:5), data.frame(y = 1:5), by = 1:3),
-    "`by` must be a (named) character vector, list, or NULL for natural joins (not recommended in production code), not integer",
+    "`by` must be a (named) character vector, list, or NULL for natural joins (not recommended in production code), not an integer vector",
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-lead-lag.R
+++ b/tests/testthat/test-lead-lag.R
@@ -58,23 +58,23 @@ test_that("#937 is fixed", {
 test_that("input checks", {
   expect_error(
     lead(letters, -1),
-    "`n` must be a nonnegative integer scalar, not double of length 1",
+    "`n` must be a nonnegative integer scalar, not a double vector of length 1",
     fixed = TRUE
   )
   expect_error(
     lead(letters, "1"),
-    "`n` must be a nonnegative integer scalar, not string of length 1",
+    "`n` must be a nonnegative integer scalar, not a character vector of length 1",
     fixed = TRUE
   )
 
   expect_error(
     lag(letters, -1),
-    "`n` must be a nonnegative integer scalar, not double of length 1",
+    "`n` must be a nonnegative integer scalar, not a double vector of length 1",
     fixed = TRUE
   )
   expect_error(
     lag(letters, "1"),
-    "`n` must be a nonnegative integer scalar, not string of length 1",
+    "`n` must be a nonnegative integer scalar, not a character vector of length 1",
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-sample.R
+++ b/tests/testthat/test-sample.R
@@ -57,13 +57,13 @@ test_that("sample_* error message", {
 test_that("sample gives informative error for unknown type", {
   expect_error(
     sample_n(list()),
-    "`tbl` must be a data frame, not list",
+    "`tbl` must be a data frame, not a list",
     fixed = TRUE
   )
 
   expect_error(
     sample_frac(list()),
-    "`tbl` must be a data frame, not list",
+    "`tbl` must be a data frame, not a list",
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-sample.R
+++ b/tests/testthat/test-sample.R
@@ -40,7 +40,7 @@ test_that("sample respects weight", {
 test_that("sample_* error message", {
   expect_error(
     check_weight(letters[1:2], 2),
-    "`weight` must be a numeric, not character",
+    "`weight` must be a numeric, not a character vector",
     fixed = TRUE
   )
   expect_error(
@@ -50,7 +50,7 @@ test_that("sample_* error message", {
   )
   expect_error(
     check_weight(letters, 2),
-    "`weight` must be a numeric, not character"
+    "`weight` must be a numeric, not a character vector"
   )
 })
 

--- a/tests/testthat/test-tbl-cube.R
+++ b/tests/testthat/test-tbl-cube.R
@@ -3,19 +3,19 @@ context("tbl_cube")
 test_that("construction errors", {
   expect_error(
     tbl_cube(1:3, 1:3),
-    "`dimensions` must be a named list of vectors, not integer",
+    "`dimensions` must be a named list of vectors, not an integer vector",
     fixed = TRUE
   )
 
   expect_error(
     tbl_cube(list(a = 1:3), 1:3),
-    "`measures` must be a named list of arrays, not integer",
+    "`measures` must be a named list of arrays, not an integer vector",
     fixed = TRUE
   )
 
   expect_error(
     tbl_cube(list(a = 1:3), list(b = 1:3)),
-    "`measures` must be a named list of arrays, not list",
+    "`measures` must be a named list of arrays, not a list",
     fixed = TRUE
   )
 


### PR DESCRIPTION
Embed `friendly_type_of()` (currently unexported from rlang) and use it instead of `type_of()`. For example:

Before: `` `measures` must be a named list of arrays, not integer``
After:  `` `measures` must be a named list of arrays, not an integer vector``

Before: `` `false` must be factor, not ordered/factor``
After: `` `false` must have class `factor`, not class `ordered/factor` ``