### PR TITLE
Run covr only on release builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ fortran: false
 jobs:
   include:
   - r: release
+    after_success:
+      - Rscript -e 'covr::codecov()'
   - os: osx
   - r: devel
   - r: 3.4
@@ -28,6 +30,3 @@ env:
   - MAKEFLAGS="-j 2"
   - TRAVIS_CXXFLAGS="-Wall -Wextra -pedantic -Werror"
   - R_REMOTES_NO_ERRORS_FROM_WARNINGS=true
-
-after_success:
-  - Rscript -e 'covr::codecov()'


### PR DESCRIPTION
This simply runs covr only on the release build.

Running it on all builds doesn't really hurt anything, the coverage reports are automatically merged by codecov. However it takes additional time because dplyr has to be fully re-compiled in order to track the coverage.

Running only on the release build will allow the rest of the builds to finish much faster.