### PR TITLE
Add .preserve to slice()

### DIFF
--- a/R/dataframe.R
+++ b/R/dataframe.R
@@ -67,13 +67,13 @@ filter_.data.frame <- function(.data, ..., .dots = list(), .preserve = TRUE) {
 }
 
 #' @export
-slice.data.frame <- function(.data, ...) {
-  as.data.frame(slice(tbl_df(.data), ...))
+slice.data.frame <- function(.data, ..., .preserve = FALSE) {
+  as.data.frame(slice(tbl_df(.data), ..., .preserve = .preserve))
 }
 #' @export
-slice_.data.frame <- function(.data, ..., .dots = list()) {
+slice_.data.frame <- function(.data, ..., .dots = list(), .preserve = FALSE) {
   dots <- compat_lazy_dots(.dots, caller_env(), ...)
-  slice(.data, !!!dots)
+  slice(.data, !!!dots, .preserve = .preserve)
 }
 
 #' @export

--- a/R/manip.r
+++ b/R/manip.r
@@ -165,16 +165,16 @@ filter_ <- function(.data, ..., .dots = list(), .preserve = TRUE) {
 #' filter(mtcars, row_number() == 1L)
 #' filter(mtcars, row_number() == n())
 #' filter(mtcars, between(row_number(), 5, n()))
-slice <- function(.data, ...) {
+slice <- function(.data, ..., .preserve = FALSE) {
   UseMethod("slice")
 }
 #' @export
-slice.default <- function(.data, ...) {
-  slice_(.data, .dots = compat_as_lazy_dots(...))
+slice.default <- function(.data, ..., .preserve = FALSE) {
+  slice_(.data, .dots = compat_as_lazy_dots(...), .preserve = .preserve)
 }
 #' @export
 #' @rdname se-deprecated
-slice_ <- function(.data, ..., .dots = list()) {
+slice_ <- function(.data, ..., .dots = list(), .preserve = FALSE) {
   UseMethod("slice_")
 }
 

--- a/R/tbl-df.r
+++ b/R/tbl-df.r
@@ -66,19 +66,27 @@ filter_.tbl_df <- function(.data, ..., .dots = list(), .preserve = TRUE) {
 }
 
 #' @export
-slice.tbl_df <- function(.data, ...) {
+slice.tbl_df <- function(.data, ..., .preserve = FALSE) {
   dots <- quos(...)
   if (is_empty(dots)) {
     return(.data)
   }
 
   quo <- quo(c(!!!dots))
-  slice_impl(.data, quo)
+  out <- slice_impl(.data, quo)
+  if (!.preserve) {
+    out <- group_by(out, add = TRUE)
+  }
+  out
 }
 #' @export
-slice_.tbl_df <- function(.data, ..., .dots = list()) {
+slice_.tbl_df <- function(.data, ..., .dots = list(), .preserve = FALSE) {
   dots <- compat_lazy_dots(.dots, caller_env(), ..., .named = TRUE)
-  slice_impl(.data, dots[[1L]])
+  out <- slice_impl(.data, dots[[1L]])
+  if (!.preserve) {
+    out <- group_by(out, add = TRUE)
+  }
+  out
 }
 
 #' @export

--- a/man/se-deprecated.Rd
+++ b/man/se-deprecated.Rd
@@ -45,7 +45,7 @@ group_indices_(.data, ..., .dots = list())
 
 filter_(.data, ..., .dots = list(), .preserve = TRUE)
 
-slice_(.data, ..., .dots = list())
+slice_(.data, ..., .dots = list(), .preserve = FALSE)
 
 summarise_(.data, ..., .dots = list())
 

--- a/man/slice.Rd
+++ b/man/slice.Rd
@@ -4,7 +4,7 @@
 \alias{slice}
 \title{Choose rows by position}
 \usage{
-slice(.data, ...)
+slice(.data, ..., .preserve = FALSE)
 }
 \arguments{
 \item{.data}{A tbl.}
@@ -19,6 +19,9 @@ The arguments in \code{...} are automatically \link[rlang:quo]{quoted} and
 frame. They support \link[rlang:quasiquotation]{unquoting} and
 splicing. See \code{vignette("programming")} for an introduction to
 these concepts.}
+
+\item{.preserve}{when \code{TRUE} (the default), the grouping structure
+is preserved, otherwise it is recalculated based on the resulting data.}
 }
 \description{
 Choose rows by their ordinal position in the tbl.  Grouped tbls use

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -51,6 +51,10 @@ test_that("slice works with grouped data", {
   res <- slice(g, -(1:2))
   exp <- filter(g, row_number() >= 3)
   expect_equal(res, exp)
+
+  g <- group_by(data.frame(x = c(1, 1, 2, 2, 2)), x)
+  expect_equal(group_keys(slice(g, 3, .preserve = TRUE))$x, c(1, 2))
+  expect_equal(group_keys(slice(g, 3, .preserve = FALSE))$x, 2)
 })
 
 test_that("slice gives correct rows (#649)", {


### PR DESCRIPTION
There are some cases `slice()` makes some group empty. So, `.preserve` option should be provided just as `filter()`.

``` r
library(dplyr, warn.conflicts = FALSE)

data.frame(x = c(1, 1, 2, 2, 2)) %>% 
  group_by(x) %>% 
  slice(3)
#> # A tibble: 1 x 1
#> # Groups:   x [2]
#>       x
#>   <dbl>
#> 1     2
```

<sup>Created on 2018-12-10 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>
