### PR TITLE
filter() and slice() preserve order across groups

### DIFF
--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -81,7 +81,7 @@ public:
   }
 
   // the group i contains all the data from the original
-  void add_dense_group(int i, int n) {
+  void add_dense_group(int i) {
     typename SlicedTibble::slicing_index idx = *git;
     int ng = idx.size();
 
@@ -251,7 +251,7 @@ SEXP filter_template(const SlicedTibble& gdf, const Quosure& quo) {
       // we get length 1 so either we have an empty group, or a dense group, i.e.
       // a group that has all the rows from the original data
       if (g_test[0] == TRUE) {
-        group_indices.add_dense_group(i, chunk_size) ;
+        group_indices.add_dense_group(i) ;
       } else {
         group_indices.empty_group(i);
       }

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -122,8 +122,8 @@ public:
     indices = IntegerVector(no_init(k));
     std::vector<int*> p_rows(ngroups);
     for (int i = 0; i < ngroups; i++) {
-      SEXP idx = rows[i] = Rf_allocVector(INTSXP, new_sizes[i]);
-      p_rows[i] = INTEGER(idx);
+      rows[i] = Rf_allocVector(INTSXP, new_sizes[i]);
+      p_rows[i] = INTEGER(rows[i]);
     }
 
     // process test and groups, fill indices and rows

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -220,20 +220,21 @@ private:
 
 };
 
+
 // template class to rebuild the attributes
 // in the general case there is nothing to do
 template <typename SlicedTibble>
-class SlicedTibbleRebuilder {
+class FilterTibbleRebuilder {
 public:
-  SlicedTibbleRebuilder(const GroupFilterIndices<SlicedTibble>& index, const SlicedTibble& data) {}
+  FilterTibbleRebuilder(const GroupFilterIndices<SlicedTibble>& index, const SlicedTibble& data) {}
   void reconstruct(List& out) {}
 };
 
 // specific case for GroupedDataFrame, we need to take care of `groups`
 template <>
-class SlicedTibbleRebuilder<GroupedDataFrame> {
+class FilterTibbleRebuilder<GroupedDataFrame> {
 public:
-  SlicedTibbleRebuilder(const GroupFilterIndices<GroupedDataFrame>& index_, const GroupedDataFrame& data_) :
+  FilterTibbleRebuilder(const GroupFilterIndices<GroupedDataFrame>& index_, const GroupedDataFrame& data_) :
     index(index_),
     data(data_)
   {}
@@ -285,7 +286,7 @@ SEXP structure_filter(const SlicedTibble& gdf, const GroupFilterIndices<SlicedTi
 
   // set the specific attributes
   // currently this only does anything for SlicedTibble = GroupedDataFrame
-  SlicedTibbleRebuilder<SlicedTibble>(group_indices, gdf).reconstruct(out);
+  FilterTibbleRebuilder<SlicedTibble>(group_indices, gdf).reconstruct(out);
 
   return out;
 }
@@ -355,6 +356,8 @@ SEXP filter_impl(DataFrame df, Quosure quo) {
   }
 }
 
+// ------------------------------------------------- slice()
+
 class CountIndices {
 public:
   CountIndices(int nr_, IntegerVector test_) : nr(nr_), test(test_), n_pos(0), n_neg(0) {
@@ -397,6 +400,233 @@ private:
 };
 
 template <typename SlicedTibble>
+class GroupSliceIndices {
+public:
+  typedef typename SlicedTibble::slicing_index slicing_index;
+  int ngroups;
+
+  // the results of the test expression for each group
+  // we only keep those that we need
+  Rcpp::List tests;
+
+  // The new indices
+  Rcpp::List new_indices;
+
+  // dense
+  std::vector<bool> dense;
+
+private:
+
+  int k;
+
+public:
+
+  GroupSliceIndices(int ngroups_) :
+    ngroups(ngroups_),
+    tests(ngroups),
+    new_indices(ngroups),
+    dense(ngroups, false),
+    k(0)
+  {}
+
+  // set the group i to be empty
+  void empty_group(int i) {
+    new_indices[i] = Rcpp::IntegerVector::create();
+  }
+
+  // the group i contains all the data from the original
+  void add_dense_group(int i, int n) {
+    add_group(i, n);
+    dense[i] = true;
+  }
+
+  // the group i contains some data, available in g_test
+  void add_group_lgl(int i, int n, Rcpp::LogicalVector g_test) {
+    if (n == 0) {
+      empty_group(i);
+    } else {
+      add_group(i, n) ;
+      tests[i] = g_test;
+    }
+  }
+
+  void add_group_slice_positive(int i, int old_group_size, const IntegerVector& g_idx) {
+    int new_group_size = std::count_if(g_idx.begin(), g_idx.end(), SlicePositivePredicate(old_group_size));
+    if (new_group_size == 0) {
+      empty_group(i);
+    } else {
+      add_group(i, new_group_size);
+      tests[i] = g_idx ;
+    }
+  }
+
+  void add_group_slice_negative(int i, int old_group_size, const IntegerVector& g_idx) {
+    SliceNegativePredicate pred(old_group_size);
+    LogicalVector test(old_group_size, TRUE);
+    for (int j = 0; j < g_idx.size(); j++) {
+      int idx = g_idx[j];
+      if (pred(idx)) {
+        test[-idx - 1] = FALSE;
+      }
+    }
+    int n = std::count(test.begin(), test.end(), TRUE);
+    add_group_lgl(i, n, test);
+  }
+
+  // the total number of rows
+  // only makes sense when the object is fully trained
+  inline int size() const {
+    return k;
+  }
+
+  inline int group_size(int i) const {
+    return Rf_length(new_indices[i]);
+  }
+
+  // after this has been trained, materialize
+  // a 1-based integer vector
+  IntegerVector get(const SlicedTibble& df) const {
+    int n = size();
+    IntegerVector out(n);
+    typename SlicedTibble::group_iterator git = df.group_begin();
+
+    int ii = 0;
+    for (int i = 0; i < ngroups; i++, ++git) {
+      int chunk_size = group_size(i);
+      // because there is nothing to do when the group is empty
+      if (chunk_size > 0) {
+        // the indices relevant to the original data
+        slicing_index old_idx = *git;
+
+        // the new indices
+        const IntegerVector& new_idx = new_indices[i];
+        if (dense[i]) {
+          // in that case we can just copy all the data
+          for (int j = 0; j < chunk_size; j++, ii++) {
+            out[ii] = old_idx[j] + 1;
+          }
+        } else {
+          SEXP test = tests[i];
+
+          if (is<LogicalVector>(test)) {
+            // then we take the indices where test is TRUE
+            int* p_test = LOGICAL(test);
+
+            int jj = 0;
+            for (int j = 0; j < chunk_size ; j++, ii++, jj++, ++p_test) {
+              // skip until TRUE
+              while (*p_test != 1) {
+                ++p_test;
+                jj++;
+              }
+
+              // 1-based
+              out[ii] = old_idx[jj] + 1;
+            }
+          } else {
+            int* p_test = INTEGER(test);
+            SlicePositivePredicate pred(old_idx.size());
+            for (int j = 0; j < chunk_size; j++, ii++, ++p_test) {
+              // skip until the index valids the predicate
+              while (!pred(*p_test)) {
+                ++p_test;
+              }
+
+              // 1-based
+              out[ii] = old_idx[*p_test - 1] + 1;
+            }
+          }
+        }
+      }
+    }
+    return out;
+  }
+
+private:
+
+  void add_group(int i, int n) {
+    // the new grouped indices
+    new_indices[i] = Rcpp::seq(k + 1, k + n);
+
+    // increase the size of indices subset vector
+    k += n;
+  }
+
+};
+
+
+// template class to rebuild the attributes
+// in the general case there is nothing to do
+template <typename SlicedTibble>
+class SliceTibbleRebuilder {
+public:
+  SliceTibbleRebuilder(const GroupSliceIndices<SlicedTibble>& index, const SlicedTibble& data) {}
+  void reconstruct(List& out) {}
+};
+
+// specific case for GroupedDataFrame, we need to take care of `groups`
+template <>
+class SliceTibbleRebuilder<GroupedDataFrame> {
+public:
+  SliceTibbleRebuilder(const GroupSliceIndices<GroupedDataFrame>& index_, const GroupedDataFrame& data_) :
+    index(index_),
+    data(data_)
+  {}
+
+  void reconstruct(List& out) {
+    GroupedDataFrame::set_groups(out, update_groups(data.group_data(), index.new_indices));
+  }
+
+  SEXP update_groups(DataFrame old, List indices) {
+    int nc = old.size();
+    List groups(nc);
+    copy_most_attributes(groups, old);
+    copy_names(groups, old);
+
+    // labels
+    for (int i = 0; i < nc - 1; i++) groups[i] = old[i];
+
+    // indices
+    groups[nc - 1] = indices;
+
+    return groups;
+  }
+
+private:
+  const GroupSliceIndices<GroupedDataFrame>& index;
+  const GroupedDataFrame& data;
+};
+
+template <typename SlicedTibble>
+SEXP structure_slice(const SlicedTibble& gdf, const GroupSliceIndices<SlicedTibble>& group_indices, SEXP frame) {
+  const DataFrame& data = gdf.data();
+  // create the result data frame
+  int nc = data.size();
+  List out(nc);
+
+  // this is shared by all types of SlicedTibble
+  copy_most_attributes(out, data);
+  copy_class(out, data);
+  copy_names(out, data);
+  set_rownames(out, group_indices.size());
+
+  // retrieve the 1-based indices vector
+  IntegerVector idx = group_indices.get(gdf);
+
+  // extract each column with column_subset
+  for (int i = 0; i < nc; i++) {
+    out[i] = column_subset(data[i], idx, frame);
+  }
+
+  // set the specific attributes
+  // currently this only does anything for SlicedTibble = GroupedDataFrame
+  SliceTibbleRebuilder<SlicedTibble>(group_indices, gdf).reconstruct(out);
+
+  return out;
+}
+
+
+template <typename SlicedTibble>
 DataFrame slice_template(const SlicedTibble& gdf, const Quosure& quo) {
   typedef typename SlicedTibble::group_iterator group_iterator;
   typedef typename SlicedTibble::slicing_index slicing_index ;
@@ -408,7 +638,7 @@ DataFrame slice_template(const SlicedTibble& gdf, const Quosure& quo) {
   int ngroups = gdf.ngroups() ;
   SymbolVector names = data.names();
 
-  GroupFilterIndices<SlicedTibble> group_indices(ngroups);
+  GroupSliceIndices<SlicedTibble> group_indices(ngroups);
 
   group_iterator git = gdf.group_begin();
   for (int i = 0; i < ngroups; i++, ++git) {
@@ -437,7 +667,7 @@ DataFrame slice_template(const SlicedTibble& gdf, const Quosure& quo) {
     }
   }
 
-  return structure_filter<SlicedTibble>(gdf, group_indices, quo.env());
+  return structure_slice<SlicedTibble>(gdf, group_indices, quo.env());
 }
 
 // [[Rcpp::export]]

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -116,29 +116,6 @@ public:
     }
   }
 
-  void add_group_slice_positive(int i, int old_group_size, const IntegerVector& g_idx) {
-    int new_group_size = std::count_if(g_idx.begin(), g_idx.end(), SlicePositivePredicate(old_group_size));
-    if (new_group_size == 0) {
-      empty_group(i);
-    } else {
-      add_group(i, new_group_size);
-      tests[i] = g_idx ;
-    }
-  }
-
-  void add_group_slice_negative(int i, int old_group_size, const IntegerVector& g_idx) {
-    SliceNegativePredicate pred(old_group_size);
-    LogicalVector test(old_group_size, TRUE);
-    for (int j = 0; j < g_idx.size(); j++) {
-      int idx = g_idx[j];
-      if (pred(idx)) {
-        test[-idx - 1] = FALSE;
-      }
-    }
-    int n = std::count(test.begin(), test.end(), TRUE);
-    add_group_lgl(i, n, test);
-  }
-
   // the total number of rows
   // only makes sense when the object is fully trained
   inline int size() const {
@@ -174,34 +151,21 @@ public:
         } else {
           SEXP test = tests[i];
 
-          if (is<LogicalVector>(test)) {
-            // then we take the indices where test is TRUE
-            int* p_test = LOGICAL(test);
+          // then we take the indices where test is TRUE
+          int* p_test = LOGICAL(test);
 
-            int jj = 0;
-            for (int j = 0; j < chunk_size ; j++, ii++, jj++, ++p_test) {
-              // skip until TRUE
-              while (*p_test != 1) {
-                ++p_test;
-                jj++;
-              }
-
-              // 1-based
-              out[ii] = old_idx[jj] + 1;
+          int jj = 0;
+          for (int j = 0; j < chunk_size ; j++, ii++, jj++, ++p_test) {
+            // skip until TRUE
+            while (*p_test != 1) {
+              ++p_test;
+              jj++;
             }
-          } else {
-            int* p_test = INTEGER(test);
-            SlicePositivePredicate pred(old_idx.size());
-            for (int j = 0; j < chunk_size; j++, ii++, ++p_test) {
-              // skip until the index valids the predicate
-              while (!pred(*p_test)) {
-                ++p_test;
-              }
 
-              // 1-based
-              out[ii] = old_idx[*p_test - 1] + 1;
-            }
+            // 1-based
+            out[ii] = old_idx[jj] + 1;
           }
+
         }
       }
     }

--- a/tests/testthat/test-filter.r
+++ b/tests/testthat/test-filter.r
@@ -350,3 +350,27 @@ test_that("hybrid function row_number does not trigger warning in filter (#3750)
   }, warning = function(w) FALSE )
   expect_true(out)
 })
+
+test_that("filter() preserve order accross groups (#3989)", {
+  tb <- tibble(g = c(1, 2, 1, 2, 1), time = 5:1, x = 5:1)
+  res1 <- tb %>%
+    group_by(g) %>%
+    filter(x <= 4) %>%
+    arrange(time)
+
+  res2 <- tb %>%
+    group_by(g) %>%
+    arrange(time) %>%
+    filter(x <= 4)
+
+  res3 <- tb %>%
+    filter(x <= 4) %>%
+    arrange(time) %>%
+    group_by(g)
+
+  expect_equal(res1, res2)
+  expect_equal(res1, res3)
+  expect_false(is.unsorted(res1$time))
+  expect_false(is.unsorted(res2$time))
+  expect_false(is.unsorted(res3$time))
+})

--- a/tests/testthat/test-sample.R
+++ b/tests/testthat/test-sample.R
@@ -75,7 +75,7 @@ test_that("sampling grouped tbl samples each group", {
   expect_is(sampled, "grouped_df")
   expect_groups(sampled, "cyl")
   expect_equal(nrow(sampled), 6)
-  expect_equal(sampled$cyl, rep(c(4, 6, 8), each = 2))
+  expect_equal(map_int(group_rows(sampled), length), c(2,2,2))
 })
 
 test_that("can't sample more values than obs (without replacement)", {

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -102,10 +102,7 @@ test_that("slice works fine if n > nrow(df) (#1269)", {
 test_that("slice strips grouped indices (#1405)", {
   res <- mtcars %>% group_by(cyl) %>% slice(1) %>% mutate(mpgplus = mpg + 1)
   expect_equal(nrow(res), 3L)
-
-  rows <- group_rows(res)
-  expect_true(all(map_int(rows, length) == 1))
-  expect_equal(sort(unlist(rows)), 1:3)
+  expect_equal(group_rows(res), as.list(1:3))
 })
 
 test_that("slice works with zero-column data frames (#2490)", {
@@ -161,7 +158,7 @@ test_that("slice skips 0 (#3313)", {
 
 test_that("slice is not confused about dense groups (#3753)",{
   df <- tibble(row = 1:3)
-  expect_equal(slice(df, c(2,1,3))$row, 1:3)
+  expect_equal(slice(df, c(2,1,3))$row, c(2L,1L,3L))
   expect_equal(slice(df, c(1,1,1))$row, rep(1L, 3))
 })
 
@@ -185,21 +182,4 @@ test_that("slice does not evaluate the expression in empty groups (#1438)", {
     NA
   )
   expect_equal(nrow(res), 3L)
-})
-
-test_that("slice() preserve order accross groups (#3989)", {
-  tb <- tibble(g = c(1, 2, 1, 2, 1), time = 5:1, x = 5:1)
-  res1 <- tb %>%
-    group_by(g) %>%
-    slice(1, n()) %>%
-    arrange(time)
-
-  res2 <- tb %>%
-    group_by(g) %>%
-    arrange(time) %>%
-    slice(1, n())
-
-  expect_equal(res1, res2)
-  expect_false(is.unsorted(res1$time))
-  expect_false(is.unsorted(res2$time))
 })


### PR DESCRIPTION
I also made `slice()` preserve the original order

``` r
library(dplyr, warn.conflicts = FALSE)
tb <- tibble(g = c(1, 2, 1, 2, 1), time = 5:1, x = 5:1)

tb %>%
  group_by(g) %>%
  arrange(time) %>%
  filter(x <= 4)
#> # A tibble: 4 x 3
#> # Groups:   g [2]
#>       g  time     x
#>   <dbl> <int> <int>
#> 1     1     1     1
#> 2     2     2     2
#> 3     1     3     3
#> 4     2     4     4

tb %>%
  group_by(g) %>%
  filter(x <= 4) %>%
  arrange(time)
#> # A tibble: 4 x 3
#> # Groups:   g [2]
#>       g  time     x
#>   <dbl> <int> <int>
#> 1     1     1     1
#> 2     2     2     2
#> 3     1     3     3
#> 4     2     4     4

tb %>%
  group_by(g) %>%
  arrange(time) %>%
  slice(1,n())
#> # A tibble: 4 x 3
#> # Groups:   g [2]
#>       g  time     x
#>   <dbl> <int> <int>
#> 1     1     1     1
#> 2     2     2     2
#> 3     2     4     4
#> 4     1     5     5

tb %>%
  group_by(g) %>%
  slice(1, n()) %>%
  arrange(time)
#> # A tibble: 4 x 3
#> # Groups:   g [2]
#>       g  time     x
#>   <dbl> <int> <int>
#> 1     1     1     1
#> 2     2     2     2
#> 3     2     4     4
#> 4     1     5     5
```

<sup>Created on 2018-12-11 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)</sup>