### PR TITLE
Performance of bind rows(.id =)

### DIFF
--- a/inst/include/tools/SymbolVector.h
+++ b/inst/include/tools/SymbolVector.h
@@ -52,7 +52,7 @@ public:
     return r_match(v, t);
   }
 
-  const Rcpp::CharacterVector get_vector() const {
+  const Rcpp::CharacterVector& get_vector() const {
     return v;
   }
 

--- a/inst/include/tools/utils.h
+++ b/inst/include/tools/utils.h
@@ -19,7 +19,6 @@ SEXP vec_names(SEXP x);
 SEXP vec_names_or_empty(SEXP x);
 bool is_str_empty(SEXP str);
 bool has_name_at(SEXP x, R_len_t i);
-SEXP name_at(SEXP x, size_t i);
 
 SEXP child_env(SEXP parent);
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -313,7 +313,7 @@ bool has_name_at(SEXP x, R_len_t i) {
 SEXP name_at(SEXP x, size_t i) {
   SEXP names = vec_names(x);
   if (Rf_isNull(names))
-    return Rf_mkChar("");
+    return R_BlankString;
   else
     return STRING_ELT(names, i);
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -310,14 +310,6 @@ bool has_name_at(SEXP x, R_len_t i) {
   return TYPEOF(nms) == STRSXP && !is_str_empty(STRING_ELT(nms, i));
 }
 
-SEXP name_at(SEXP x, size_t i) {
-  SEXP names = vec_names(x);
-  if (Rf_isNull(names))
-    return R_BlankString;
-  else
-    return STRING_ELT(names, i);
-}
-
 // [[Rcpp::export]]
 bool is_data_pronoun(SEXP expr) {
   if (TYPEOF(expr) != LANGSXP || Rf_length(expr) != 3)


### PR DESCRIPTION
``` r
library(dplyr)
library(purrr)

make_df = function(x){
  nrows = sample(1:1000,1)
  df = data.frame(id = seq(1,nrows), val = rep("character",nrows), stringsAsFactors = FALSE)
  return(df)
}

make_list = function(n){
  ll = lapply(1:n, function(x) make_df(x))
  names(ll) = as.character(1:n)
  return(ll)
}

bench_list <- function(n){
  data <- make_list(n)
  sizes <- map_int(data, nrow)
  bench::mark(check = FALSE, 
    bind_rows(data), 
    bind_rows(data, .id = "id"), 
    rep(names(data), sizes)
  )
}

bench_list(1e3)
#> # A tibble: 3 x 10
#>   expression    min    mean  median     max `itr/sec` mem_alloc  n_gc n_itr
#>   <chr>      <bch:> <bch:t> <bch:t> <bch:t>     <dbl> <bch:byt> <dbl> <int>
#> 1 bind_rows… 7.04ms  8.03ms  7.87ms 10.23ms     125.     5.87MB    15    38
#> 2 "bind_row… 9.97ms 11.26ms  11.1ms 14.43ms      88.8    9.76MB    18    16
#> 3 rep(names… 5.06ms  5.61ms  5.59ms  7.09ms     178.     3.86MB    10    71
#> # … with 1 more variable: total_time <bch:tm>
bench_list(1e4)
#> # A tibble: 3 x 10
#>   expression     min    mean  median     max `itr/sec` mem_alloc  n_gc
#>   <chr>      <bch:t> <bch:t> <bch:t> <bch:t>     <dbl> <bch:byt> <dbl>
#> 1 bind_rows… 101.7ms 103.9ms 103.9ms 106.2ms      9.62      58MB     3
#> 2 "bind_row… 137.7ms 137.7ms 137.7ms 137.7ms      7.26    96.7MB     3
#> 3 rep(names…  55.3ms  59.4ms  56.6ms  73.7ms     16.8     38.5MB     2
#> # … with 2 more variables: n_itr <int>, total_time <bch:tm>
bench_list(1e5)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 3 x 10
#>   expression      min     mean   median      max `itr/sec` mem_alloc  n_gc
#>   <chr>      <bch:tm> <bch:tm> <bch:tm> <bch:tm>     <dbl> <bch:byt> <dbl>
#> 1 bind_rows…    2.75s    2.75s    2.75s    2.75s     0.364     575MB     1
#> 2 "bind_row…    2.68s    2.68s    2.68s    2.68s     0.373     958MB     4
#> 3 rep(names… 739.82ms 739.82ms 739.82ms 739.82ms     1.35      382MB     0
#> # … with 2 more variables: n_itr <int>, total_time <bch:tm>
```

<sup>Created on 2018-12-14 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)</sup>
