### PR TITLE
count() not group_by'ing first if no ...

### DIFF
--- a/R/count-tally.R
+++ b/R/count-tally.R
@@ -119,7 +119,9 @@ n_name <- function(x) {
 count <- function(x, ..., wt = NULL, sort = FALSE) {
   groups <- group_vars(x)
 
-  x <- group_by(x, ..., add = TRUE)
+  if (dots_n(...)) {
+    x <- group_by(x, ..., add = TRUE)
+  }
   x <- tally(x, wt = !!enquo(wt), sort = sort)
   x <- group_by(x, !!!syms(groups), add = FALSE)
   x

--- a/tests/testthat/test-count-tally.r
+++ b/tests/testthat/test-count-tally.r
@@ -33,6 +33,21 @@ test_that("grouped count includes group", {
   expect_equal(group_vars(res), "g")
 })
 
+test_that("count() does not ignore non-factor empty groups (#4013)",  {
+  d <- data.frame(x = c("a", "a", "b", "b"),
+    value = 1:4,
+    stringsAsFactors = FALSE)
+
+  g <- d %>%
+    group_by(x) %>%
+    filter(value > 3, .preserve = TRUE)
+
+  res <- count(g)
+  expect_equal(nrow(res), 2L)
+  expect_equal(res$x, c("a", "b"))
+  expect_equal(res$n, c(0L, 1L))
+})
+
 
 # add_count ---------------------------------------------------------------
 


### PR DESCRIPTION
closes #4013 

``` r
library(dplyr, warn.conflicts = FALSE)

d <- data.frame(x = c("a", "a", "b", "b"),
                value = 1:4,
                stringsAsFactors = FALSE)

g <- d %>%
  group_by(x) %>%
  filter(value > 3, .preserve = TRUE)

count(g)
#> # A tibble: 2 x 2
#> # Groups:   x [2]
#>   x         n
#>   <chr> <int>
#> 1 a         0
#> 2 b         1

summarise(g, n = n())
#> # A tibble: 2 x 2
#>   x         n
#>   <chr> <int>
#> 1 a         0
#> 2 b         1
```

<sup>Created on 2018-12-18 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)</sup>