### PR TITLE
DataMask<> does nothing when .rm() a name it does not know.

### DIFF
--- a/inst/include/dplyr/data/DataMask.h
+++ b/inst/include/dplyr/data/DataMask.h
@@ -373,14 +373,15 @@ public:
   // remove this variable from the environments
   void rm(const SymbolString& symbol) {
     int idx = symbol_map.find(symbol);
+    if (idx >= 0) {
+      if (active_bindings_ready) {
+        column_bindings[idx].detach(mask_active, mask_resolved);
+      }
 
-    if (active_bindings_ready) {
-      column_bindings[idx].detach(mask_active, mask_resolved);
+      // so that hybrid evaluation does not find it
+      // see maybe_get_subset_binding above
+      column_bindings[idx].rm();
     }
-
-    // so that hybrid evaluation does not find it
-    // see maybe_get_subset_binding above
-    column_bindings[idx].rm();
   }
 
   // add a new binding, used by mutate

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -879,3 +879,7 @@ test_that("rlang lambda inherit from the data mask (#3843)", {
     )
   expect_equal(res, expected)
 })
+
+test_that("mutate() does not segfault when setting an unknown column to NULL (#4035)", {
+  expect_true(all_equal(mutate(mtcars, dummy = NULL), mtcars))
+})


### PR DESCRIPTION
closes #4035