### PR TITLE
group_split(keep = FALSE) is careful about "virtual" grouping columns.

### DIFF
--- a/src/group_indices.cpp
+++ b/src/group_indices.cpp
@@ -664,19 +664,24 @@ List group_split_impl(GroupedDataFrame gdf, bool keep, SEXP frame) {
   DataFrame data = gdf.data();
 
   if (!keep) {
-    int ng = group_data.ncol() - 1;
-    CharacterVector group_names = vec_names(group_data);
-    dplyr_hash_set<SEXP> set;
-    for (int i = 0; i < ng; i++) {
-      set.insert(group_names[i]);
+    CharacterVector all_names = vec_names(data);
+    int nv = data.size();
+    dplyr_hash_set<SEXP> all_set;
+    for (int i = 0; i < nv; i++) {
+      all_set.insert(all_names[i]);
     }
 
-    int nv = data.size();
-    CharacterVector all_names = vec_names(data);
-    IntegerVector kept_cols(nv - ng);
+    int ng = group_data.ncol() - 1;
+    CharacterVector group_names = vec_names(group_data);
+    for (int i = 0; i < ng; i++) {
+      SEXP name = group_names[i];
+      if (all_set.count(name)) all_set.erase(name);
+    }
+
+    IntegerVector kept_cols(all_set.size());
     int k = 0;
     for (int i = 0; i < nv; i++) {
-      if (!set.count(all_names[i])) {
+      if (all_set.count(all_names[i])) {
         kept_cols[k++] = i + 1;
       }
     }

--- a/tests/testthat/test-group_split.R
+++ b/tests/testthat/test-group_split.R
@@ -46,3 +46,18 @@ test_that("group_split / bind_rows round trip", {
 test_that("group_split() works if no grouping column", {
   expect_equal(group_split(iris), list(iris))
 })
+
+test_that("group_split(keep=FALSE) does not try to remove virtual grouping columns (#4045)", {
+  iris3 <- iris[1:3,]
+  rows <- list(c(1L, 3L, 2L), c(3L, 2L, 3L))
+  df <- new_grouped_df(
+    iris3,
+    groups = tibble(.bootstrap = 1:2, .rows := rows)
+  )
+  res <- group_split(df, keep = FALSE)
+
+  expect_equal(
+    res,
+    list(iris3[rows[[1L]],], iris3[rows[[2L]],])
+    )
+})


### PR DESCRIPTION
closes #4045