### PR TITLE
use `enquos(...)`, not `quos(...)` inside a function

### DIFF
--- a/vignettes/programming.Rmd
+++ b/vignettes/programming.Rmd
@@ -438,7 +438,7 @@ variables. We need to make three changes:
 
 ```{r}
 my_summarise <- function(df, ...) {
-  group_var <- quos(...)
+  group_var <- enquos(...)
 
   df %>%
     group_by(!!! group_var) %>%


### PR DESCRIPTION
Although is this special case (`...`) it works, I think generally we should stick to `enquos()` inside a function.