### PR TITLE
keep a ptype attribute when `group_nest()`ing

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -116,8 +116,8 @@ ungroup_grouped_df <- function(df) {
     .Call(`_dplyr_ungroup_grouped_df`, df)
 }
 
-group_split_impl <- function(gdf, keep, frame) {
-    .Call(`_dplyr_group_split_impl`, gdf, keep, frame)
+group_split_impl <- function(gdf, keep, frame, ptype) {
+    .Call(`_dplyr_group_split_impl`, gdf, keep, frame, ptype)
 }
 
 hybrids <- function() {

--- a/R/group_nest.R
+++ b/R/group_nest.R
@@ -1,6 +1,6 @@
 
 group_nest_impl <- function(.tbl, .key, keep = FALSE){
-  mutate(group_keys(.tbl), !!.key := group_split(.tbl, keep = keep))
+  mutate(group_keys(.tbl), !!.key := group_split_impl(.tbl, isTRUE(keep), environment(), TRUE))
 }
 
 #' Nest a tibble using a grouping specification

--- a/R/group_split.R
+++ b/R/group_split.R
@@ -85,7 +85,7 @@ group_split <- function(.tbl, ..., keep = TRUE) {
 #' @export
 group_split.data.frame <- function(.tbl, ..., keep = TRUE) {
   if (dots_n(...)) {
-    group_split_impl(group_by(.tbl, ...), isTRUE(keep), environment())
+    group_split_impl(group_by(.tbl, ...), isTRUE(keep), environment(), FALSE)
   } else {
     list(.tbl)
   }
@@ -107,5 +107,5 @@ group_split.grouped_df <- function(.tbl, ..., keep = TRUE) {
   if (dots_n(...)) {
     warn("... is ignored in group_split(<grouped_df>), please use group_by(..., add = TRUE) %>% group_split()")
   }
-  group_split_impl(.tbl, isTRUE(keep), environment())
+  group_split_impl(.tbl, isTRUE(keep), environment(), FALSE)
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -276,15 +276,16 @@ BEGIN_RCPP
 END_RCPP
 }
 // group_split_impl
-List group_split_impl(GroupedDataFrame gdf, bool keep, SEXP frame);
-RcppExport SEXP _dplyr_group_split_impl(SEXP gdfSEXP, SEXP keepSEXP, SEXP frameSEXP) {
+List group_split_impl(GroupedDataFrame gdf, bool keep, SEXP frame, bool ptype);
+RcppExport SEXP _dplyr_group_split_impl(SEXP gdfSEXP, SEXP keepSEXP, SEXP frameSEXP, SEXP ptypeSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< GroupedDataFrame >::type gdf(gdfSEXP);
     Rcpp::traits::input_parameter< bool >::type keep(keepSEXP);
     Rcpp::traits::input_parameter< SEXP >::type frame(frameSEXP);
-    rcpp_result_gen = Rcpp::wrap(group_split_impl(gdf, keep, frame));
+    Rcpp::traits::input_parameter< bool >::type ptype(ptypeSEXP);
+    rcpp_result_gen = Rcpp::wrap(group_split_impl(gdf, keep, frame, ptype));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -794,7 +795,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dplyr_grouped_df_impl", (DL_FUNC) &_dplyr_grouped_df_impl, 2},
     {"_dplyr_group_data_grouped_df", (DL_FUNC) &_dplyr_group_data_grouped_df, 1},
     {"_dplyr_ungroup_grouped_df", (DL_FUNC) &_dplyr_ungroup_grouped_df, 1},
-    {"_dplyr_group_split_impl", (DL_FUNC) &_dplyr_group_split_impl, 3},
+    {"_dplyr_group_split_impl", (DL_FUNC) &_dplyr_group_split_impl, 4},
     {"_dplyr_hybrids", (DL_FUNC) &_dplyr_hybrids, 0},
     {"_dplyr_get_date_classes", (DL_FUNC) &_dplyr_get_date_classes, 0},
     {"_dplyr_get_time_classes", (DL_FUNC) &_dplyr_get_time_classes, 0},

--- a/src/group_indices.cpp
+++ b/src/group_indices.cpp
@@ -657,7 +657,7 @@ DataFrame ungroup_grouped_df(DataFrame df) {
 }
 
 // [[Rcpp::export]]
-List group_split_impl(GroupedDataFrame gdf, bool keep, SEXP frame) {
+List group_split_impl(GroupedDataFrame gdf, bool keep, SEXP frame, bool ptype) {
   ListView rows = gdf.indices();
   R_xlen_t n = rows.size();
   DataFrame group_data = gdf.group_data();
@@ -694,6 +694,9 @@ List group_split_impl(GroupedDataFrame gdf, bool keep, SEXP frame) {
     DataFrame out_i = dataframe_subset(data, *git, NaturalDataFrame::classes(), frame);
     GroupedDataFrame::strip_groups(out_i);
     out[i] = out_i;
+  }
+  if (ptype) {
+    out.attr("ptype") = dataframe_subset(data, IntegerVector(0), NaturalDataFrame::classes(), frame);
   }
   return out;
 }


### PR DESCRIPTION
This is to help `tidyr`, i.e.  in this branch: https://github.com/tidyverse/tidyr/pull/511

specifically to uncomment this test: https://github.com/tidyverse/tidyr/blob/dce9a0939dffbfd72eff8cb7f68a147aaa969fe9/tests/testthat/test-nest.R#L48

```r
test_that("nesting works for empty data frames", {
  df <- tibble(x = 1:3, y = c("B", "A", "A"))[0, ]

  out <- nest(df, x)
  expect_equal(names(out), c("y", "data"))

  # if (utils::packageVersion("dplyr") > "0.7.99") {
  #   expect_equal(unnest(out), df)
  # }
  expect_equal(nrow(out), 0L)
  expect_equal(length(out$data), 0L)

  out <- nest(df, x, y)
  expect_equal(length(out$data), 1L)
  expect_equal(out$data[[1L]], df)
})
``` 