### PR TITLE
re-instate `add` passing for group_by.default

### DIFF
--- a/R/group-by.r
+++ b/R/group-by.r
@@ -93,7 +93,7 @@ group_by <- function(.data, ..., add = FALSE) {
 }
 #' @export
 group_by.default <- function(.data, ..., add = FALSE) {
-  group_by_(.data, .dots = compat_as_lazy_dots(...))
+  group_by_(.data, .dots = compat_as_lazy_dots(...), add = add)
 }
 #' @export
 #' @rdname se-deprecated

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -10,6 +10,15 @@ test_that("group_by with add = TRUE adds groups", {
   expect_groups(add_groups2(df), c("x", "y"))
 })
 
+test_that("group_by_ backwards compatibility with add = TRUE adds groups", {
+  add_groups_extendedclass <- function(tbl) {
+    grouped <- group_by(tbl, x)
+    group_by.default(grouped, y, add = TRUE)
+  }
+
+  expect_groups(add_groups_extendedclass(df), c("x", "y"))
+})
+
 test_that("joins preserve grouping", {
   g <- group_by(df, x)
 


### PR DESCRIPTION
I'm one of the people responsible for maintaining [crplyr](https://github.com/Crunch-io/crplyr) and in that package we have extended some dplyr methods to work with other R objects.

Our tests are failing with the current release candidate, and I'm pretty sure I've tracked it down to the removal of passing the `add` from `group_by.default` to `group_by` which this PR fixes. We are in the process of updating crplyr to use the `group_by` method instead of `group_by_` which will also fix the problem for us, but thought we would submit this in case anyone else was running into this inconsistency. 