### PR TITLE
travis job to check against dev rlang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ jobs:
   - r: devel
   - r: 3.1
     warnings_are_errors: false
+
   - stage: full
     os: osx
   - r: release
@@ -26,7 +27,7 @@ jobs:
       - DEVEL_PACKAGES=true
     r_github_packages:
       - RcppCore/Rcpp
-      - r-lib/lang
+      - r-lib/rlang
       - tidyverse/tibble
       - tidyverse/tidyselect
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ jobs:
     warnings_are_errors: false
   - r: 3.1
     warnings_are_errors: false
+  - r: release
+    before_install:
+      - Rscript -e "remotes::install_github('r-lib/rlang')"
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ fortran: false
 jobs:
   include:
   - r: devel
+  - r: 3.1
+    warnings_are_errors: false
   - stage: full
     os: osx
   - r: release
@@ -19,11 +21,14 @@ jobs:
   - r: 3.3
   - r: 3.2
     warnings_are_errors: false
-  - r: 3.1
-    warnings_are_errors: false
   - r: release
+    env:
+      - DEVEL_PACKAGES=true
     before_install:
+      - Rscript -e "remotes::install_github('RcppCore/Rcpp')"
       - Rscript -e "remotes::install_github('r-lib/rlang')"
+      - Rscript -e "remotes::install_github('tidyverse/tibble')"
+      - Rscript -e "remotes::install_github('tidyverse/tidyselect')"
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,11 @@ jobs:
   - r: release
     env:
       - DEVEL_PACKAGES=true
-    before_install:
-      - Rscript -e "remotes::install_github('RcppCore/Rcpp')"
-      - Rscript -e "remotes::install_github('r-lib/rlang')"
-      - Rscript -e "remotes::install_github('tidyverse/tibble')"
-      - Rscript -e "remotes::install_github('tidyverse/tidyselect')"
+    r_github_packages:
+      - RcppCore/Rcpp
+      - r-lib/lang
+      - tidyverse/tibble
+      - tidyverse/tidyselect
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Because of the tight relationship between `rlang` and `dplyr` and the use of C level api, I've added a job that tests dplyr on the release version of R, but using the dev rlang. 

This would have helped with things like: https://github.com/tidyverse/dplyr/issues/4049 where even though this was a dplyr problem, it was only apparent with a dev rlang. 

I'm not sure it would make sense to do something similar for dev versions of `Rcpp` or `tidyselect`, but it's nice to find out about these things quickly enough