### PR TITLE
Add description about arrang()ing `NA`

### DIFF
--- a/R/manip.r
+++ b/R/manip.r
@@ -510,6 +510,11 @@ transmute_.grouped_df <- function(.data, ..., .dots = list()) {
 #' The sort order for character vectors will depend on the collating sequence
 #' of the locale in use: see [locales()].
 #'
+#' @section Missing values:
+#' Unlike base sorting with `sort()`, `NA` are:
+#' * always sorted to the end for local data, even when wrapped with `desc()`.
+#' * treated differently for remote data, depending on the backend.
+#'
 #' @export
 #' @inheritParams filter
 #' @inheritSection filter Tidy data

--- a/man/arrange.Rd
+++ b/man/arrange.Rd
@@ -31,6 +31,15 @@ The sort order for character vectors will depend on the collating sequence
 of the locale in use: see \code{\link[=locales]{locales()}}.
 }
 
+\section{Missing values}{
+
+Unlike base sorting with \code{sort()}, \code{NA} are:
+\itemize{
+\item always sorted to the end for local data, even when wrapped with \code{desc()}.
+\item treated differently for remote data, depending on the backend.
+}
+}
+
 \section{Tidy data}{
 
 When applied to a data frame, row names are silently dropped. To preserve,


### PR DESCRIPTION
(This is not related to the release of 0.8.0)

`arrange()` sorts `NA` to the end, whether the column is wrapped with `desc()` or not.

``` r
dplyr::arrange(data.frame(x = c(NA, 0, 1)), x)
#>    x
#> 1  0
#> 2  1
#> 3 NA
dplyr::arrange(data.frame(x = c(NA, 0, 1)), desc(x))
#>    x
#> 1  1
#> 2  0
#> 3 NA
```

<sup>Created on 2019-01-05 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

I guess this is intentional as [the test case says so](https://github.com/tidyverse/dplyr/blob/1f440d51bb8acee2d562f9bdc00400cdc0f6ae84/tests/testthat/test-arrange.r#L18). I haven't seen someone complained about this behaviour, but I feel this is worth noting.