### PR TITLE
More stable reconstruction of grouping structure after a summarise().

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -184,8 +184,8 @@ setdiff_data_frame <- function(x, y) {
     .Call(`_dplyr_setdiff_data_frame`, x, y)
 }
 
-summarise_impl <- function(df, dots) {
-    .Call(`_dplyr_summarise_impl`, df, dots)
+summarise_impl <- function(df, dots, frame) {
+    .Call(`_dplyr_summarise_impl`, df, dots, frame)
 }
 
 hybrid_impl <- function(df, quosure) {

--- a/R/tbl-df.r
+++ b/R/tbl-df.r
@@ -99,12 +99,12 @@ mutate_.tbl_df <- function(.data, ..., .dots = list()) {
 #' @export
 summarise.tbl_df <- function(.data, ...) {
   dots <- quos(..., .named = TRUE)
-  summarise_impl(.data, dots)
+  summarise_impl(.data, dots, environment())
 }
 #' @export
 summarise_.tbl_df <- function(.data, ..., .dots = list()) {
   dots <- compat_lazy_dots(.dots, caller_env(), ..., .named = TRUE)
-  summarise_impl(.data, dots)
+  summarise_impl(.data, dots, environment())
 }
 
 # Joins ------------------------------------------------------------------------

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -589,14 +589,15 @@ BEGIN_RCPP
 END_RCPP
 }
 // summarise_impl
-SEXP summarise_impl(DataFrame df, QuosureList dots);
-RcppExport SEXP _dplyr_summarise_impl(SEXP dfSEXP, SEXP dotsSEXP) {
+SEXP summarise_impl(DataFrame df, QuosureList dots, SEXP frame);
+RcppExport SEXP _dplyr_summarise_impl(SEXP dfSEXP, SEXP dotsSEXP, SEXP frameSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< DataFrame >::type df(dfSEXP);
     Rcpp::traits::input_parameter< QuosureList >::type dots(dotsSEXP);
-    rcpp_result_gen = Rcpp::wrap(summarise_impl(df, dots));
+    Rcpp::traits::input_parameter< SEXP >::type frame(frameSEXP);
+    rcpp_result_gen = Rcpp::wrap(summarise_impl(df, dots, frame));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -814,7 +815,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dplyr_union_data_frame", (DL_FUNC) &_dplyr_union_data_frame, 2},
     {"_dplyr_intersect_data_frame", (DL_FUNC) &_dplyr_intersect_data_frame, 2},
     {"_dplyr_setdiff_data_frame", (DL_FUNC) &_dplyr_setdiff_data_frame, 2},
-    {"_dplyr_summarise_impl", (DL_FUNC) &_dplyr_summarise_impl, 2},
+    {"_dplyr_summarise_impl", (DL_FUNC) &_dplyr_summarise_impl, 3},
     {"_dplyr_hybrid_impl", (DL_FUNC) &_dplyr_hybrid_impl, 2},
     {"_dplyr_test_comparisons", (DL_FUNC) &_dplyr_test_comparisons, 0},
     {"_dplyr_test_matches", (DL_FUNC) &_dplyr_test_matches, 0},

--- a/src/summarise.cpp
+++ b/src/summarise.cpp
@@ -30,56 +30,13 @@ SEXP validate_unquoted_value(SEXP value, int nrows, const SymbolString& name) {
   return value;
 }
 
-template <int RTYPE>
-class ExtractVectorVisitor {
-public:
-  typedef typename Rcpp::Vector<RTYPE> Vec;
-
-  ExtractVectorVisitor(SEXP origin_) :
-    origin(origin_)
-  {}
-
-  virtual SEXP extract(const std::vector<IntegerVector>& new_indices) {
-    int n = new_indices.size();
-    Vec out(no_init(n));
-    copy_most_attributes(out, origin);
-    for (int i = 0; i < n; i++) {
-      int new_index = new_indices[i][0];
-      out[i] = origin[new_index - 1];
-    }
-    return out ;
-  }
-
-private:
-  Vec origin;
-};
-
-inline SEXP extract_visit(SEXP origin, const std::vector<IntegerVector>& new_indices) {
-  switch (TYPEOF(origin)) {
-  case INTSXP:
-    return ExtractVectorVisitor<INTSXP>(origin).extract(new_indices);
-  case REALSXP:
-    return ExtractVectorVisitor<REALSXP>(origin).extract(new_indices);
-  case LGLSXP:
-    return ExtractVectorVisitor<LGLSXP>(origin).extract(new_indices);
-  case STRSXP:
-    return ExtractVectorVisitor<STRSXP>(origin).extract(new_indices);
-  case RAWSXP:
-    return ExtractVectorVisitor<RAWSXP>(origin).extract(new_indices);
-  case CPLXSXP:
-    return ExtractVectorVisitor<CPLXSXP>(origin).extract(new_indices);
-  }
-
-  return R_NilValue;
-}
-
-SEXP reconstruct_groups(const DataFrame& old_groups, const std::vector<IntegerVector>& new_indices) {
+SEXP reconstruct_groups(const DataFrame& old_groups, const List& new_indices, const IntegerVector& firsts) {
   int nv = old_groups.size() - 1 ;
   List out(nv);
   CharacterVector names(nv);
   CharacterVector old_names(old_groups.names());
   for (int i = 0; i < nv - 1; i++) {
-    out[i] = extract_visit(old_groups[i], new_indices);
+    out[i] = column_subset(old_groups[i], firsts, R_BaseEnv);
     names[i] = old_names[i];
   }
   out[nv - 1] = new_indices;
@@ -108,18 +65,44 @@ void structure_summarise<GroupedDataFrame>(List& out, const GroupedDataFrame& gd
     DataFrame old_groups = gdf.group_data();
     int nv = gdf.nvars() - 1;
     DataFrameVisitors visitors(old_groups, nv) ;
-
-    // collect the new indices
-    std::vector<IntegerVector> new_indices;
     int old_nrows = old_groups.nrow();
+
+    // the number of new groups
+    int ngroups = 0;
+
+    // sizes of each new group, there are at most old_nrows groups
+    std::vector<int> sizes(old_nrows);
+
     for (int i = 0; i < old_nrows;) {
-      int start = i;
+      // go through one old group
+      int start = i++;
       while (i < old_nrows && visitors.equal(start, i)) i++ ;
-      new_indices.push_back(seq(start + 1, i));
+
+      sizes[ngroups++] = i - start;
+    }
+
+    // collect the new indices, now that we know the size
+    List new_indices(ngroups);
+
+    // the first index of each group
+    IntegerVector firsts(no_init(ngroups));
+
+    int start = 0;
+    for (int i = 0; i < ngroups; i++) {
+      firsts[i] = start + 1;
+
+      int n = sizes[i];
+      if (n) {
+        new_indices[i] = IntegerVectorView(seq(start + 1, start + n));
+      } else {
+        new_indices[i] = IntegerVectorView(0);
+      }
+
+      start += sizes[i];
     }
 
     // groups
-    DataFrame groups = reconstruct_groups(old_groups, new_indices);
+    DataFrame groups = reconstruct_groups(old_groups, new_indices, firsts);
     GroupedDataFrame::set_groups(out, groups);
   } else {
     // clear groups and reset to non grouped classes


### PR DESCRIPTION
This was using a `std::vector<IntegerVector>` and growing it for some reason. 

Also, it now uses the better `column_subset()` to filter rows of the grouping structure instead of some custom visitor that only knew how to deal with trivial types. 