### PR TITLE
Replace data_frame() by tibble()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -938,7 +938,7 @@ Functions related to the creation and coercion of `tbl_df`s, now live in their o
   `as_data_frame()`), data frames (trivial), and matrices (with efficient
   C++ implementation) (#876). It no longer strips subclasses.
 
-* The internals of `data_frame()` and `as_data_frame()` have been aligned,
+* The internals of `tibble()` and `as_data_frame()` have been aligned,
   so `as_data_frame()` will now automatically recycle length-1 vectors.
   Both functions give more informative error messages if you attempting to
   create an invalid data frame. You can no longer create a data frame with
@@ -952,7 +952,7 @@ Functions related to the creation and coercion of `tbl_df`s, now live in their o
   (#1325).  It now (invisibly) returns its first argument (#1570).
 
 *  `lst()` and `lst_()` which create lists in the same way that
-  `data_frame()` and `data_frame_()` create data frames (#1290).
+  `tibble()` and `data_frame_()` create data frames (#1290).
 
 * `print.tbl_df()` is considerably faster if you have very wide data frames.
   It will now also only list the first 100 additional variables not already
@@ -1001,7 +1001,7 @@ Functions related to the creation and coercion of `tbl_df`s, now live in their o
 ### SQLite
 
 * `src_memdb()` is a session-local in-memory SQLite database.
-  `memdb_frame()` works like `data_frame()`, but creates a new table in
+  `memdb_frame()` works like `tibble()`, but creates a new table in
   that database.
 
 * `src_sqlite()` now uses a stricter quoting character, `` ` ``, instead of
@@ -1235,7 +1235,7 @@ Until now, dplyr's support for non-UTF8 encodings has been rather shaky. This re
   when determining if two `POSIXct` vectors are comparable. If the `tz` of
   all inputs is the same, it's used, otherwise its set to `UTC`.
 
-* `data_frame()` always produces a `tbl_df` (#1151, @kevinushey)
+* `tibble()` always produces a `tbl_df` (#1151, @kevinushey)
 
 * `filter(x, TRUE, TRUE)` now just returns `x` (#1210),
   it doesn't internally modify the first argument (#971), and
@@ -1383,7 +1383,7 @@ This is a minor release containing fixes for a number of crashes and issues iden
 
 ## Minor improvements
 
-* `data_frame()` (and `as_data_frame()` & `tbl_df()`) now explicitly
+* `tibble()` (and `as_data_frame()` & `tbl_df()`) now explicitly
   forbid columns that are data frames or matrices (#775). All columns
   must be either a 1d atomic vector or a 1d list.
 
@@ -1482,7 +1482,7 @@ This is a minor release containing fixes for a number of crashes and issues iden
   problems with xtable (#656). `[.grouped_df` will silently drop grouping
   if you don't include the grouping columns (#733).
 
-* `data_frame()` now acts correctly if the first argument is a vector to be
+* `tibble()` now acts correctly if the first argument is a vector to be
   recycled. (#680 thanks @jimhester)
 
 * `filter.data.table()` works if the table has a variable called "V1" (#615).
@@ -1527,7 +1527,7 @@ This is a minor release containing fixes for a number of crashes and issues iden
 
 * `count()` makes it even easier to do (weighted) counts (#358).
 
-* `data_frame()` by @kevinushey is a nicer way of creating data frames.
+* `tibble()` by @kevinushey is a nicer way of creating data frames.
   It never coerces column types (no more `stringsAsFactors = FALSE`!),
   never munges column names, and never adds row names. You can use previously
   defined columns to compute new columns (#376).

--- a/NEWS.md
+++ b/NEWS.md
@@ -938,7 +938,7 @@ Functions related to the creation and coercion of `tbl_df`s, now live in their o
   `as_data_frame()`), data frames (trivial), and matrices (with efficient
   C++ implementation) (#876). It no longer strips subclasses.
 
-* The internals of `tibble()` and `as_data_frame()` have been aligned,
+* The internals of `data_frame()` and `as_data_frame()` have been aligned,
   so `as_data_frame()` will now automatically recycle length-1 vectors.
   Both functions give more informative error messages if you attempting to
   create an invalid data frame. You can no longer create a data frame with
@@ -952,7 +952,7 @@ Functions related to the creation and coercion of `tbl_df`s, now live in their o
   (#1325).  It now (invisibly) returns its first argument (#1570).
 
 *  `lst()` and `lst_()` which create lists in the same way that
-  `tibble()` and `data_frame_()` create data frames (#1290).
+  `data_frame()` and `data_frame_()` create data frames (#1290).
 
 * `print.tbl_df()` is considerably faster if you have very wide data frames.
   It will now also only list the first 100 additional variables not already
@@ -1001,7 +1001,7 @@ Functions related to the creation and coercion of `tbl_df`s, now live in their o
 ### SQLite
 
 * `src_memdb()` is a session-local in-memory SQLite database.
-  `memdb_frame()` works like `tibble()`, but creates a new table in
+  `memdb_frame()` works like `data_frame()`, but creates a new table in
   that database.
 
 * `src_sqlite()` now uses a stricter quoting character, `` ` ``, instead of
@@ -1235,7 +1235,7 @@ Until now, dplyr's support for non-UTF8 encodings has been rather shaky. This re
   when determining if two `POSIXct` vectors are comparable. If the `tz` of
   all inputs is the same, it's used, otherwise its set to `UTC`.
 
-* `tibble()` always produces a `tbl_df` (#1151, @kevinushey)
+* `data_frame()` always produces a `tbl_df` (#1151, @kevinushey)
 
 * `filter(x, TRUE, TRUE)` now just returns `x` (#1210),
   it doesn't internally modify the first argument (#971), and
@@ -1383,7 +1383,7 @@ This is a minor release containing fixes for a number of crashes and issues iden
 
 ## Minor improvements
 
-* `tibble()` (and `as_data_frame()` & `tbl_df()`) now explicitly
+* `data_frame()` (and `as_data_frame()` & `tbl_df()`) now explicitly
   forbid columns that are data frames or matrices (#775). All columns
   must be either a 1d atomic vector or a 1d list.
 
@@ -1482,7 +1482,7 @@ This is a minor release containing fixes for a number of crashes and issues iden
   problems with xtable (#656). `[.grouped_df` will silently drop grouping
   if you don't include the grouping columns (#733).
 
-* `tibble()` now acts correctly if the first argument is a vector to be
+* `data_frame()` now acts correctly if the first argument is a vector to be
   recycled. (#680 thanks @jimhester)
 
 * `filter.data.table()` works if the table has a variable called "V1" (#615).
@@ -1527,7 +1527,7 @@ This is a minor release containing fixes for a number of crashes and issues iden
 
 * `count()` makes it even easier to do (weighted) counts (#358).
 
-* `tibble()` by @kevinushey is a nicer way of creating data frames.
+* `data_frame()` by @kevinushey is a nicer way of creating data frames.
   It never coerces column types (no more `stringsAsFactors = FALSE`!),
   never munges column names, and never adds row names. You can use previously
   defined columns to compute new columns (#376).

--- a/R/bind.r
+++ b/R/bind.r
@@ -57,7 +57,7 @@
 #' # You can mix vectors and data frames:
 #' bind_rows(
 #'   c(a = 1, b = 2),
-#'   data_frame(a = 3:4, b = 5:6),
+#'   tibble(a = 3:4, b = 5:6),
 #'   c(a = 7, b = 8)
 #' )
 #'

--- a/R/colwise-distinct.R
+++ b/R/colwise-distinct.R
@@ -13,7 +13,7 @@
 #' into account to determine distinct rows.
 #'
 #' @examples
-#' df <- data_frame(x = rep(2:5, each = 2) / 2, y = rep(2:3, each = 4) / 2)
+#' df <- tibble(x = rep(2:5, each = 2) / 2, y = rep(2:3, each = 4) / 2)
 #' df
 #' distinct_all(df)
 #' distinct_at(df, vars(x,y))

--- a/R/dataframe.R
+++ b/R/dataframe.R
@@ -20,7 +20,7 @@ add_rownames <- function(df, var = "rowname") {
 
   stopifnot(is.data.frame(df))
 
-  rn <- as_data_frame(setNames(list(rownames(df)), var))
+  rn <- as_tibble(setNames(list(rownames(df)), var))
   rownames(df) <- NULL
 
   bind_cols(rn, df)

--- a/R/tbl-cube.r
+++ b/R/tbl-cube.r
@@ -184,11 +184,11 @@ as.data.frame.tbl_cube <- function(x, ...) {
 
 #' @rdname as.table.tbl_cube
 #' @description For a cube, the data frame returned by
-#'   [tibble::as_data_frame()] resulting data frame contains the
+#'   [tibble::as_tibble()] resulting data frame contains the
 #'   dimensions as character values (and not as factors).
 #' @export
 as_tibble.tbl_cube <- function(x, ...) {
-  as_data_frame(as.data.frame(x, ..., stringsAsFactors = FALSE))
+  as_tibble(as.data.frame(x, ..., stringsAsFactors = FALSE))
 }
 
 # Coercion methods -------------------------------------------------------------

--- a/man/as.table.tbl_cube.Rd
+++ b/man/as.table.tbl_cube.Rd
@@ -23,6 +23,6 @@
 Supports conversion to tables, data frames, tibbles.
 
 For a cube, the data frame returned by
-\code{\link[tibble:as_data_frame]{tibble::as_data_frame()}} resulting data frame contains the
+\code{\link[tibble:as_tibble]{tibble::as_tibble()}} resulting data frame contains the
 dimensions as character values (and not as factors).
 }

--- a/man/bind.Rd
+++ b/man/bind.Rd
@@ -77,7 +77,7 @@ bind_rows(
 # You can mix vectors and data frames:
 bind_rows(
   c(a = 1, b = 2),
-  data_frame(a = 3:4, b = 5:6),
+  tibble(a = 3:4, b = 5:6),
   c(a = 7, b = 8)
 )
 

--- a/man/distinct_all.Rd
+++ b/man/distinct_all.Rd
@@ -43,7 +43,7 @@ into account to determine distinct rows.
 }
 
 \examples{
-df <- data_frame(x = rep(2:5, each = 2) / 2, y = rep(2:3, each = 4) / 2)
+df <- tibble(x = rep(2:5, each = 2) / 2, y = rep(2:3, each = 4) / 2)
 df
 distinct_all(df)
 distinct_at(df, vars(x,y))

--- a/tests/testthat/test-arrange.r
+++ b/tests/testthat/test-arrange.r
@@ -76,7 +76,7 @@ test_that("grouped arrange ignores group (#491 -> #1206)", {
 })
 
 test_that("arrange keeps the grouping structure (#605)", {
-  dat <- data_frame(g = c(2, 2, 1, 1), x = c(1, 3, 2, 4))
+  dat <- tibble(g = c(2, 2, 1, 1), x = c(1, 3, 2, 4))
   res <- dat %>% group_by(g) %>% arrange()
   expect_is(res, "grouped_df")
   expect_equal(res$x, dat$x)
@@ -123,7 +123,7 @@ test_that("arrange works with empty data frame (#1142)", {
 })
 
 test_that("arrange respects locale (#1280)", {
-  df2 <- data_frame(words = c("casa", "\u00e1rbol", "zona", "\u00f3rgano"))
+  df2 <- tibble(words = c("casa", "\u00e1rbol", "zona", "\u00f3rgano"))
 
   res <- df2 %>% arrange(words)
   expect_equal(res$words, sort(df2$words))
@@ -158,7 +158,7 @@ test_that("arrange fails gracefully on list columns (#1489)", {
 })
 
 test_that("arrange supports raw columns (#1803)", {
-  df <- data_frame(a = 1:3, b = as.raw(1:3))
+  df <- tibble(a = 1:3, b = as.raw(1:3))
   expect_identical(arrange(df, a), df)
   expect_identical(arrange(df, b), df)
   expect_identical(arrange(df, desc(a)), df[3:1, ])
@@ -166,7 +166,7 @@ test_that("arrange supports raw columns (#1803)", {
 })
 
 test_that("arrange fails gracefully on matrix input (#1870)", {
-  df <- data_frame(a = 1:3, b = 4:6)
+  df <- tibble(a = 1:3, b = 4:6)
   expect_error(
     arrange(df, is.na(df)),
     "Argument 1 is of unsupported type matrix",

--- a/tests/testthat/test-binds.R
+++ b/tests/testthat/test-binds.R
@@ -4,7 +4,7 @@ context("binds")
 # error -------------------------------------------------------------------
 
 test_that("bind_rows() and bind_cols() err for non-data frames (#2373)", {
-  df1 <- data_frame(x = 1)
+  df1 <- tibble(x = 1)
   df2 <- structure(list(x = 1), class = "blah_frame")
 
   expect_error(
@@ -20,8 +20,8 @@ test_that("bind_rows() and bind_cols() err for non-data frames (#2373)", {
 })
 
 test_that("bind_rows() err for invalid ID", {
-  df1 <- data_frame(x = 1:3)
-  df2 <- data_frame(x = 4:6)
+  df1 <- tibble(x = 1:3)
+  df2 <- tibble(x = 4:6)
 
   expect_error(
     bind_rows(df1, df2, .id = 5),
@@ -52,7 +52,7 @@ test_that("cbind uses shallow copies", {
 })
 
 test_that("bind_cols handles lists (#1104)", {
-  exp <- data_frame(x = 1, y = "a", z = 2)
+  exp <- tibble(x = 1, y = "a", z = 2)
 
   l1 <- list(x = 1, y = "a")
   l2 <- list(z = 2)
@@ -84,7 +84,7 @@ test_that("bind_cols repairs names", {
 
 # rows --------------------------------------------------------------------
 
-df_var <- data_frame(
+df_var <- tibble(
   l = c(T, F, F),
   i = c(1, 1, 2),
   d = Sys.Date() + c(1, 1, 2),
@@ -110,7 +110,7 @@ test_that("bind_rows reorders columns", {
 })
 
 test_that("bind_rows ignores NULL", {
-  df <- data_frame(a = 1)
+  df <- tibble(a = 1)
 
   expect_equal(bind_rows(df, NULL), df)
   expect_equal(bind_rows(list(df, NULL)), df)
@@ -132,20 +132,20 @@ test_that("bind_rows only accepts data frames or named vectors", {
 })
 
 test_that("bind_rows handles list columns (#463)", {
-  dfl <- data_frame(x = I(list(1:2, 1:3, 1:4)))
+  dfl <- tibble(x = I(list(1:2, 1:3, 1:4)))
   res <- bind_rows(list(dfl, dfl))
   expect_equal(rep(dfl$x, 2L), res$x)
 })
 
 test_that("can bind lists of data frames #1389", {
-  df <- data_frame(x = 1)
+  df <- tibble(x = 1)
 
   res <- bind_rows(list(df, df), list(df, df))
   expect_equal(nrow(res), 4)
 })
 
 test_that("bind_rows handles data frames with no rows (#597)", {
-  df1 <- data_frame(x = 1, y = factor("a"))
+  df1 <- tibble(x = 1, y = factor("a"))
   df0 <- df1[0, ]
 
   expect_equal(bind_rows(df0), df0)
@@ -154,7 +154,7 @@ test_that("bind_rows handles data frames with no rows (#597)", {
 })
 
 test_that("bind_rows handles data frames with no columns (#1346)", {
-  df1 <- data_frame(x = 1, y = factor("a"))
+  df1 <- tibble(x = 1, y = factor("a"))
   df0 <- df1[, 0]
 
   expect_equal(bind_rows(df0), df0)
@@ -165,11 +165,11 @@ test_that("bind_rows handles data frames with no columns (#1346)", {
 })
 
 test_that("bind_rows handles lists with NULL values (#2056)", {
-  df1 <- data_frame(x = 1, y = 1)
-  df2 <- data_frame(x = 2, y = 2)
+  df1 <- tibble(x = 1, y = 1)
+  df2 <- tibble(x = 2, y = 2)
   lst1 <- list(a = df1, NULL, b = df2)
 
-  df3 <- data_frame(
+  df3 <- tibble(
     names = c("a", "b"),
     x = c(1, 2),
     y = c(1, 2)
@@ -183,7 +183,7 @@ test_that("bind_rows handles lists with list() values (#2826)", {
 })
 
 test_that("bind_rows puts data frames in order received even if no columns (#2175)", {
-  df2 <- data_frame(x = 2, y = "b")
+  df2 <- tibble(x = 2, y = "b")
   df1 <- df2[, 0]
 
   res <- bind_rows(df1, df2)
@@ -195,8 +195,8 @@ test_that("bind_rows puts data frames in order received even if no columns (#217
 # Column coercion --------------------------------------------------------------
 
 test_that("bind_rows promotes integer to numeric", {
-  df1 <- data_frame(a = 1L, b = 1L)
-  df2 <- data_frame(a = 1, b = 1L)
+  df1 <- tibble(a = 1L, b = 1L)
+  df2 <- tibble(a = 1, b = 1L)
 
   res <- bind_rows(df1, df2)
   expect_equal(typeof(res$a), "double")
@@ -204,8 +204,8 @@ test_that("bind_rows promotes integer to numeric", {
 })
 
 test_that("bind_rows does not coerce logical to integer", {
-  df1 <- data_frame(a = FALSE)
-  df2 <- data_frame(a = 1L)
+  df1 <- tibble(a = FALSE)
+  df2 <- tibble(a = 1L)
 
   expect_error(
     bind_rows(df1, df2),
@@ -215,8 +215,8 @@ test_that("bind_rows does not coerce logical to integer", {
 })
 
 test_that("bind_rows promotes factor to character with warning", {
-  df1 <- data_frame(a = factor("a"))
-  df2 <- data_frame(a = "b")
+  df1 <- tibble(a = factor("a"))
+  df2 <- tibble(a = "b")
 
   expect_warning(
     res <- bind_rows(df1, df2),
@@ -237,17 +237,17 @@ test_that("bind_rows coerces factor to character when levels don't match", {
 })
 
 test_that("bind_rows handles NA in factors #279", {
-  df1 <- data_frame(a = factor("a"))
-  df2 <- data_frame(a = factor(NA))
+  df1 <- tibble(a = factor("a"))
+  df2 <- tibble(a = factor(NA))
 
   expect_warning(res <- bind_rows(df1, df2), "Unequal factor levels")
   expect_equal(res$a, c("a", NA))
 })
 
 test_that("bind_rows doesn't promote integer/numeric to factor", {
-  df1 <- data_frame(a = factor("a"))
-  df2 <- data_frame(a = 1L)
-  df3 <- data_frame(a = 1)
+  df1 <- tibble(a = factor("a"))
+  df2 <- tibble(a = 1L)
+  df3 <- tibble(a = 1)
 
   expect_error(
     bind_rows(df1, df2),
@@ -431,8 +431,8 @@ test_that("bind_rows handles POSIXct stored as integer (#1402)", {
 })
 
 test_that("bind_cols accepts NULL (#1148)", {
-  df1 <- data_frame(a = 1:10, b = 1:10)
-  df2 <- data_frame(c = 1:10, d = 1:10)
+  df1 <- tibble(a = 1:10, b = 1:10)
+  df2 <- tibble(c = 1:10, d = 1:10)
 
   res1 <- bind_cols(df1, df2)
   res2 <- bind_cols(NULL, df1, df2)
@@ -452,10 +452,10 @@ test_that("bind_rows handles 0-length named list (#1515)", {
 })
 
 test_that("bind_rows handles promotion to strings (#1538)", {
-  df1 <- data_frame(b = c(1, 2))
-  df2 <- data_frame(b = c(1L, 2L))
-  df3 <- data_frame(b = factor(c("A", "B")))
-  df4 <- data_frame(b = c("C", "D"))
+  df1 <- tibble(b = c(1, 2))
+  df2 <- tibble(b = c(1L, 2L))
+  df3 <- tibble(b = factor(c("A", "B")))
+  df4 <- tibble(b = c("C", "D"))
 
   expect_error(
     bind_rows(df1, df3),
@@ -498,7 +498,7 @@ test_that("bind_rows infers classes from first result (#1692)", {
 
 test_that("bind_cols infers classes from first result (#1692)", {
   d1 <- data.frame(a = 1:10, b = rep(1:2, each = 5))
-  d2 <- data_frame(c = 1:10, d = rep(1:2, each = 5))
+  d2 <- tibble(c = 1:10, d = rep(1:2, each = 5))
   d3 <- group_by(d2, d)
   d4 <- rowwise(d2)
   d5 <- list(c = 1:10, d = rep(1:2, each = 5))
@@ -513,7 +513,7 @@ test_that("bind_cols infers classes from first result (#1692)", {
 })
 
 test_that("bind_rows rejects POSIXlt columns (#1789)", {
-  df <- data_frame(x = Sys.time() + 1:12)
+  df <- tibble(x = Sys.time() + 1:12)
   df$y <- as.POSIXlt(df$x)
   expect_error(
     bind_rows(df, df),

--- a/tests/testthat/test-colwise-arrange.R
+++ b/tests/testthat/test-colwise-arrange.R
@@ -13,7 +13,7 @@ test_that(".funs is applied to variables before sorting", {
 })
 
 test_that("arrange_at can arrange by grouping variables (#3351, #3332, #3480)", {
-  tbl <- data_frame(gr1 = rep(1:2, 4), gr2 = rep(1:2, each = 4), x = 1:8) %>%
+  tbl <- tibble(gr1 = rep(1:2, 4), gr2 = rep(1:2, each = 4), x = 1:8) %>%
     group_by(gr1)
 
   expect_identical(
@@ -28,7 +28,7 @@ test_that("arrange_at can arrange by grouping variables (#3351, #3332, #3480)", 
 })
 
 test_that("arrange_all arranges by grouping variable (#3351, #3480)", {
-  tbl <- data_frame(gr1 = rep(1:2, 4), gr2 = rep(1:2, each = 4), x = 1:8) %>%
+  tbl <- tibble(gr1 = rep(1:2, 4), gr2 = rep(1:2, each = 4), x = 1:8) %>%
     group_by(gr1)
 
   expect_identical(
@@ -43,7 +43,7 @@ test_that("arrange_all arranges by grouping variable (#3351, #3480)", {
 })
 
 test_that("arrange_if arranges by grouping variable (#3351, #3480)", {
-  tbl <- data_frame(gr1 = rep(1:2, 4), gr2 = rep(1:2, each = 4), x = 1:8) %>%
+  tbl <- tibble(gr1 = rep(1:2, 4), gr2 = rep(1:2, each = 4), x = 1:8) %>%
     group_by(gr1)
 
   expect_identical(

--- a/tests/testthat/test-colwise-distinct.R
+++ b/tests/testthat/test-colwise-distinct.R
@@ -1,7 +1,7 @@
 context("colwise distinct")
 
 test_that("scoped distinct is identical to manual distinct", {
-  df <- data_frame(
+  df <- tibble(
     x = rep(2:5, each=2),
     y = rep(2:3, each = 4),
     z = "a"
@@ -13,7 +13,7 @@ test_that("scoped distinct is identical to manual distinct", {
 })
 
 test_that(".funs is applied to variables before getting distinct rows", {
-  df <- data_frame(
+  df <- tibble(
     x = rep(2:5, each=2),
     y = rep(2:3, each = 4)
   )

--- a/tests/testthat/test-colwise-filter.R
+++ b/tests/testthat/test-colwise-filter.R
@@ -37,7 +37,7 @@ test_that("aborts when supplied funs() or list", {
 })
 
 test_that("filter_at can filter by grouping variables (#3351, #3480)", {
-  tbl <- data_frame(gr1 = rep(1:2, 4), gr2 = rep(1:2, each = 4), x = 1:8) %>%
+  tbl <- tibble(gr1 = rep(1:2, 4), gr2 = rep(1:2, each = 4), x = 1:8) %>%
     group_by(gr1)
 
   expect_identical(
@@ -47,7 +47,7 @@ test_that("filter_at can filter by grouping variables (#3351, #3480)", {
 })
 
 test_that("filter_if and filter_all includes grouping variables (#3351, #3480)", {
-  tbl <- data_frame(gr1 = rep(1:2, 4), gr2 = rep(1:2, each = 4), x = 1:8) %>%
+  tbl <- tibble(gr1 = rep(1:2, 4), gr2 = rep(1:2, each = 4), x = 1:8) %>%
     group_by(gr1)
 
   res <- filter_all(tbl, all_vars(. > 1))

--- a/tests/testthat/test-colwise-group-by.R
+++ b/tests/testthat/test-colwise-group-by.R
@@ -7,7 +7,7 @@ test_that("group_by_ verbs take scoped inputs", {
 })
 
 test_that("group_by_ verbs accept optional operations", {
-  df <- data_frame(x = 1:2, y = 2:3)
+  df <- tibble(x = 1:2, y = 2:3)
   gdf <- group_by(mutate_all(df, as.factor), x, y)
 
   expect_identical(group_by_all(df, as.factor), gdf)
@@ -16,7 +16,7 @@ test_that("group_by_ verbs accept optional operations", {
 })
 
 test_that("group_by variants can group by an already grouped by data (#3351)", {
-  tbl <- data_frame(gr1 = rep(1:2, 4), gr2 = rep(c(1, 2), each = 4), x = 1:8) %>%
+  tbl <- tibble(gr1 = rep(1:2, 4), gr2 = rep(c(1, 2), each = 4), x = 1:8) %>%
     group_by(gr1)
 
   expect_identical(

--- a/tests/testthat/test-colwise-mutate.R
+++ b/tests/testthat/test-colwise-mutate.R
@@ -84,7 +84,7 @@ test_that("can probe colwise", {
 })
 
 test_that("non syntactic colnames work", {
-  df <- data_frame(`x 1` = 1:3)
+  df <- tibble(`x 1` = 1:3)
   expect_identical(summarise_at(df, "x 1", sum)[[1]], 6L)
   expect_identical(summarise_if(df, is.numeric, sum)[[1]], 6L)
   expect_identical(summarise_all(df, sum)[[1]], 6L)
@@ -111,13 +111,13 @@ test_that("predicate can be quoted", {
 })
 
 test_that("transmute verbs do not retain original variables", {
-  expect_named(transmute_all(data_frame(x = 1:3, y = 1:3), funs(mean, sd)), c("x_mean", "y_mean", "x_sd", "y_sd"))
-  expect_named(transmute_if(data_frame(x = 1:3, y = 1:3), is_integer, funs(mean, sd)), c("x_mean", "y_mean", "x_sd", "y_sd"))
-  expect_named(transmute_at(data_frame(x = 1:3, y = 1:3), vars(x:y), funs(mean, sd)), c("x_mean", "y_mean", "x_sd", "y_sd"))
+  expect_named(transmute_all(tibble(x = 1:3, y = 1:3), funs(mean, sd)), c("x_mean", "y_mean", "x_sd", "y_sd"))
+  expect_named(transmute_if(tibble(x = 1:3, y = 1:3), is_integer, funs(mean, sd)), c("x_mean", "y_mean", "x_sd", "y_sd"))
+  expect_named(transmute_at(tibble(x = 1:3, y = 1:3), vars(x:y), funs(mean, sd)), c("x_mean", "y_mean", "x_sd", "y_sd"))
 
-  expect_named(transmute_all(data_frame(x = 1:3, y = 1:3), list(mean = mean, sd = sd)), c("x_mean", "y_mean", "x_sd", "y_sd"))
-  expect_named(transmute_if(data_frame(x = 1:3, y = 1:3), is_integer, list(mean = mean, sd = sd)), c("x_mean", "y_mean", "x_sd", "y_sd"))
-  expect_named(transmute_at(data_frame(x = 1:3, y = 1:3), vars(x:y), list(mean = mean, sd = sd)), c("x_mean", "y_mean", "x_sd", "y_sd"))
+  expect_named(transmute_all(tibble(x = 1:3, y = 1:3), list(mean = mean, sd = sd)), c("x_mean", "y_mean", "x_sd", "y_sd"))
+  expect_named(transmute_if(tibble(x = 1:3, y = 1:3), is_integer, list(mean = mean, sd = sd)), c("x_mean", "y_mean", "x_sd", "y_sd"))
+  expect_named(transmute_at(tibble(x = 1:3, y = 1:3), vars(x:y), list(mean = mean, sd = sd)), c("x_mean", "y_mean", "x_sd", "y_sd"))
 })
 
 test_that("can rename with vars() (#2594)", {
@@ -140,7 +140,7 @@ test_that("can use a purrr-style lambda", {
 })
 
 test_that("mutate_at and transmute_at refuses to mutate a grouping variable (#3351, #3480)", {
-  tbl <- data_frame(gr1 = rep(1:2, 4), gr2 = rep(1:2, each = 4), x = 1:8) %>%
+  tbl <- tibble(gr1 = rep(1:2, 4), gr2 = rep(1:2, each = 4), x = 1:8) %>%
     group_by(gr1)
 
   expect_error(
@@ -157,7 +157,7 @@ test_that("mutate_at and transmute_at refuses to mutate a grouping variable (#33
 })
 
 test_that("mutate and transmute variants does not mutate grouping variable (#3351, #3480)", {
-  tbl <- data_frame(gr1 = rep(1:2, 4), gr2 = rep(1:2, each = 4), x = 1:8) %>%
+  tbl <- tibble(gr1 = rep(1:2, 4), gr2 = rep(1:2, each = 4), x = 1:8) %>%
     group_by(gr1)
   res <- mutate(tbl, gr2 = sqrt(gr2), x = sqrt(x))
 
@@ -172,7 +172,7 @@ test_that("mutate and transmute variants does not mutate grouping variable (#335
 })
 
 test_that("summarise_at refuses to treat grouping variables (#3351, #3480)", {
-  tbl <- data_frame(gr1 = rep(1:2, 4), gr2 = rep(1:2, each = 4), x = 1:8) %>%
+  tbl <- tibble(gr1 = rep(1:2, 4), gr2 = rep(1:2, each = 4), x = 1:8) %>%
     group_by(gr1)
 
   expect_error(
@@ -181,7 +181,7 @@ test_that("summarise_at refuses to treat grouping variables (#3351, #3480)", {
 })
 
 test_that("summarise variants does not summarise grouping variable (#3351, #3480)", {
-  tbl <- data_frame(gr1 = rep(1:2, 4), gr2 = rep(1:2, each = 4), x = 1:8) %>%
+  tbl <- tibble(gr1 = rep(1:2, 4), gr2 = rep(1:2, each = 4), x = 1:8) %>%
     group_by(gr1)
   res <- summarise(tbl, gr2 = mean(gr2), x = mean(x))
 

--- a/tests/testthat/test-colwise-select.R
+++ b/tests/testthat/test-colwise-select.R
@@ -1,6 +1,6 @@
 context("colwise select")
 
-df <- data_frame(x = 0L, y = 0.5, z = 1)
+df <- tibble(x = 0L, y = 0.5, z = 1)
 
 test_that("can select/rename all variables", {
   expect_identical(select_all(df), df)
@@ -71,7 +71,7 @@ test_that("can select/rename with vars()", {
 })
 
 test_that("select variants can use grouping variables (#3351, #3480)", {
-  tbl <- data_frame(gr1 = rep(1:2, 4), gr2 = rep(1:2, each = 4), x = 1:8) %>%
+  tbl <- tibble(gr1 = rep(1:2, 4), gr2 = rep(1:2, each = 4), x = 1:8) %>%
     group_by(gr1)
 
   expect_identical(
@@ -94,7 +94,7 @@ test_that("select_if keeps grouping cols", {
 })
 
 test_that("select_if() handles non-syntactic colnames", {
-  df <- data_frame(`x 1` = 1:3)
+  df <- tibble(`x 1` = 1:3)
   expect_identical(select_if(df, is_integer)[[1]], 1:3)
 })
 
@@ -126,7 +126,7 @@ test_that("scoping (#3426)", {
 })
 
 test_that("rename variants can rename a grouping variable (#3351)", {
-  tbl <- data_frame(gr1 = rep(1:2, 4), gr2 = rep(1:2, each = 4), x = 1:8) %>%
+  tbl <- tibble(gr1 = rep(1:2, 4), gr2 = rep(1:2, each = 4), x = 1:8) %>%
     group_by(gr1)
   res <- rename(tbl, GR1 = gr1, GR2 = gr2, X = x)
 

--- a/tests/testthat/test-count-tally.r
+++ b/tests/testthat/test-count-tally.r
@@ -41,7 +41,7 @@ test_that("returns user defined variable name", {
   expect_equal(names(res), c("g", var_name))
   expect_equal(res[[var_name]], c(2, 3))
 })
-          
+
 test_that("count() does not ignore non-factor empty groups (#4013)",  {
   d <- data.frame(x = c("a", "a", "b", "b"),
     value = 1:4,
@@ -106,13 +106,13 @@ test_that("returns error if user-defined name equals a grouped variable", {
 # tally -------------------------------------------------------------------
 
 test_that("weighted tally drops NAs (#1145)", {
-  df <- data_frame(x = c(1, 1, NA))
+  df <- tibble(x = c(1, 1, NA))
 
   expect_equal(tally(df, x)$n, 2)
 })
 
 test_that("returns column with user-defined name", {
-  df <- data_frame(g = c(1, 2, 2, 2), val = c("b", "b", "b", "c"))
+  df <- tibble(g = c(1, 2, 2, 2), val = c("b", "b", "b", "c"))
   name <- "counts"
   res <- df %>% tally(name = name)
 
@@ -120,7 +120,7 @@ test_that("returns column with user-defined name", {
 })
 
 test_that("returns column with user-defined name if it is not a grouped variable", {
-  df <- data_frame(g = c(1, 2, 2, 2), val = c("b", "b", "b", "c"))
+  df <- tibble(g = c(1, 2, 2, 2), val = c("b", "b", "b", "c"))
   name <- "g"
   res <- df %>% tally(name = name)
 
@@ -128,7 +128,7 @@ test_that("returns column with user-defined name if it is not a grouped variable
 })
 
 test_that("returns error if user-defined name equals a grouped variable", {
-  df <- data_frame(g = c(1, 2, 2, 2), val = c("b", "b", "b", "c"))
+  df <- tibble(g = c(1, 2, 2, 2), val = c("b", "b", "b", "c"))
   name <- "g"
 
   expect_error(df %>% group_by(g) %>% tally(name = name))
@@ -171,7 +171,7 @@ test_that("add_tally can be given a weighting variable", {
 })
 
 test_that("adds column with user-defined variable name if it is not a grouped variable name", {
-  df <- data_frame(g = c(1, 2, 2, 2), val = c("b", "b", "b", "c"))
+  df <- tibble(g = c(1, 2, 2, 2), val = c("b", "b", "b", "c"))
   name <- "val"
   res <- df %>% add_tally(name = name)
 
@@ -179,7 +179,7 @@ test_that("adds column with user-defined variable name if it is not a grouped va
 })
 
 test_that("returns error if user-defined name equals a grouped variable", {
-  df <- data_frame(g = c(1, 2, 2, 2), val = c("b", "b", "b", "c"))
+  df <- tibble(g = c(1, 2, 2, 2), val = c("b", "b", "b", "c"))
   name <- "val"
   expect_error(df %>% group_by(val) %>% add_tally(name = name))
 })

--- a/tests/testthat/test-distinct.R
+++ b/tests/testthat/test-distinct.R
@@ -22,26 +22,26 @@ test_that("distinct for single column works as expected (#1937)", {
 })
 
 test_that("distinct works for 0-sized columns (#1437)", {
-  df <- data_frame(x = 1:10) %>% select(-x)
+  df <- tibble(x = 1:10) %>% select(-x)
   ddf <- distinct(df)
   expect_equal(ncol(ddf), 0L)
 })
 
 test_that("if no variables specified, uses all", {
-  df <- data_frame(x = c(1, 1), y = c(2, 2))
-  expect_equal(distinct(df), data_frame(x = 1, y = 2))
+  df <- tibble(x = c(1, 1), y = c(2, 2))
+  expect_equal(distinct(df), tibble(x = 1, y = 2))
 })
 
 test_that("distinct keeps only specified cols", {
-  df <- data_frame(x = c(1, 1, 1), y = c(1, 1, 1))
-  expect_equal(df %>% distinct(x), data_frame(x = 1))
+  df <- tibble(x = c(1, 1, 1), y = c(1, 1, 1))
+  expect_equal(df %>% distinct(x), tibble(x = 1))
 })
 
 test_that("unless .keep_all = TRUE", {
-  df <- data_frame(x = c(1, 1, 1), y = 3:1)
+  df <- tibble(x = c(1, 1, 1), y = 3:1)
 
-  expect_equal(df %>% distinct(x), data_frame(x = 1))
-  expect_equal(df %>% distinct(x, .keep_all = TRUE), data_frame(x = 1, y = 3L))
+  expect_equal(df %>% distinct(x), tibble(x = 1))
+  expect_equal(df %>% distinct(x, .keep_all = TRUE), tibble(x = 1, y = 3L))
 })
 
 test_that("distinct doesn't duplicate columns", {

--- a/tests/testthat/test-do.R
+++ b/tests/testthat/test-do.R
@@ -51,7 +51,7 @@ test_that("named argument become list columns", {
 })
 
 test_that("multiple outputs can access data (#2998)", {
-  out <- do(data_frame(a = 1), g = nrow(.), h = nrow(.))
+  out <- do(tibble(a = 1), g = nrow(.), h = nrow(.))
   expect_equal(names(out), c("g", "h"))
   expect_equal(out$g, list(1L))
   expect_equal(out$h, list(1L))
@@ -128,7 +128,7 @@ test_that("can do on rowwise dataframe", {
 # Zero row inputs --------------------------------------------------------------
 
 test_that("empty data frames give consistent outputs", {
-  dat <- data_frame(x = numeric(0), g = character(0))
+  dat <- tibble(x = numeric(0), g = character(0))
   grp <- dat %>% group_by(g)
   emt <- grp %>% filter(FALSE)
 

--- a/tests/testthat/test-empty-groups.R
+++ b/tests/testthat/test-empty-groups.R
@@ -1,6 +1,6 @@
 context("empty groups")
 
-df <- data_frame(
+df <- tibble(
   e = 1,
   f = factor(c(1, 1, 2, 2), levels = 1:3),
   g = c(1, 1, 2, 2),
@@ -55,10 +55,10 @@ test_that("bind_rows respect the drop attribute of grouped df",{
 })
 
 test_that("joins respect zero length groups", {
-  df1 <- data_frame(f = factor( c(1,1,2,2), levels = 1:3), x = c(1,2,1,4)) %>%
+  df1 <- tibble(f = factor( c(1,1,2,2), levels = 1:3), x = c(1,2,1,4)) %>%
     group_by(f)
 
-  df2 <- data_frame(f = factor( c(2,2,3,3), levels = 1:3), y = c(1,2,3,4)) %>%
+  df2 <- tibble(f = factor( c(2,2,3,3), levels = 1:3), y = c(1,2,3,4)) %>%
     group_by(f)
 
   expect_equal(group_size(left_join( df1, df2, by = "f")),  c(2,4,0))

--- a/tests/testthat/test-equality.r
+++ b/tests/testthat/test-equality.r
@@ -78,7 +78,7 @@ test_that("factor comparison requires strict equality of levels (#2440)", {
 })
 
 test_that("BoolResult does not overwrite singleton R_TrueValue", {
-  dplyr:::equal_tibble(mtcars, mtcars)
+  dplyr:::equal_data_frame(mtcars, mtcars)
   expect_equal(class(2 == 2), "logical")
 })
 

--- a/tests/testthat/test-equality.r
+++ b/tests/testthat/test-equality.r
@@ -50,8 +50,8 @@ test_that("data frames not equal if missing col", {
 })
 
 test_that("factors equal only if levels equal", {
-  df1 <- data_frame(x = factor(c("a", "b")))
-  df2 <- data_frame(x = factor(c("a", "d")))
+  df1 <- tibble(x = factor(c("a", "b")))
+  df2 <- tibble(x = factor(c("a", "d")))
   expect_equal(
     all.equal(df1, df2),
     "Factor levels not equal for column `x`"
@@ -63,8 +63,8 @@ test_that("factors equal only if levels equal", {
 })
 
 test_that("factor comparison requires strict equality of levels (#2440)", {
-  df1 <- data_frame(x = factor("a"))
-  df2 <- data_frame(x = factor("a", levels = c("a", "b")))
+  df1 <- tibble(x = factor("a"))
+  df2 <- tibble(x = factor("a", levels = c("a", "b")))
   expect_equal(
     all.equal(df1, df2),
     "Factor levels not equal for column `x`"
@@ -78,7 +78,7 @@ test_that("factor comparison requires strict equality of levels (#2440)", {
 })
 
 test_that("BoolResult does not overwrite singleton R_TrueValue", {
-  dplyr:::equal_data_frame(mtcars, mtcars)
+  dplyr:::equal_tibble(mtcars, mtcars)
   expect_equal(class(2 == 2), "logical")
 })
 
@@ -89,20 +89,20 @@ test_that("all.equal.data.frame handles data.frames with NULL names", {
 })
 
 test_that("data frame equality test with ignore_row_order=TRUE detects difference in number of rows. #1065", {
-  DF1 <- data_frame(a = 1:4, b = letters[1:4])
-  DF2 <- data_frame(a = c(1:4, 4L), b = letters[c(1:4, 4L)])
+  DF1 <- tibble(a = 1:4, b = letters[1:4])
+  DF2 <- tibble(a = c(1:4, 4L), b = letters[c(1:4, 4L)])
   expect_false(isTRUE(all.equal(DF1, DF2, ignore_row_order = TRUE)))
 
-  DF1 <- data_frame(a = c(1:4, 2L), b = letters[c(1:4, 2L)])
-  DF2 <- data_frame(a = c(1:4, 4L), b = letters[c(1:4, 4L)])
+  DF1 <- tibble(a = c(1:4, 2L), b = letters[c(1:4, 2L)])
+  DF2 <- tibble(a = c(1:4, 4L), b = letters[c(1:4, 4L)])
   expect_false(isTRUE(all.equal(DF1, DF2, ignore_row_order = TRUE)))
 })
 
 test_that("all.equal handles NA_character_ correctly. #1095", {
-  d1 <- data_frame(x = c(NA_character_))
+  d1 <- tibble(x = c(NA_character_))
   expect_true(all.equal(d1, d1))
 
-  d2 <- data_frame(x = c(NA_character_, "foo", "bar"))
+  d2 <- tibble(x = c(NA_character_, "foo", "bar"))
   expect_true(all.equal(d2, d2))
 })
 
@@ -113,8 +113,8 @@ test_that("handle Date columns of different types, integer and numeric (#1204)",
 })
 
 test_that("equality test fails when convert is FALSE and types don't match (#1484)", {
-  df1 <- data_frame(x = "a")
-  df2 <- data_frame(x = factor("a"))
+  df1 <- tibble(x = "a")
+  df2 <- tibble(x = factor("a"))
 
   expect_equal(
     all_equal(df1, df2, convert = FALSE),
@@ -124,37 +124,37 @@ test_that("equality test fails when convert is FALSE and types don't match (#148
 })
 
 test_that("equality handles data frames with 0 rows (#1506)", {
-  df0 <- data_frame(x = numeric(0), y = character(0))
+  df0 <- tibble(x = numeric(0), y = character(0))
   expect_equal(df0, df0)
 })
 
 test_that("equality handles data frames with 0 columns (#1506)", {
-  df0 <- data_frame(a = 1:10)[-1]
+  df0 <- tibble(a = 1:10)[-1]
   expect_equal(df0, df0)
 })
 
 test_that("equality handle raw columns", {
-  df <- data_frame(a = 1:3, b = as.raw(1:3))
+  df <- tibble(a = 1:3, b = as.raw(1:3))
   expect_true(all.equal(df, df))
 })
 
 test_that("equality returns a message for convert = TRUE", {
-  df1 <- data_frame(x = 1:3)
-  df2 <- data_frame(x = as.character(1:3))
+  df1 <- tibble(x = 1:3)
+  df2 <- tibble(x = as.character(1:3))
   expect_match(all.equal(df1, df2), "Incompatible")
   expect_match(all.equal(df1, df2, convert = TRUE), "Incompatible")
 })
 
 test_that("numeric and integer can be compared if convert = TRUE", {
-  df1 <- data_frame(x = 1:3)
-  df2 <- data_frame(x = as.numeric(1:3))
+  df1 <- tibble(x = 1:3)
+  df2 <- tibble(x = as.numeric(1:3))
   expect_match(all.equal(df1, df2), "Incompatible")
   expect_true(all.equal(df1, df2, convert = TRUE))
 })
 
 test_that("returns vector for more than one difference (#1819)", {
   expect_equal(
-    all.equal(data_frame(a = 1, b = 2), data_frame(a = 1L, b = 2L)),
+    all.equal(tibble(a = 1, b = 2), tibble(a = 1L, b = 2L)),
     c(
       "Incompatible type for column `a`: x numeric, y integer",
       "Incompatible type for column `b`: x numeric, y integer"
@@ -163,8 +163,8 @@ test_that("returns vector for more than one difference (#1819)", {
 })
 
 test_that("returns UTF-8 column names (#2441)", {
-  df1 <- data_frame("\u5e78" := 1)
-  df2 <- data_frame("\u798f" := 1)
+  df1 <- tibble("\u5e78" := 1)
+  df2 <- tibble("\u798f" := 1)
 
   expect_equal(
     all.equal(df1, df2),
@@ -178,13 +178,13 @@ test_that("returns UTF-8 column names (#2441)", {
 
 test_that("proper message formatting for set operations", {
   expect_error(
-    union(data_frame(a = 1), data_frame(a = "1")),
+    union(tibble(a = 1), tibble(a = "1")),
     "not compatible: Incompatible type for column `a`: x numeric, y character",
     fixed = TRUE
   )
 
   expect_error(
-    union(data_frame(a = 1, b = 2), data_frame(a = "1", b = "2")),
+    union(tibble(a = 1, b = 2), tibble(a = "1", b = "2")),
     "not compatible: \n- Incompatible type for column `a`: x numeric, y character\n- Incompatible type for column `b`: x numeric, y character",
     fixed = TRUE
   )
@@ -192,12 +192,12 @@ test_that("proper message formatting for set operations", {
 
 test_that("ignore column order", {
   expect_equal(
-    all.equal(data_frame(a = 1, b = 2), data_frame(b = 2, a = 1), ignore_col_order = FALSE),
+    all.equal(tibble(a = 1, b = 2), tibble(b = 2, a = 1), ignore_col_order = FALSE),
     "Same column names, but different order"
   )
 
   expect_equal(
-    all.equal(data_frame(a = 1, b = 2), data_frame(a = 1), ignore_col_order = FALSE),
+    all.equal(tibble(a = 1, b = 2), tibble(a = 1), ignore_col_order = FALSE),
     "Cols in x but not y: `b`. "
   )
 })

--- a/tests/testthat/test-filter.r
+++ b/tests/testthat/test-filter.r
@@ -190,7 +190,7 @@ test_that("filter handles complex vectors (#436)", {
 })
 
 test_that("%in% works as expected (#126)", {
-  df <- data_frame(a = c("a", "b", "ab"), g = c(1, 1, 2))
+  df <- tibble(a = c("a", "b", "ab"), g = c(1, 1, 2))
 
   res <- df %>% filter(a %in% letters)
   expect_equal(nrow(res), 2L)
@@ -219,13 +219,13 @@ test_that("filter does not alter expression (#971)", {
 })
 
 test_that("hybrid evaluation handles $ correctly (#1134)", {
-  df <- data_frame(x = 1:10, g = rep(1:5, 2))
+  df <- tibble(x = 1:10, g = rep(1:5, 2))
   res <- df %>% group_by(g) %>% filter(x > min(df$x))
   expect_equal(nrow(res), 9L)
 })
 
 test_that("filter correctly handles empty data frames (#782)", {
-  res <- data_frame() %>% filter(F)
+  res <- tibble() %>% filter(F)
   expect_equal(nrow(res), 0L)
   expect_equal(length(names(res)), 0L)
 })
@@ -264,7 +264,7 @@ test_that("filter, slice and arrange preserves attributes (#1064)", {
 })
 
 test_that("filter works with rowwise data (#1099)", {
-  df <- data_frame(First = c("string1", "string2"), Second = c("Sentence with string1", "something"))
+  df <- tibble(First = c("string1", "string2"), Second = c("Sentence with string1", "something"))
   res <- df %>% rowwise() %>% filter(grepl(First, Second, fixed = TRUE))
   expect_equal(nrow(res), 1L)
   expect_equal(df[1, ], res)
@@ -328,9 +328,9 @@ test_that("hybrid lag and default value for string columns work (#1403)", {
 # .data and .env tests now in test-hybrid-traverse.R
 
 test_that("filter handles raw vectors (#1803)", {
-  df <- data_frame(a = 1:3, b = as.raw(1:3))
-  expect_identical(filter(df, a == 1), data_frame(a = 1L, b = as.raw(1)))
-  expect_identical(filter(df, b == 1), data_frame(a = 1L, b = as.raw(1)))
+  df <- tibble(a = 1:3, b = as.raw(1:3))
+  expect_identical(filter(df, a == 1), tibble(a = 1L, b = as.raw(1)))
+  expect_identical(filter(df, b == 1), tibble(a = 1L, b = as.raw(1)))
 })
 
 test_that("`vars` attribute is not added if empty (#2772)", {

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -43,7 +43,7 @@ test_that("grouping by constant adds column (#410)", {
 
 
 test_that("local group_by preserves variable types", {
-  df_var <- data_frame(
+  df_var <- tibble(
     l = c(T, F),
     i = 1:2,
     d = Sys.Date() + 1:2,
@@ -54,7 +54,7 @@ test_that("local group_by preserves variable types", {
   )
 
   for (var in names(df_var)) {
-    expected <- data_frame(unique(df_var[[var]]), n = 1L)
+    expected <- tibble(unique(df_var[[var]]), n = 1L)
     names(expected)[1] <- var
 
     summarised <- df_var %>% group_by(!!sym(var)) %>% summarise(n = n())
@@ -217,7 +217,7 @@ test_that("group_by gives meaningful message with unknow column (#716)", {
 })
 
 test_that("[ on grouped_df preserves grouping if subset includes grouping vars", {
-  df <- data_frame(x = 1:5, ` ` = 6:10)
+  df <- tibble(x = 1:5, ` ` = 6:10)
   by_x <- df %>% group_by(x)
   expect_equal(by_x %>% groups(), by_x %>% `[`(1:2) %>% groups())
 
@@ -235,7 +235,7 @@ test_that("[ on grouped_df drops grouping if subset doesn't include grouping var
 })
 
 test_that("group_by works after arrange (#959)", {
-  df <- data_frame(Log = c(1, 2, 1, 2, 1, 2), Time = c(10, 1, 3, 0, 15, 11))
+  df <- tibble(Log = c(1, 2, 1, 2, 1, 2), Time = c(10, 1, 3, 0, 15, 11))
   res <- df %>%
     arrange(Time) %>%
     group_by(Log) %>%
@@ -281,13 +281,13 @@ test_that(paste0("group_by handles encodings for native strings (#1507)"), {
 })
 
 test_that("group_by handles raw columns (#1803)", {
-  df <- data_frame(a = 1:3, b = as.raw(1:3))
+  df <- tibble(a = 1:3, b = as.raw(1:3))
   expect_identical(ungroup(group_by(df, a)), df)
   expect_identical(ungroup(group_by(df, b)), df)
 })
 
 test_that("rowwise handles raw columns (#1803)", {
-  df <- data_frame(a = 1:3, b = as.raw(1:3))
+  df <- tibble(a = 1:3, b = as.raw(1:3))
   expect_is(rowwise(df), "rowwise_df")
 })
 

--- a/tests/testthat/test-group-indices.R
+++ b/tests/testthat/test-group-indices.R
@@ -47,19 +47,19 @@ test_that("group_indices() warns when passed extra arguments on grouped or rowwi
 })
 
 test_that("group_indices() can be used inside mutate (#1185)", {
-  df <- data_frame(v1 = c(3, 3, 2, 2, 3, 1), v2 = 1:6) %>% group_by(v1)
+  df <- tibble(v1 = c(3, 3, 2, 2, 3, 1), v2 = 1:6) %>% group_by(v1)
   expect_identical(
     pull(mutate(df, g = group_indices())),
     group_indices(df)
   )
 
-  df <- data_frame(v1 = c(3, 3, 2, 2, 3, 1), v2 = 1:6)
+  df <- tibble(v1 = c(3, 3, 2, 2, 3, 1), v2 = 1:6)
   expect_identical(
     pull(mutate(df, g = group_indices())),
     group_indices(df)
   )
 
-  df <- rowwise(data_frame(v1 = c(3, 3, 2, 2, 3, 1), v2 = 1:6))
+  df <- rowwise(tibble(v1 = c(3, 3, 2, 2, 3, 1), v2 = 1:6))
   expect_identical(
     pull(mutate(df, g = group_indices())),
     group_indices(df)

--- a/tests/testthat/test-hybrid-traverse.R
+++ b/tests/testthat/test-hybrid-traverse.R
@@ -1,6 +1,6 @@
 context("hybrid-traverse")
 
-test_df <- data_frame(
+test_df <- tibble(
   id = c(1L, 2L, 2L),
   a = 1:3,
   b = as.numeric(1:3),
@@ -64,7 +64,7 @@ test_that("[[ works for rowwise access of list columns (#912)", {
 
   expect_equal(
     df %>% rowwise() %>% transmute(z = y[[x]]),
-    data_frame(z = c(1, 4))
+    tibble(z = c(1, 4))
   )
 })
 
@@ -438,7 +438,7 @@ test_hybrid <- function(grouping) {
   })
 
   test_that("columns named .data and .env are overridden", {
-    conflict_data <- data_frame(id = test_df$id, .data = 1:3, .env = 3:1)
+    conflict_data <- tibble(id = test_df$id, .data = 1:3, .env = 3:1)
 
     expect_equal(
       conflict_data %>%
@@ -449,12 +449,12 @@ test_hybrid <- function(grouping) {
           is_env_env = all(vapply(env, is.environment, logical(1))),
           is_data_env = all(vapply(env, is.environment, logical(1)))
         ),
-      data_frame(is_env_env = TRUE, is_data_env = TRUE)
+      tibble(is_env_env = TRUE, is_data_env = TRUE)
     )
   })
 
   test_that("contents of columns named .data and .env can be accessed", {
-    conflict_data <- data_frame(id = test_df$id, .data = 1:3, .env = 3:1)
+    conflict_data <- tibble(id = test_df$id, .data = 1:3, .env = 3:1)
 
     expect_equal(
       conflict_data %>%

--- a/tests/testthat/test-hybrid.R
+++ b/tests/testthat/test-hybrid.R
@@ -6,7 +6,7 @@ test_that("hybrid evaluation environment is cleaned up (#2358)", {
   }
 
   # Can't use pipe here, f and g should have top-level parent.env()
-  df <- data_frame(a = 1) %>% group_by(a)
+  df <- tibble(a = 1) %>% group_by(a)
   df <- mutate(df, f = {
     a
     list(function() {})

--- a/tests/testthat/test-joins.r
+++ b/tests/testthat/test-joins.r
@@ -349,8 +349,8 @@ test_that("join functions error on column not found #371", {
 })
 
 test_that("inner_join is symmetric (even when joining on character & factor)", {
-  foo <- data_frame(id = factor(c("a", "b")), var1 = "foo")
-  bar <- data_frame(id = c("a", "b"), var2 = "bar")
+  foo <- tibble(id = factor(c("a", "b")), var1 = "foo")
+  bar <- tibble(id = c("a", "b"), var2 = "bar")
 
   expect_warning(tmp1 <- inner_join(foo, bar, by = "id"), "joining factor and character")
   expect_warning(tmp2 <- inner_join(bar, foo, by = "id"), "joining character vector and factor")
@@ -378,8 +378,8 @@ test_that("inner_join is symmetric, even when type of join var is different (#45
 })
 
 test_that("left_join by different variable names (#617)", {
-  x <- data_frame(x1 = c(1, 3, 2))
-  y <- data_frame(y1 = c(1, 2, 3), y2 = c("foo", "foo", "bar"))
+  x <- tibble(x1 = c(1, 3, 2))
+  y <- tibble(y1 = c(1, 2, 3), y2 = c("foo", "foo", "bar"))
   res <- left_join(x, y, by = c("x1" = "y1"))
   expect_equal(names(res), c("x1", "y2"))
   expect_equal(res$x1, c(1, 3, 2))
@@ -474,15 +474,15 @@ test_that("JoinFactorFactorVisitor_SameLevels preserve levels order (#675)", {
 })
 
 test_that("inner_join does not reorder (#684)", {
-  test <- data_frame(Greek = c("Alpha", "Beta", "Gamma"), Letters = LETTERS[1:3])
-  lookup <- data_frame(Letters = c("C", "B", "C"))
+  test <- tibble(Greek = c("Alpha", "Beta", "Gamma"), Letters = LETTERS[1:3])
+  lookup <- tibble(Letters = c("C", "B", "C"))
   res <- inner_join(lookup, test)
   expect_equal(res$Letters, c("C", "B", "C"))
 })
 
 test_that("joins coerce factors with different levels to character (#684)", {
-  d1 <- data_frame(a = factor(c("a", "b", "c")))
-  d2 <- data_frame(a = factor(c("a", "e")))
+  d1 <- tibble(a = factor(c("a", "b", "c")))
+  d2 <- tibble(a = factor(c("a", "e")))
   expect_warning(res <- inner_join(d1, d2))
   expect_is(res$a, "character")
 
@@ -494,8 +494,8 @@ test_that("joins coerce factors with different levels to character (#684)", {
 })
 
 test_that("joins between factor and character coerces to character with a warning (#684)", {
-  d1 <- data_frame(a = factor(c("a", "b", "c")))
-  d2 <- data_frame(a = c("a", "e"))
+  d1 <- tibble(a = factor(c("a", "b", "c")))
+  d2 <- tibble(a = c("a", "e"))
   expect_warning(res <- inner_join(d1, d2))
   expect_is(res$a, "character")
 
@@ -504,16 +504,16 @@ test_that("joins between factor and character coerces to character with a warnin
 })
 
 test_that("group column names reflect renamed duplicate columns (#2330)", {
-  d1 <- data_frame(x = 1:5, y = 1:5) %>% group_by(x, y)
-  d2 <- data_frame(x = 1:5, y = 1:5)
+  d1 <- tibble(x = 1:5, y = 1:5) %>% group_by(x, y)
+  d2 <- tibble(x = 1:5, y = 1:5)
   res <- inner_join(d1, d2, by = "x")
   expect_groups(d1, c("x", "y"))
   expect_groups(res, c("x", "y.x"))
 })
 
 test_that("group column names are null when joined data frames are not grouped (#2330)", {
-  d1 <- data_frame(x = 1:5, y = 1:5)
-  d2 <- data_frame(x = 1:5, y = 1:5)
+  d1 <- tibble(x = 1:5, y = 1:5)
+  d2 <- tibble(x = 1:5, y = 1:5)
   res <- inner_join(d1, d2, by = "x")
   expect_no_groups(res)
 })
@@ -541,26 +541,26 @@ test_that("join columns are not moved to the left (#802)", {
 test_that("join can handle multiple encodings (#769)", {
   text <- c("\xC9lise", "Pierre", "Fran\xE7ois")
   Encoding(text) <- "latin1"
-  x <- data_frame(name = text, score = c(5, 7, 6))
-  y <- data_frame(name = text, attendance = c(8, 10, 9))
+  x <- tibble(name = text, score = c(5, 7, 6))
+  y <- tibble(name = text, attendance = c(8, 10, 9))
   res <- left_join(x, y, by = "name")
   expect_equal(nrow(res), 3L)
   expect_equal(res$name, x$name)
 
-  x <- data_frame(name = factor(text), score = c(5, 7, 6))
-  y <- data_frame(name = text, attendance = c(8, 10, 9))
+  x <- tibble(name = factor(text), score = c(5, 7, 6))
+  y <- tibble(name = text, attendance = c(8, 10, 9))
   res <- suppressWarnings(left_join(x, y, by = "name"))
   expect_equal(nrow(res), 3L)
   expect_equal(res$name, y$name)
 
-  x <- data_frame(name = text, score = c(5, 7, 6))
-  y <- data_frame(name = factor(text), attendance = c(8, 10, 9))
+  x <- tibble(name = text, score = c(5, 7, 6))
+  y <- tibble(name = factor(text), attendance = c(8, 10, 9))
   res <- suppressWarnings(left_join(x, y, by = "name"))
   expect_equal(nrow(res), 3L)
   expect_equal(res$name, x$name)
 
-  x <- data_frame(name = factor(text), score = c(5, 7, 6))
-  y <- data_frame(name = factor(text), attendance = c(8, 10, 9))
+  x <- tibble(name = factor(text), score = c(5, 7, 6))
+  y <- tibble(name = factor(text), attendance = c(8, 10, 9))
   res <- suppressWarnings(left_join(x, y, by = "name"))
   expect_equal(nrow(res), 3L)
   expect_equal(res$name, x$name)
@@ -593,8 +593,8 @@ test_that("inner join gives same result as merge by default (#1281)", {
 })
 
 test_that("join handles matrices #1230", {
-  df1 <- data_frame(x = 1:10, text = letters[1:10])
-  df2 <- data_frame(x = 1:5, text = "")
+  df1 <- tibble(x = 1:10, text = letters[1:10])
+  df2 <- tibble(x = 1:5, text = "")
   df2$text <- matrix(LETTERS[1:10], nrow = 5)
 
   res <- left_join(df1, df2, by = c("x" = "x")) %>% filter(x > 5)
@@ -687,8 +687,8 @@ test_that("join functions are protected against empty by (#1496)", {
 })
 
 test_that("joins takes care of duplicates in by (#1192)", {
-  data2 <- data_frame(a = 1:3)
-  data1 <- data_frame(a = 1:3, c = 3:5)
+  data2 <- tibble(a = 1:3)
+  data1 <- tibble(a = 1:3, c = 3:5)
 
   res1 <- left_join(data1, data2, by = c("a", "a"))
   res2 <- left_join(data1, data2, by = c("a" = "a"))
@@ -698,7 +698,7 @@ test_that("joins takes care of duplicates in by (#1192)", {
 # Joined columns result in correct type ----------------------------------------
 
 test_that("result of joining POSIXct is POSIXct (#1578)", {
-  data1 <- data_frame(
+  data1 <- tibble(
     t = seq(as.POSIXct("2015-12-01", tz = "UTC"), length.out = 2, by = "days"),
     x = 1:2
   )
@@ -709,11 +709,11 @@ test_that("result of joining POSIXct is POSIXct (#1578)", {
 })
 
 test_that("joins allows extra attributes if they are identical (#1636)", {
-  tbl_left <- data_frame(
+  tbl_left <- tibble(
     i = rep(c(1, 2, 3), each = 2),
     x1 = letters[1:6]
   )
-  tbl_right <- data_frame(
+  tbl_right <- tibble(
     i = c(1, 2, 3),
     x2 = letters[1:3]
   )
@@ -767,7 +767,7 @@ test_that("anti and semi joins give correct result when by variable is a factor 
 })
 
 test_that("inner join not crashing (#1559)", {
-  df3 <- data_frame(
+  df3 <- tibble(
     id = c(102, 102, 102, 121),
     name = c("qwer", "qwer", "qwer", "asdf"),
     k = factor(c("one", "two", "total", "one"), levels = c("one", "two", "total")),
@@ -776,7 +776,7 @@ test_that("inner join not crashing (#1559)", {
     btm = c(25654.957609, 29375.7547216667, 55030.7123306667, 10469.3523273333),
     top = c(22238.368946, 30341.516924, 52579.88587, 9541.893144)
   )
-  df4 <- data_frame(
+  df4 <- tibble(
     id = c(102, 102, 102, 121),
     name = c("qwer", "qwer", "qwer", "asdf"),
     k = factor(c("one", "two", "total", "one"), levels = c("one", "two", "total")),
@@ -863,10 +863,10 @@ test_that("left_join handles mix of encodings in column names (#1571)", {
   with_non_utf8_encoding({
     special <- get_native_lang_string()
 
-    df1 <- data_frame(x = 1:6, foo = 1:6)
+    df1 <- tibble(x = 1:6, foo = 1:6)
     names(df1)[1] <- special
 
-    df2 <- data_frame(x = 1:6, baz = 1:6)
+    df2 <- tibble(x = 1:6, baz = 1:6)
     names(df2)[1] <- enc2native(special)
 
     expect_message(res <- left_join(df1, df2), special, fixed = TRUE)
@@ -880,8 +880,8 @@ test_that("left_join handles mix of encodings in column names (#1571)", {
 # Misc --------------------------------------------------------------------
 
 test_that("NAs match in joins only with na_matches = 'na' (#2033)", {
-  df1 <- data_frame(a = NA)
-  df2 <- data_frame(a = NA, b = 1:3)
+  df1 <- tibble(a = NA)
+  df2 <- tibble(a = NA, b = 1:3)
   for (na_matches in c("na", "never")) {
     accept_na_match <- (na_matches == "na")
     expect_equal(inner_join(df1, df2, na_matches = na_matches) %>% nrow(), 0 + 3 * accept_na_match)
@@ -894,8 +894,8 @@ test_that("NAs match in joins only with na_matches = 'na' (#2033)", {
 })
 
 test_that("joins regroups (#1597, #3566)", {
-  df1 <- data_frame(a = 1:3) %>% group_by(a)
-  df2 <- data_frame(a = rep(1:4, 2)) %>% group_by(a)
+  df1 <- tibble(a = 1:3) %>% group_by(a)
+  df2 <- tibble(a = rep(1:4, 2)) %>% group_by(a)
 
   expect_grouped <- function(df) {
     expect_true(is_grouped_df(df))
@@ -912,8 +912,8 @@ test_that("joins regroups (#1597, #3566)", {
 
 test_that("join accepts tz attributes (#2643)", {
   # It's the same time:
-  df1 <- data_frame(a = as.POSIXct("2009-01-01 10:00:00", tz = "Europe/London"))
-  df2 <- data_frame(a = as.POSIXct("2009-01-01 11:00:00", tz = "Europe/Paris"))
+  df1 <- tibble(a = as.POSIXct("2009-01-01 10:00:00", tz = "Europe/London"))
+  df2 <- tibble(a = as.POSIXct("2009-01-01 11:00:00", tz = "Europe/Paris"))
   result <- inner_join(df1, df2, by = "a")
   expect_equal(nrow(result), 1)
 })
@@ -963,37 +963,37 @@ test_that("common_by() message", {
 
 test_that("semi- and anti-joins preserve order (#2964)", {
   expect_identical(
-    data_frame(a = 3:1) %>% semi_join(data_frame(a = 1:3)),
-    data_frame(a = 3:1)
+    tibble(a = 3:1) %>% semi_join(tibble(a = 1:3)),
+    tibble(a = 3:1)
   )
   expect_identical(
-    data_frame(a = 3:1) %>% anti_join(data_frame(a = 4:6)),
-    data_frame(a = 3:1)
+    tibble(a = 3:1) %>% anti_join(tibble(a = 4:6)),
+    tibble(a = 3:1)
   )
 })
 
 test_that("join handles raw vectors", {
-  df1 <- data_frame(r = as.raw(1:4), x = 1:4)
-  df2 <- data_frame(r = as.raw(3:6), y = 3:6)
+  df1 <- tibble(r = as.raw(1:4), x = 1:4)
+  df2 <- tibble(r = as.raw(3:6), y = 3:6)
 
   expect_identical(
     left_join(df1, df2, by = "r"),
-    data_frame(r = as.raw(1:4), x = 1:4, y = c(NA, NA, 3:4))
+    tibble(r = as.raw(1:4), x = 1:4, y = c(NA, NA, 3:4))
   )
 
   expect_identical(
     right_join(df1, df2, by = "r"),
-    data_frame(r = as.raw(3:6), x = c(3:4, NA, NA), y = c(3:6))
+    tibble(r = as.raw(3:6), x = c(3:4, NA, NA), y = c(3:6))
   )
 
   expect_identical(
     full_join(df1, df2, by = "r"),
-    data_frame(r = as.raw(1:6), x = c(1:4, NA, NA), y = c(NA, NA, 3:6))
+    tibble(r = as.raw(1:6), x = c(1:4, NA, NA), y = c(NA, NA, 3:6))
   )
 
   expect_identical(
     inner_join(df1, df2, by = "r"),
-    data_frame(r = as.raw(3:4), x = c(3:4), y = c(3:4))
+    tibble(r = as.raw(3:4), x = c(3:4), y = c(3:4))
   )
 })
 

--- a/tests/testthat/test-lead-lag.R
+++ b/tests/testthat/test-lead-lag.R
@@ -19,7 +19,7 @@ test_that("lead and lag preserves dates and times", {
 })
 
 test_that("#925 is fixed", {
-  data <- data_frame(
+  data <- tibble(
     name = c("Rob", "Pete", "Rob", "John", "Rob", "Pete", "John", "Pete", "John", "Pete", "Rob", "Rob"),
     time = c(3, 2, 5, 3, 2, 3, 2, 4, 1, 1, 4, 1)
   )
@@ -39,7 +39,7 @@ test_that("#925 is fixed", {
 })
 
 test_that("#937 is fixed", {
-  df <- data_frame(
+  df <- tibble(
     name = rep(c("Al", "Jen"), 3),
     score = rep(c(100, 80, 60), 2)
   )

--- a/tests/testthat/test-mutate-windowed.R
+++ b/tests/testthat/test-mutate-windowed.R
@@ -145,7 +145,7 @@ test_that("ntile works with one argument (#3418)", {
 })
 
 test_that("rank functions deal correctly with NA (#774)", {
-  data <- data_frame(x = c(1, 2, NA, 1, 0, NA))
+  data <- tibble(x = c(1, 2, NA, 1, 0, NA))
   res <- data %>% mutate(
     min_rank = min_rank(x),
     percent_rank = percent_rank(x),
@@ -168,7 +168,7 @@ test_that("rank functions deal correctly with NA (#774)", {
   expect_equal(res$ntile[ c(1, 2, 4, 5) ], c(1L, 2L, 2L, 1L))
   expect_equal(res$row_number[ c(1, 2, 4, 5) ], c(2L, 4L, 3L, 1L))
 
-  data <- data_frame(
+  data <- tibble(
     x = rep(c(1, 2, NA, 1, 0, NA), 2),
     g = rep(c(1, 2), each = 6)
   )

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -279,26 +279,26 @@ test_that("mutate remove variables with = NULL syntax (#462)", {
 })
 
 test_that("mutate strips names, but only if grouped (#1689, #2675)", {
-  data <- data_frame(a = 1:3) %>% mutate(b = setNames(nm = a))
+  data <- tibble(a = 1:3) %>% mutate(b = setNames(nm = a))
   expect_equal(names(data$b), as.character(1:3))
 
-  data <- data_frame(a = 1:3) %>% rowwise() %>% mutate(b = setNames(nm = a))
+  data <- tibble(a = 1:3) %>% rowwise() %>% mutate(b = setNames(nm = a))
   expect_null(names(data$b))
 
-  data <- data_frame(a = c(1, 1, 2)) %>% group_by(a) %>% mutate(b = setNames(nm = a))
+  data <- tibble(a = c(1, 1, 2)) %>% group_by(a) %>% mutate(b = setNames(nm = a))
   expect_null(names(data$b))
 })
 
 test_that("mutate does not strip names of list-columns (#2675)", {
   vec <- list(a = 1, b = 2)
-  data <- data_frame(x = vec)
+  data <- tibble(x = vec)
   data <- mutate(data, x)
   expect_identical(names(vec), c("a", "b"))
   expect_identical(names(data$x), c("a", "b"))
 })
 
 test_that("mutate removes columns when the expression evaluates to NULL for all groups (#2945)", {
-  df <- data_frame(a = 1:3, b=4:6)
+  df <- tibble(a = 1:3, b=4:6)
   gf <- group_by(df, a)
   rf <- rowwise(df)
 
@@ -317,7 +317,7 @@ test_that("mutate removes columns when the expression evaluates to NULL for all 
 })
 
 test_that("mutate treats NULL specially when the expression sometimes evaulates to NULL (#2945)", {
-  df <- data_frame(a = 1:3, b=4:6) %>% group_by(a)
+  df <- tibble(a = 1:3, b=4:6) %>% group_by(a)
   expect_equal( mutate(df, if(a==1) NULL else "foo") %>% pull(), c(NA, "foo", "foo"))
   expect_equal( mutate(df, if(a==1) NULL else list(b)) %>% pull(), list(NULL, 5L, 6L))
 })
@@ -370,13 +370,13 @@ test_that("namespace extraction works in hybrid (#412)", {
 })
 
 test_that("hybrid not get in the way of order_by (#169)", {
-  df <- data_frame(x = 10:1, y = 1:10)
+  df <- tibble(x = 10:1, y = 1:10)
   res <- mutate(df, z = order_by(x, cumsum(y)))
   expect_equal(res$z, rev(cumsum(10:1)))
 })
 
 test_that("mutate supports difftime objects (#390)", {
-  df <- data_frame(
+  df <- tibble(
     grp = c(1, 1, 2, 2),
     val = c(1, 3, 4, 6),
     date1 = c(rep(Sys.Date() - 10, 2), rep(Sys.Date() - 20, 2)),
@@ -409,7 +409,7 @@ test_that("mutate works on zero-row grouped data frame (#596)", {
 test_that("Non-ascii column names in version 0.3 are not duplicated (#636)", {
   # Currently failing (#2967)
   skip_on_os("windows")
-  df <- data_frame(a = "1", b = "2")
+  df <- tibble(a = "1", b = "2")
   names(df) <- c("a", enc2native("\u4e2d"))
 
   res <- df %>% mutate_all(funs(as.numeric)) %>% names()
@@ -425,7 +425,7 @@ test_that("nested hybrid functions do the right thing (#637)", {
 })
 
 test_that("mutate handles using and gathering complex data (#436)", {
-  d <- data_frame(x = 1:10, y = 1:10 + 2i)
+  d <- tibble(x = 1:10, y = 1:10 + 2i)
   res <- mutate(d, real = Re(y), imag = Im(y), z = 2 * y, constant = 2 + 2i)
   expect_equal(names(res), c("x", "y", "real", "imag", "z", "constant"))
   expect_equal(res$real, Re(d$y))
@@ -452,7 +452,7 @@ test_that("mutate forbids POSIXlt results (#670)", {
 })
 
 test_that("constant factor can be handled by mutate (#715)", {
-  d <- data_frame(x = 1:2) %>% mutate(y = factor("A"))
+  d <- tibble(x = 1:2) %>% mutate(y = factor("A"))
   expect_true(is.factor(d$y))
   expect_equal(d$y, factor(c("A", "A")))
 })
@@ -494,8 +494,8 @@ test_that("mutate works on empty data frames (#1142)", {
 })
 
 test_that("mutate handles 0 rows rowwise (#1300)", {
-  a <- data_frame(x = 1)
-  b <- data_frame(y = character())
+  a <- tibble(x = 1)
+  b <- tibble(y = character())
 
   g <- function(y) {
     1
@@ -568,12 +568,12 @@ test_that("mutate handles the all NA case (#958)", {
 
 test_that("rowwise mutate gives expected results (#1381)", {
   f <- function(x) ifelse(x < 2, NA_real_, x)
-  res <- data_frame(x = 1:3) %>% rowwise() %>% mutate(y = f(x))
+  res <- tibble(x = 1:3) %>% rowwise() %>% mutate(y = f(x))
   expect_equal(res$y, c(NA, 2, 3))
 })
 
 test_that("mutate handles factors (#1414)", {
-  d <- data_frame(
+  d <- tibble(
     g = c(1, 1, 1, 2, 2, 3, 3),
     f = c("a", "b", "a", "a", "a", "b", "b")
   )
@@ -582,7 +582,7 @@ test_that("mutate handles factors (#1414)", {
 })
 
 test_that("mutate handles results from one group with all NA values (#1463) ", {
-  df <- data_frame(x = c(1, 2), y = c(1, NA))
+  df <- tibble(x = c(1, 2), y = c(1, NA))
   res <- df %>% group_by(x) %>% mutate(z = ifelse(y > 1, 1, 2))
   expect_true(is.na(res$z[2]))
   expect_is(res$z, "numeric")
@@ -615,7 +615,7 @@ test_that("mutate disambiguates NA and NaN (#1448)", {
     mutate(pass2 = P2 / (P2 + F2))
   expect_true(is.nan(res$pass2[1]))
 
-  Pass <- data_frame(
+  Pass <- tibble(
     P1 = c(2L, 0L, 10L, 8L, 9L),
     F1 = c(0L, 2L, 0L, 4L, 3L),
     P2 = c(0L, 3L, 2L, 2L, 2L),
@@ -634,7 +634,7 @@ test_that("mutate disambiguates NA and NaN (#1448)", {
 })
 
 test_that("hybrid evaluator leaves formulas untouched (#1447)", {
-  d <- data_frame(g = 1:2, training = list(mtcars, mtcars * 2))
+  d <- tibble(g = 1:2, training = list(mtcars, mtcars * 2))
   mpg <- data.frame(x = 1:10, y = 1:10)
   res <- d %>%
     group_by(g) %>%
@@ -645,7 +645,7 @@ test_that("hybrid evaluator leaves formulas untouched (#1447)", {
 })
 
 test_that("lead/lag inside mutate handles expressions as value for default (#1411) ", {
-  df <- data_frame(x = 1:3)
+  df <- tibble(x = 1:3)
   res <- mutate(df, leadn = lead(x, default = x[1]), lagn = lag(x, default = x[1]))
   expect_equal(res$leadn, lead(df$x, default = df$x[1]))
   expect_equal(res$lagn, lag(df$x, default = df$x[1]))
@@ -663,7 +663,7 @@ test_that("grouped mutate does not drop grouping attributes (#1020)", {
 })
 
 test_that("grouped mutate coerces integer + double -> double (#1892)", {
-  df <- data_frame(
+  df <- tibble(
     id = c(1, 4),
     value = c(1L, NA),
     group = c("A", "B")
@@ -683,7 +683,7 @@ test_that("grouped mutate coerces factor + character -> character (WARN) (#1892)
     }
   }
 
-  df <- data_frame(
+  df <- tibble(
     id = c(1, 4),
     group = c("A", "B")
   ) %>%
@@ -697,13 +697,13 @@ test_that("grouped mutate coerces factor + character -> character (WARN) (#1892)
 })
 
 test_that("lead/lag works on more complex expressions (#1588)", {
-  df <- data_frame(x = rep(1:5, 2), g = rep(1:2, each = 5)) %>% group_by(g)
+  df <- tibble(x = rep(1:5, 2), g = rep(1:2, each = 5)) %>% group_by(g)
   res <- df %>% mutate(y = lead(x > 3))
   expect_equal(res$y, rep(lead(1:5 > 3), 2))
 })
 
 test_that("Adding a Column of NA to a Grouped Table gives expected results (#1645)", {
-  dataset <- data_frame(A = 1:10, B = 10:1, group = factor(sample(LETTERS[25:26], 10, TRUE)))
+  dataset <- tibble(A = 1:10, B = 10:1, group = factor(sample(LETTERS[25:26], 10, TRUE)))
   res <- dataset %>% group_by(group) %>% mutate(prediction = factor(NA))
   expect_true(all(is.na(res$prediction)))
   expect_is(res$prediction, "factor")
@@ -750,7 +750,7 @@ test_that("mutate() supports unquoted values", {
 })
 
 test_that("gathering handles promotion from raw", {
-  df <- data_frame(a = 1:4, g = c(1, 1, 2, 2))
+  df <- tibble(a = 1:4, g = c(1, 1, 2, 2))
   # collecting raw in the first group, then other types
   expect_identical(
     df %>% group_by(g) %>% mutate(b = if (all(a < 3)) as.raw(a) else a) %>% pull(b),
@@ -765,13 +765,13 @@ test_that("gathering handles promotion from raw", {
 # Error messages ----------------------------------------------------------
 
 test_that("mutate handles raw vectors in columns (#1803)", {
-  df <- data_frame(a = 1:3, b = as.raw(1:3))
-  expect_identical(mutate(df, a = 1), data_frame(a = 1, b = as.raw(1:3)))
-  expect_identical(mutate(df, b = 1), data_frame(a = 1:3, b = 1))
-  expect_identical(mutate(df, c = 1), data_frame(a = 1:3, b = as.raw(1:3), c = 1))
-  expect_identical(mutate(df, c = as.raw(a)), data_frame(a = 1:3, b = as.raw(1:3), c = as.raw(1:3)))
+  df <- tibble(a = 1:3, b = as.raw(1:3))
+  expect_identical(mutate(df, a = 1), tibble(a = 1, b = as.raw(1:3)))
+  expect_identical(mutate(df, b = 1), tibble(a = 1:3, b = 1))
+  expect_identical(mutate(df, c = 1), tibble(a = 1:3, b = as.raw(1:3), c = 1))
+  expect_identical(mutate(df, c = as.raw(a)), tibble(a = 1:3, b = as.raw(1:3), c = as.raw(1:3)))
 
-  df <- data_frame(a = 1:4, g = c(1, 1, 2, 2))
+  df <- tibble(a = 1:4, g = c(1, 1, 2, 2))
   expect_identical(mutate(df, b = as.raw(a)) %>% group_by(g) %>% pull(b), as.raw(1:4))
   expect_identical(mutate(df, b = as.raw(a)) %>% rowwise() %>% pull(b), as.raw(1:4))
 })
@@ -798,7 +798,7 @@ test_that("can reuse new variables", {
 
 test_that("can use character vectors in grouped mutate (#2971)", {
   df <-
-    data_frame(x = 1:10000) %>%
+    tibble(x = 1:10000) %>%
     group_by(x) %>%
     mutate(
       y = as.character(runif(1L)),
@@ -809,7 +809,7 @@ test_that("can use character vectors in grouped mutate (#2971)", {
 })
 
 test_that("mutate() to UTF-8 column names", {
-  df <- data_frame(a = 1) %>% mutate("\u5e78" := a)
+  df <- tibble(a = 1) %>% mutate("\u5e78" := a)
 
   expect_equal(colnames(df), c("a", "\u5e78"))
 })

--- a/tests/testthat/test-overscope.R
+++ b/tests/testthat/test-overscope.R
@@ -2,12 +2,12 @@ context("overscope")
 
 test_that(".data has strict matching semantics (#2591)", {
   expect_error(
-    data_frame(a = 1) %>% mutate(c = .data$b),
+    tibble(a = 1) %>% mutate(c = .data$b),
     "data"
   )
 
   expect_error(
-    data_frame(a = 1:3) %>% group_by(a) %>% mutate(c = .data$b),
+    tibble(a = 1:3) %>% group_by(a) %>% mutate(c = .data$b),
     "data"
   )
 })

--- a/tests/testthat/test-pull.R
+++ b/tests/testthat/test-pull.R
@@ -1,13 +1,13 @@
 context("pull")
 
 test_that("default extracts last var from data frame", {
-  df <- data_frame(x = 1:10, y = 1:10)
+  df <- tibble(x = 1:10, y = 1:10)
   expect_equal(pull(df), 1:10)
 })
 
 test_that("can extract by name, or positive/negative position", {
   x <- 1:10
-  df <- data_frame(x = x, y = runif(10))
+  df <- tibble(x = x, y = runif(10))
 
   expect_equal(pull(df, x), x)
   expect_equal(pull(df, 1L), x)

--- a/tests/testthat/test-rbind.R
+++ b/tests/testthat/test-rbind.R
@@ -292,7 +292,7 @@ test_that("bind_rows() creates a column of identifiers (#1337)", {
 })
 
 test_that("empty data frame are handled (#1346)", {
-  res <- data_frame() %>% bind_rows(data_frame(x = "a"))
+  res <- tibble() %>% bind_rows(tibble(x = "a"))
   expect_equal(nrow(res), 1L)
 })
 

--- a/tests/testthat/test-select.r
+++ b/tests/testthat/test-select.r
@@ -8,14 +8,14 @@ test_that("select does not lose grouping (#147)", {
 })
 
 test_that("grouping variables preserved with a message (#1511)", {
-  df <- data_frame(g = 1:3, x = 3:1) %>% group_by(g)
+  df <- tibble(g = 1:3, x = 3:1) %>% group_by(g)
 
   expect_message(res <- select(df, x), "Adding missing grouping variables")
   expect_named(res, c("g", "x"))
 })
 
 test_that("non-syntactic grouping variable is preserved (#1138)", {
-  df <- data_frame(`a b` = 1L) %>% group_by(`a b`) %>% select()
+  df <- tibble(`a b` = 1L) %>% group_by(`a b`) %>% select()
   expect_named(df, "a b")
 })
 
@@ -65,7 +65,7 @@ test_that("select can be before group_by (#309)", {
 })
 
 test_that("rename errors with invalid grouped data frame (#640)", {
-  df <- data_frame(a = 1:3, b = 2:4, d = 3:5) %>% group_by(a, b)
+  df <- tibble(a = 1:3, b = 2:4, d = 3:5) %>% group_by(a, b)
   df$a <- NULL
   expect_error(
     df %>% rename(e = d),
@@ -82,7 +82,7 @@ test_that("rename() handles data pronoun", {
 })
 
 test_that("select succeeds in presence of raw columns (#1803)", {
-  df <- data_frame(a = 1:3, b = as.raw(1:3))
+  df <- tibble(a = 1:3, b = as.raw(1:3))
   expect_identical(select(df, a), df["a"])
   expect_identical(select(df, b), df["b"])
   expect_identical(select(df, -b), df["a"])
@@ -116,7 +116,7 @@ test_that("can select() with character vectors", {
 
 test_that("rename() to UTF-8 column names", {
   skip_on_os("windows") # needs an rlang update? #3049
-  df <- data_frame(a = 1) %>% rename("\u5e78" := a)
+  df <- tibble(a = 1) %>% rename("\u5e78" := a)
 
   expect_equal(colnames(df), "\u5e78")
 })

--- a/tests/testthat/test-sets.R
+++ b/tests/testthat/test-sets.R
@@ -1,12 +1,12 @@
 context("Set ops")
 
 test_that("set operation give useful error message. #903", {
-  alfa <- data_frame(
+  alfa <- tibble(
     land = c("Sverige", "Norway", "Danmark", "Island", "GB"),
     data = rnorm(length(land))
   )
 
-  beta <- data_frame(
+  beta <- tibble(
     land = c("Norge", "Danmark", "Island", "Storbritannien"),
     data2 = rnorm(length(land))
   )
@@ -28,34 +28,34 @@ test_that("set operation give useful error message. #903", {
 })
 
 test_that("set operations use coercion rules (#799)", {
-  df1 <- data_frame(x = 1:2, y = c(1, 1))
-  df2 <- data_frame(x = 1:2, y = 1:2)
+  df1 <- tibble(x = 1:2, y = c(1, 1))
+  df2 <- tibble(x = 1:2, y = 1:2)
 
   expect_equal(nrow(union(df1, df2)), 3L)
   expect_equal(nrow(intersect(df1, df2)), 1L)
   expect_equal(nrow(setdiff(df1, df2)), 1L)
 
-  df1 <- data_frame(x = factor(letters[1:10]))
-  df2 <- data_frame(x = letters[6:15])
+  df1 <- tibble(x = factor(letters[1:10]))
+  df2 <- tibble(x = letters[6:15])
   expect_warning(res <- intersect(df1, df2))
-  expect_equal(res, data_frame(x = letters[6:10]))
+  expect_equal(res, tibble(x = letters[6:10]))
   expect_warning(res <- intersect(df2, df1))
-  expect_equal(res, data_frame(x = letters[6:10]))
+  expect_equal(res, tibble(x = letters[6:10]))
 
   expect_warning(res <- union(df1, df2))
-  expect_equal(res, data_frame(x = letters[1:15]))
+  expect_equal(res, tibble(x = letters[1:15]))
   expect_warning(res <- union(df2, df1))
-  expect_equal(res, data_frame(x = letters[1:15]))
+  expect_equal(res, tibble(x = letters[1:15]))
 
   expect_warning(res <- setdiff(df1, df2))
-  expect_equal(res, data_frame(x = letters[1:5]))
+  expect_equal(res, tibble(x = letters[1:5]))
   expect_warning(res <- setdiff(df2, df1))
-  expect_equal(res, data_frame(x = letters[11:15]))
+  expect_equal(res, tibble(x = letters[11:15]))
 })
 
 test_that("setdiff handles factors with NA (#1526)", {
-  df1 <- data_frame(x = factor(c(NA, "a")))
-  df2 <- data_frame(x = factor("a"))
+  df1 <- tibble(x = factor(c(NA, "a")))
+  df2 <- tibble(x = factor("a"))
 
   res <- setdiff(df1, df2)
   expect_is(res$x, "factor")
@@ -64,7 +64,7 @@ test_that("setdiff handles factors with NA (#1526)", {
 })
 
 test_that("intersect does not unnecessarily coerce (#1722)", {
-  df <- data_frame(a = 1L)
+  df <- tibble(a = 1L)
   res <- intersect(df, df)
   expect_is(res$a, "integer")
 })

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -58,11 +58,11 @@ test_that("slice works with grouped data", {
 })
 
 test_that("slice gives correct rows (#649)", {
-  a <- data_frame(value = paste0("row", 1:10))
+  a <- tibble(value = paste0("row", 1:10))
   expect_equal(slice(a, 1:3)$value, paste0("row", 1:3))
   expect_equal(slice(a, c(4, 6, 9))$value, paste0("row", c(4, 6, 9)))
 
-  a <- data_frame(
+  a <- tibble(
     value = paste0("row", 1:10),
     group = rep(1:2, each = 5)
   ) %>%
@@ -73,18 +73,18 @@ test_that("slice gives correct rows (#649)", {
 })
 
 test_that("slice handles NA (#1235)", {
-  df <- data_frame(x = 1:3)
+  df <- tibble(x = 1:3)
   expect_equal(nrow(slice(df, NA_integer_)), 0L)
   expect_equal(nrow(slice(df, c(1L, NA_integer_))), 1L)
   expect_equal(nrow(slice(df, c(-1L, NA_integer_))), 2L)
 
-  df <- data_frame(x = 1:4, g = rep(1:2, 2)) %>% group_by(g)
+  df <- tibble(x = 1:4, g = rep(1:2, 2)) %>% group_by(g)
   expect_equal(nrow(slice(df, c(1, NA))), 2)
   expect_equal(nrow(slice(df, c(-1, NA))), 2)
 })
 
 test_that("slice handles logical NA (#3970)", {
-  df <- data_frame(x = 1:3)
+  df <- tibble(x = 1:3)
   expect_equal(nrow(slice(df, NA)), 0L)
   expect_error(slice(df, TRUE))
   expect_error(slice(df, FALSE))
@@ -111,7 +111,7 @@ test_that("slice strips grouped indices (#1405)", {
 
 test_that("slice works with zero-column data frames (#2490)", {
   expect_equal(
-    data_frame(a = 1:3) %>% select(-a) %>% slice(1) %>% nrow(),
+    tibble(a = 1:3) %>% select(-a) %>% slice(1) %>% nrow(),
     1L
   )
 })

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -40,13 +40,13 @@ test_that("summarise can refer to variables that were just created (#138)", {
 })
 
 test_that("summarise can refer to factor variables that were just created (#2217)", {
-  df <- data_frame(a = 1:3) %>%
+  df <- tibble(a = 1:3) %>%
     group_by(a)
   res <- df %>%
     summarise(f = factor(if_else(a <= 1, "a", "b")), g = (f == "a"))
   expect_equal(
     res,
-    data_frame(a = 1:3, f = factor(c("a", "b", "b")), g = c(TRUE, FALSE, FALSE))
+    tibble(a = 1:3, f = factor(c("a", "b", "b")), g = c(TRUE, FALSE, FALSE))
   )
 })
 
@@ -60,7 +60,7 @@ test_that("summarise refuses to modify grouping variable (#143)", {
 })
 
 test_that("summarise gives proper errors (#153)", {
-  df <- data_frame(
+  df <- tibble(
     x = 1,
     y = c(1, 2, 2),
     z = runif(3)
@@ -208,13 +208,13 @@ test_that("summarise propagate attributes (#194)", {
 })
 
 test_that("summarise strips names, but only if grouped (#2231, #2675)", {
-  data <- data_frame(a = 1:3) %>% summarise(b = setNames(nm = a[[1]]))
+  data <- tibble(a = 1:3) %>% summarise(b = setNames(nm = a[[1]]))
   expect_equal(names(data$b), "1")
 
-  data <- data_frame(a = 1:3) %>% rowwise() %>% summarise(b = setNames(nm = a))
+  data <- tibble(a = 1:3) %>% rowwise() %>% summarise(b = setNames(nm = a))
   expect_null(names(data$b))
 
-  data <- data_frame(a = c(1, 1, 2)) %>% group_by(a) %>% summarise(b = setNames(nm = a[[1]]))
+  data <- tibble(a = c(1, 1, 2)) %>% group_by(a) %>% summarise(b = setNames(nm = a[[1]]))
   expect_null(names(data$b))
 })
 
@@ -400,7 +400,7 @@ test_that("LazySubset is not confused about input data size (#452)", {
 })
 
 test_that("nth, first, last promote dates and times (#509)", {
-  data <- data_frame(
+  data <- tibble(
     ID = rep(letters[1:4], each = 5),
     date = Sys.Date() + 1:20,
     time = Sys.time() + 1:20,
@@ -427,7 +427,7 @@ test_that("nth, first, last promote dates and times (#509)", {
 })
 
 test_that("nth, first, last preserves factor data (#509)", {
-  dat <- data_frame(a = rep(seq(1, 20, 2), 3), b = as.ordered(a))
+  dat <- tibble(a = rep(seq(1, 20, 2), 3), b = as.ordered(a))
   dat1 <- dat %>%
     group_by(a) %>%
     summarise(
@@ -468,7 +468,7 @@ test_that("nth handle negative value (#1584) ", {
 })
 
 test_that("LazyGroupSubsets is robust about columns not from the data (#600)", {
-  foo <- data_frame(x = 1:10, y = 1:10)
+  foo <- tibble(x = 1:10, y = 1:10)
   # error messages from rlang
   expect_error(foo %>% group_by(x) %>% summarise(first_y = first(z)))
 })
@@ -551,7 +551,7 @@ test_that("summarise is not polluted by logical NA (#599)", {
 })
 
 test_that("summarise handles list output columns (#832)", {
-  df <- data_frame(x = 1:10, g = rep(1:2, each = 5))
+  df <- tibble(x = 1:10, g = rep(1:2, each = 5))
   res <- df %>% group_by(g) %>% summarise(y = list(x))
   expect_equal(res$y[[1]], 1:5)
   expect_equal(res$y[[2]], 6:10)
@@ -560,7 +560,7 @@ test_that("summarise handles list output columns (#832)", {
   expect_equal(res$y[[1]], 1:5 + 1)
   expect_equal(res$y[[2]], 6:10 + 1)
 
-  df <- data_frame(x = 1:10, g = rep(1:2, each = 5))
+  df <- tibble(x = 1:10, g = rep(1:2, each = 5))
   res <- df %>% summarise(y = list(x))
   expect_equal(res$y[[1]], 1:10)
   res <- df %>% summarise(y = list(x + 1))
@@ -598,7 +598,7 @@ test_that("n_distinct without arguments stops (#1957)", {
 
 test_that("hybrid evaluation does not take place for objects with a class (#1237)", {
   mean.foo <- function(x) 42
-  df <- data_frame(x = structure(1:10, class = "foo"))
+  df <- tibble(x = structure(1:10, class = "foo"))
   expect_equal(summarise(df, m = mean(x))$m[1], 42)
 
   env <- environment()
@@ -657,7 +657,7 @@ test_that("summarise correctly handles logical (#1291)", {
 })
 
 test_that("summarise correctly handles NA groups (#1261)", {
-  tmp <- data_frame(
+  tmp <- tibble(
     a = c(1, 1, 1, 2, 2),
     b1 = NA_integer_,
     b2 = NA_character_
@@ -695,14 +695,14 @@ test_that("n_distinct handles multiple columns (#1084)", {
 })
 
 test_that("hybrid max works when not used on columns (#1369)", {
-  df <- data_frame(x = 1:1000)
+  df <- tibble(x = 1:1000)
   y <- 1:10
   expect_equal(summarise(df, z = max(y))$z, 10)
   expect_equal(summarise(df, z = max(10))$z, 10)
 })
 
 test_that("min and max handle empty sets in summarise (#1481)", {
-  df <- data_frame(A = numeric())
+  df <- tibble(A = numeric())
   res <- df %>% summarise(Min = min(A, na.rm = TRUE), Max = max(A, na.rm = TRUE))
   expect_equal(res$Min, Inf)
   expect_equal(res$Max, -Inf)
@@ -819,7 +819,7 @@ test_that("hybrid n_distinct falls back to R evaluation when needed (#1657)", {
 })
 
 test_that("summarise() correctly coerces factors with different levels (#1678)", {
-  res <- data_frame(x = 1:3) %>%
+  res <- tibble(x = 1:3) %>%
     group_by(x) %>%
     summarise(
       y = if (x == 1) "a" else "b",
@@ -831,9 +831,9 @@ test_that("summarise() correctly coerces factors with different levels (#1678)",
 })
 
 test_that("summarise handles raw columns (#1803)", {
-  df <- data_frame(a = 1:3, b = as.raw(1:3))
-  expect_equal(summarise(df, c = sum(a)), data_frame(c = 6L))
-  expect_identical(summarise(df, c = b[[1]]), data_frame(c = as.raw(1)))
+  df <- tibble(a = 1:3, b = as.raw(1:3))
+  expect_equal(summarise(df, c = sum(a)), tibble(c = 6L))
+  expect_identical(summarise(df, c = b[[1]]), tibble(c = as.raw(1)))
 })
 
 test_that("dim attribute is stripped from grouped summarise (#1918)", {
@@ -850,7 +850,7 @@ test_that("dim attribute is stripped from grouped summarise (#1918)", {
 
 test_that("typing and NAs for grouped summarise (#1839)", {
   expect_identical(
-    data_frame(id = 1L, a = NA_character_) %>%
+    tibble(id = 1L, a = NA_character_) %>%
       group_by(id) %>%
       summarise(a = a[[1]]) %>%
       .$a,
@@ -858,7 +858,7 @@ test_that("typing and NAs for grouped summarise (#1839)", {
   )
 
   expect_identical(
-    data_frame(id = 1:2, a = c(NA, "a")) %>%
+    tibble(id = 1:2, a = c(NA, "a")) %>%
       group_by(id) %>%
       summarise(a = a[[1]]) %>%
       .$a,
@@ -867,7 +867,7 @@ test_that("typing and NAs for grouped summarise (#1839)", {
 
   # Properly upgrade NA (logical) to character
   expect_identical(
-    data_frame(id = 1:2, a = 1:2) %>%
+    tibble(id = 1:2, a = 1:2) %>%
       group_by(id) %>%
       summarise(a = ifelse(all(a < 2), NA, "yes")) %>%
       .$a,
@@ -875,7 +875,7 @@ test_that("typing and NAs for grouped summarise (#1839)", {
   )
 
   expect_error(
-    data_frame(id = 1:2, a = list(1, "2")) %>%
+    tibble(id = 1:2, a = list(1, "2")) %>%
       group_by(id) %>%
       summarise(a = a[[1]]) %>%
       .$a,
@@ -884,7 +884,7 @@ test_that("typing and NAs for grouped summarise (#1839)", {
   )
 
   expect_identical(
-    data_frame(id = 1:2, a = list(1, "2")) %>%
+    tibble(id = 1:2, a = list(1, "2")) %>%
       group_by(id) %>%
       summarise(a = a[1]) %>%
       .$a,
@@ -894,7 +894,7 @@ test_that("typing and NAs for grouped summarise (#1839)", {
 
 test_that("typing and NAs for rowwise summarise (#1839)", {
   expect_identical(
-    data_frame(id = 1L, a = NA_character_) %>%
+    tibble(id = 1L, a = NA_character_) %>%
       rowwise() %>%
       summarise(a = a[[1]]) %>%
       .$a,
@@ -902,7 +902,7 @@ test_that("typing and NAs for rowwise summarise (#1839)", {
   )
 
   expect_identical(
-    data_frame(id = 1:2, a = c(NA, "a")) %>%
+    tibble(id = 1:2, a = c(NA, "a")) %>%
       rowwise() %>%
       summarise(a = a[[1]]) %>%
       .$a,
@@ -911,7 +911,7 @@ test_that("typing and NAs for rowwise summarise (#1839)", {
 
   # Properly promote NA (logical) to character
   expect_identical(
-    data_frame(id = 1:2, a = 1:2) %>%
+    tibble(id = 1:2, a = 1:2) %>%
       group_by(id) %>%
       summarise(a = ifelse(all(a < 2), NA, "yes")) %>%
       .$a,
@@ -919,7 +919,7 @@ test_that("typing and NAs for rowwise summarise (#1839)", {
   )
 
   expect_error(
-    data_frame(id = 1:2, a = list(1, "2")) %>%
+    tibble(id = 1:2, a = list(1, "2")) %>%
       rowwise() %>%
       summarise(a = a[[1]]) %>%
       .$a,
@@ -928,7 +928,7 @@ test_that("typing and NAs for rowwise summarise (#1839)", {
   )
 
   expect_error(
-    data_frame(id = 1:2, a = list(1, "2")) %>%
+    tibble(id = 1:2, a = list(1, "2")) %>%
       rowwise() %>%
       summarise(a = a[1]) %>%
       .$a,
@@ -977,7 +977,7 @@ test_that("ungrouped summarise() uses summary variables correctly (#2404)", {
 })
 
 test_that("proper handling of names in summarised list columns (#2231)", {
-  d <- data_frame(x = rep(1:3, 1:3), y = 1:6, names = letters[1:6])
+  d <- tibble(x = rep(1:3, 1:3), y = 1:6, names = letters[1:6])
   res <- d %>% group_by(x) %>% summarise(y = list(setNames(y, names)))
   expect_equal(names(res$y[[1]]), letters[[1]])
   expect_equal(names(res$y[[2]]), letters[2:3])

--- a/tests/testthat/test-transmute.R
+++ b/tests/testthat/test-transmute.R
@@ -1,7 +1,7 @@
 context("transmute")
 
 test_that("non-syntactic grouping variable is preserved (#1138)", {
-  df <- data_frame(`a b` = 1L) %>% group_by(`a b`) %>% transmute()
+  df <- tibble(`a b` = 1L) %>% group_by(`a b`) %>% transmute()
   expect_named(df, "a b")
 })
 
@@ -17,7 +17,7 @@ test_that("transmute with no args returns nothing", {
 # transmute variables -----------------------------------------------
 
 test_that("transmute succeeds in presence of raw columns (#1803)", {
-  df <- data_frame(a = 1:3, b = as.raw(1:3))
+  df <- tibble(a = 1:3, b = as.raw(1:3))
   expect_identical(transmute(df, a), df["a"])
   expect_identical(transmute(df, b), df["b"])
 })

--- a/tests/testthat/test-underscore.R
+++ b/tests/testthat/test-underscore.R
@@ -1,6 +1,6 @@
 context("underscore")
 
-df <- data_frame(
+df <- tibble(
   a = c(1:3, 2:3),
   b = letters[c(1:4, 4L)]
 )
@@ -83,18 +83,18 @@ test_that("distinct_ works", {
 test_that("do_ works", {
   scoped_lifecycle_silence()
   expect_equal(
-    do_(df, ~ data_frame(-.$a)),
-    do(df, data_frame(-.$a))
+    do_(df, ~ tibble(-.$a)),
+    do(df, tibble(-.$a))
   )
 
   expect_equal(
-    do_(df, .dots = list(quote(dplyr::data_frame(-.$a)))),
-    do(df, data_frame(-.$a))
+    do_(df, .dots = list(quote(dplyr::tibble(-.$a)))),
+    do(df, tibble(-.$a))
   )
 
   expect_equal(
-    do_(df, .dots = list(~ dplyr::data_frame(-.$a))),
-    do(df, data_frame(-.$a))
+    do_(df, .dots = list(~ dplyr::tibble(-.$a))),
+    do(df, tibble(-.$a))
   )
 
   foo <- "foobar"
@@ -104,18 +104,18 @@ test_that("do_ works", {
   )
 
   expect_equal(
-    do_(df %>% group_by(b), ~ data_frame(-.$a)),
-    do(df %>% group_by(b), data_frame(-.$a))
+    do_(df %>% group_by(b), ~ tibble(-.$a)),
+    do(df %>% group_by(b), tibble(-.$a))
   )
 
   expect_equal(
-    do_(df %>% group_by(b), .dots = list(quote(dplyr::data_frame(-.$a)))),
-    do(df %>% group_by(b), data_frame(-.$a))
+    do_(df %>% group_by(b), .dots = list(quote(dplyr::tibble(-.$a)))),
+    do(df %>% group_by(b), tibble(-.$a))
   )
 
   expect_equal(
-    do_(df %>% group_by(b), .dots = list(~ dplyr::data_frame(-.$a))),
-    do(df %>% group_by(b), data_frame(-.$a))
+    do_(df %>% group_by(b), .dots = list(~ dplyr::tibble(-.$a))),
+    do(df %>% group_by(b), tibble(-.$a))
   )
 })
 

--- a/tests/testthat/test-union-all.R
+++ b/tests/testthat/test-union-all.R
@@ -5,8 +5,8 @@ test_that("union all on vectors concatenates", {
 })
 
 test_that("union all on data frames calls bind rows", {
-  df1 <- data_frame(x = 1:2)
-  df2 <- data_frame(y = 1:2)
+  df1 <- tibble(x = 1:2)
+  df2 <- tibble(y = 1:2)
 
   expect_equal(union_all(df1, df2), bind_rows(df1, df2))
 })

--- a/vignettes/two-table.Rmd
+++ b/vignettes/two-table.Rmd
@@ -85,8 +85,8 @@ As well as `x` and `y`, each mutating join takes an argument `by` that controls 
 There are four types of mutating join, which differ in their behaviour when a match is not found. We'll illustrate each with a simple example:
 
 ```{r}
-df1 <- data_frame(x = c(1, 2), y = 2:1)
-df2 <- data_frame(x = c(1, 3), a = 10, b = "a")
+df1 <- tibble(x = c(1, 2), y = 2:1)
+df2 <- tibble(x = c(1, 3), a = 10, b = "a")
 ```
 
   * `inner_join(x, y)` only includes observations that match in both `x` and `y`.
@@ -124,8 +124,8 @@ The left, right and full joins are collectively know as __outer joins__. When a 
 While mutating joins are primarily used to add new variables, they can also generate new observations. If a match is not unique, a join will add all possible combinations (the Cartesian product) of the matching observations:
 
 ```{r}
-df1 <- data_frame(x = c(1, 1, 2), y = 1:3)
-df2 <- data_frame(x = c(1, 1, 2), z = c("a", "b", "a"))
+df1 <- tibble(x = c(1, 1, 2), y = 1:3)
+df2 <- tibble(x = c(1, 1, 2), z = c("a", "b", "a"))
 
 df1 %>% left_join(df2)
 ```
@@ -149,8 +149,8 @@ flights %>%
 If you're worried about what observations your joins will match, start with a `semi_join()` or `anti_join()`. `semi_join()` and `anti_join()` never duplicate; they only ever remove observations. 
 
 ```{r}
-df1 <- data_frame(x = c(1, 1, 3, 4), y = 1:4)
-df2 <- data_frame(x = c(1, 1, 2), z = c("a", "b", "a"))
+df1 <- tibble(x = c(1, 1, 3, 4), y = 1:4)
+df2 <- tibble(x = c(1, 1, 2), z = c("a", "b", "a"))
 
 # Four rows to start with:
 df1 %>% nrow()
@@ -171,8 +171,8 @@ The final type of two-table verb is set operations. These expect the `x` and `y`
 Given this simple data:
 
 ```{r}
-(df1 <- data_frame(x = 1:2, y = c(1L, 1L)))
-(df2 <- data_frame(x = 1:2, y = 1:2))
+(df1 <- tibble(x = 1:2, y = c(1L, 1L)))
+(df2 <- tibble(x = 1:2, y = 1:2))
 ```
 
 The four possibilities are:
@@ -193,8 +193,8 @@ When joining tables, dplyr is a little more conservative than base R about the t
   * Factors with different levels are coerced to character with a warning:
     
     ```{r}
-    df1 <- data_frame(x = 1, y = factor("a"))
-    df2 <- data_frame(x = 2, y = factor("b"))
+    df1 <- tibble(x = 1, y = factor("a"))
+    df2 <- tibble(x = 2, y = factor("b"))
     full_join(df1, df2) %>% str()
     ```
 
@@ -202,36 +202,36 @@ When joining tables, dplyr is a little more conservative than base R about the t
     with a warning:
   
     ```{r}
-    df1 <- data_frame(x = 1, y = factor("a", levels = c("a", "b")))
-    df2 <- data_frame(x = 2, y = factor("b", levels = c("b", "a")))
+    df1 <- tibble(x = 1, y = factor("a", levels = c("a", "b")))
+    df2 <- tibble(x = 2, y = factor("b", levels = c("b", "a")))
     full_join(df1, df2) %>% str()
     ```
 
   * Factors are preserved only if the levels match exactly:
     
     ```{r}
-    df1 <- data_frame(x = 1, y = factor("a", levels = c("a", "b")))
-    df2 <- data_frame(x = 2, y = factor("b", levels = c("a", "b")))
+    df1 <- tibble(x = 1, y = factor("a", levels = c("a", "b")))
+    df2 <- tibble(x = 2, y = factor("b", levels = c("a", "b")))
     full_join(df1, df2) %>% str()
     ```    
 
   * A factor and a character are coerced to character with a warning:
     
     ```{r}
-    df1 <- data_frame(x = 1, y = "a")
-    df2 <- data_frame(x = 2, y = factor("a"))
+    df1 <- tibble(x = 1, y = "a")
+    df2 <- tibble(x = 2, y = factor("a"))
     full_join(df1, df2) %>% str()
     ```
     
 Otherwise logicals will be silently upcast to integer, and integer to numeric, but coercing to character will raise an error:
 
 ```{r, error = TRUE, purl = FALSE}
-df1 <- data_frame(x = 1, y = 1L)
-df2 <- data_frame(x = 2, y = 1.5)
+df1 <- tibble(x = 1, y = 1L)
+df2 <- tibble(x = 2, y = 1.5)
 full_join(df1, df2) %>% str()
 
-df1 <- data_frame(x = 1, y = 1L)
-df2 <- data_frame(x = 2, y = "a")
+df1 <- tibble(x = 1, y = 1L)
+df2 <- tibble(x = 2, y = "a")
 full_join(df1, df2) %>% str()
 ```
 


### PR DESCRIPTION
Changed data_frame() to tibble() in dplyr from issue 4096

Original issue:
This issue is to be dealt with on Tidyverse developer day 2019. 🙏 don't submit pull requests for it outside of the event. We are of course interested in having this fixed, but much more interested in doing it as part of the developer day

  identify uses of the deprecated function data_frame() in the dplyr codebase: code, docs, tests, vignette.
  replace with uses of tibble()