### PR TITLE
Support for non-syntactic variable names in mutate_all()

### DIFF
--- a/R/colwise-mutate.R
+++ b/R/colwise-mutate.R
@@ -293,7 +293,7 @@ manip_apply_syms <- function(funs, syms, tbl) {
   dim(out) <- c(length(syms), length(funs))
   for (i in seq_along(syms)) {
     for (j in seq_along(funs)) {
-      var_call <- call('[[', sym(".data"), as_string(syms[[i]]))
+      var_call <- call('$', sym(".data"), sym(syms[[i]]))
       out[[i, j]] <- expr_substitute(funs[[j]], quote(.), var_call)
     }
   }

--- a/R/colwise-mutate.R
+++ b/R/colwise-mutate.R
@@ -293,8 +293,8 @@ manip_apply_syms <- function(funs, syms, tbl) {
   dim(out) <- c(length(syms), length(funs))
   for (i in seq_along(syms)) {
     for (j in seq_along(funs)) {
-      var_sym <- sym(syms[[i]])
-      out[[i, j]] <- expr_substitute(funs[[j]], quote(.), var_sym)
+      var_call <- call('[[', sym(".data"), as_string(syms[[i]]))
+      out[[i, j]] <- expr_substitute(funs[[j]], quote(.), var_call)
     }
   }
   dim(out) <- NULL

--- a/tests/testthat/test-colwise-mutate.R
+++ b/tests/testthat/test-colwise-mutate.R
@@ -299,3 +299,10 @@ test_that("*_(all,at) handle utf-8 names (#2967)", {
     expect_equal(res, name)
   })
 })
+
+test_that("mutate_all() handles non syntactic names (#4094)", {
+  tbl <- tibble(`..1` = "a")
+  res <- mutate_all(tbl, toupper)
+  expect_equal(names(tbl), names(res))
+  expect_equal(res[["..1"]], "A")
+})


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)

mutate_all(tibble(`..1` = "1"), toupper)
#> # A tibble: 1 x 1
#>   ..1  
#>   <chr>
#> 1 1
```

This uses `.data` as @krlmlr suggested, so that: 

``` r
library(dplyr, warn.conflicts = FALSE)

trace(dplyr:::mutate_impl, tracer = quote({ print(dots) ; cat("--------\n\n")}))
#> Tracing function "mutate_impl" in package "dplyr
#> (not-exported)"
#> [1] "mutate_impl"
mutate_all(tibble(`..1` = "1"), toupper)
#> Tracing mutate_impl(.data, dots) on entry 
#> <list_of<quosure>>
#> 
#> $..1
#> <quosure>
#> expr: ^toupper(.data[["..1"]])
#> env:  global
#> 
#> --------
#> # A tibble: 1 x 1
#>   ..1  
#>   <chr>
#> 1 1
```

I think this is good enough (for now), but at some point I'd like to think about moving some logic internally for the colwise verbs. 
