### PR TITLE
warn on cases like min(c(NA, NA), na.rm = TRUE) in hybrid

### DIFF
--- a/inst/include/dplyr/hybrid/Expression.h
+++ b/inst/include/dplyr/hybrid/Expression.h
@@ -273,6 +273,10 @@ public:
     return package;
   }
 
+  inline SEXP get_expr() const {
+    return expr;
+  }
+
 private:
   SEXP expr;
   SEXP env;

--- a/inst/include/dplyr/hybrid/scalar_result/min_max.h
+++ b/inst/include/dplyr/hybrid/scalar_result/min_max.h
@@ -17,18 +17,19 @@ public:
   typedef HybridVectorScalarResult<REALSXP, SlicedTibble, MinMax> Parent ;
   typedef typename Rcpp::Vector<RTYPE>::stored_type STORAGE;
 
-  MinMax(const SlicedTibble& data, Column column_):
+  MinMax(const SlicedTibble& data, Column column_, SEXP expr_):
     Parent(data),
     column(column_.data),
-    warn(false)
+    warn(false),
+    expr(expr_)
   {}
 
   ~MinMax(){
     if(NA_RM && warn) {
       if (MINIMUM) {
-        Rf_warningcall(R_NilValue, "no non-missing arguments to min; returning Inf");
+        Rf_warningcall(expr, "no non-missing arguments to min; returning Inf");
       } else {
-        Rf_warningcall(R_NilValue, "no non-missing arguments to max; returning -Inf");
+        Rf_warningcall(expr, "no non-missing arguments to max; returning -Inf");
       }
     }
   }
@@ -67,6 +68,7 @@ public:
 private:
   Rcpp::Vector<RTYPE> column;
   mutable bool warn;
+  SEXP expr;
 
   static const double Inf;
 
@@ -85,16 +87,16 @@ const double MinMax<RTYPE, SlicedTibble, MINIMUM, NA_RM>::Inf = (MINIMUM ? R_Pos
 
 // min( <column> )
 template <typename SlicedTibble, typename Operation, bool MINIMUM, bool NARM>
-SEXP minmax_narm(const SlicedTibble& data, Column x, const Operation& op) {
+SEXP minmax_narm(const SlicedTibble& data, Column x, const Operation& op, SEXP expr) {
 
   // only handle basic number types, anything else goes through R
   switch (TYPEOF(x.data)) {
   case RAWSXP:
-    return op(internal::MinMax<RAWSXP, SlicedTibble, MINIMUM, NARM>(data, x));
+    return op(internal::MinMax<RAWSXP, SlicedTibble, MINIMUM, NARM>(data, x, expr));
   case INTSXP:
-    return op(internal::MinMax<INTSXP, SlicedTibble, MINIMUM, NARM>(data, x));
+    return op(internal::MinMax<INTSXP, SlicedTibble, MINIMUM, NARM>(data, x, expr));
   case REALSXP:
-    return op(internal::MinMax<REALSXP, SlicedTibble, MINIMUM, NARM>(data, x));
+    return op(internal::MinMax<REALSXP, SlicedTibble, MINIMUM, NARM>(data, x, expr));
   default:
     break;
   }
@@ -103,11 +105,11 @@ SEXP minmax_narm(const SlicedTibble& data, Column x, const Operation& op) {
 }
 
 template <typename SlicedTibble, typename Operation, bool MINIMUM>
-SEXP minmax_(const SlicedTibble& data, Column x, bool narm, const Operation& op) {
+SEXP minmax_(const SlicedTibble& data, Column x, bool narm, const Operation& op, SEXP expr) {
   if (narm) {
-    return minmax_narm<SlicedTibble, Operation, MINIMUM, true>(data, x, op) ;
+    return minmax_narm<SlicedTibble, Operation, MINIMUM, true>(data, x, op, expr) ;
   } else {
-    return minmax_narm<SlicedTibble, Operation, MINIMUM, false>(data, x, op) ;
+    return minmax_narm<SlicedTibble, Operation, MINIMUM, false>(data, x, op, expr) ;
   }
 }
 
@@ -118,14 +120,14 @@ SEXP minmax_dispatch(const SlicedTibble& data, const Expression<SlicedTibble>& e
   case 1:
     // min( <column> )
     if (expression.is_unnamed(0) && expression.is_column(0, x)) {
-      return minmax_<SlicedTibble, Operation, MINIMUM>(data, x, false, op) ;
+      return minmax_<SlicedTibble, Operation, MINIMUM>(data, x, false, op, expression.get_expr()) ;
     }
   case 2:
     // min( <column>, na.rm = <bool> )
     bool test;
 
     if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols::narm) && expression.is_scalar_logical(1, test)) {
-      return minmax_<SlicedTibble, Operation, MINIMUM>(data, x, test, op) ;
+      return minmax_<SlicedTibble, Operation, MINIMUM>(data, x, test, op, expression.get_expr()) ;
     }
   default:
     break;

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -1118,3 +1118,17 @@ test_that("hybrid sum(), mean() treats NA and NaN differently (#4108)", {
   expect_true(is.nan(res$max))
   expect_true(is.nan(res$min))
 })
+
+test_that("hybrid min() and max() warn, just like R's (#3997)", {
+  d <- tibble(
+    x = c(NA, NA,NA, 1),
+    y = c("a","a","b","b")
+  ) %>%
+    group_by(y)
+
+  res <- expect_warning(summarise(d,  z = min(x, na.rm=TRUE)), "no non-missing arguments to min")
+  expect_equal(res$z, c(Inf, 1))
+
+  res <- expect_warning(summarise(d,  z = max(x, na.rm=TRUE)), "no non-missing arguments to max")
+  expect_equal(res$z, c(-Inf, 1))
+})


### PR DESCRIPTION
```r
> tibble(
+     x = c(NA, NA,NA, 1), 
+     y = c("a","a","b","b")
+ ) %>% 
+     group_by(y) %>% 
+     summarise( z = min(x, na.rm=TRUE))
# A tibble: 2 x 2
  y         z
  <chr> <dbl>
1 a       Inf
2 b         1
Warning message:
no non-missing arguments to min; returning Inf 
```

similar to: 

```r
> tibble(
+     x = c(NA, NA,NA, 1), 
+     y = c("a","a","b","b")
+ ) %>% 
+     group_by(y) %>% 
+     summarise( z = min(x, na.rm=T))
# A tibble: 2 x 2
  y         z
  <chr> <dbl>
1 a       Inf
2 b         1
Warning message:
In min(x, na.rm = T) : no non-missing arguments to min; returning Inf
```

although without the call. Don't think that's a big deal, and would be more work to get to the call. 
