### PR TITLE
Scoped mutate/summarize with multiple columns AND functions

### DIFF
--- a/R/colwise-mutate.R
+++ b/R/colwise-mutate.R
@@ -309,6 +309,13 @@ manip_apply_syms <- function(funs, syms, tbl) {
     names(out) <- names(funs)
   } else {
     syms_names <- map_chr(syms, as_string)
+    if (!attr(funs, "have_name")) {
+      names(funs) <- if_else(
+        names(funs) == "<fn>",
+        paste0("<fn>_", seq_along(funs)),
+        names(funs)
+      )
+    }
     grid <- expand.grid(var = syms_names, call = names(funs))
     names(out) <- paste(grid$var, grid$call, sep = "_")
   }

--- a/R/colwise-mutate.R
+++ b/R/colwise-mutate.R
@@ -305,19 +305,23 @@ manip_apply_syms <- function(funs, syms, tbl) {
 
   if (length(funs) == 1 && !attr(funs, "have_name")) {
     names(out) <- names(syms)
-  } else if (length(syms) == 1 && all(unnamed)) {
-    names(out) <- names(funs)
   } else {
-    syms_names <- map_chr(syms, as_string)
+
     names(funs) <- if_else(
       names(funs) == "<fn>",
-      paste0("<fn>_", seq_along(funs)),
+      paste0("fn", seq_along(funs)),
       names(funs)
     )
-    grid <- expand.grid(var = syms_names, call = names(funs))
-    names(out) <- paste(grid$var, grid$call, sep = "_")
-  }
+    # TODO: still needs to deal with makeing names unique
 
+    if (length(syms) == 1 && all(unnamed)) {
+      names(out) <- names(funs)
+    } else {
+      syms_names <- map_chr(syms, as_string)
+      grid <- expand.grid(var = syms_names, call = names(funs))
+      names(out) <- paste(grid$var, grid$call, sep = "_")
+    }
+  }
   out
 }
 

--- a/R/colwise-mutate.R
+++ b/R/colwise-mutate.R
@@ -308,10 +308,11 @@ manip_apply_syms <- function(funs, syms, tbl) {
   } else {
     nms <- names(funs)
     nms[nms == "<fn>"] <- "fn"
-    nms <- tibble:::universal_names(nms, quiet = TRUE)
-    # while(any(dup <- duplicated(nms))) {
-    #   nms[dup] <- paste(nms[dup], which(dup), sep = ".")
-    # }
+
+    # append ..<position> to duplicates
+    dup <- duplicated(nms)
+    test <- nms %in% nms[dup]
+    nms[test] <- paste(nms[test], which(test), sep = "..")
     names(funs) <- nms
 
     if (length(syms) == 1 && all(unnamed)) {

--- a/R/colwise-mutate.R
+++ b/R/colwise-mutate.R
@@ -309,13 +309,11 @@ manip_apply_syms <- function(funs, syms, tbl) {
     names(out) <- names(funs)
   } else {
     syms_names <- map_chr(syms, as_string)
-    if (!attr(funs, "have_name")) {
-      names(funs) <- if_else(
-        names(funs) == "<fn>",
-        paste0("<fn>_", seq_along(funs)),
-        names(funs)
-      )
-    }
+    names(funs) <- if_else(
+      names(funs) == "<fn>",
+      paste0("<fn>_", seq_along(funs)),
+      names(funs)
+    )
     grid <- expand.grid(var = syms_names, call = names(funs))
     names(out) <- paste(grid$var, grid$call, sep = "_")
   }

--- a/R/colwise-mutate.R
+++ b/R/colwise-mutate.R
@@ -308,11 +308,7 @@ manip_apply_syms <- function(funs, syms, tbl) {
   } else {
     nms <- names(funs)
     nms[nms == "<fn>"] <- "fn"
-
-    # append ..<position> to duplicates
-    dup <- duplicated(nms)
-    test <- nms %in% nms[dup]
-    nms[test] <- paste(nms[test], which(test), sep = "..")
+    nms <- universal_names(nms, quiet = TRUE)
     names(funs) <- nms
 
     if (length(syms) == 1 && all(unnamed)) {

--- a/R/colwise-mutate.R
+++ b/R/colwise-mutate.R
@@ -306,13 +306,13 @@ manip_apply_syms <- function(funs, syms, tbl) {
   if (length(funs) == 1 && !attr(funs, "have_name")) {
     names(out) <- names(syms)
   } else {
-
-    names(funs) <- if_else(
-      names(funs) == "<fn>",
-      paste0("fn", seq_along(funs)),
-      names(funs)
-    )
-    # TODO: still needs to deal with makeing names unique
+    nms <- names(funs)
+    nms[nms == "<fn>"] <- "fn"
+    nms <- tibble:::universal_names(nms, quiet = TRUE)
+    # while(any(dup <- duplicated(nms))) {
+    #   nms[dup] <- paste(nms[dup], which(dup), sep = ".")
+    # }
+    names(funs) <- nms
 
     if (length(syms) == 1 && all(unnamed)) {
       names(out) <- names(funs)

--- a/R/compat-name-repair.R
+++ b/R/compat-name-repair.R
@@ -1,0 +1,192 @@
+# compat-name-repair (last updated: tibble 2.0.1.9000)
+
+# This file serves as a reference for compatibility functions for
+# name repair in tibble, until name repair is available in rlang.
+
+minimal_names <- function(name, n) {
+  if (is.null(name) && missing(n)) {
+    abort(error_name_length_required())
+  }
+
+  ## TODO: address scenarios where name is not NULL and n != length(name)?
+  if (is.null(name)) {
+    rep_len("", n)
+  } else {
+    name %|% ""
+  }
+}
+
+set_minimal_names <- function(x) {
+  new_names <- minimal_names(names(x), n = length(x))
+  set_names(x, new_names)
+}
+
+unique_names <- function(name, quiet = FALSE, transform = identity) {
+  min_name <- minimal_names(name)
+  naked_name <- strip_pos(min_name)
+  naked_is_empty <- (naked_name == "")
+
+  new_name <- transform(naked_name)
+
+  new_name <- append_pos(new_name, needs_suffix = naked_is_empty)
+
+  duped_after <- duplicated(new_name) | duplicated(new_name, fromLast = TRUE)
+  new_name <- append_pos(new_name, duped_after)
+
+  if (!quiet) {
+    describe_repair(name, new_name)
+  }
+
+  new_name
+}
+
+set_unique_names <- function(x, quiet = FALSE) {
+  x <- set_minimal_names(x)
+  new_names <- unique_names(names(x), quiet = quiet)
+  set_names(x, new_names)
+}
+
+universal_names <- function(name, quiet = FALSE) {
+  unique_names(name, quiet = quiet, transform = make_syntactic)
+}
+
+set_universal_names <- function(x, quiet = FALSE) {
+  x <- set_minimal_names(x)
+  new_names <- universal_names(names(x), quiet = quiet)
+  set_names(x, new_names)
+}
+
+## makes each individual name syntactic
+## does not enforce unique-ness
+make_syntactic <- function(name) {
+  name[is.na(name)]       <- ""
+  name[name == ""]        <- "."
+  name[name == "..."]     <- "...."
+  name <- sub("^_", "._", name)
+
+  new_name <- make.names(name)
+
+  X_prefix <- grepl("^X", new_name) & !grepl("^X", name)
+  new_name[X_prefix] <- sub("^X", "", new_name[X_prefix])
+
+  dot_suffix <- which(new_name == paste0(name, "."))
+  new_name[dot_suffix] <- sub("^(.*)[.]$", ".\\1", new_name[dot_suffix])
+  ## illegal characters have been replaced with '.' via make.names()
+  ## however, we have:
+  ##   * declined its addition of 'X' prefixes
+  ##   * turned its '.' suffixes to '.' prefixes
+
+  regex <- paste0(
+    "^(?<leading_dots>[.]{0,2})",
+    "(?<numbers>[0-9]*)",
+    "(?<leftovers>[^0-9]?.*$)"
+  )
+
+  re <- re_match(new_name, pattern = regex)
+  needs_dots <- which(re$numbers != "")
+  needs_third_dot <- (re$leftovers[needs_dots] == "")
+  re$leading_dots[needs_dots] <- ifelse(needs_third_dot, "...", "..")
+  new_name <- paste0(re$leading_dots, re$numbers, re$leftovers)
+
+  new_name
+}
+
+append_pos <- function(name, needs_suffix) {
+  need_append_pos <- which(needs_suffix)
+  name[need_append_pos] <- paste0(name[need_append_pos], "..", need_append_pos)
+  name
+}
+
+strip_pos <- function(name) {
+  rx <- "[.][.][1-9][0-9]*$"
+  gsub(rx, "", name) %|% ""
+}
+
+describe_repair <- function(orig_name, name) {
+  stopifnot(length(orig_name) == length(name))
+
+  new_names <- name != minimal_names(orig_name)
+  if (any(new_names)) {
+    msg <- bullets(
+      "New names:",
+      paste0(
+        tick_if_needed(orig_name[new_names]),
+        " -> ",
+        tick_if_needed(name[new_names]),
+        .problem = ""
+      )
+    )
+    message(msg)
+  }
+}
+
+## from rematch2, except we don't add tbl_df or tbl classes to the return value
+re_match <- function(text, pattern, perl = TRUE, ...) {
+
+  stopifnot(is.character(pattern), length(pattern) == 1, !is.na(pattern))
+  text <- as.character(text)
+
+  match <- regexpr(pattern, text, perl = perl, ...)
+
+  start  <- as.vector(match)
+  length <- attr(match, "match.length")
+  end    <- start + length - 1L
+
+  matchstr <- substring(text, start, end)
+  matchstr[ start == -1 ] <- NA_character_
+
+  res <- data.frame(
+    stringsAsFactors = FALSE,
+    .text = text,
+    .match = matchstr
+  )
+
+  if (!is.null(attr(match, "capture.start"))) {
+
+    gstart  <- attr(match, "capture.start")
+    glength <- attr(match, "capture.length")
+    gend    <- gstart + glength - 1L
+
+    groupstr <- substring(text, gstart, gend)
+    groupstr[ gstart == -1 ] <- NA_character_
+    dim(groupstr) <- dim(gstart)
+
+    res <- cbind(groupstr, res, stringsAsFactors = FALSE)
+  }
+
+  names(res) <- c(attr(match, "capture.names"), ".text", ".match")
+  res
+}
+
+# A better version (with far more dependencies) exists in msg-format.R
+bullets <- function(header, ..., .problem) {
+  problems <- c(...)
+  MAX_BULLETS <- 6L
+  if (length(problems) >= MAX_BULLETS) {
+    n_more <- length(problems) - MAX_BULLETS + 1L
+    problems[[MAX_BULLETS]] <- "..."
+    length(problems) <- MAX_BULLETS
+  }
+
+  paste0(
+    header, "\n",
+    paste0("* ", problems, collapse = "\n")
+  )
+}
+
+# FIXME: Also exists in pillar, do we need to export?
+tick <- function(x) {
+  ifelse(is.na(x), "NA", encodeString(x, quote = "`"))
+}
+
+is_syntactic <- function(x) {
+  ret <- (make_syntactic(x) == x)
+  ret[is.na(x)] <- FALSE
+  ret
+}
+
+tick_if_needed <- function(x) {
+  needs_ticks <- !is_syntactic(x)
+  x[needs_ticks] <- tick(x[needs_ticks])
+  x
+}

--- a/inst/include/dplyr/hybrid/scalar_result/min_max.h
+++ b/inst/include/dplyr/hybrid/scalar_result/min_max.h
@@ -24,8 +24,8 @@ public:
     expr(expr_)
   {}
 
-  ~MinMax(){
-    if(NA_RM && warn) {
+  ~MinMax() {
+    if (NA_RM && warn) {
       if (MINIMUM) {
         Rf_warningcall(expr, "no non-missing arguments to min; returning Inf");
       } else {

--- a/tests/testthat/test-colwise-mutate.R
+++ b/tests/testthat/test-colwise-mutate.R
@@ -44,7 +44,6 @@ test_that("default names are smallest unique set", {
   expect_named(summarise_at(df, vars(x), list(mean = mean, sd = sd)), c("mean", "sd"))
   expect_named(summarise_at(df, vars(x:y), list(mean = mean, sd = sd)), c("x_mean", "y_mean", "x_sd", "y_sd"))
 
-  skip("discussed in #4125")
   expect_named(summarise_at(df, vars(x:y), funs(base::mean, stats::sd)), c("x_base::mean", "y_base::mean", "x_stats::sd", "y_stats::sd"))
 })
 

--- a/tests/testthat/test-colwise-mutate.R
+++ b/tests/testthat/test-colwise-mutate.R
@@ -312,7 +312,7 @@ test_that("summarise_at with multiple columns AND unnamed functions works (#4119
     summarise_at(vars(wind, pressure), list(mean, median))
 
   expect_equal(ncol(res), 4L)
-  expect_equal(names(res), c("wind_<fn>_1", "pressure_<fn>_1", "wind_<fn>_2", "pressure_<fn>_2"))
+  expect_equal(names(res), c("wind_fn1", "pressure_fn1", "wind_fn2", "pressure_fn2"))
 })
 
 test_that("mutate_at with multiple columns AND unnamed functions works (#4119)", {
@@ -322,6 +322,6 @@ test_that("mutate_at with multiple columns AND unnamed functions works (#4119)",
   expect_equal(ncol(res), ncol(storms) + 4L)
   expect_equal(
     names(res),
-    c(names(storms), c("wind_<fn>_1", "pressure_<fn>_1", "wind_<fn>_2", "pressure_<fn>_2"))
+    c(names(storms), c("wind_fn1", "pressure_fn1", "wind_fn2", "pressure_fn2"))
   )
 })

--- a/tests/testthat/test-colwise-mutate.R
+++ b/tests/testthat/test-colwise-mutate.R
@@ -38,12 +38,14 @@ test_that("default names are smallest unique set", {
   expect_named(summarise_at(df, vars(x:y), funs(mean)), c("x", "y"))
   expect_named(summarise_at(df, vars(x), funs(mean, sd)), c("mean", "sd"))
   expect_named(summarise_at(df, vars(x:y), funs(mean, sd)), c("x_mean", "y_mean", "x_sd", "y_sd"))
-  expect_named(summarise_at(df, vars(x:y), funs(base::mean, stats::sd)), c("x_base::mean", "y_base::mean", "x_stats::sd", "y_stats::sd"))
   expect_named(summarise_at(df, vars(x = x), funs(mean, sd)), c("x_mean", "x_sd"))
 
   expect_named(summarise_at(df, vars(x:y), list(mean)), c("x", "y"))
   expect_named(summarise_at(df, vars(x), list(mean = mean, sd = sd)), c("mean", "sd"))
   expect_named(summarise_at(df, vars(x:y), list(mean = mean, sd = sd)), c("x_mean", "y_mean", "x_sd", "y_sd"))
+
+  skip("discussed in #4125")
+  expect_named(summarise_at(df, vars(x:y), funs(base::mean, stats::sd)), c("x_base::mean", "y_base::mean", "x_stats::sd", "y_stats::sd"))
 })
 
 test_that("named arguments force complete named", {
@@ -312,7 +314,7 @@ test_that("summarise_at with multiple columns AND unnamed functions works (#4119
     summarise_at(vars(wind, pressure), list(mean, median))
 
   expect_equal(ncol(res), 4L)
-  expect_equal(names(res), c("wind_fn1", "pressure_fn1", "wind_fn2", "pressure_fn2"))
+  expect_equal(names(res), c("wind_fn..1", "pressure_fn..1", "wind_fn..2", "pressure_fn..2"))
 })
 
 test_that("mutate_at with multiple columns AND unnamed functions works (#4119)", {
@@ -322,6 +324,6 @@ test_that("mutate_at with multiple columns AND unnamed functions works (#4119)",
   expect_equal(ncol(res), ncol(storms) + 4L)
   expect_equal(
     names(res),
-    c(names(storms), c("wind_fn1", "pressure_fn1", "wind_fn2", "pressure_fn2"))
+    c(names(storms), c("wind_fn..1", "pressure_fn..1", "wind_fn..2", "pressure_fn..2"))
   )
 })

--- a/tests/testthat/test-colwise-mutate.R
+++ b/tests/testthat/test-colwise-mutate.R
@@ -44,7 +44,7 @@ test_that("default names are smallest unique set", {
   expect_named(summarise_at(df, vars(x), list(mean = mean, sd = sd)), c("mean", "sd"))
   expect_named(summarise_at(df, vars(x:y), list(mean = mean, sd = sd)), c("x_mean", "y_mean", "x_sd", "y_sd"))
 
-  expect_named(summarise_at(df, vars(x:y), funs(base::mean, stats::sd)), c("x_base::mean", "y_base::mean", "x_stats::sd", "y_stats::sd"))
+  expect_named(summarise_at(df, vars(x:y), funs(base::mean, stats::sd)), c("x_base..mean", "y_base..mean", "x_stats..sd", "y_stats..sd"))
 })
 
 test_that("named arguments force complete named", {

--- a/tests/testthat/test-colwise-mutate.R
+++ b/tests/testthat/test-colwise-mutate.R
@@ -306,3 +306,22 @@ test_that("mutate_all() handles non syntactic names (#4094)", {
   expect_equal(names(tbl), names(res))
   expect_equal(res[["..1"]], "A")
 })
+
+test_that("summarise_at with multiple columns AND unnamed functions works (#4119)", {
+  res <- storms %>%
+    summarise_at(vars(wind, pressure), list(mean, median))
+
+  expect_equal(ncol(res), 4L)
+  expect_equal(names(res), c("wind_<fn>_1", "pressure_<fn>_1", "wind_<fn>_2", "pressure_<fn>_2"))
+})
+
+test_that("mutate_at with multiple columns AND unnamed functions works (#4119)", {
+  res <- storms %>%
+    mutate_at(vars(wind, pressure), list(mean, median))
+
+  expect_equal(ncol(res), ncol(storms) + 4L)
+  expect_equal(
+    names(res),
+    c(names(storms), c("wind_<fn>_1", "pressure_<fn>_1", "wind_<fn>_2", "pressure_<fn>_2"))
+  )
+})


### PR DESCRIPTION
``` r
library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union

storms %>% 
  summarize_at(vars(wind, pressure), list(mean, median)) 
#> # A tibble: 1 x 4
#>   `wind_<fn>_1` `pressure_<fn>_1` `wind_<fn>_2` `pressure_<fn>_2`
#>           <dbl>             <dbl>         <dbl>             <dbl>
#> 1          53.5              992.            45               999
```

<sup>Created on 2019-01-24 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)</sup>