### PR TITLE
Remove r_build_args: --no-manual

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ dist: trusty
 cache: packages
 latex: false
 fortran: false
-r_build_args: '--no-manual'
 
 jobs:
   include:


### PR DESCRIPTION
I added this workaround in #4085, but this is fixed on upstream:

https://github.com/travis-ci/travis-build/pull/1632