### PR TITLE
internal::column_subset() falls back on R indexing on esoteric

### DIFF
--- a/inst/include/dplyr/visitors/subset/column_subset.h
+++ b/inst/include/dplyr/visitors/subset/column_subset.h
@@ -144,30 +144,30 @@ SEXP column_subset(SEXP x, const Index& index, SEXP frame) {
     return dataframe_subset(x, index, Rf_getAttrib(x, R_ClassSymbol), frame);
   }
 
-  // this has a class, so just use R `[` or `[[`
-  if (OBJECT(x) || !Rf_isNull(Rf_getAttrib(x, R_ClassSymbol))) {
-    return r_column_subset(x, index, frame);
+  // trivial types, treat them specially
+  if (!OBJECT(x) && Rf_isNull(Rf_getAttrib(x, R_ClassSymbol))) {
+    switch (TYPEOF(x)) {
+    case LGLSXP:
+      return column_subset_impl<LGLSXP, Index>(x, index);
+    case RAWSXP:
+      return column_subset_impl<RAWSXP, Index>(x, index);
+    case INTSXP:
+      return column_subset_impl<INTSXP, Index>(x, index);
+    case STRSXP:
+      return column_subset_impl<STRSXP, Index>(x, index);
+    case REALSXP:
+      return column_subset_impl<REALSXP, Index>(x, index);
+    case CPLXSXP:
+      return column_subset_impl<CPLXSXP, Index>(x, index);
+    case VECSXP:
+      return column_subset_impl<VECSXP, Index>(x, index);
+    default:
+      break;
+    }
   }
 
-  switch (TYPEOF(x)) {
-  case LGLSXP:
-    return column_subset_impl<LGLSXP, Index>(x, index);
-  case RAWSXP:
-    return column_subset_impl<RAWSXP, Index>(x, index);
-  case INTSXP:
-    return column_subset_impl<INTSXP, Index>(x, index);
-  case STRSXP:
-    return column_subset_impl<STRSXP, Index>(x, index);
-  case REALSXP:
-    return column_subset_impl<REALSXP, Index>(x, index);
-  case CPLXSXP:
-    return column_subset_impl<CPLXSXP, Index>(x, index);
-  case VECSXP:
-    return column_subset_impl<VECSXP, Index>(x, index);
-  default:
-    break;
-  }
-
+  // anything else, fall back to R indexing and
+  // possibly dispatch on [ or [[
   return r_column_subset(x, index, frame);
 }
 

--- a/inst/include/dplyr/visitors/subset/column_subset.h
+++ b/inst/include/dplyr/visitors/subset/column_subset.h
@@ -168,8 +168,7 @@ SEXP column_subset(SEXP x, const Index& index, SEXP frame) {
     break;
   }
 
-  stop("type not supported");
-  return R_NilValue;
+  return r_column_subset(x, index, frame);
 }
 
 template <typename Index>

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -186,3 +186,8 @@ test_that("slice does not evaluate the expression in empty groups (#1438)", {
   )
   expect_equal(nrow(res), 3L)
 })
+
+test_that("column_subset() falls back to R indexing on esoteric data types (#4128)", {
+  res <- slice(tibble::enframe(formals(rnorm)), 2:3)
+  expect_identical(res, tibble(name = c("mean", "sd"), value = list(0, 1)))
+})


### PR DESCRIPTION
This incidentally fix #4128 

``` r
dplyr::slice(tibble::enframe(formals(rnorm)), 2:3)
#> # A tibble: 2 x 2
#>   name  value    
#>   <chr> <list>   
#> 1 mean  <dbl [1]>
#> 2 sd    <dbl [1]>
```

<sup>Created on 2019-01-26 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)</sup>