### PR TITLE
improve performance for POSIXct.

### DIFF
--- a/inst/include/dplyr/symbols.h
+++ b/inst/include/dplyr/symbols.h
@@ -63,6 +63,11 @@ struct fns {
   static SEXP quote;
 };
 
+struct strings {
+  static SEXP POSIXct;
+  static SEXP POSIXt;
+};
+
 } // namespace dplyr
 
 

--- a/inst/include/dplyr/visitors/subset/column_subset.h
+++ b/inst/include/dplyr/visitors/subset/column_subset.h
@@ -138,13 +138,8 @@ inline SEXP r_column_subset<RowwiseSlicingIndex>(SEXP x, const RowwiseSlicingInd
   }
 }
 
-template <int RTYPE, typename Index>
-SEXP column_subset_posixct(SEXP x, const Index& index) {
-  return column_subset_impl<RTYPE, Index>(x, index);
-}
-
-inline bool is_trivial_POSIXct(SEXP klass) {
-  return TYPEOF(klass) == STRSXP && Rf_length(klass) == 2 && STRING_ELT(klass, 0) == strings::POSIXct && STRING_ELT(klass, 1) == strings::POSIXt;
+inline bool is_trivial_POSIXct(SEXP x, SEXP klass) {
+  return TYPEOF(x) == REALSXP && TYPEOF(klass) == STRSXP && Rf_length(klass) == 2 && STRING_ELT(klass, 0) == strings::POSIXct && STRING_ELT(klass, 1) == strings::POSIXt;
 }
 
 template <typename Index>
@@ -178,17 +173,8 @@ SEXP column_subset(SEXP x, const Index& index, SEXP frame) {
   }
 
   // special case POSIXct (#3988)
-  if (is_trivial_POSIXct(klass)) {
-    switch (TYPEOF(x)) {
-    case INTSXP:
-      return column_subset_posixct<INTSXP>(x, index);
-    case REALSXP:
-      return column_subset_posixct<REALSXP>(x, index);
-    default:
-      break;
-    }
-
-    return r_column_subset(x, index, frame);
+  if (is_trivial_POSIXct(x, klass)) {
+    return column_subset_impl<REALSXP, Index>(x, index);
   }
 
   // anything else, fall back to R indexing and

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -95,4 +95,7 @@ SEXP symbols::eval_tidy = Rf_install("eval_tidy");
 SEXP symbols::quote = Rf_install("quote");
 
 SEXP fns::quote = Rf_eval(Rf_install("quote"), R_BaseEnv);
+
+SEXP strings::POSIXct = STRING_ELT(get_time_classes(), 0);
+SEXP strings::POSIXt = STRING_ELT(get_time_classes(), 1);
 }


### PR DESCRIPTION
Bring back performance from @earowang example: 

``` r
library(dplyr, warn.conflicts = FALSE)

id <- rep(seq.int(8143667, by = 1, length.out = 4e+3), each = 1e+4)
time <- as.POSIXct("2015-01-01 00:00", tz = "UTC") + seq(0, by = 1800, length.out = 1e+4)
index <- rep(time, 4e+3)
tbl <- tibble(id = id, index = index)
system.time(
  tbl %>% 
    group_by(id) %>% 
    summarise(len = length(index))
)
#>    user  system elapsed 
#>   0.946   0.242   1.191
```

<sup>Created on 2019-01-28 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)</sup>