### PR TITLE
group_drops() implemented in grouped_df method because data base back…

### DIFF
--- a/R/colwise-group-by.R
+++ b/R/colwise-group-by.R
@@ -36,7 +36,7 @@ group_by_all <- function(.tbl, .funs = list(), ..., .add = FALSE, .drop = group_
   if (!length(funs)) {
     funs <- syms(tbl_vars(.tbl))
   }
-  group_by(.tbl, !!!funs, add = .add, .drop = .drop)
+  .group_by_static_drop(.tbl, !!!funs, add = .add, .drop = .drop)
 }
 #' @rdname group_by_all
 #' @export
@@ -45,7 +45,7 @@ group_by_at <- function(.tbl, .vars, .funs = list(), ..., .add = FALSE, .drop = 
   if (!length(funs)) {
     funs <- tbl_at_syms(.tbl, .vars, .include_group_vars = TRUE)
   }
-  group_by(.tbl, !!!funs, add = .add, .drop = .drop)
+  .group_by_static_drop(.tbl, !!!funs, add = .add, .drop = .drop)
 }
 #' @rdname group_by_all
 #' @export
@@ -54,5 +54,5 @@ group_by_if <- function(.tbl, .predicate, .funs = list(), ..., .add = FALSE, .dr
   if (!length(funs)) {
     funs <- tbl_if_syms(.tbl, .predicate, .include_group_vars = TRUE)
   }
-  group_by(.tbl, !!!funs, add = .add, .drop = .drop)
+  .group_by_static_drop(.tbl, !!!funs, add = .add, .drop = .drop)
 }

--- a/R/compat-future-group_by.R
+++ b/R/compat-future-group_by.R
@@ -12,6 +12,6 @@
   if(.drop) {
     group_by(...)
   } else {
-    group_by(..., .drop = TRUE)
+    group_by(..., .drop = FALSE)
   }
 }

--- a/R/compat-future-group_by.R
+++ b/R/compat-future-group_by.R
@@ -1,0 +1,17 @@
+# workaround so that methods that do not have the .drop argument yet
+# don't create the auto mutate .drop column
+#
+# things like count() and group_by_all()
+# can call .group_by_static_drop() instead of group_by()
+# so that .drop is only part of the group_by() call if it is FALSE
+#
+# this is only meant to stay in dplyr until 0.8.0 to give
+# implementers of group_by() methods a chance to add .drop in their
+# arguments
+.group_by_static_drop <- function(..., .drop) {
+  if(.drop) {
+    group_by(...)
+  } else {
+    group_by(..., .drop = TRUE)
+  }
+}

--- a/R/count-tally.R
+++ b/R/count-tally.R
@@ -130,10 +130,18 @@ count <- function(x, ..., wt = NULL, sort = FALSE, name = "n", .drop = group_dro
   groups <- group_vars(x)
 
   if (dots_n(...)) {
-    x <- group_by(x, ..., add = TRUE, .drop = .drop)
+    x <- if(.drop) {
+      group_by(x, ..., add = TRUE)
+    } else {
+      group_by(x, ..., add = TRUE, .drop = FALSE)
+    }
   }
   x <- tally(x, wt = !!enquo(wt), sort = sort, name = name)
-  x <- group_by(x, !!!syms(groups), add = FALSE, .drop = .drop)
+  x <- if(.drop) {
+    group_by(x, !!!syms(groups), add = FALSE)
+  } else {
+    group_by(x, !!!syms(groups), add = FALSE, .drop = FALSE)
+  }
   x
 }
 #' @export

--- a/R/count-tally.R
+++ b/R/count-tally.R
@@ -130,7 +130,7 @@ count <- function(x, ..., wt = NULL, sort = FALSE, name = "n", .drop = group_dro
   groups <- group_vars(x)
 
   if (dots_n(...)) {
-    .group_by_static_drop(x, ..., add = TRUE, .drop = .drop)
+    x <- .group_by_static_drop(x, ..., add = TRUE, .drop = .drop)
   }
   x <- tally(x, wt = !!enquo(wt), sort = sort, name = name)
   x <- .group_by_static_drop(x, !!!syms(groups), add = FALSE, .drop = .drop)

--- a/R/count-tally.R
+++ b/R/count-tally.R
@@ -130,18 +130,10 @@ count <- function(x, ..., wt = NULL, sort = FALSE, name = "n", .drop = group_dro
   groups <- group_vars(x)
 
   if (dots_n(...)) {
-    x <- if(.drop) {
-      group_by(x, ..., add = TRUE)
-    } else {
-      group_by(x, ..., add = TRUE, .drop = FALSE)
-    }
+    .group_by_static_drop(x, ..., add = TRUE, .drop = .drop)
   }
   x <- tally(x, wt = !!enquo(wt), sort = sort, name = name)
-  x <- if(.drop) {
-    group_by(x, !!!syms(groups), add = FALSE)
-  } else {
-    group_by(x, !!!syms(groups), add = FALSE, .drop = FALSE)
-  }
+  x <- .group_by_static_drop(x, !!!syms(groups), add = FALSE, .drop = .drop)
   x
 }
 #' @export

--- a/R/group-by.r
+++ b/R/group-by.r
@@ -200,13 +200,5 @@ group_vars.default <- function(x) {
 #
 # absence of the .drop attribute -> drop = TRUE for backwards compatibility reasons
 group_drops <- function(x) {
-  UseMethod("group_drops")
-}
-
-group_drops.default <- function(x) {
-  TRUE
-}
-
-group_drops.grouped_df <- function(x) {
-  !identical(attr(group_data(x), ".drop"), FALSE)
+  !is_grouped_df(x) || is.null(attr(x, "groups")) || !identical(attr(group_data(x), ".drop"), FALSE)
 }

--- a/R/group-by.r
+++ b/R/group-by.r
@@ -200,5 +200,13 @@ group_vars.default <- function(x) {
 #
 # absence of the .drop attribute -> drop = TRUE for backwards compatibility reasons
 group_drops <- function(x) {
+  UseMethod("group_drops")
+}
+
+group_drops.default <- function(x) {
+  TRUE
+}
+
+group_drops.grouped_df <- function(x) {
   !identical(attr(group_data(x), ".drop"), FALSE)
 }


### PR DESCRIPTION
~partial~ fix for #4139

``` r
library(dplyr)                                                                                                
set.seed(42)                                                                                                  
tibble(value = 1:10, key = sample(c("a", "b"), 10, replace = TRUE)) %>% 
  group_by(key) %>% 
  count()             
#> # A tibble: 2 x 2
#> # Groups:   key [2]
#>   key       n
#>   <chr> <int>
#> 1 a         2
#> 2 b         8

dbplyr::memdb_frame(value = 1:10, key = sample(c("a", "b"), 10, replace = TRUE)) %>% 
  group_by(key) %>% 
  count()
#> # Source:   lazy query [?? x 3]
#> # Database: sqlite 3.22.0 [:memory:]
#> # Groups:   key, .drop
#>   key       n .drop
#>   <chr> <int> <int>
#> 1 a         4     1
#> 2 b         6     1
```

Note the additional `.drop` column because of how `count` is implemented: 

```r
count <- function(x, ..., wt = NULL, sort = FALSE, name = "n", .drop = group_drops(x)) {
  groups <- group_vars(x)

  if (dots_n(...)) {
    x <- group_by(x, ..., add = TRUE, .drop = .drop)
  }
  x <- tally(x, wt = !!enquo(wt), sort = sort, name = name)
  x <- group_by(x, !!!syms(groups), add = FALSE, .drop = .drop)
  x
}
```

I guess eventually `group_by()` implementations also need the `.drop` argument, even to just ignore it, in the meantime I guess I can just code around it in `count()` 
