### PR TITLE
improve performance for Date #3988

### DIFF
--- a/inst/include/dplyr/symbols.h
+++ b/inst/include/dplyr/symbols.h
@@ -67,6 +67,7 @@ struct fns {
 struct strings {
   static SEXP POSIXct;
   static SEXP POSIXt;
+  static SEXP Date;
 };
 
 } // namespace dplyr

--- a/inst/include/dplyr/visitors/subset/column_subset.h
+++ b/inst/include/dplyr/visitors/subset/column_subset.h
@@ -142,6 +142,10 @@ inline bool is_trivial_POSIXct(SEXP x, SEXP klass) {
   return TYPEOF(x) == REALSXP && TYPEOF(klass) == STRSXP && Rf_length(klass) == 2 && STRING_ELT(klass, 0) == strings::POSIXct && STRING_ELT(klass, 1) == strings::POSIXt;
 }
 
+inline bool is_trivial_Date(SEXP x, SEXP klass) {
+  return TYPEOF(x) == REALSXP && TYPEOF(klass) == STRSXP && Rf_length(klass) == 1 && STRING_ELT(klass, 0) == strings::Date;
+}
+
 template <typename Index>
 SEXP column_subset(SEXP x, const Index& index, SEXP frame) {
   if (Rf_inherits(x, "data.frame")) {
@@ -174,6 +178,11 @@ SEXP column_subset(SEXP x, const Index& index, SEXP frame) {
 
   // special case POSIXct (#3988)
   if (is_trivial_POSIXct(x, klass)) {
+    return column_subset_impl<REALSXP, Index>(x, index);
+  }
+
+  // special case Date (#3988)
+  if (is_trivial_Date(x, klass)) {
     return column_subset_impl<REALSXP, Index>(x, index);
   }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -99,4 +99,5 @@ SEXP fns::quote = Rf_eval(Rf_install("quote"), R_BaseEnv);
 
 SEXP strings::POSIXct = STRING_ELT(get_time_classes(), 0);
 SEXP strings::POSIXt = STRING_ELT(get_time_classes(), 1);
+SEXP strings::Date = STRING_ELT(get_date_classes(), 0);
 }


### PR DESCRIPTION
Performance for `Date` is back.

``` r
library(dplyr, warn.conflicts = FALSE)
library(purrr)

id <- rep(seq.int(8143667, by = 1, length.out = 400), each = 1e+4)
time <- as.Date("2015-01-01") + seq(0, by = 1800, length.out = 1e+4)
index <- rep(time, 400)
tbl <- tibble(id = id, index = index)

system.time(g <- tbl %>% group_by(id))
#>    user  system elapsed 
#>   0.087   0.012   0.098
system.time(summarise(g, len = length(index)))
#>    user  system elapsed 
#>   0.019   0.004   0.024
indices <- group_rows(g)
system.time(map_int(indices, ~length(index[.])))
#>    user  system elapsed 
#>   0.048   0.013   0.061
```

More groups:

``` r
library(dplyr, warn.conflicts = FALSE)

id <- rep(seq.int(8143667, by = 1, length.out = 4e+3), each = 1e+4)
time <- as.Date("2015-01-01") + seq(0, by = 1800, length.out = 1e+4)
index <- rep(time, 4e+3)
tbl <- tibble(id = id, index = index)
system.time(
  tbl %>% 
    group_by(id) %>% 
    summarise(len = length(index))
)
#>    user  system elapsed 
#>   0.999   0.260   1.260
```

<sup>Created on 2019-02-01 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>