### PR TITLE
Call warn_deprecated() instead of simple warning for n() 

### DIFF
--- a/inst/include/dplyr/hybrid/Expression.h
+++ b/inst/include/dplyr/hybrid/Expression.h
@@ -5,6 +5,7 @@
 #include <tools/SymbolString.h>
 #include <dplyr/data/DataMask.h>
 #include <dplyr/symbols.h>
+#include <dplyr/lifecycle.h>
 
 namespace dplyr {
 namespace hybrid {
@@ -370,8 +371,8 @@ private:
              << "::"
              << CHAR(PRINTNAME(head))
              << "()`.";
-      Rcpp::warningcall(R_NilValue, stream.str());
 
+      lifecycle::warn_deprecated(stream.str());
     }
   }
 

--- a/inst/include/dplyr/lifecycle.h
+++ b/inst/include/dplyr/lifecycle.h
@@ -1,0 +1,12 @@
+#ifndef DPLYR_LIFECYCLE_H
+#define DPLYR_LIFECYCLE_H
+
+namespace dplyr {
+namespace lifecycle {
+
+void warn_deprecated(const std::string&);
+
+}
+}
+
+#endif

--- a/inst/include/dplyr/symbols.h
+++ b/inst/include/dplyr/symbols.h
@@ -58,6 +58,7 @@ struct symbols {
   static SEXP eval_tidy;
   static SEXP quote;
   static SEXP dot_drop;
+  static SEXP warn_deprecated;
 };
 
 struct fns {

--- a/inst/include/dplyr/visitors/subset/column_subset.h
+++ b/inst/include/dplyr/visitors/subset/column_subset.h
@@ -8,8 +8,6 @@
 #include <tools/SlicingIndex.h>
 #include <dplyr/symbols.h>
 
-SEXP ns_methods();
-
 namespace base {
 SEXP bracket_one();
 SEXP bracket_two();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -33,11 +33,6 @@ SEXP get_time_classes() {
   return VECTOR_ELT(get_cache(), 1);
 }
 
-SEXP ns_methods() {
-  static Environment ns = Environment::namespace_env("methods");
-  return ns;
-}
-
 namespace dplyr {
 SEXP symbols::package = Rf_install("package");
 SEXP symbols::n = Rf_install("n");
@@ -94,6 +89,7 @@ SEXP symbols::rlang = Rf_install("rlang");
 SEXP symbols::eval_tidy = Rf_install("eval_tidy");
 SEXP symbols::quote = Rf_install("quote");
 SEXP symbols::dot_drop = Rf_install(".drop");
+SEXP symbols::warn_deprecated = Rf_install("warn_deprecated");
 
 SEXP fns::quote = Rf_eval(Rf_install("quote"), R_BaseEnv);
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -7,6 +7,7 @@
 #include <tools/bad.h>
 #include <dplyr/data/GroupedDataFrame.h>
 #include <dplyr/symbols.h>
+#include <dplyr/lifecycle.h>
 
 using namespace Rcpp;
 
@@ -361,3 +362,20 @@ int get_size(SEXP x) {
     return Rf_length(x);
   }
 }
+
+namespace dplyr {
+namespace lifecycle {
+
+void warn_deprecated(const std::string& s) {
+  static Rcpp::Environment ns_dplyr(Environment::namespace_env("dplyr"));
+
+  Rcpp::CharacterVector msg(Rcpp::CharacterVector::create(s));
+  Shield<SEXP> call(Rf_lang2(symbols::warn_deprecated, msg));
+
+  Rcpp::Rcpp_eval(call, ns_dplyr);
+}
+
+}
+}
+
+


### PR DESCRIPTION
``` r
dplyr::summarise(iris, n())
#> Warning: Calling `n()` without importing or prefixing it is deprecated, use `dplyr::n()`.
#> This warning is displayed once per session.
#>   n()
#> 1 150
dplyr::summarise(iris, n())
#>   n()
#> 1 150
```

<sup>Created on 2019-02-04 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)</sup>