### PR TITLE
n() is now signal_soft_deprecated() in dplyr::summarise(n = n())

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -152,8 +152,8 @@ full_join_impl <- function(x, y, by_x, by_y, aux_x, aux_y, na_match, frame) {
     .Call(`_dplyr_full_join_impl`, x, y, by_x, by_y, aux_x, aux_y, na_match, frame)
 }
 
-mutate_impl <- function(df, dots) {
-    .Call(`_dplyr_mutate_impl`, df, dots)
+mutate_impl <- function(df, dots, caller_env) {
+    .Call(`_dplyr_mutate_impl`, df, dots, caller_env)
 }
 
 select_impl <- function(df, vars) {
@@ -184,12 +184,12 @@ setdiff_data_frame <- function(x, y) {
     .Call(`_dplyr_setdiff_data_frame`, x, y)
 }
 
-summarise_impl <- function(df, dots, frame) {
-    .Call(`_dplyr_summarise_impl`, df, dots, frame)
+summarise_impl <- function(df, dots, frame, caller_env) {
+    .Call(`_dplyr_summarise_impl`, df, dots, frame, caller_env)
 }
 
-hybrid_impl <- function(df, quosure) {
-    .Call(`_dplyr_hybrid_impl`, df, quosure)
+hybrid_impl <- function(df, quosure, caller_env) {
+    .Call(`_dplyr_hybrid_impl`, df, quosure, caller_env)
 }
 
 test_comparisons <- function() {

--- a/R/hybrid.R
+++ b/R/hybrid.R
@@ -16,7 +16,7 @@ hybrid_call <- function(.data, expr){
 
 #' @export
 hybrid_call.data.frame <- function(.data, expr){
-  hybrid_impl(.data, enquo(expr))
+  hybrid_impl(.data, enquo(expr), caller_env())
 }
 
 #' @export

--- a/R/tbl-df.r
+++ b/R/tbl-df.r
@@ -88,23 +88,23 @@ slice_.tbl_df <- function(.data, ..., .dots = list()) {
 #' @export
 mutate.tbl_df <- function(.data, ...) {
   dots <- quos(..., .named = TRUE)
-  mutate_impl(.data, dots)
+  mutate_impl(.data, dots, caller_env())
 }
 #' @export
 mutate_.tbl_df <- function(.data, ..., .dots = list()) {
   dots <- compat_lazy_dots(.dots, caller_env(), ..., .named = TRUE)
-  mutate_impl(.data, dots)
+  mutate_impl(.data, dots, caller_env())
 }
 
 #' @export
 summarise.tbl_df <- function(.data, ...) {
   dots <- quos(..., .named = TRUE)
-  summarise_impl(.data, dots, environment())
+  summarise_impl(.data, dots, environment(), caller_env())
 }
 #' @export
 summarise_.tbl_df <- function(.data, ..., .dots = list()) {
   dots <- compat_lazy_dots(.dots, caller_env(), ..., .named = TRUE)
-  summarise_impl(.data, dots, environment())
+  summarise_impl(.data, dots, environment(), caller_env())
 }
 
 # Joins ------------------------------------------------------------------------

--- a/inst/include/dplyr/hybrid/Expression.h
+++ b/inst/include/dplyr/hybrid/Expression.h
@@ -93,6 +93,7 @@ class Expression {
 private:
   SEXP expr;
   SEXP env;
+  SEXP caller_env;
 
   SEXP func;
   SEXP package;
@@ -111,9 +112,10 @@ private:
 public:
   typedef std::pair<bool, SEXP> ArgPair;
 
-  Expression(SEXP expr_, const DataMask<SlicedTibble>& data_mask_, SEXP env_) :
+  Expression(SEXP expr_, const DataMask<SlicedTibble>& data_mask_, SEXP env_, SEXP caller_env_) :
     expr(expr_),
     env(env_),
+    caller_env(caller_env_),
     func(R_NilValue),
     package(R_NilValue),
     data_mask(data_mask_),
@@ -372,7 +374,7 @@ private:
              << CHAR(PRINTNAME(head))
              << "()`.";
 
-      lifecycle::warn_deprecated(stream.str());
+      lifecycle::signal_soft_deprecated(stream.str(), caller_env);
     }
   }
 

--- a/inst/include/dplyr/lifecycle.h
+++ b/inst/include/dplyr/lifecycle.h
@@ -5,6 +5,7 @@ namespace dplyr {
 namespace lifecycle {
 
 void warn_deprecated(const std::string&);
+void signal_soft_deprecated(const std::string&, SEXP);
 
 }
 }

--- a/inst/include/dplyr/symbols.h
+++ b/inst/include/dplyr/symbols.h
@@ -59,6 +59,7 @@ struct symbols {
   static SEXP quote;
   static SEXP dot_drop;
   static SEXP warn_deprecated;
+  static SEXP signal_soft_deprecated;
 };
 
 struct fns {

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -488,14 +488,15 @@ BEGIN_RCPP
 END_RCPP
 }
 // mutate_impl
-SEXP mutate_impl(DataFrame df, QuosureList dots);
-RcppExport SEXP _dplyr_mutate_impl(SEXP dfSEXP, SEXP dotsSEXP) {
+SEXP mutate_impl(DataFrame df, QuosureList dots, SEXP caller_env);
+RcppExport SEXP _dplyr_mutate_impl(SEXP dfSEXP, SEXP dotsSEXP, SEXP caller_envSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< DataFrame >::type df(dfSEXP);
     Rcpp::traits::input_parameter< QuosureList >::type dots(dotsSEXP);
-    rcpp_result_gen = Rcpp::wrap(mutate_impl(df, dots));
+    Rcpp::traits::input_parameter< SEXP >::type caller_env(caller_envSEXP);
+    rcpp_result_gen = Rcpp::wrap(mutate_impl(df, dots, caller_env));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -590,27 +591,29 @@ BEGIN_RCPP
 END_RCPP
 }
 // summarise_impl
-SEXP summarise_impl(DataFrame df, QuosureList dots, SEXP frame);
-RcppExport SEXP _dplyr_summarise_impl(SEXP dfSEXP, SEXP dotsSEXP, SEXP frameSEXP) {
+SEXP summarise_impl(DataFrame df, QuosureList dots, SEXP frame, SEXP caller_env);
+RcppExport SEXP _dplyr_summarise_impl(SEXP dfSEXP, SEXP dotsSEXP, SEXP frameSEXP, SEXP caller_envSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< DataFrame >::type df(dfSEXP);
     Rcpp::traits::input_parameter< QuosureList >::type dots(dotsSEXP);
     Rcpp::traits::input_parameter< SEXP >::type frame(frameSEXP);
-    rcpp_result_gen = Rcpp::wrap(summarise_impl(df, dots, frame));
+    Rcpp::traits::input_parameter< SEXP >::type caller_env(caller_envSEXP);
+    rcpp_result_gen = Rcpp::wrap(summarise_impl(df, dots, frame, caller_env));
     return rcpp_result_gen;
 END_RCPP
 }
 // hybrid_impl
-SEXP hybrid_impl(DataFrame df, Quosure quosure);
-RcppExport SEXP _dplyr_hybrid_impl(SEXP dfSEXP, SEXP quosureSEXP) {
+SEXP hybrid_impl(DataFrame df, Quosure quosure, SEXP caller_env);
+RcppExport SEXP _dplyr_hybrid_impl(SEXP dfSEXP, SEXP quosureSEXP, SEXP caller_envSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< DataFrame >::type df(dfSEXP);
     Rcpp::traits::input_parameter< Quosure >::type quosure(quosureSEXP);
-    rcpp_result_gen = Rcpp::wrap(hybrid_impl(df, quosure));
+    Rcpp::traits::input_parameter< SEXP >::type caller_env(caller_envSEXP);
+    rcpp_result_gen = Rcpp::wrap(hybrid_impl(df, quosure, caller_env));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -808,7 +811,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dplyr_left_join_impl", (DL_FUNC) &_dplyr_left_join_impl, 8},
     {"_dplyr_right_join_impl", (DL_FUNC) &_dplyr_right_join_impl, 8},
     {"_dplyr_full_join_impl", (DL_FUNC) &_dplyr_full_join_impl, 8},
-    {"_dplyr_mutate_impl", (DL_FUNC) &_dplyr_mutate_impl, 2},
+    {"_dplyr_mutate_impl", (DL_FUNC) &_dplyr_mutate_impl, 3},
     {"_dplyr_select_impl", (DL_FUNC) &_dplyr_select_impl, 2},
     {"_dplyr_compatible_data_frame_nonames", (DL_FUNC) &_dplyr_compatible_data_frame_nonames, 3},
     {"_dplyr_compatible_data_frame", (DL_FUNC) &_dplyr_compatible_data_frame, 4},
@@ -816,8 +819,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dplyr_union_data_frame", (DL_FUNC) &_dplyr_union_data_frame, 2},
     {"_dplyr_intersect_data_frame", (DL_FUNC) &_dplyr_intersect_data_frame, 2},
     {"_dplyr_setdiff_data_frame", (DL_FUNC) &_dplyr_setdiff_data_frame, 2},
-    {"_dplyr_summarise_impl", (DL_FUNC) &_dplyr_summarise_impl, 3},
-    {"_dplyr_hybrid_impl", (DL_FUNC) &_dplyr_hybrid_impl, 2},
+    {"_dplyr_summarise_impl", (DL_FUNC) &_dplyr_summarise_impl, 4},
+    {"_dplyr_hybrid_impl", (DL_FUNC) &_dplyr_hybrid_impl, 3},
     {"_dplyr_test_comparisons", (DL_FUNC) &_dplyr_test_comparisons, 0},
     {"_dplyr_test_matches", (DL_FUNC) &_dplyr_test_matches, 0},
     {"_dplyr_test_length_wrap", (DL_FUNC) &_dplyr_test_length_wrap, 0},

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -90,6 +90,7 @@ SEXP symbols::eval_tidy = Rf_install("eval_tidy");
 SEXP symbols::quote = Rf_install("quote");
 SEXP symbols::dot_drop = Rf_install(".drop");
 SEXP symbols::warn_deprecated = Rf_install("warn_deprecated");
+SEXP symbols::signal_soft_deprecated = Rf_install("signal_soft_deprecated");
 
 SEXP fns::quote = Rf_eval(Rf_install("quote"), R_BaseEnv);
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -379,7 +379,7 @@ void signal_soft_deprecated(const std::string& s, SEXP caller_env) {
   static Rcpp::Environment ns_dplyr(Environment::namespace_env("dplyr"));
 
   Rcpp::CharacterVector msg(Rcpp::CharacterVector::create(s));
-  Shield<SEXP> call(Rf_lang3(symbols::signal_soft_deprecated, msg, caller_env));
+  Shield<SEXP> call(Rf_lang4(symbols::signal_soft_deprecated, msg, msg, caller_env));
 
   Rcpp::Rcpp_eval(call, ns_dplyr);
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -375,6 +375,16 @@ void warn_deprecated(const std::string& s) {
   Rcpp::Rcpp_eval(call, ns_dplyr);
 }
 
+void signal_soft_deprecated(const std::string& s, SEXP caller_env) {
+  static Rcpp::Environment ns_dplyr(Environment::namespace_env("dplyr"));
+
+  Rcpp::CharacterVector msg(Rcpp::CharacterVector::create(s));
+  Shield<SEXP> call(Rf_lang3(symbols::signal_soft_deprecated, msg, caller_env));
+
+  Rcpp::Rcpp_eval(call, ns_dplyr);
+}
+
+
 }
 }
 

--- a/tests/testthat/helper-hybrid.R
+++ b/tests/testthat/helper-hybrid.R
@@ -1,7 +1,7 @@
 expect_hybrid <- function(data, expr, info = NULL, label = NULL) {
-  expect_true(hybrid_impl(data, enquo(expr)), info = info, label = label)
+  expect_true(hybrid_impl(data, enquo(expr), caller_env()), info = info, label = label)
 }
 
 expect_not_hybrid <- function(data, expr, info = NULL, label = NULL) {
-  expect_false(hybrid_impl(data, enquo(expr)), info = info, label = label)
+  expect_false(hybrid_impl(data, enquo(expr), caller_env()), info = info, label = label)
 }


### PR DESCRIPTION
But I'm probably doing it wrong because: 

``` r
dplyr::summarise(iris, n = n())
#>     n
#> 1 150

dplyr:::with_lifecycle_warnings({
  dplyr::summarise(iris, n = n())
})
#> Error: Evaluation error: is_string(nm) is not TRUE.
```

