### PR TITLE
using unique_names() and more natural numbering

### DIFF
--- a/R/colwise-mutate.R
+++ b/R/colwise-mutate.R
@@ -307,8 +307,10 @@ manip_apply_syms <- function(funs, syms, tbl) {
     names(out) <- names(syms)
   } else {
     nms <- names(funs)
-    nms[nms == "<fn>"] <- "fn"
-    nms <- universal_names(nms, quiet = TRUE)
+    is_fun <- nms == "<fn>"
+    nms[is_fun] <- paste0("fn", seq_len(sum(is_fun)))
+
+    nms <- unique_names(nms, quiet = TRUE)
     names(funs) <- nms
 
     if (length(syms) == 1 && all(unnamed)) {

--- a/R/colwise-mutate.R
+++ b/R/colwise-mutate.R
@@ -30,7 +30,8 @@
 #'   [vars()] selection to avoid this:
 #'
 #'   ```
-#'   data %>% summarise_at(vars(-group_cols(), ...), myoperation)
+#'   data %>%
+#'     summarise_at(vars(-group_cols(), ...), myoperation)
 #'   ```
 #'
 #'   Or remove `group_vars()` from the character vector of column names:
@@ -43,34 +44,61 @@
 #' * Grouping variables covered by implicit selections are silently
 #'   ignored by `summarise_all()` and `summarise_if()`.
 #'
+#' @section Naming:
+#'
+#' The names of the created columns is derived from the names of the
+#' input variables and the names of the functions.
+#'
+#' - if there is only one unnamed function, the names of the input variables
+#'   are used to name the created columns
+#'
+#' - if there is only one unnamed variable, the names of the functions
+#'   are used to name the created columns.
+#'
+#' - otherwise in the most general case, the created names are created by
+#'   concatenating the names of the input variables and the names of the functions.
+#'
+#' The names of the functions here means the names of the list of functions
+#' that is supplied. When needed and not supplied, the name of a function
+#' is the prefix "fn" followed by the index of this function within the
+#' unnamed functions in the list. Ultimately, names are made
+#' unique.
+#'
 #' @examples
-#' by_species <- iris %>% group_by(Species)
+#' by_species <- iris %>%
+#'   group_by(Species)
 #'
 #'
 #' # The _at() variants directly support strings:
-#' starwars %>% summarise_at(c("height", "mass"), mean, na.rm = TRUE)
+#' starwars %>%
+#'   summarise_at(c("height", "mass"), mean, na.rm = TRUE)
 #'
 #' # You can also supply selection helpers to _at() functions but you have
 #' # to quote them with vars():
-#' starwars %>% summarise_at(vars(height:mass), mean, na.rm = TRUE)
+#' starwars %>%
+#'   summarise_at(vars(height:mass), mean, na.rm = TRUE)
 #'
 #' # The _if() variants apply a predicate function (a function that
 #' # returns TRUE or FALSE) to determine the relevant subset of
 #' # columns. Here we apply mean() to the numeric columns:
-#' starwars %>% summarise_if(is.numeric, mean, na.rm = TRUE)
+#' starwars %>%
+#'   summarise_if(is.numeric, mean, na.rm = TRUE)
 #'
 #' # If you want to apply multiple transformations, pass a list of
 #' # functions. When there are multiple functions, they create new
 #' # variables instead of modifying the variables in place:
-#' by_species %>% summarise_all(list(min, max))
+#' by_species %>%
+#'   summarise_all(list(min, max))
 #'
 #' # Note how the new variables include the function name, in order to
 #' # keep things distinct. Passing purrr-style lambdas often creates
 #' # better default names:
-#' by_species %>% summarise_all(list(~min(.), ~max(.)))
+#' by_species %>%
+#'   summarise_all(list(~min(.), ~max(.)))
 #'
 #' # When that's not good enough, you can also supply the names explicitly:
-#' by_species %>% summarise_all(list(min = min, max = max))
+#' by_species %>%
+#'   summarise_all(list(min = min, max = max))
 #'
 #' # When there's only one function in the list, it modifies existing
 #' # variables in place. Give it a name to create new variables instead:
@@ -147,6 +175,8 @@ summarize_at <- summarise_at
 #' * Grouping variables covered by implicit selections are ignored by
 #'   `mutate_all()`, `transmute_all()`, `mutate_if()`, and
 #'   `transmute_if()`.
+#'
+#' @inheritSection summarise_all Naming
 #'
 #' @examples
 #' iris <- as_tibble(iris)

--- a/man/mutate_all.Rd
+++ b/man/mutate_all.Rd
@@ -78,6 +78,27 @@ data \%>\% mutate_at(vars, myoperation)
 }
 }
 
+\section{Naming}{
+
+
+The names of the created columns is derived from the names of the
+input variables and the names of the functions.
+\itemize{
+\item if there is only one unnamed function, the names of the input variables
+are used to name the created columns
+\item if there is only one unnamed variable, the names of the functions
+are used to name the created columns.
+\item otherwise in the most general case, the created names are created by
+concatenating the names of the input variables and the names of the functions.
+}
+
+The names of the functions here means the names of the list of functions
+that is supplied. When needed and not supplied, the name of a function
+is the prefix "fn" followed by the index of this function within the
+unnamed functions in the list. Ultimately, names are made
+unique.
+}
+
 \examples{
 iris <- as_tibble(iris)
 

--- a/man/summarise_all.Rd
+++ b/man/summarise_all.Rd
@@ -68,7 +68,8 @@ selection is \strong{implicit} (\code{all} and \code{if} selections) or
 \itemize{
 \item Grouping variables covered by explicit selections in
 \code{summarise_at()} are always an error. Add \code{-group_cols()} to the
-\code{\link[=vars]{vars()}} selection to avoid this:\preformatted{data \%>\% summarise_at(vars(-group_cols(), ...), myoperation)
+\code{\link[=vars]{vars()}} selection to avoid this:\preformatted{data \%>\%
+  summarise_at(vars(-group_cols(), ...), myoperation)
 }
 
 Or remove \code{group_vars()} from the character vector of column names:\preformatted{nms <- setdiff(nms, group_vars(data))
@@ -79,34 +80,62 @@ ignored by \code{summarise_all()} and \code{summarise_if()}.
 }
 }
 
+\section{Naming}{
+
+
+The names of the created columns is derived from the names of the
+input variables and the names of the functions.
+\itemize{
+\item if there is only one unnamed function, the names of the input variables
+are used to name the created columns
+\item if there is only one unnamed variable, the names of the functions
+are used to name the created columns.
+\item otherwise in the most general case, the created names are created by
+concatenating the names of the input variables and the names of the functions.
+}
+
+The names of the functions here means the names of the list of functions
+that is supplied. When needed and not supplied, the name of a function
+is the prefix "fn" followed by the index of this function within the
+unnamed functions in the list. Ultimately, names are made
+unique.
+}
+
 \examples{
-by_species <- iris \%>\% group_by(Species)
+by_species <- iris \%>\%
+  group_by(Species)
 
 
 # The _at() variants directly support strings:
-starwars \%>\% summarise_at(c("height", "mass"), mean, na.rm = TRUE)
+starwars \%>\%
+  summarise_at(c("height", "mass"), mean, na.rm = TRUE)
 
 # You can also supply selection helpers to _at() functions but you have
 # to quote them with vars():
-starwars \%>\% summarise_at(vars(height:mass), mean, na.rm = TRUE)
+starwars \%>\%
+  summarise_at(vars(height:mass), mean, na.rm = TRUE)
 
 # The _if() variants apply a predicate function (a function that
 # returns TRUE or FALSE) to determine the relevant subset of
 # columns. Here we apply mean() to the numeric columns:
-starwars \%>\% summarise_if(is.numeric, mean, na.rm = TRUE)
+starwars \%>\%
+  summarise_if(is.numeric, mean, na.rm = TRUE)
 
 # If you want to apply multiple transformations, pass a list of
 # functions. When there are multiple functions, they create new
 # variables instead of modifying the variables in place:
-by_species \%>\% summarise_all(list(min, max))
+by_species \%>\%
+  summarise_all(list(min, max))
 
 # Note how the new variables include the function name, in order to
 # keep things distinct. Passing purrr-style lambdas often creates
 # better default names:
-by_species \%>\% summarise_all(list(~min(.), ~max(.)))
+by_species \%>\%
+  summarise_all(list(~min(.), ~max(.)))
 
 # When that's not good enough, you can also supply the names explicitly:
-by_species \%>\% summarise_all(list(min = min, max = max))
+by_species \%>\%
+  summarise_all(list(min = min, max = max))
 
 # When there's only one function in the list, it modifies existing
 # variables in place. Give it a name to create new variables instead:

--- a/tests/testthat/test-colwise-mutate.R
+++ b/tests/testthat/test-colwise-mutate.R
@@ -44,7 +44,7 @@ test_that("default names are smallest unique set", {
   expect_named(summarise_at(df, vars(x), list(mean = mean, sd = sd)), c("mean", "sd"))
   expect_named(summarise_at(df, vars(x:y), list(mean = mean, sd = sd)), c("x_mean", "y_mean", "x_sd", "y_sd"))
 
-  expect_named(summarise_at(df, vars(x:y), funs(base::mean, stats::sd)), c("x_base..mean", "y_base..mean", "x_stats..sd", "y_stats..sd"))
+  expect_named(summarise_at(df, vars(x:y), funs(base::mean, stats::sd)), c("x_base::mean", "y_base::mean", "x_stats::sd", "y_stats::sd"))
 })
 
 test_that("named arguments force complete named", {
@@ -313,7 +313,13 @@ test_that("summarise_at with multiple columns AND unnamed functions works (#4119
     summarise_at(vars(wind, pressure), list(mean, median))
 
   expect_equal(ncol(res), 4L)
-  expect_equal(names(res), c("wind_fn..1", "pressure_fn..1", "wind_fn..2", "pressure_fn..2"))
+  expect_equal(names(res), c("wind_fn1", "pressure_fn1", "wind_fn2", "pressure_fn2"))
+
+  res <- storms %>%
+    summarise_at(vars(wind, pressure), list(n = length, mean, median))
+
+  expect_equal(ncol(res), 6L)
+  expect_equal(names(res), c("wind_n", "pressure_n", "wind_fn1", "pressure_fn1", "wind_fn2", "pressure_fn2"))
 })
 
 test_that("mutate_at with multiple columns AND unnamed functions works (#4119)", {
@@ -323,6 +329,6 @@ test_that("mutate_at with multiple columns AND unnamed functions works (#4119)",
   expect_equal(ncol(res), ncol(storms) + 4L)
   expect_equal(
     names(res),
-    c(names(storms), c("wind_fn..1", "pressure_fn..1", "wind_fn..2", "pressure_fn..2"))
+    c(names(storms), c("wind_fn1", "pressure_fn1", "wind_fn2", "pressure_fn2"))
   )
 })


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)
storms %>%
  summarise_at(vars(wind, pressure), list(n = length, mean, median))
#> # A tibble: 1 x 6
#>   wind_n pressure_n wind_fn1 pressure_fn1 wind_fn2 pressure_fn2
#>    <int>      <int>    <dbl>        <dbl>    <dbl>        <dbl>
#> 1  10010      10010     53.5         992.       45          999
```

unnamed functions are called `fn1`, `fn2` etc ... the numbering is based on unnamed functions only. 

And we use `unique_names()` instead of `universal_names()`

Needs to be documented somewhere (e.g. related to #4146) 