### PR TITLE
Fix hybrid min(), max(), mean(), sum() 

### DIFF
--- a/inst/include/dplyr/hybrid/scalar_result/mean_sd_var.h
+++ b/inst/include/dplyr/hybrid/scalar_result/mean_sd_var.h
@@ -97,9 +97,16 @@ struct MeanImpl {
       //
       // INTSXP, LGLSXP: no shortcut, need to test
       if (NA_RM || RTYPE == INTSXP || RTYPE == LGLSXP) {
-        if (is_really_na<RTYPE>(value)) {
+        // both NA and NaN
+        if (Rcpp::traits::is_na<RTYPE>(value)) {
           if (!NA_RM) {
-            return NA_REAL;
+            // make sure we return the right kind of naan
+            // because of this:
+            // mean(c(NaN, 1)) -> NaN
+            // mean(c(NA, 1) ) -> NA
+            //
+            // there are no NaN for INTSXP so we return NA_REAL in that case
+            return RTYPE == REALSXP ? value : NA_REAL;
           }
 
           --m;
@@ -117,7 +124,8 @@ struct MeanImpl {
       long double t = 0.0;
       for (int i = 0; i < n; i++) {
         STORAGE value = ptr[indices[i]];
-        if (!NA_RM || ! is_really_na<RTYPE>(value)) {
+        // need to take both NA and NaN into account here
+        if (!NA_RM || ! Rcpp::traits::is_na<RTYPE>(value)) {
           t += value - res;
         }
       }

--- a/inst/include/dplyr/hybrid/scalar_result/min_max.h
+++ b/inst/include/dplyr/hybrid/scalar_result/min_max.h
@@ -32,20 +32,17 @@ public:
     for (int i = 0; i < n; ++i) {
       STORAGE current = column[indices[i]];
 
-      if (is_really_na<RTYPE>(current)) {
+      // both NA and NaN in the REALSXP case
+      if (Rcpp::traits::is_na<RTYPE>(current)) {
         if (NA_RM) {
           continue;
         } else {
-          return NA_REAL;
+          return RTYPE == REALSXP ? current : NA_REAL;
         }
-
-      }
-      else if (is_nan<RTYPE>(current)) {
-        return current;
       } else {
-        double current_res = current;
-        if (is_better(current_res, res))
-          res = current_res;
+        if (is_better(current, res)) {
+          res = current;
+        }
       }
     }
     return res;

--- a/inst/include/tools/default_value.h
+++ b/inst/include/tools/default_value.h
@@ -19,15 +19,6 @@ inline SEXP default_value<VECSXP>() {
 }
 
 template <int RTYPE>
-inline bool is_really_na(typename Rcpp::Vector<RTYPE>::stored_type value) {
-  return Rcpp::traits::is_na<RTYPE>(value);
-}
-template <>
-inline bool is_really_na<REALSXP>(double value) {
-  return R_IsNA(value);
-}
-
-template <int RTYPE>
 inline bool is_nan(typename Rcpp::Vector<RTYPE>::stored_type value) {
   return false;
 }

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -1110,11 +1110,23 @@ test_that("tidy eval does not infloop (#4049)", {
   expect_identical(summarise(df, x = eval_tidy(call)), data.frame(x = 5L))
 })
 
-test_that("hybrid sum(), mean() treats NA and NaN differently (#4108)", {
+test_that("hybrid sum(), mean(), min(), max() treats NA and NaN correctly (#4108, #4163)", {
   res <- data.frame(x = c(1, NaN)) %>%
     summarise(sum = sum(x), mean = mean(x), max = max(x), min = min(x))
   expect_true(is.nan(res$sum))
   expect_true(is.nan(res$mean))
   expect_true(is.nan(res$max))
   expect_true(is.nan(res$min))
+
+  res <- data.frame(x = c(1, NaN)) %>%
+    summarise(
+      sum = sum(x, na.rm = TRUE),
+      mean = mean(x, na.rm = TRUE),
+      max = max(x, na.rm = TRUE),
+      min = min(x, na.rm = TRUE)
+    )
+  expect_equal(res$sum , 1)
+  expect_equal(res$mean, 1)
+  expect_equal(res$max , 1)
+  expect_equal(res$min , 1)
 })


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)
df <- data.frame(
  month = rep(month.abb, 2), 
  year = c(rep(2019, 12), rep(2020, 12)),
  value = c(rep(1, 15), NaN, rep(1, 8))
)
df %>% 
  group_by(year) %>% 
  summarise(value = sum(value, na.rm = TRUE))
#> # A tibble: 2 x 2
#>    year value
#>   <dbl> <dbl>
#> 1  2019    12
#> 2  2020    11
```

So `na.rm = TRUE` also ignores `NaN` 
