### PR TITLE
tweak group_trim example by adding `.preserve = TRUE`

### DIFF
--- a/R/group_trim.R
+++ b/R/group_trim.R
@@ -19,7 +19,7 @@
 #' @examples
 #' iris %>%
 #'   group_by(Species) %>%
-#'   filter(Species == "setosa") %>%
+#'   filter(Species == "setosa", .preserve = TRUE) %>%
 #'   group_trim()
 #'
 #' @export

--- a/man/group_trim.Rd
+++ b/man/group_trim.Rd
@@ -27,7 +27,7 @@ to select a subset of groups.
 \examples{
 iris \%>\%
   group_by(Species) \%>\%
-  filter(Species == "setosa") \%>\%
+  filter(Species == "setosa", .preserve = TRUE) \%>\%
   group_trim()
 
 }


### PR DESCRIPTION
Since `filter()` reverts to the previous behaviour, specifying `.preserve = TRUE` in the `group_trim()` docs would probably serve the `group_trim()` purpose.

``` r
library(dplyr, warn.conflicts = FALSE)
iris_fct <- iris %>%
  group_by(Species) %>%
  filter(Species == "setosa", .preserve = TRUE) %>% 
  print()
#> # A tibble: 50 x 5
#> # Groups:   Species [3]
#>    Sepal.Length Sepal.Width Petal.Length Petal.Width Species
#>           <dbl>       <dbl>        <dbl>       <dbl> <fct>  
#>  1          5.1         3.5          1.4         0.2 setosa 
#>  2          4.9         3            1.4         0.2 setosa 
#>  3          4.7         3.2          1.3         0.2 setosa 
#>  4          4.6         3.1          1.5         0.2 setosa 
#>  5          5           3.6          1.4         0.2 setosa 
#>  6          5.4         3.9          1.7         0.4 setosa 
#>  7          4.6         3.4          1.4         0.3 setosa 
#>  8          5           3.4          1.5         0.2 setosa 
#>  9          4.4         2.9          1.4         0.2 setosa 
#> 10          4.9         3.1          1.5         0.1 setosa 
#> # … with 40 more rows

iris_fct %>%
  group_trim()
#> # A tibble: 50 x 5
#> # Groups:   Species [1]
#>    Sepal.Length Sepal.Width Petal.Length Petal.Width Species
#>           <dbl>       <dbl>        <dbl>       <dbl> <fct>  
#>  1          5.1         3.5          1.4         0.2 setosa 
#>  2          4.9         3            1.4         0.2 setosa 
#>  3          4.7         3.2          1.3         0.2 setosa 
#>  4          4.6         3.1          1.5         0.2 setosa 
#>  5          5           3.6          1.4         0.2 setosa 
#>  6          5.4         3.9          1.7         0.4 setosa 
#>  7          4.6         3.4          1.4         0.3 setosa 
#>  8          5           3.4          1.5         0.2 setosa 
#>  9          4.4         2.9          1.4         0.2 setosa 
#> 10          4.9         3.1          1.5         0.1 setosa 
#> # … with 40 more rows
```

<sup>Created on 2019-02-09 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>