### PR TITLE
better old grouping format repair

### DIFF
--- a/inst/include/dplyr/data/GroupedDataFrame.h
+++ b/inst/include/dplyr/data/GroupedDataFrame.h
@@ -82,8 +82,6 @@ public:
     return symbols.get_names();
   }
 
-  static SymbolVector group_vars(SEXP x);
-
   inline const DataFrame& group_data() const {
     return groups;
   }
@@ -113,6 +111,8 @@ public:
   }
 
 private:
+
+  SymbolVector group_vars() const ;
 
   DataFrame data_;
   SymbolMap symbols;

--- a/tests/testthat/test-group_data.R
+++ b/tests/testthat/test-group_data.R
@@ -78,3 +78,14 @@ test_that("GroupedDataFrame is compatible with older style grouped_df (#3604)", 
   expect_null(attr(df, "vars"))
 })
 
+test_that("old group format repair does not keep a vars attribute around", {
+  tbl <- tibble(x = 1:10, y = 1:10)
+  attr(tbl, "vars") <- rlang::sym("x")
+  class(tbl) <- c("grouped_df", "tbl_df", "tbl", "data.frame")
+
+  res <- tbl %>%
+    group_by(y)
+  expect_equal(group_vars(res), "y")
+  expect_null(attr(res, " vars"))
+  expect_null(attr(tbl, " vars"))
+})


### PR DESCRIPTION
The old grouping repair was not working correctly. Evidence of that appeared in the revdepchecks of 0.7.8 vs 0.8.0 on the `rzeit2` 📦  