### PR TITLE
Support .data$. in colwise filter_*()

### DIFF
--- a/R/colwise-filter.R
+++ b/R/colwise-filter.R
@@ -80,20 +80,19 @@ apply_filter_syms <- function(pred, syms, tbl) {
     if (inherits(pred, "any_vars")) {
       joiner <- any_exprs
     }
-    pred <- new_function(exprs(. = ), quo_get_expr(pred), quo_get_env(pred))
-  } else if (is_bare_formula(pred)) {
+    pred <- map(syms, function(sym) expr_substitute(pred, quote(.), sym))
+  } else if (is_bare_formula(pred) || is_function(pred)) {
     pred <- as_function(pred)
-  } else if (!is_function(pred)) {
+    pred <- map(syms, function(sym) call2(pred, sym))
+  } else {
     bad_args(".vars_predicate", "must be a function or a call to `all_vars()` or `any_vars()`, ",
       "not {friendly_type_of(pred)}"
     )
   }
 
-  pred <- map(syms, function(sym) call2(pred, sym))
-
-  if (length(pred)) {
-    joiner(!!!pred)
+  if (length(pred) == 1) {
+    pred[[1L]]
   } else {
-    pred
+    joiner(!!!pred)
   }
 }

--- a/tests/testthat/test-colwise-filter.R
+++ b/tests/testthat/test-colwise-filter.R
@@ -66,3 +66,20 @@ test_that("can supply functions to scoped filters", {
   out <- mtcars %>% filter_at(c("cyl", "am"), function(.x) .x == 4 | .x == 0)
   expect_identical(as.list(out), exp)
 })
+
+test_that("colwise filter support .data$. in the quosure versions", {
+   expect_identical(
+     filter_if(iris, is.numeric, any_vars(.data$. > 4)),
+     filter_if(iris, is.numeric, any_vars(. > 4))
+   )
+
+  expect_identical(
+    filter_all(select(iris, -Species), any_vars(.data$. > 4)),
+    filter_all(select(iris, -Species), any_vars(. > 4))
+  )
+
+  expect_identical(
+    filter_at(iris, vars(contains(".")), any_vars(.data$. > 4)),
+    filter_at(iris, vars(contains(".")), any_vars(. > 4))
+  )
+})


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)

iris %>% 
  filter_if(is.numeric, any_vars(.data$. > 7))
#>    Sepal.Length Sepal.Width Petal.Length Petal.Width   Species
#> 1           7.1         3.0          5.9         2.1 virginica
#> 2           7.6         3.0          6.6         2.1 virginica
#> 3           7.3         2.9          6.3         1.8 virginica
#> 4           7.2         3.6          6.1         2.5 virginica
#> 5           7.7         3.8          6.7         2.2 virginica
#> 6           7.7         2.6          6.9         2.3 virginica
#> 7           7.7         2.8          6.7         2.0 virginica
#> 8           7.2         3.2          6.0         1.8 virginica
#> 9           7.2         3.0          5.8         1.6 virginica
#> 10          7.4         2.8          6.1         1.9 virginica
#> 11          7.9         3.8          6.4         2.0 virginica
#> 12          7.7         3.0          6.1         2.3 virginica
```

<sup>Created on 2019-02-12 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)</sup>