### PR TITLE
Add missing paranthesis in deprecation warning

### DIFF
--- a/R/funs.R
+++ b/R/funs.R
@@ -46,7 +46,7 @@ funs <- function(..., .args = list()) {
     "please use list() instead",
     "",
     "# Before:",
-    "funs(name = f(.)",
+    "funs(name = f(.))",
     "",
     "# After: ",
     "list(name = ~f(.))"


### PR DESCRIPTION
Just a minor thing I noticed in the warning