### PR TITLE
Make group_indices.data.frame() to drop empty groups by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 * Fixed integer C/C++ division, forced released by CRAN (#4185). 
 
+* `group_indices()` now ignores empty groups by default for `data.frame`, which is
+  consistent with the default of `group_by()` (@yutannihilation, #4208). 
+
 # dplyr 0.8.0 (2019-02-14)
 
 ## Breaking changes

--- a/R/group-indices.R
+++ b/R/group-indices.R
@@ -34,7 +34,7 @@ group_indices_ <- function(.data, ..., .dots = list()) {
 }
 
 #' @export
-group_indices.data.frame <- function(.data, ..., .drop = FALSE) {
+group_indices.data.frame <- function(.data, ..., .drop = TRUE) {
   dots <- quos(...)
   if (length(dots) == 0L) {
     return(rep(1L, nrow(.data)))

--- a/tests/testthat/test-group-indices.R
+++ b/tests/testthat/test-group-indices.R
@@ -68,6 +68,12 @@ test_that("group_indices() can be used inside mutate (#1185)", {
 
 test_that("group_indices() recognizes .drop", {
   d <- tibble(f = factor("b", levels = c("a", "b", "c")))
-  expect_equal(group_indices(d, f), 2L)
-  expect_equal(group_indices(d, f, .drop = TRUE), 1L)
+  expect_equal(group_indices(d, f), 1L)
+  expect_equal(group_indices(d, f, .drop = FALSE), 2L)
+
+  # these two should return the same result (#4208):
+  #   d %>% group_indices(...)
+  #   d %>% group_by(...) %>% group_indices()
+  d2 <- group_by(d, f)
+  expect_equal(group_indices(d2), 1L)
 })


### PR DESCRIPTION
Fix #4208

Change the default value of `.drop` of `group_indices.data.frame()` to `TRUE`, which makes `d %>% group_indices(...)` and `d %>% group_by(...) %>% group_indices()` return the same value.

``` r
library(dplyr, warn.conflicts = FALSE)

d <- tibble(x = letters[1:10], y = rep(1:2, each = 5), z = factor(rep(LETTERS[1:2], each = 5)))

d %>% 
  group_by(y, z) %>%
  group_indices()
#>  [1] 1 1 1 1 1 2 2 2 2 2

d %>% 
  group_indices(y, z)
#>  [1] 1 1 1 1 1 2 2 2 2 2
```

<sup>Created on 2019-02-21 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)</sup>