### PR TITLE
use `group_drops(.data)` as the default for group_by(.drop=)

### DIFF
--- a/R/group-by.r
+++ b/R/group-by.r
@@ -89,11 +89,11 @@
 #'   group_by(y) %>%
 #'   group_rows()
 #'
-group_by <- function(.data, ..., add = FALSE, .drop = FALSE) {
+group_by <- function(.data, ..., add = FALSE, .drop = group_drops(.data)) {
   UseMethod("group_by")
 }
 #' @export
-group_by.default <- function(.data, ..., add = FALSE, .drop = FALSE) {
+group_by.default <- function(.data, ..., add = FALSE, .drop = group_drops(.data)) {
   group_by_(.data, .dots = compat_as_lazy_dots(...), add = add)
 }
 #' @export

--- a/R/rowwise.r
+++ b/R/rowwise.r
@@ -62,12 +62,12 @@ n_groups.rowwise_df <- function(x) {
 }
 
 #' @export
-group_by.rowwise_df <- function(.data, ..., add = FALSE, .drop = FALSE) {
+group_by.rowwise_df <- function(.data, ..., add = FALSE, .drop = group_drops(.data)) {
   warn("Grouping rowwise data frame strips rowwise nature")
   .data <- ungroup(.data)
 
   groups <- group_by_prepare(.data, ..., add = add)
-  grouped_df(groups$data, groups$group_names, group_drops(.data))
+  grouped_df(groups$data, groups$group_names, .drop)
 }
 #' @export
 group_by_.rowwise_df <- function(.data, ..., .dots = list(), add = FALSE, .drop = FALSE) {

--- a/man/group_by.Rd
+++ b/man/group_by.Rd
@@ -5,7 +5,7 @@
 \alias{ungroup}
 \title{Group by one or more variables}
 \usage{
-group_by(.data, ..., add = FALSE, .drop = FALSE)
+group_by(.data, ..., add = FALSE, .drop = group_drops(.data))
 
 ungroup(x, ...)
 }


### PR DESCRIPTION
This only affects perceived default for the `.drop=` argument of `group_by()`. 

But now we'd have this: `group_by()` generic: 

```r
> group_by
function(.data, ..., add = FALSE, .drop = group_drops(.data)) {
  UseMethod("group_by")
}
```

so perhaps we should be exporting `group_drops()`, maybe under a different name. 