### PR TITLE
Uniform handling of bare formulas in colwise verbs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: dplyr
 Title: A Grammar of Data Manipulation
-Version: 0.8.0.9002
+Version: 0.8.0.9003
 Authors@R: c(
     person("Hadley", "Wickham", , "hadley@rstudio.com", c("aut", "cre"), comment = c(ORCID = "0000-0003-4757-117X")),
     person("Romain", "Fran\u00e7ois", role = "aut", comment = c(ORCID = "0000-0002-2444-4226")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,13 +1,15 @@
 # dplyr 0.8.0.9000
 
+* Fixed handling of bare formulas in colwise verbs (#4183).
+
 * Fixed performance of `n_distint()` (#4202). 
+
+* `group_indices()` now ignores empty groups by default for `data.frame`, which is
+  consistent with the default of `group_by()` (@yutannihilation, #4208). 
 
 # dplyr 0.8.0.1 (2019-02-15)
 
 * Fixed integer C/C++ division, forced released by CRAN (#4185). 
-
-* `group_indices()` now ignores empty groups by default for `data.frame`, which is
-  consistent with the default of `group_by()` (@yutannihilation, #4208). 
 
 # dplyr 0.8.0 (2019-02-14)
 

--- a/R/funs.R
+++ b/R/funs.R
@@ -88,13 +88,16 @@ as_fun_list <- function(.x, .quo, .env, ...) {
     .x <- list(.quo)
   } else if (is_character(.x)) {
     .x <- as.list(.x)
-  } else if (is_bare_formula(.x, lhs = FALSE)) {
-    .x <- list(as_function(.x))
   } else if (!is_list(.x)) {
     .x <- list(.x)
   }
 
-  funs <- map(.x, as_fun, .env = fun_env(.quo, .env), args)
+  funs <- map(.x, function(fun) {
+    if (is_bare_formula(fun, lhs = FALSE)) {
+      fun <- as_function(fun)
+    }
+    as_fun(fun, .env = fun_env(.quo, .env), args)
+  })
   new_funs(funs)
 }
 

--- a/inst/include/dplyr/data/DataMask.h
+++ b/inst/include/dplyr/data/DataMask.h
@@ -449,6 +449,11 @@ public:
     }
   }
 
+  SEXP get_data_mask() const {
+    return data_mask;
+  }
+
+
   // get ready to evaluate an R expression for a given group
   // as identified by the indices
   void update(const slicing_index& indices) {
@@ -505,20 +510,12 @@ public:
   }
 
   SEXP eval(const Quosure& quo, const slicing_index& indices) {
-    setup();
-
     // update the bindings
     update(indices);
 
     // update the data context variables, these are used by n(), ...
     get_context_env()["..group_size"] = indices.size();
     get_context_env()["..group_number"] = indices.group() + 1;
-
-    SEXP expr = quo.expr();
-    if (TYPEOF(expr) == LANGSXP && Rf_inherits(CAR(expr), "rlang_lambda_function")) {
-      // FIXME: Mutation
-      SET_CLOENV(CAR(expr), mask_resolved) ;
-    }
 
 #if (R_VERSION < R_Version(3, 5, 0))
     Shield<SEXP> call_quote(Rf_lang2(fns::quote, quo));

--- a/inst/include/tools/utils.h
+++ b/inst/include/tools/utils.h
@@ -29,16 +29,16 @@ namespace dplyr {
 
 SEXP constant_recycle(SEXP x, int n, const SymbolString& name);
 std::string get_single_class(SEXP x);
-CharacterVector default_chars(SEXP x, R_xlen_t len);
-CharacterVector get_class(SEXP x);
-SEXP set_class(SEXP x, const CharacterVector& class_);
+Rcpp::CharacterVector default_chars(SEXP x, R_xlen_t len);
+Rcpp::CharacterVector get_class(SEXP x);
+SEXP set_class(SEXP x, const Rcpp::CharacterVector& class_);
 void copy_attrib(SEXP out, SEXP origin, SEXP symbol);
 void copy_class(SEXP out, SEXP origin);
 void copy_names(SEXP out, SEXP origin);
-CharacterVector get_levels(SEXP x);
-SEXP set_levels(SEXP x, const CharacterVector& levels);
+Rcpp::CharacterVector get_levels(SEXP x);
+SEXP set_levels(SEXP x, const Rcpp::CharacterVector& levels);
 bool same_levels(SEXP left, SEXP right);
-bool character_vector_equal(const CharacterVector& x, const CharacterVector& y);
+bool character_vector_equal(const Rcpp::CharacterVector& x, const Rcpp::CharacterVector& y);
 
 SymbolVector get_vars(SEXP x);
 
@@ -113,6 +113,10 @@ inline SEXP as_data_pronoun(SEXP data) {
 
 inline SEXP eval_tidy(SEXP expr, SEXP data, SEXP env) {
   return dplyr::internal::rlang_api().eval_tidy(expr, data, env);
+}
+
+inline SEXP new_quosure(SEXP expr, SEXP env) {
+  return dplyr::internal::rlang_api().new_quosure(expr, env);
 }
 
 }

--- a/src/arrange.cpp
+++ b/src/arrange.cpp
@@ -59,6 +59,7 @@ SEXP arrange_template(const SlicedTibble& gdf, const QuosureList& quosures, SEXP
     }
 
     // otherwise need to evaluate in the data mask
+    mask.setup();
     if (v.isNULL()) {
       if (is_desc) {
         // we need a new quosure that peels off `desc` from the original

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -234,6 +234,8 @@ SEXP filter_template(const SlicedTibble& gdf, const Quosure& quo) {
   GroupFilterIndices<SlicedTibble> group_indices(gdf);
 
   // traverse each group and fill `group_indices`
+  mask.setup();
+
   for (int i = 0; i < ngroups; i++, ++git) {
     const slicing_index& indices = *git;
     int chunk_size = indices.size();
@@ -484,6 +486,8 @@ DataFrame slice_template(const SlicedTibble& gdf, const Quosure& quo) {
   GroupSliceIndices<SlicedTibble> group_indices(gdf);
 
   group_iterator git = gdf.group_begin();
+  mask.setup();
+
   for (int i = 0; i < ngroups; i++, ++git) {
     const slicing_index& indices = *git;
 

--- a/src/mutate.cpp
+++ b/src/mutate.cpp
@@ -456,6 +456,14 @@ DataFrame mutate_grouped(const DataFrame& df, const QuosureList& dots, SEXP call
 
       // NULL columns are not removed if `setup()` is not called here
       mask.setup();
+
+      // fix the quosure if it's an rlang lambda
+      SEXP expr = quosure.expr();
+      if (TYPEOF(expr) == LANGSXP && Rf_inherits(CAR(expr), "rlang_lambda_function")) {
+        // FIXME: Mutation
+        SET_CLOENV(CAR(expr), mask.get_data_mask()) ;
+      }
+
       variable = MutateCallProxy<SlicedTibble>(gdf, mask, quosure).get();
     }
 

--- a/src/summarise.cpp
+++ b/src/summarise.cpp
@@ -154,6 +154,14 @@ DataFrame summarise_grouped(const DataFrame& df, const QuosureList& dots, SEXP f
       // we can use a GroupedCallReducer which will callback to R.
       if (result == R_UnboundValue) {
         mask.setup();
+
+        // fix the quosure if it's an rlang lambda
+        SEXP expr = quosure.expr();
+        if (TYPEOF(expr) == LANGSXP && Rf_inherits(CAR(expr), "rlang_lambda_function")) {
+          // FIXME: Mutation
+          SET_CLOENV(CAR(expr), mask.get_data_mask()) ;
+        }
+
         result = GroupedCallReducer<SlicedTibble>(quosure, mask).process(gdf);
       }
     }

--- a/tests/testthat/test-colwise-mutate.R
+++ b/tests/testthat/test-colwise-mutate.R
@@ -335,11 +335,27 @@ test_that("mutate_at with multiple columns AND unnamed functions works (#4119)",
 })
 
 test_that("colwise mutate have .data in scope of rlang lambdas (#4183)", {
-  res1 <- iris %>% mutate_if(is.numeric, ~ . / iris$Petal.Width)
-  res2 <- iris %>% mutate_if(is.numeric, ~ . / Petal.Width)
-  res3 <- iris %>% mutate_if(is.numeric, ~ . / .data$Petal.Width)
+  results <- list(
+    iris %>% mutate_if(is.numeric, ~ . / iris$Petal.Width),
+    iris %>% mutate_if(is.numeric, ~ . / Petal.Width),
+    iris %>% mutate_if(is.numeric, ~ . / .data$Petal.Width),
 
-  expect_identical(res1, res2)
-  expect_identical(res1, res3)
+    iris %>% mutate_if(is.numeric, list(~ . / iris$Petal.Width )),
+    iris %>% mutate_if(is.numeric, list(~ . / Petal.Width      )),
+    iris %>% mutate_if(is.numeric, list(~ . / .data$Petal.Width)),
+
+    iris %>% mutate_if(is.numeric, ~ .x / iris$Petal.Width),
+    iris %>% mutate_if(is.numeric, ~ .x / Petal.Width),
+    iris %>% mutate_if(is.numeric, ~ .x / .data$Petal.Width),
+
+    iris %>% mutate_if(is.numeric, list(~ .x / iris$Petal.Width )),
+    iris %>% mutate_if(is.numeric, list(~ .x / Petal.Width      )),
+    iris %>% mutate_if(is.numeric, list(~ .x / .data$Petal.Width))
+  )
+
+  for(i in 2:12) {
+    expect_equal(results[[1]], results[[i]])
+  }
+
 })
 

--- a/tests/testthat/test-colwise-mutate.R
+++ b/tests/testthat/test-colwise-mutate.R
@@ -333,3 +333,13 @@ test_that("mutate_at with multiple columns AND unnamed functions works (#4119)",
     c(names(storms), c("wind_fn1", "pressure_fn1", "wind_fn2", "pressure_fn2"))
   )
 })
+
+test_that("colwise mutate have .data in scope of rlang lambdas (#4183)", {
+  res1 <- iris %>% mutate_if(is.numeric, ~ . / iris$Petal.Width)
+  res2 <- iris %>% mutate_if(is.numeric, ~ . / Petal.Width)
+  res3 <- iris %>% mutate_if(is.numeric, ~ . / .data$Petal.Width)
+
+  expect_identical(res1, res2)
+  expect_identical(res1, res3)
+})
+


### PR DESCRIPTION
So that all those from #4183 are equivalent: 

``` r
library(dplyr, warn.conflicts = FALSE)

iris <- head(iris, 3)

iris %>%
  mutate_if(is.numeric, ~ . / iris$Petal.Width)
#>   Sepal.Length Sepal.Width Petal.Length Petal.Width Species
#> 1         25.5        17.5          7.0           1  setosa
#> 2         24.5        15.0          7.0           1  setosa
#> 3         23.5        16.0          6.5           1  setosa
iris %>%
  mutate_if(is.numeric, ~ . / Petal.Width)
#>   Sepal.Length Sepal.Width Petal.Length Petal.Width Species
#> 1         25.5        17.5          7.0           1  setosa
#> 2         24.5        15.0          7.0           1  setosa
#> 3         23.5        16.0          6.5           1  setosa
iris %>%
  mutate_if(is.numeric, ~ . / .data$Petal.Width)
#>   Sepal.Length Sepal.Width Petal.Length Petal.Width Species
#> 1         25.5        17.5          7.0           1  setosa
#> 2         24.5        15.0          7.0           1  setosa
#> 3         23.5        16.0          6.5           1  setosa

iris %>%
  mutate_if(is.numeric, ~ .x / iris$Petal.Width)
#>   Sepal.Length Sepal.Width Petal.Length Petal.Width Species
#> 1         25.5        17.5          7.0           1  setosa
#> 2         24.5        15.0          7.0           1  setosa
#> 3         23.5        16.0          6.5           1  setosa
iris %>%
  mutate_if(is.numeric, ~ .x / Petal.Width)
#>   Sepal.Length Sepal.Width Petal.Length Petal.Width Species
#> 1         25.5        17.5          7.0           1  setosa
#> 2         24.5        15.0          7.0           1  setosa
#> 3         23.5        16.0          6.5           1  setosa
iris %>%
  mutate_if(is.numeric, ~ .x / .data$Petal.Width)
#>   Sepal.Length Sepal.Width Petal.Length Petal.Width Species
#> 1         25.5        17.5          7.0           1  setosa
#> 2         24.5        15.0          7.0           1  setosa
#> 3         23.5        16.0          6.5           1  setosa


iris %>%
  mutate_if(is.numeric, list(~ . / iris$Petal.Width))
#>   Sepal.Length Sepal.Width Petal.Length Petal.Width Species
#> 1         25.5        17.5          7.0           1  setosa
#> 2         24.5        15.0          7.0           1  setosa
#> 3         23.5        16.0          6.5           1  setosa
iris %>%
  mutate_if(is.numeric, list(~ . / Petal.Width))
#>   Sepal.Length Sepal.Width Petal.Length Petal.Width Species
#> 1         25.5        17.5          7.0           1  setosa
#> 2         24.5        15.0          7.0           1  setosa
#> 3         23.5        16.0          6.5           1  setosa
iris %>%
  mutate_if(is.numeric, list(~ . / .data$Petal.Width))
#>   Sepal.Length Sepal.Width Petal.Length Petal.Width Species
#> 1         25.5        17.5          7.0           1  setosa
#> 2         24.5        15.0          7.0           1  setosa
#> 3         23.5        16.0          6.5           1  setosa

iris %>%
  mutate_if(is.numeric, list(~ .x / iris$Petal.Width))
#>   Sepal.Length Sepal.Width Petal.Length Petal.Width Species
#> 1         25.5        17.5          7.0           1  setosa
#> 2         24.5        15.0          7.0           1  setosa
#> 3         23.5        16.0          6.5           1  setosa
iris %>%
  mutate_if(is.numeric, list(~ .x / Petal.Width))
#>   Sepal.Length Sepal.Width Petal.Length Petal.Width Species
#> 1         25.5        17.5          7.0           1  setosa
#> 2         24.5        15.0          7.0           1  setosa
#> 3         23.5        16.0          6.5           1  setosa
iris %>%
  mutate_if(is.numeric, list(~ .x / .data$Petal.Width))
#>   Sepal.Length Sepal.Width Petal.Length Petal.Width Species
#> 1         25.5        17.5          7.0           1  setosa
#> 2         24.5        15.0          7.0           1  setosa
#> 3         23.5        16.0          6.5           1  setosa
```

<sup>Created on 2019-02-22 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)</sup>