### PR TITLE
Fixed mutate() on rowwise data frames with 0 rows.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr 0.8.0.9000
 
+* Fixed mutate() on rowwise data frames with 0 rows (#4224).
+
 * Fixed handling of bare formulas in colwise verbs (#4183).
 
 * Fixed performance of `n_distint()` (#4202). 

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -406,6 +406,14 @@ test_that("mutate works on zero-row grouped data frame (#596)", {
   expect_equal(group_data(res)$b, factor(character(0)))
 })
 
+test_that("mutate works on zero-row rowwise data frame (#4224)", {
+  dat <- data.frame(a = numeric(0))
+  res <- dat %>% rowwise() %>% mutate(a2 = a * 2)
+  expect_is(res$a2, "numeric")
+  expect_is(res, "rowwise_df")
+  expect_equal(res$a2, numeric(0))
+})
+
 test_that("Non-ascii column names in version 0.3 are not duplicated (#636)", {
   # Currently failing (#2967)
   skip_on_os("windows")


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)

# any function
pass_through = function(x) { x }

# as expected, this passes an empty character array into pass_through
data.frame(a = character()) %>%
  mutate(b = pass_through(a))
#> [1] a b
#> <0 rows> (or 0-length row.names)

# this unexpectedly crashes; output below
tibble(a = character()) %>%
  rowwise() %>%
  mutate(b = pass_through(a))
#> Source: local data frame [0 x 2]
#> Groups: <by row>
#> 
#> # A tibble: 0 x 2
#> # … with 2 variables: a <chr>, b <chr>
```

<sup>Created on 2019-03-04 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)</sup>