### PR TITLE
group_by() makes a shallow copy even with no groups.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: dplyr
 Title: A Grammar of Data Manipulation
-Version: 0.8.0.9003
+Version: 0.8.0.9004
 Authors@R: c(
     person("Hadley", "Wickham", , "hadley@rstudio.com", c("aut", "cre"), comment = c(ORCID = "0000-0003-4757-117X")),
     person("Romain", "Fran\u00e7ois", role = "aut", comment = c(ORCID = "0000-0002-2444-4226")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # dplyr 0.8.0.9000
 
-* Fixed mutate() on rowwise data frames with 0 rows (#4224).
+* `group_by()` does a shallow copy even in the no groups case (#4221).
+
+* Fixed `mutate()` on rowwise data frames with 0 rows (#4224).
 
 * Fixed handling of bare formulas in colwise verbs (#4183).
 

--- a/src/group_indices.cpp
+++ b/src/group_indices.cpp
@@ -640,18 +640,19 @@ SymbolVector GroupedDataFrame::group_vars() const {
 
 // [[Rcpp::export]]
 DataFrame grouped_df_impl(DataFrame data, SymbolVector symbols, bool drop) {
+  DataFrame copy(shallow_copy(data));
+
   if (!symbols.size()) {
-    GroupedDataFrame::strip_groups(data);
-    data.attr("class") = NaturalDataFrame::classes();
-    return data;
+    GroupedDataFrame::strip_groups(copy);
+    copy.attr("class") = NaturalDataFrame::classes();
+    return copy;
   }
 
-  DataFrame copy(shallow_copy(data));
   set_class(copy, GroupedDataFrame::classes());
 
   // we've made a copy and we are about to create the groups
   // attribute, so we make sure there is no more a vars
-  // attribute lurking around from the pore 0.8.0 area
+  // attribute lurking around from the pre 0.8.0 area
   copy.attr("vars") = R_NilValue;
   copy.attr("drop") = R_NilValue;
 

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -493,3 +493,10 @@ test_that("group_by(add = TRUE) sets .drop if the origonal data was .drop", {
   expect_equal(n_groups(res), 1L)
   expect_true(group_drops(res))
 })
+
+test_that("group_by() makes a shallow copy of data even in the corner case", {
+  df <- data.frame(x = 1:4)
+  gdf <- group_by(df)
+  expect_true(inherits(gdf, "tbl_df"))
+  expect_false(inherits(df, "tbl_df"))
+})


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)

(x <- data.frame(y = 1))
#>   y
#> 1 1
(group_by(x))
#> # A tibble: 1 x 1
#>       y
#>   <dbl>
#> 1     1
x
#>   y
#> 1 1
```
