### PR TITLE
summarise_at() can rename when multiple funs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: dplyr
 Title: A Grammar of Data Manipulation
-Version: 0.8.0.9005
+Version: 0.8.0.9006
 Authors@R: c(
     person("Hadley", "Wickham", , "hadley@rstudio.com", c("aut", "cre"), comment = c(ORCID = "0000-0003-4757-117X")),
     person("Romain", "Fran\u00e7ois", role = "aut", comment = c(ORCID = "0000-0002-2444-4226")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@
 * `group_indices()` now ignores empty groups by default for `data.frame`, which is
   consistent with the default of `group_by()` (@yutannihilation, #4208). 
 
+* Fixed integer overflow in hybrid `ntile()` (#4186). 
+
 # dplyr 0.8.0.1 (2019-02-15)
 
 * Fixed integer C/C++ division, forced released by CRAN (#4185). 

--- a/inst/include/dplyr/hybrid/vector_result/ntile.h
+++ b/inst/include/dplyr/hybrid/vector_result/ntile.h
@@ -32,7 +32,7 @@ public:
   }
 
 private:
-  int ntiles;
+  R_xlen_t ntiles;
 };
 
 template <typename SlicedTibble, int RTYPE, bool ascending>
@@ -79,7 +79,7 @@ public:
 
 private:
   Rcpp::Vector<RTYPE> vec;
-  int ntiles;
+  R_xlen_t ntiles;
 };
 
 

--- a/tests/testthat/test-rank.R
+++ b/tests/testthat/test-rank.R
@@ -43,3 +43,12 @@ test_that("ntile handles character vectors consistently", {
   charvec_sort_test()
   withr::with_collate("C", charvec_sort_test())
 })
+
+test_that("ntile() does not overflow (#4186)", {
+  res <- tibble(a = 1:1e5) %>%
+    mutate(b = ntile(n = 1e5)) %>%
+    count(b) %>%
+    pull()
+
+  expect_true(all(res == 1L))
+})


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)

mtcars %>%
  group_by(cyl) %>% 
  summarise_at(vars(DISP = disp), list(mean = mean, median = median))
#> # A tibble: 3 x 3
#>     cyl DISP_mean DISP_median
#>   <dbl>     <dbl>       <dbl>
#> 1     4      105.        108 
#> 2     6      183.        168.
#> 3     8      353.        350.
```

<sup>Created on 2019-03-05 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)</sup>