### PR TITLE
Can rename in summarise_at() with multiple functions.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@
 
 * Fixed integer overflow in hybrid `ntile()` (#4186). 
 
+* colwise functions `summarise_at()` ... can rename vars in the case of multiple functions (#4180).
+
 # dplyr 0.8.0.1 (2019-02-15)
 
 * Fixed integer C/C++ division, forced released by CRAN (#4185). 

--- a/R/colwise-mutate.R
+++ b/R/colwise-mutate.R
@@ -346,7 +346,7 @@ manip_apply_syms <- function(funs, syms, tbl) {
     if (length(syms) == 1 && all(unnamed)) {
       names(out) <- names(funs)
     } else {
-      syms_names <- map_chr(syms, as_string)
+      syms_names <- ifelse(unnamed, map_chr(syms, as_string), names(syms))
       grid <- expand.grid(var = syms_names, call = names(funs))
       names(out) <- paste(grid$var, grid$call, sep = "_")
     }

--- a/tests/testthat/test-colwise-mutate.R
+++ b/tests/testthat/test-colwise-mutate.R
@@ -359,3 +359,13 @@ test_that("colwise mutate have .data in scope of rlang lambdas (#4183)", {
 
 })
 
+test_that("can choose the name of vars with multiple funs (#4180)", {
+  expect_identical(
+    mtcars %>%
+      group_by(cyl) %>%
+      summarise_at(vars(DISP = disp), list(mean = mean, median = median)),
+    mtcars %>%
+      group_by(cyl) %>%
+      summarise(DISP_mean = mean(disp), DISP_median = median(disp))
+  )
+})


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)

mtcars %>%
  group_by(cyl) %>% 
  summarise_at(vars(DISP = disp), list(mean = mean, median = median))
#> # A tibble: 3 x 3
#>     cyl DISP_mean DISP_median
#>   <dbl>     <dbl>       <dbl>
#> 1     4      105.        108 
#> 2     6      183.        168.
#> 3     8      353.        350.
```

<sup>Created on 2019-03-05 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)</sup>