### PR TITLE
select_if() and rename_if() handle lgl vectors.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,8 @@
 
 * colwise functions `summarise_at()` ... can rename vars in the case of multiple functions (#4180).
 
+* `select_if()` and `rename_if()` handle logical vector predicate (#4213). 
+
 # dplyr 0.8.0.1 (2019-02-15)
 
 * Fixed integer C/C++ division, forced released by CRAN (#4185). 

--- a/R/colwise-select.R
+++ b/R/colwise-select.R
@@ -64,7 +64,9 @@ rename_all <- function(.tbl, .funs = list(), ...) {
 #' @export
 select_if <- function(.tbl, .predicate, .funs = list(), ...) {
   funs <- as_fun_list(.funs, enquo(.funs), caller_env(), ...)
-  .predicate <- as_fun_list(.predicate, enquo(.predicate), caller_env())
+  if (!is_logical(.predicate)) {
+    .predicate <- as_fun_list(.predicate, enquo(.predicate), caller_env())
+  }
   vars <- tbl_if_vars(.tbl, .predicate, caller_env(), .include_group_vars = TRUE)
   syms <- vars_select_syms(vars, funs, .tbl)
   select(.tbl, !!!syms)
@@ -73,7 +75,9 @@ select_if <- function(.tbl, .predicate, .funs = list(), ...) {
 #' @export
 rename_if <- function(.tbl, .predicate, .funs = list(), ...) {
   funs <- as_fun_list(.funs, enquo(.funs), caller_env(), ...)
-  .predicate <- as_fun_list(.predicate, enquo(.predicate), caller_env())
+  if (!is_logical(.predicate)) {
+    .predicate <- as_fun_list(.predicate, enquo(.predicate), caller_env())
+  }
   vars <- tbl_if_vars(.tbl, .predicate, caller_env(), .include_group_vars = TRUE)
   syms <- vars_select_syms(vars, funs, .tbl, strict = TRUE)
   rename(.tbl, !!!syms)

--- a/tests/testthat/test-colwise-select.R
+++ b/tests/testthat/test-colwise-select.R
@@ -167,3 +167,18 @@ test_that("mutate_all does not change the order of columns (#3351)", {
   tbl <- group_by(tibble(x = 1:4, y = 1:4, z = 1:4), y)
   expect_message(expect_identical(names(mutate_all(tbl, identity)), names(tbl)), "ignored")
 })
+
+test_that("select_if() and rename_if() handles logical (#4213)", {
+  ids <- "Sepal.Length"
+  expect_identical(
+    iris %>% select_if(!names(.) %in% ids),
+    iris %>% select(-Sepal.Length)
+  )
+
+  expect_identical(
+    iris %>% rename_if(!names(.) %in% ids, toupper),
+    iris %>% rename_at(setdiff(names(.), "Sepal.Length"), toupper)
+  )
+
+})
+


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)

ids <- "Sepal.Length"
as_tibble(iris) %>% 
  select_if(!names(.) %in% ids)
#> # A tibble: 150 x 4
#>    Sepal.Width Petal.Length Petal.Width Species
#>          <dbl>        <dbl>       <dbl> <fct>  
#>  1         3.5          1.4         0.2 setosa 
#>  2         3            1.4         0.2 setosa 
#>  3         3.2          1.3         0.2 setosa 
#>  4         3.1          1.5         0.2 setosa 
#>  5         3.6          1.4         0.2 setosa 
#>  6         3.9          1.7         0.4 setosa 
#>  7         3.4          1.4         0.3 setosa 
#>  8         3.4          1.5         0.2 setosa 
#>  9         2.9          1.4         0.2 setosa 
#> 10         3.1          1.5         0.1 setosa 
#> # … with 140 more rows

as_tibble(iris) %>% 
  rename_if(!names(.) %in% ids, toupper)
#> # A tibble: 150 x 5
#>    Sepal.Length SEPAL.WIDTH PETAL.LENGTH PETAL.WIDTH SPECIES
#>           <dbl>       <dbl>        <dbl>       <dbl> <fct>  
#>  1          5.1         3.5          1.4         0.2 setosa 
#>  2          4.9         3            1.4         0.2 setosa 
#>  3          4.7         3.2          1.3         0.2 setosa 
#>  4          4.6         3.1          1.5         0.2 setosa 
#>  5          5           3.6          1.4         0.2 setosa 
#>  6          5.4         3.9          1.7         0.4 setosa 
#>  7          4.6         3.4          1.4         0.3 setosa 
#>  8          5           3.4          1.5         0.2 setosa 
#>  9          4.4         2.9          1.4         0.2 setosa 
#> 10          4.9         3.1          1.5         0.1 setosa 
#> # … with 140 more rows
```

<sup>Created on 2019-03-05 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)</sup>