### PR TITLE
bind_rows() aborts if `.id` is a column name

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -55,6 +55,8 @@
   https://www.tidyverse.org/articles/2019/04/r-version-support/
 
 * `rename_at()` handles empty selection (#4324). 
+* Exporting `group_by_drop_default()`, previously known as `dplyr:::group_drops()` (#4245).
+* `bind_rows()` aborts if `.id` is a column name (#4230). 
 
 # dplyr 0.8.0.1 (2019-02-15)
 

--- a/R/bind.r
+++ b/R/bind.r
@@ -117,6 +117,12 @@ bind_rows <- function(..., .id = NULL) {
       x <- compact(x)
       names(x) <- seq_along(x)
     }
+
+    walk(x, function(.x) {
+      if(.id %in% names(.x)) {
+        glubort(NULL, '"{.id}" is a column name, it cannot be used as .id')
+      }
+    })
   }
 
   bind_rows_(x, .id)

--- a/R/bind.r
+++ b/R/bind.r
@@ -117,15 +117,14 @@ bind_rows <- function(..., .id = NULL) {
       x <- compact(x)
       names(x) <- seq_along(x)
     }
-
-    for(.x in x) {
-      if(.id %in% names(.x)) {
-        glubort(NULL, '"{.id}" is a column name, it cannot be used as .id')
-      }
-    }
   }
+  res <- bind_rows_(x, .id)
 
-  bind_rows_(x, .id)
+  # only calling this for the abort() when not unique side effect
+  # there has to be a better way to do that
+  as_tibble(res, .name_repair = "check_unique")
+
+  res
 }
 
 #' @export

--- a/R/bind.r
+++ b/R/bind.r
@@ -118,11 +118,11 @@ bind_rows <- function(..., .id = NULL) {
       names(x) <- seq_along(x)
     }
 
-    walk(x, function(.x) {
+    for(.x in x) {
       if(.id %in% names(.x)) {
         glubort(NULL, '"{.id}" is a column name, it cannot be used as .id')
       }
-    })
+    }
   }
 
   bind_rows_(x, .id)

--- a/R/group-indices.R
+++ b/R/group-indices.R
@@ -60,7 +60,6 @@ group_indices_.rowwise_df <- function(.data, ..., .dots = list()) {
   group_indices(.data, !!!dots)
 }
 
-#' @importFrom rlang dots_n
 #' @export
 group_indices.grouped_df <- function(.data, ...) {
   if (dots_n(...)) {

--- a/tests/testthat/test-binds.R
+++ b/tests/testthat/test-binds.R
@@ -635,3 +635,10 @@ test_that("bind_rows handles typed lists (#3924)", {
   lst <- structure(list(df, df, df), class = "special_lst")
   expect_equal(bind_rows(lst), bind_rows(df,df,df))
 })
+
+test_that("bind_rows() refuses .id that is a column (#4230)", {
+  d1 <- tibble(x = 1:2, y = 1:2)
+  d2 <- tibble(x = 1:2, y = 1:2)
+
+  expect_error(bind_rows(d1, d2, .id = "x"))
+})


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)

d1 <- tibble(x = 1:2, y = 1:2)
d2 <- tibble(x = 1:2, y = 1:2)

bind_rows(d1, d2, .id = "x")
#> Error: "x" is a column name, it cannot be used as .id
```

<sup>Created on 2019-03-05 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)</sup>