### PR TITLE
Fix ntile()  in win32

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,7 @@ install:
 environment:
   global:
     WARNINGS_ARE_ERRORS: 1
+    _R_CHECK_SYSTEM_CLOCK_: FALSE
     GITHUB_PAT:
       secure: SAjXHKPAFPipSOE/6giubmF50pmgGtSFxyhe88E7RDv+q4PucnkyRK7Rs+/a7Vo0
 

--- a/inst/include/dplyr/hybrid/vector_result/ntile.h
+++ b/inst/include/dplyr/hybrid/vector_result/ntile.h
@@ -26,13 +26,14 @@ public:
 
   void fill(const typename SlicedTibble::slicing_index& indices, Rcpp::IntegerVector& out) const {
     int m = indices.size();
+    double ratio = static_cast<double>(ntiles) / m;
     for (int j = m - 1; j >= 0; j--) {
-      out[ indices[j] ] = (ntiles * j) / m + 1;
+      out[ indices[j] ] = static_cast<int>(floor(ratio * j)) + 1;
     }
   }
 
 private:
-  R_xlen_t ntiles;
+  int ntiles;
 };
 
 template <typename SlicedTibble, int RTYPE, bool ascending>
@@ -72,14 +73,15 @@ public:
         break;
       }
     }
+    double ratio = static_cast<double>(ntiles) / m;
     for (; j >= 0; j--) {
-      out_slice[idx[j]] = (ntiles * j) / m + 1;
+      out_slice[idx[j]] = static_cast<int>(floor(ratio * j)) + 1;
     }
   }
 
 private:
   Rcpp::Vector<RTYPE> vec;
-  R_xlen_t ntiles;
+  int ntiles;
 };
 
 

--- a/tests/testthat/helper-hybrid.R
+++ b/tests/testthat/helper-hybrid.R
@@ -1,7 +1,7 @@
 expect_hybrid <- function(data, expr, info = NULL, label = NULL) {
-  expect_true(hybrid_impl(data, enquo(expr), caller_env()), info = info, label = label)
+  expect_true(hybrid_impl(data, enquo(expr), rlang::caller_env()), info = info, label = label)
 }
 
 expect_not_hybrid <- function(data, expr, info = NULL, label = NULL) {
-  expect_false(hybrid_impl(data, enquo(expr), caller_env()), info = info, label = label)
+  expect_false(hybrid_impl(data, enquo(expr), rlang::caller_env()), info = info, label = label)
 }


### PR DESCRIPTION
Use floating point division again, because in some situation (incl the ones we use for testing) we'd get an overflow on 32 bit platforms (i.e. where `R_xlen_t` is `int`). 