### PR TITLE
Attempt to coerce results of min() and max() to int

### DIFF
--- a/inst/include/dplyr/hybrid/scalar_result/min_max.h
+++ b/inst/include/dplyr/hybrid/scalar_result/min_max.h
@@ -65,6 +65,23 @@ private:
 template <int RTYPE, typename SlicedTibble, bool MINIMUM, bool NA_RM>
 const double MinMax<RTYPE, SlicedTibble, MINIMUM, NA_RM>::Inf = (MINIMUM ? R_PosInf : R_NegInf);
 
+inline bool is_infinite(double x) {
+  return !R_FINITE(x);
+}
+
+template <int RTYPE>
+SEXP maybe_coerce_minmax(SEXP x) {
+  double* end = REAL(x) + XLENGTH(x);
+  if (std::find_if(REAL(x), end, is_infinite) != end) {
+    return x;
+  }
+
+  PROTECT(x);
+  SEXP out = Rcpp::as< Rcpp::Vector<RTYPE> >(x);
+  UNPROTECT(1);
+  return out;
+}
+
 }
 
 // min( <column> )
@@ -74,9 +91,9 @@ SEXP minmax_narm(const SlicedTibble& data, Column x, const Operation& op) {
   // only handle basic number types, anything else goes through R
   switch (TYPEOF(x.data)) {
   case RAWSXP:
-    return op(internal::MinMax<RAWSXP, SlicedTibble, MINIMUM, NARM>(data, x));
+    return internal::maybe_coerce_minmax<RAWSXP>(op(internal::MinMax<RAWSXP, SlicedTibble, MINIMUM, NARM>(data, x)));
   case INTSXP:
-    return op(internal::MinMax<INTSXP, SlicedTibble, MINIMUM, NARM>(data, x));
+    return internal::maybe_coerce_minmax<INTSXP>(op(internal::MinMax<INTSXP, SlicedTibble, MINIMUM, NARM>(data, x)));
   case REALSXP:
     return op(internal::MinMax<REALSXP, SlicedTibble, MINIMUM, NARM>(data, x));
   default:

--- a/inst/include/dplyr/hybrid/scalar_result/min_max.h
+++ b/inst/include/dplyr/hybrid/scalar_result/min_max.h
@@ -71,6 +71,8 @@ inline bool is_infinite(double x) {
 
 template <int RTYPE>
 SEXP maybe_coerce_minmax(SEXP x) {
+  if (TYPEOF(x) != REALSXP) return x;
+
   double* end = REAL(x) + XLENGTH(x);
   if (std::find_if(REAL(x), end, is_infinite) != end) {
     return x;
@@ -92,8 +94,10 @@ SEXP minmax_narm(const SlicedTibble& data, Column x, const Operation& op) {
   switch (TYPEOF(x.data)) {
   case RAWSXP:
     return internal::maybe_coerce_minmax<RAWSXP>(op(internal::MinMax<RAWSXP, SlicedTibble, MINIMUM, NARM>(data, x)));
+
   case INTSXP:
     return internal::maybe_coerce_minmax<INTSXP>(op(internal::MinMax<INTSXP, SlicedTibble, MINIMUM, NARM>(data, x)));
+
   case REALSXP:
     return op(internal::MinMax<REALSXP, SlicedTibble, MINIMUM, NARM>(data, x));
   default:

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -1130,3 +1130,23 @@ test_that("hybrid sum(), mean(), min(), max() treats NA and NaN correctly (#4108
   expect_equal(res$max , 1)
   expect_equal(res$min , 1)
 })
+
+test_that("hybrid min() and max() coerce to integer if there is no infinity (#4258)", {
+  tbl <- data.frame(a = 1L) %>% summarise_all(list(min = min, max = max))
+  expect_equal(tbl, data.frame(min = 1L, max = 1L))
+  expect_is(tbl$min, "integer")
+  expect_is(tbl$max, "integer")
+
+  tbl <- data.frame(a = 1L, b = factor("a", levels = c("a", "b"))) %>%
+    group_by(b, .drop = FALSE) %>%
+    summarise_all(list(min = min, max = max))
+  expect_equal(tbl,
+    data.frame(
+      b = factor(c("a", "b"), levels = c("a", "b")),
+      min = c(1, Inf),
+      max = c(1, -Inf)
+    )
+  )
+  expect_is(tbl$min, "numeric")
+  expect_is(tbl$max, "numeric")
+})


### PR DESCRIPTION
That's only possible when there are no empty groups after NA removal. 