### PR TITLE
colwise expressions using position of variable instead of symbol.

### DIFF
--- a/R/colwise-mutate.R
+++ b/R/colwise-mutate.R
@@ -321,13 +321,18 @@ manip_apply_syms <- function(funs, syms, tbl) {
 
   out <- vector("list", length(syms) * length(funs))
   dim(out) <- c(length(syms), length(funs))
+  syms_position <- match(tbl_vars(tbl), as.character(syms))
+
   for (i in seq_along(syms)) {
+    pos <- syms_position[i]
     for (j in seq_along(funs)) {
-      var_sym <- sym(syms[[i]])
-      out[[i, j]] <- expr_substitute(funs[[j]], quote(.), var_sym)
+      out[[i, j]] <- expr_substitute(funs[[j]], quote(.), syms[[i]])
+      attr(out[[i, j]], "position") <- pos
     }
   }
+
   dim(out) <- NULL
+
 
   # Use symbols as default names
   unnamed <- !have_name(syms)

--- a/inst/include/dplyr/data/DataMask.h
+++ b/inst/include/dplyr/data/DataMask.h
@@ -392,6 +392,15 @@ public:
     }
   }
 
+  const ColumnBinding<SlicedTibble>*
+  get_subset_binding(int position) const {
+    const ColumnBinding<SlicedTibble>& res = column_bindings[position];
+    if (res.is_null()) {
+      return 0;
+    }
+    return &res;
+  }
+
   // remove this variable from the environments
   void rm(const SymbolString& symbol) {
     int idx = symbol_map.find(symbol);

--- a/inst/include/dplyr/hybrid/Expression.h
+++ b/inst/include/dplyr/hybrid/Expression.h
@@ -108,6 +108,7 @@ private:
   hybrid_id id;
 
   SEXP dot_alias;
+  int colwise_position;
 
 public:
   typedef std::pair<bool, SEXP> ArgPair;
@@ -121,8 +122,15 @@ public:
     data_mask(data_mask_),
     n(0),
     id(NOMATCH),
-    dot_alias(R_NilValue)
+    dot_alias(R_NilValue),
+    colwise_position(-1)
   {
+    // handle the case when the expression has been colwise spliced
+    SEXP position_attr = Rf_getAttrib(expr, symbols::position);
+    if (!Rf_isNull(position_attr)) {
+      colwise_position = Rcpp::as<int>(position_attr);
+    }
+
     // the function called, e.g. n, or dplyr::n
     SEXP head = CAR(expr);
 
@@ -202,7 +210,7 @@ public:
     {
       if (Rf_length(val) != 1) return false;
       int value = INTEGER(val)[0];
-      if (IntegerVector::is_na(value)) {
+      if (Rcpp::IntegerVector::is_na(value)) {
         return false;
       }
       out = unary_minus ? -value : value;
@@ -212,7 +220,7 @@ public:
     {
       if (Rf_length(val) != 1) return false;
       int value = Rcpp::internal::r_coerce<REALSXP, INTSXP>(REAL(val)[0]);
-      if (IntegerVector::is_na(value)) {
+      if (Rcpp::IntegerVector::is_na(value)) {
         return false;
       }
       out = unary_minus ? -value : value;
@@ -241,7 +249,7 @@ public:
     }
 
     LOG_VERBOSE << "is_column_impl(false)";
-    bool result = is_column_impl(val, column, false) || is_desc_column_impl(val, column);
+    bool result = is_column_impl(i, val, column, false) || is_desc_column_impl(i, val, column);
     UNPROTECT(nprot);
     return result;
   }
@@ -286,18 +294,18 @@ private:
     return f;
   }
 
-  inline bool is_desc_column_impl(SEXP val, Column& column) const {
+  inline bool is_desc_column_impl(int i, SEXP val, Column& column) const {
     return TYPEOF(val) == LANGSXP &&
            Rf_length(val) == 1 &&
            CAR(val) == symbols::desc &&
-           is_column_impl(CADR(val), column, true)
+           is_column_impl(i, CADR(val), column, true)
            ;
   }
 
 
-  inline bool is_column_impl(SEXP val, Column& column, bool desc) const {
+  inline bool is_column_impl(int i, SEXP val, Column& column, bool desc) const {
     if (TYPEOF(val) == SYMSXP) {
-      return test_is_column(val, column, desc);
+      return test_is_column(i, val, column, desc);
     }
 
     if (TYPEOF(val) == LANGSXP && Rf_length(val) == 3 && CADR(val) == symbols::dot_data) {
@@ -306,30 +314,44 @@ private:
 
       if (fun == R_DollarSymbol) {
         // .data$x
-        if (TYPEOF(rhs) == SYMSXP) return test_is_column(rhs, column, desc);
+        if (TYPEOF(rhs) == SYMSXP) return test_is_column(i, rhs, column, desc);
 
         // .data$"x"
-        if (TYPEOF(rhs) == STRSXP && Rf_length(rhs) == 1) return test_is_column(Rf_installChar(STRING_ELT(rhs, 0)), column, desc);
+        if (TYPEOF(rhs) == STRSXP && Rf_length(rhs) == 1) return test_is_column(i, Rf_installChar(STRING_ELT(rhs, 0)), column, desc);
       } else if (fun == R_Bracket2Symbol) {
         // .data[["x"]]
-        if (TYPEOF(rhs) == STRSXP && Rf_length(rhs) == 1) return test_is_column(Rf_installChar(STRING_ELT(rhs, 0)), column, desc);
+        if (TYPEOF(rhs) == STRSXP && Rf_length(rhs) == 1) return test_is_column(i, Rf_installChar(STRING_ELT(rhs, 0)), column, desc);
       }
     }
     return false;
   }
 
-  inline bool test_is_column(Rcpp::Symbol s, Column& column, bool desc) const {
+  inline bool test_is_column(int i, Rcpp::Symbol s, Column& column, bool desc) const {
     if (!Rf_isNull(dot_alias) && (s == symbols::dot || s == symbols::dot_x)) {
       s = dot_alias;
     }
-    SymbolString symbol(s);
+    SEXP data;
+    if (i == 0 && colwise_position > 0) {
+      // we know the position for sure because this has been clowise spliced
+      const ColumnBinding<SlicedTibble>* subset = data_mask.get_subset_binding(colwise_position - 1);
+      if (!subset->is_summary()) {
+        return false;
+      }
+      data = subset->get_data();
 
-    // does the data mask have this symbol, and if so is it a real column (not a summarised)
-    const ColumnBinding<SlicedTibble>* subset = data_mask.maybe_get_subset_binding(symbol);
-    if (!subset || subset->is_summary()) return false;
+    } else {
+      // otherwise use the hashmap
+      SymbolString symbol(s);
+
+      // does the data mask have this symbol, and if so is it a real column (not a summarised)
+      const ColumnBinding<SlicedTibble>* subset = data_mask.maybe_get_subset_binding(symbol);
+      if (!subset || subset->is_summary()) {
+        return false;
+      }
+      data = subset->get_data() ;
+    }
 
     // only treat very simple columns as columns, leave other to R
-    SEXP data = subset->get_data() ;
     if (Rf_isObject(data) || Rf_isS4(data) || RCPP_GET_CLASS(data) != R_NilValue) return false;
 
     column.data = data;
@@ -342,7 +364,6 @@ private:
     // If this happens to be a rlang_lambda_function we need to look further
     SEXP f = resolve_rlang_lambda(finder.res);
 
-    // this also may update expr
     dplyr_hash_map<SEXP, hybrid_function>& map = get_hybrid_inline_map();
     dplyr_hash_map<SEXP, hybrid_function>::const_iterator it = map.find(f);
     if (it != map.end()) {

--- a/inst/include/dplyr/symbols.h
+++ b/inst/include/dplyr/symbols.h
@@ -46,6 +46,7 @@ struct symbols {
   static SEXP comment;
   static SEXP groups;
   static SEXP vars;
+  static SEXP position;
 
   static SEXP op_minus;
   static SEXP str;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -66,6 +66,7 @@ SEXP symbols::new_env = Rf_install("new.env");
 SEXP symbols::comment = Rf_install("comment");
 SEXP symbols::groups = Rf_install("groups");
 SEXP symbols::vars = Rf_install("vars");
+SEXP symbols::position = Rf_install("position");
 
 SEXP symbols::op_minus = Rf_install("-");
 SEXP symbols::str = Rf_install("str");


### PR DESCRIPTION
`manip_all()` ... record position of each of the used symbols in the `position` attribute. This is then used internally to bypass some encoding problems in hybrid evaluation, e.g. #4258 