### PR TITLE
Clarify `summarise()` behaviour.

### DIFF
--- a/R/manip.r
+++ b/R/manip.r
@@ -247,7 +247,7 @@ slice_ <- function(.data, ..., .dots = list()) {
 #'   group_vars()
 #'
 #' # Note that with data frames, newly created summaries immediately
-#' # overwrite existing variables
+#' # overwrite existing variables of the same name.
 #' mtcars %>%
 #'   group_by(cyl) %>%
 #'   summarise(disp = mean(disp), sd = sd(disp))

--- a/man/summarise.Rd
+++ b/man/summarise.Rd
@@ -78,7 +78,7 @@ mtcars \%>\%
   group_vars()
 
 # Note that with data frames, newly created summaries immediately
-# overwrite existing variables
+# overwrite existing variables of the same name.
 mtcars \%>\%
   group_by(cyl) \%>\%
   summarise(disp = mean(disp), sd = sd(disp))


### PR DESCRIPTION
Clarify that `summarise()` will overwrite a variable of the same name.
* Fixes #4285.