### PR TITLE
Support R > 3.2.0 and use_tidy_versions(CRAN)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ fortran: false
 jobs:
   include:
   - r: devel
-  - r: 3.1
-    warnings_are_errors: false
   - os: osx
   - r: release
     after_success:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,49 +15,49 @@ License: MIT + file LICENSE
 URL: http://dplyr.tidyverse.org, https://github.com/tidyverse/dplyr
 BugReports: https://github.com/tidyverse/dplyr/issues
 Depends: 
-    R (>= 3.1.2)
+    R (>= 3.2.0)
 Imports: 
-    assertthat (>= 0.2.0),
-    glue (>= 1.1.1),
+    assertthat (>= 0.2.1),
+    glue (>= 1.3.1),
     magrittr (>= 1.5),
     methods,
-    pkgconfig (>= 2.0.1),
-    R6 (>= 2.2.2),
-    Rcpp (>= 1.0.0),
-    rlang (>= 0.3.0),
-    tibble (>= 2.0.0),
+    pkgconfig (>= 2.0.2),
+    R6 (>= 2.4.0),
+    Rcpp (>= 1.0.1),
+    rlang (>= 0.3.3),
+    tibble (>= 2.1.1),
     tidyselect (>= 0.2.5),
     utils
 Suggests: 
-    bit64 (>= 0.9.7),
-    callr (>= 3.1.1),
-    covr (>= 3.0.1),
-    DBI (>= 0.7.14),
-    dbplyr (>= 1.2.0),
-    dtplyr (>= 0.0.2),
-    ggplot2 (>= 2.2.1),
-    hms (>= 0.4.1),
-    knitr (>= 1.19),
-    Lahman (>= 3.0-1),
+    bit64 (>= 0.9-7),
+    callr (>= 3.2.0),
+    covr (>= 3.2.1),
+    DBI (>= 1.0.0),
+    dbplyr (>= 1.3.0),
+    dtplyr (>= 0.0.3),
+    ggplot2 (>= 3.1.0),
+    hms (>= 0.4.2),
+    knitr (>= 1.22),
+    Lahman (>= 6.0-0),
     lubridate (>= 1.7.4),
     MASS,
     mgcv (>= 1.8.23),
-    microbenchmark (>= 1.4.4),
-    nycflights13 (>= 0.2.2),
-    rmarkdown (>= 1.8),
-    RMySQL (>= 0.10.13),
-    RPostgreSQL (>= 0.6.2),
-    RSQLite (>= 2.0),
-    testthat (>= 2.0.0),
-    withr (>= 2.1.1),
+    microbenchmark (>= 1.4-6),
+    nycflights13 (>= 1.0.0),
+    rmarkdown (>= 1.12),
+    RMySQL (>= 0.10.17),
+    RPostgreSQL (>= 0.6-2),
+    RSQLite (>= 2.1.1),
+    testthat (>= 2.0.1),
+    withr (>= 2.1.2),
     broom (>= 0.5.1),
-    purrr (>= 0.3.0),
+    purrr (>= 0.3.2),
     readr (>= 1.3.1),
     crayon (>= 1.3.4)
 LinkingTo: 
-    BH (>= 1.58.0-1),
-    plogr (>= 0.1.10),
-    Rcpp (>= 1.0.0)
+    BH (>= 1.69.0-1),
+    plogr (>= 0.2.0),
+    Rcpp (>= 1.0.1)
 VignetteBuilder: knitr
 Encoding: UTF-8
 LazyData: yes

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,8 @@
 
 * `bind_rows()` correctly handles the cases where there are multiple consecutive `NULL` (#4296). 
 
+* Support for R 3.1.* has been dropped. The minimal R version supported is now 3.2.0. 
+
 # dplyr 0.8.0.1 (2019-02-15)
 
 * Fixed integer C/C++ division, forced released by CRAN (#4185). 


### PR DESCRIPTION
https://www.tidyverse.org/articles/2019/04/r-version-support/