### PR TITLE
src_tbls() includes all tbls.

### DIFF
--- a/R/src-local.r
+++ b/R/src-local.r
@@ -43,7 +43,7 @@ src_df <- function(pkg = NULL, env = NULL) {
 
 #' @export
 src_tbls.src_local <- function(x, ...) {
-  objs <- ls(envir = x$env)
+  objs <- ls(envir = x$env, all.names = TRUE)
   Filter(function(obj) is.data.frame(get(obj, envir = x$env)), objs)
 }
 

--- a/tests/testthat/test-copy_to.R
+++ b/tests/testthat/test-copy_to.R
@@ -63,3 +63,10 @@ test_that("src_sqlite() errs if path does not exist", {
     fixed = TRUE
   )
 })
+
+test_that("src_tbls() includes all tbls (#4326)", {
+  expect_equal(
+    src_tbls(src_df(env = env(. = iris))),
+    "."
+  )
+})


### PR DESCRIPTION
``` r
dplyr::src_df(env = rlang::env(. = iris))
#> src:  <environment: 0x7feac82c5838>
#> tbls: .
```

<sup>Created on 2019-04-11 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>