### PR TITLE
rename_at() handles empty selection.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dplyr 0.8.1.9000
+
+* `rename_at()` handles empty selection (#4324). 
+
 # dplyr 0.8.0.9000
 
 ## Breaking changes

--- a/R/colwise-select.R
+++ b/R/colwise-select.R
@@ -108,7 +108,11 @@ vars_select_syms <- function(vars, funs, tbl, strict = FALSE) {
     if (is_quosure(fun)) {
       fun <- quo_as_function(fun)
     }
-    syms <- set_names(syms(vars), fun(vars))
+    syms <- if (length(vars)) {
+      set_names(syms(vars), fun(vars))
+    } else {
+      set_names(syms(vars))
+    }
   } else if (!strict) {
     syms <- syms(vars)
   } else {

--- a/tests/testthat/test-colwise-select.R
+++ b/tests/testthat/test-colwise-select.R
@@ -182,3 +182,9 @@ test_that("select_if() and rename_if() handles logical (#4213)", {
 
 })
 
+test_that("rename_at() handles empty selection (#4324)", {
+  expect_identical(
+    mtcars %>% rename_at(vars(contains("fake_col")),~paste0("NewCol.",.)),
+    mtcars
+  )
+})


### PR DESCRIPTION
``` r
dplyr::rename_at(head(mtcars), character(),~paste0("NewCol.",.))
#>                    mpg cyl disp  hp drat    wt  qsec vs am gear carb
#> Mazda RX4         21.0   6  160 110 3.90 2.620 16.46  0  1    4    4
#> Mazda RX4 Wag     21.0   6  160 110 3.90 2.875 17.02  0  1    4    4
#> Datsun 710        22.8   4  108  93 3.85 2.320 18.61  1  1    4    1
#> Hornet 4 Drive    21.4   6  258 110 3.08 3.215 19.44  1  0    3    1
#> Hornet Sportabout 18.7   8  360 175 3.15 3.440 17.02  0  0    3    2
#> Valiant           18.1   6  225 105 2.76 3.460 20.22  1  0    3    1
```

<sup>Created on 2019-04-11 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>