### PR TITLE
unsupport quosures in colwise functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # dplyr 0.8.1.9000
 
-* Updated `distinct_if()`, `distinct_at()` and `distinct_all()` to include `.keep_all` argument (@beansrowning, #4343)
+* Using quosures in colwise verbs is deprecated (#4330).
+
+* Updated `distinct_if()`, `distinct_at()` and `distinct_all()` to include `.keep_all` argument (@beansrowning, #4343).
 
 * `arrange()` handles integer64 objects (#4366). 
 

--- a/R/funs.R
+++ b/R/funs.R
@@ -99,7 +99,7 @@ as_fun_list <- function(.funs, .env, ...) {
         signal_soft_deprecated(paste_line(
           "Using quosures is deprecated",
           "Please use a one-sided formula, a function, or a function name"
-        ))
+        ), env = .env)
         .x <- new_formula(NULL, quo_squash(.x), quo_get_env(.x))
       }
       .x <- as_inlined_function(.x, env = .env)

--- a/R/funs.R
+++ b/R/funs.R
@@ -100,6 +100,7 @@ as_fun_list <- function(.funs, .env, ...) {
           "Using quosures is deprecated",
           "Please use a one-sided formula, a function, or a function name"
         ))
+        .x <- new_formula(NULL, quo_squash(.x), quo_get_env(.x))
       }
       .x <- as_inlined_function(.x, env = .env)
     } else {

--- a/R/funs.R
+++ b/R/funs.R
@@ -94,13 +94,13 @@ as_fun_list <- function(.funs, .env, ...) {
   }
 
   funs <- map(.funs, function(.x){
-    if (is_formula(.x)) {
+    if (is_bare_formula(.x)) {
       .x <- as_inlined_function(.x, env = .env)
     } else {
       if (is_character(.x)) {
         .x <- get(.x, .env, mode = "function")
       } else if (!is_function(.x)) {
-        abort("not expecting this")
+        abort("expecting a one sided formula, a function, or a function name.")
       }
       if (length(args)) {
         .x <- new_quosure(

--- a/R/funs.R
+++ b/R/funs.R
@@ -94,7 +94,13 @@ as_fun_list <- function(.funs, .env, ...) {
   }
 
   funs <- map(.funs, function(.x){
-    if (is_bare_formula(.x)) {
+    if (is_formula(.x)) {
+      if (is_quosure(.x)) {
+        signal_soft_deprecated(paste_line(
+          "Using quosures is deprecated",
+          "Please use a one-sided formula, a function, or a function name"
+        ))
+      }
       .x <- as_inlined_function(.x, env = .env)
     } else {
       if (is_character(.x)) {

--- a/R/utils.r
+++ b/R/utils.r
@@ -22,7 +22,7 @@ any_apply <- function(xs, f) {
 
 deparse_names <- function(x) {
   x <- map_if(x, is_quosure, quo_expr)
-  x <- map_if(x, is_formula, f_rhs)
+  x <- map_if(x, is_bare_formula, f_rhs)
   map_chr(x, deparse)
 }
 

--- a/tests/testthat/test-colwise-mutate.R
+++ b/tests/testthat/test-colwise-mutate.R
@@ -430,3 +430,11 @@ test_that("colwise mutate handle named chr vectors", {
   expect_identical(res, tibble(x = 1:10, y = 5.5))
 })
 
+test_that("colwise verbs do not handle quosures (#4330)", {
+  expect_error(
+    mutate_at(mtcars, vars(mpg), quo(mean(.)))
+  )
+  expect_error(
+    summarise_at(mtcars, vars(mpg), quo(mean(.)))
+  )
+})

--- a/tests/testthat/test-colwise-mutate.R
+++ b/tests/testthat/test-colwise-mutate.R
@@ -430,7 +430,7 @@ test_that("colwise mutate handle named chr vectors", {
   expect_identical(res, tibble(x = 1:10, y = 5.5))
 })
 
-test_that("colwise verbs do not handle quosures (#4330)", {
+test_that("colwise verbs soft deprecate quosures (#4330)", {
   with_lifecycle_errors({
     expect_error(
       mutate_at(mtcars, vars(mpg), quo(mean(.)))
@@ -439,4 +439,9 @@ test_that("colwise verbs do not handle quosures (#4330)", {
       summarise_at(mtcars, vars(mpg), quo(mean(.)))
     )
   })
+
+  expect_equal(
+    transmute_at(mtcars, vars(mpg), ~. > mean(.)),
+    transmute_at(mtcars, vars(mpg), quo(. > mean(.)))
+  )
 })

--- a/tests/testthat/test-colwise-mutate.R
+++ b/tests/testthat/test-colwise-mutate.R
@@ -431,10 +431,12 @@ test_that("colwise mutate handle named chr vectors", {
 })
 
 test_that("colwise verbs do not handle quosures (#4330)", {
-  expect_error(
-    mutate_at(mtcars, vars(mpg), quo(mean(.)))
-  )
-  expect_error(
-    summarise_at(mtcars, vars(mpg), quo(mean(.)))
-  )
+  with_lifecycle_errors({
+    expect_error(
+      mutate_at(mtcars, vars(mpg), quo(mean(.)))
+    )
+    expect_error(
+      summarise_at(mtcars, vars(mpg), quo(mean(.)))
+    )
+  })
 })


### PR DESCRIPTION
``` r
suppressPackageStartupMessages(library(dplyr))
library(rlang)

df <- mtcars[1:5, ]

transmute_at(df, vars(mpg), ~ . > mean(.))
#>     mpg
#> 1  TRUE
#> 2  TRUE
#> 3  TRUE
#> 4  TRUE
#> 5 FALSE
transmute_at(df, vars(mpg), quo(. > mean(.)))
#> expecting a one sided formula, a function, or a function name.

transmute_at(df, vars(mpg), ~ mean(.))
#>     mpg
#> 1 20.98
#> 2 20.98
#> 3 20.98
#> 4 20.98
#> 5 20.98
transmute_at(df, vars(mpg), quo(mean(.)))
#> expecting a one sided formula, a function, or a function name.
```

<sup>Created on 2019-04-29 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>