### PR TITLE
support for arrange() for integer64

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr 0.8.1.9000
 
+* `arrange()` handles integer64 objects (#4366). 
+
 * `rename_at()` handles empty selection (#4324). 
 
 # dplyr 0.8.1

--- a/inst/include/dplyr/visitors/order/OrderVisitorImpl.h
+++ b/inst/include/dplyr/visitors/order/OrderVisitorImpl.h
@@ -85,6 +85,31 @@ private:
   OrderVectorVisitorImpl<INTSXP, ascending, Rcpp::IntegerVector> orders;
 };
 
+// ---------- int 64
+
+template <bool ascensing>
+class OrderInt64VectorVisitor : public OrderVisitor {
+public:
+
+  OrderInt64VectorVisitor(const Rcpp::NumericVector& vec_) :
+    vec(vec_),
+    data(reinterpret_cast<int64_t*>(vec.begin()))
+  {}
+
+  inline bool equal(int i, int j) const {
+    return comparisons_int64::equal_or_both_na(data[i], data[j]);
+  }
+
+  inline bool before(int i, int j) const {
+    return ascensing ? comparisons_int64::is_less(data[i], data[j]) : comparisons_int64::is_greater(data[i], data[j]);
+  }
+
+private:
+  Rcpp::NumericVector vec;
+  int64_t* data;
+};
+
+
 // ---------- data frame columns
 
 // ascending = true
@@ -229,6 +254,9 @@ inline OrderVisitor* order_visitor_asc_vector(SEXP vec) {
   case INTSXP:
     return new OrderVectorVisitorImpl<INTSXP, ascending, Rcpp::Vector<INTSXP > >(vec);
   case REALSXP:
+    if (Rf_inherits(vec, "integer64")) {
+      return new OrderInt64VectorVisitor<ascending>(vec);
+    }
     return new OrderVectorVisitorImpl<REALSXP, ascending, Rcpp::Vector<REALSXP> >(vec);
   case LGLSXP:
     return new OrderVectorVisitorImpl<LGLSXP, ascending, Rcpp::Vector<LGLSXP > >(vec);

--- a/inst/include/tools/comparisons.h
+++ b/inst/include/tools/comparisons.h
@@ -28,6 +28,29 @@ struct comparisons {
 
 };
 
+struct comparisons_int64 {
+  static inline bool is_less(int64_t lhs, int64_t rhs) {
+    if (is_na(lhs)) return false;
+    if (is_na(rhs)) return true;
+
+    return lhs < rhs;
+  }
+
+  static inline bool is_greater(int64_t lhs, int64_t rhs) {
+    return lhs > rhs;
+  }
+
+  static inline bool equal_or_both_na(int64_t lhs, int64_t rhs) {
+    return lhs == rhs;
+  }
+
+  static inline bool is_na(int64_t x) {
+    return x == NA_INT64;
+  }
+
+  static int64_t NA_INT64;
+};
+
 template <>
 struct comparisons<RAWSXP> {
   typedef Rbyte STORAGE;

--- a/src/arrange.cpp
+++ b/src/arrange.cpp
@@ -16,6 +16,8 @@
 
 namespace dplyr {
 
+int64_t comparisons_int64::NA_INT64 = std::numeric_limits<int64_t>::min();
+
 template <typename SlicedTibble>
 SEXP arrange_template(const SlicedTibble& gdf, const QuosureList& quosures, SEXP frame) {
   const Rcpp::DataFrame& data = gdf.data();

--- a/tests/testthat/test-arrange.r
+++ b/tests/testthat/test-arrange.r
@@ -195,6 +195,18 @@ test_that("desc(<not just a symbol>) works (#4099)", {
   )
 })
 
+test_that("arrange supports bit64::integer64 (#4366)", {
+  df <- tibble(x = bit64::as.integer64(c(1, 3, 2, 1)))
+  expect_identical(
+    arrange(df, x),
+    tibble(x = bit64::as.integer64(c(1, 1, 2, 3)))
+  )
+  expect_identical(
+    arrange(df, desc(x)),
+    tibble(x = bit64::as.integer64(c(3, 2, 1, 1)))
+  )
+})
+
 # grouped_df --------------------------------------------------------------
 
 test_that("can choose to include grouping vars", {

--- a/tests/testthat/test-arrange.r
+++ b/tests/testthat/test-arrange.r
@@ -205,6 +205,10 @@ test_that("arrange supports bit64::integer64 (#4366)", {
     arrange(df, desc(x)),
     tibble(x = bit64::as.integer64(c(3, 2, 1, 1)))
   )
+  expect_identical(
+    arrange(df, -x),
+    tibble(x = bit64::as.integer64(c(3, 2, 1, 1)))
+  )
 })
 
 # grouped_df --------------------------------------------------------------


### PR DESCRIPTION
This is temporary workaround until `vctrs::vec_order()` can handle integer64 objects (and we use `vec_order()`). related to https://github.com/r-lib/vctrs/issues/348

``` r
library(dplyr, warn.conflicts = FALSE)
suppressPackageStartupMessages(library(bit64))

df <- tibble(x = bit64::as.integer64(c(1, 3, 2, 1)))
arrange(df, x)
#> # A tibble: 4 x 1
#>   x      
#>   <int64>
#> 1 1      
#> 2 1      
#> 3 2      
#> 4 3
arrange(df, -x)
#> # A tibble: 4 x 1
#>   x      
#>   <int64>
#> 1 3      
#> 2 2      
#> 3 1      
#> 4 1
arrange(df, desc(x))
#> # A tibble: 4 x 1
#>   x      
#>   <int64>
#> 1 3      
#> 2 2      
#> 3 1      
#> 4 1
```

<sup>Created on 2019-05-20 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>