### PR TITLE
bind_cols() uses as_tibble(.name_repair="unique")

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,11 @@
 # dplyr 0.8.1.9000
 
+* `bind_cols()` uses tibble's name repair (#3772).
+
 * Using quosures in colwise verbs is deprecated (#4330).
 
 * Updated `distinct_if()`, `distinct_at()` and `distinct_all()` to include `.keep_all` argument (@beansrowning, #4343).
+
 * `select.list()` method added so that `select()` does not dispatch on lists (#4279). 
 
 * Updated `distinct_if()`, `distinct_at()` and `distinct_all()` to include `.keep_all` argument (@beansrowning, #4343)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # dplyr 0.8.1.9000
 
-* `bind_cols()` uses tibble's name repair (#3772).
+* `bind_cols()` exposes tibble's .name_repair argument (#3772).
 
 * Using quosures in colwise verbs is deprecated (#4330).
 

--- a/R/bind.r
+++ b/R/bind.r
@@ -130,14 +130,10 @@ bind_cols <- function(..., .name_repair = "unique") {
   x <- flatten_bindable(dots_values(...))
   out <- cbind_all(x)
 
-  # Using `.name_repair` but then gymnastics to keep
-  # attributes in case cbind_all did not return a tibble
-  repaired <- as_tibble(out, .name_repair = .name_repair)
-  repaired_names <- names(repaired)
-  attributes(repaired) <- attributes(out)
-  names(repaired) <- repaired_names
+  # repair names but not enforce `out` to be a tibble
+  names(out) <- names(as_tibble(out, .name_repair = .name_repair))
+  out
 
-  repaired
 }
 
 #' Combine vectors

--- a/R/bind.r
+++ b/R/bind.r
@@ -127,7 +127,15 @@ bind_rows <- function(..., .id = NULL) {
 bind_cols <- function(...) {
   x <- flatten_bindable(dots_values(...))
   out <- cbind_all(x)
-  tibble::repair_names(out)
+
+  # Using `.name_repair` but then gymnastics to keep
+  # attributes in case cbind_all did not return a tibble
+  repaired <- as_tibble(out, .name_repair = "unique")
+  repaired_names <- names(repaired)
+  attributes(repaired) <- attributes(out)
+  names(repaired) <- repaired_names
+
+  repaired
 }
 
 #' Combine vectors

--- a/R/bind.r
+++ b/R/bind.r
@@ -30,6 +30,8 @@
 #'   list of data frames is supplied, the labels are taken from the
 #'   names of the list. If no names are found a numeric sequence is
 #'   used instead.
+#' @param .name_repair Treatment of problematic column names, see [tibble::as_tibble()] for details
+#'
 #' @return `bind_rows()` and `bind_cols()` return the same type as
 #'   the first input, either a data frame, `tbl_df`, or `grouped_df`.
 #' @aliases rbind_all rbind_list
@@ -124,13 +126,13 @@ bind_rows <- function(..., .id = NULL) {
 
 #' @export
 #' @rdname bind
-bind_cols <- function(...) {
+bind_cols <- function(..., .name_repair = "unique") {
   x <- flatten_bindable(dots_values(...))
   out <- cbind_all(x)
 
   # Using `.name_repair` but then gymnastics to keep
   # attributes in case cbind_all did not return a tibble
-  repaired <- as_tibble(out, .name_repair = "unique")
+  repaired <- as_tibble(out, .name_repair = .name_repair)
   repaired_names <- names(repaired)
   attributes(repaired) <- attributes(out)
   names(repaired) <- repaired_names

--- a/R/dataframe.R
+++ b/R/dataframe.R
@@ -241,7 +241,7 @@ do.data.frame <- function(.data, ...) {
   } else {
     out <- map(args, function(arg) list(eval_tidy(arg, mask)))
     names(out) <- names(args)
-    out <- tibble::as_tibble(out, validate = FALSE)
+    out <- tibble::as_tibble(out, .name_repair = "minimal")
   }
 
   out

--- a/man/bind.Rd
+++ b/man/bind.Rd
@@ -10,7 +10,7 @@
 \usage{
 bind_rows(..., .id = NULL)
 
-bind_cols(...)
+bind_cols(..., .name_repair = "unique")
 }
 \arguments{
 \item{...}{Data frames to combine.
@@ -33,6 +33,8 @@ are taken from the named arguments to \code{bind_rows()}. When a
 list of data frames is supplied, the labels are taken from the
 names of the list. If no names are found a numeric sequence is
 used instead.}
+
+\item{.name_repair}{Treatment of problematic column names, see \code{\link[tibble:as_tibble]{tibble::as_tibble()}} for details}
 }
 \value{
 \code{bind_rows()} and \code{bind_cols()} return the same type as

--- a/tests/testthat/test-binds.R
+++ b/tests/testthat/test-binds.R
@@ -624,7 +624,7 @@ test_that("supports NULL values", {
 test_that("bind_cols handles unnamed list (#3402)", {
   expect_identical(
     bind_cols(list(1, 2)),
-    bind_cols(list(`...1` = 1, `...2` = 2))
+    bind_cols(list(...1 = 1, ...2 = 2))
   )
 })
 

--- a/tests/testthat/test-binds.R
+++ b/tests/testthat/test-binds.R
@@ -74,9 +74,7 @@ test_that("bind_cols repairs names", {
   df <- tibble(a = 1, b = 2)
   bound <- bind_cols(df, df)
 
-  repaired <- as_tibble(tibble::repair_names(
-    data.frame(a = 1, b = 2, a = 1, b = 2, check.names = FALSE)
-  ))
+  repaired <- as_tibble(data.frame(a = 1, b = 2, a = 1, b = 2, check.names = FALSE), .name_repair = "unique")
 
   expect_equal(bound, repaired)
 })
@@ -626,7 +624,7 @@ test_that("supports NULL values", {
 test_that("bind_cols handles unnamed list (#3402)", {
   expect_identical(
     bind_cols(list(1, 2)),
-    bind_cols(list(V1 = 1, V2 = 2))
+    bind_cols(list(`...1` = 1, `...2` = 2))
   )
 })
 


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)

bind_cols(tibble(a = 1, b = 2), tibble(a = 3, b = 4))
#> New names:
#> * a -> a...1
#> * b -> b...2
#> * a -> a...3
#> * b -> b...4
#> # A tibble: 1 x 4
#>   a...1 b...2 a...3 b...4
#> * <dbl> <dbl> <dbl> <dbl>
#> 1     1     2     3     4
bind_cols(data.frame(a = 1, b = 2), tibble(a = 3, b = 4))
#> New names:
#> * a -> a...1
#> * b -> b...2
#> * a -> a...3
#> * b -> b...4
#>   a...1 b...2 a...3 b...4
#> 1     1     2     3     4
```

The underlying code does not force the result to be a tibble so I've tried to keep that, although since I'm using `as_tibble()` to invoke name repair, I have to do a 💃 , maybe there's another way?