### PR TITLE
hybrid version of first() and friends for factors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,11 @@
 # dplyr 0.8.1.9000
 
+* `first()`, `last()` and `nth()` hybrid version handles factors (#4295).
+
 * Using quosures in colwise verbs is deprecated (#4330).
 
 * Updated `distinct_if()`, `distinct_at()` and `distinct_all()` to include `.keep_all` argument (@beansrowning, #4343).
+
 * `select.list()` method added so that `select()` does not dispatch on lists (#4279). 
 
 * Updated `distinct_if()`, `distinct_at()` and `distinct_all()` to include `.keep_all` argument (@beansrowning, #4343)

--- a/inst/include/dplyr/hybrid/Column.h
+++ b/inst/include/dplyr/hybrid/Column.h
@@ -7,6 +7,10 @@ namespace hybrid {
 struct Column {
   SEXP data;
   bool is_desc;
+
+  inline bool is_trivial() const {
+    return !Rf_isObject(data) && !Rf_isS4(data) && RCPP_GET_CLASS(data) == R_NilValue;
+  }
 };
 
 }

--- a/inst/include/dplyr/hybrid/Expression.h
+++ b/inst/include/dplyr/hybrid/Expression.h
@@ -362,9 +362,6 @@ private:
       data = subset->get_data() ;
     }
 
-    // only treat very simple columns as columns, leave other to R
-    if (Rf_isObject(data) || Rf_isS4(data) || RCPP_GET_CLASS(data) != R_NilValue) return false;
-
     column.data = data;
     column.is_desc = desc;
     return true;

--- a/inst/include/dplyr/hybrid/scalar_result/first_last.h
+++ b/inst/include/dplyr/hybrid/scalar_result/first_last.h
@@ -135,13 +135,13 @@ SEXP first_dispatch(const SlicedTibble& data, const Expression<SlicedTibble>& ex
   switch (expression.size()) {
   case 1:
     // first( <column> )
-    if (expression.is_unnamed(0) && expression.is_column(0, x)) {
+    if (expression.is_unnamed(0) && expression.is_column(0, x) && x.is_trivial()) {
       return first1_(data, x, op);
     }
     break;
   case 2:
     // first( <column>, default = <scalar> )
-    if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols::default_)) {
+    if (expression.is_unnamed(0) && expression.is_column(0, x) && x.is_trivial() && expression.is_named(1, symbols::default_)) {
       return first2_(data, x, /* default = */ expression.value(1), op);
     }
   default:
@@ -157,13 +157,13 @@ SEXP last_dispatch(const SlicedTibble& data, const Expression<SlicedTibble>& exp
   switch (expression.size()) {
   case 1:
     // last( <column> )
-    if (expression.is_unnamed(0) && expression.is_column(0, x)) {
+    if (expression.is_unnamed(0) && expression.is_column(0, x) && x.is_trivial()) {
       return last1_(data, x, op);
     }
     break;
   case 2:
     // last( <column>, default = <scalar> )
-    if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols::default_)) {
+    if (expression.is_unnamed(0) && expression.is_column(0, x) && x.is_trivial() && expression.is_named(1, symbols::default_)) {
       return last2_(data, x, /* default = */ expression.value(1), op);
     }
   default:
@@ -180,13 +180,13 @@ inline SEXP nth_dispatch(const SlicedTibble& data, const Expression<SlicedTibble
   switch (expression.size()) {
   case 2:
     // nth( <column>, n = <int> )
-    if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols::n) && expression.is_scalar_int(1, n)) {
+    if (expression.is_unnamed(0) && expression.is_column(0, x) && x.is_trivial() && expression.is_named(1, symbols::n) && expression.is_scalar_int(1, n)) {
       return nth2_(data, x, n, op);
     }
     break;
   case 3:
     // nth( <column>, n = <int>, default = <scalar> )
-    if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols::n) && expression.is_scalar_int(1, n) && expression.is_named(2, symbols::default_)) {
+    if (expression.is_unnamed(0) && expression.is_column(0, x) && x.is_trivial() && expression.is_named(1, symbols::n) && expression.is_scalar_int(1, n) && expression.is_named(2, symbols::default_)) {
       return nth3_default(data, x, n, expression.value(2), op);
     }
   default:

--- a/inst/include/dplyr/hybrid/scalar_result/mean_sd_var.h
+++ b/inst/include/dplyr/hybrid/scalar_result/mean_sd_var.h
@@ -185,12 +185,12 @@ SEXP meansdvar_dispatch(const SlicedTibble& data, const Expression<SlicedTibble>
   switch (expression.size()) {
   case 1:
     // fun( <column> )
-    if (expression.is_unnamed(0) && expression.is_column(0, x)) {
+    if (expression.is_unnamed(0) && expression.is_column(0, x) && x.is_trivial()) {
       return internal::SimpleDispatch<SlicedTibble, Impl, Operation>(data, x, na_rm, op).get();
     }
   case 2:
     // fun( <column>, na.rm = <bool> )
-    if (expression.is_unnamed(0) && expression.is_column(0, x) &&
+    if (expression.is_unnamed(0) && expression.is_column(0, x) && x.is_trivial() &&
         expression.is_named(1, symbols::narm) && expression.is_scalar_logical(1, na_rm)
        ) {
       return internal::SimpleDispatch<SlicedTibble, Impl, Operation>(data, x, na_rm, op).get();

--- a/inst/include/dplyr/hybrid/scalar_result/min_max.h
+++ b/inst/include/dplyr/hybrid/scalar_result/min_max.h
@@ -119,14 +119,14 @@ SEXP minmax_dispatch(const SlicedTibble& data, const Expression<SlicedTibble>& e
   switch (expression.size()) {
   case 1:
     // min( <column> )
-    if (expression.is_unnamed(0) && expression.is_column(0, x)) {
+    if (expression.is_unnamed(0) && expression.is_column(0, x) && x.is_trivial()) {
       return minmax_<SlicedTibble, Operation, MINIMUM>(data, x, false, op) ;
     }
   case 2:
     // min( <column>, na.rm = <bool> )
     bool test;
 
-    if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols::narm) && expression.is_scalar_logical(1, test)) {
+    if (expression.is_unnamed(0) && expression.is_column(0, x) && x.is_trivial() && expression.is_named(1, symbols::narm) && expression.is_scalar_logical(1, test)) {
       return minmax_<SlicedTibble, Operation, MINIMUM>(data, x, test, op) ;
     }
   default:

--- a/inst/include/dplyr/hybrid/scalar_result/n_distinct.h
+++ b/inst/include/dplyr/hybrid/scalar_result/n_distinct.h
@@ -68,7 +68,7 @@ SEXP n_distinct_dispatch(const SlicedTibble& tbl, const Expression& expression, 
         // otherwise, we need R to evaluate it, so we give up
         return R_UnboundValue;
       }
-    } else if (expression.is_column(i, column)) {
+    } else if (expression.is_column(i, column) && column.is_trivial()) {
       columns.push_back(shelter(column.data));
     } else {
       // give up, R will handle the call

--- a/inst/include/dplyr/hybrid/scalar_result/sum.h
+++ b/inst/include/dplyr/hybrid/scalar_result/sum.h
@@ -119,13 +119,13 @@ SEXP sum_dispatch(const SlicedTibble& data, const Expression<SlicedTibble>& expr
   switch (expression.size()) {
   case 1:
     // sum( <column> )
-    if (expression.is_unnamed(0) && expression.is_column(0, x)) {
+    if (expression.is_unnamed(0) && expression.is_column(0, x) && x.is_trivial()) {
       return sum_(data, x, /* na.rm = */ false, op);
     }
     break;
   case 2:
     bool test;
-    if (expression.is_unnamed(0) && expression.is_column(0, x) &&
+    if (expression.is_unnamed(0) && expression.is_column(0, x) && x.is_trivial() &&
         expression.is_named(1, symbols::narm) && expression.is_scalar_logical(1, test)
        ) {
       return sum_(data, x, test, op);

--- a/inst/include/dplyr/hybrid/vector_result/in.h
+++ b/inst/include/dplyr/hybrid/vector_result/in.h
@@ -85,7 +85,7 @@ inline SEXP in_dispatch(const SlicedTibble& data, const Expression<SlicedTibble>
     Column lhs;
     Column rhs;
 
-    if (expression.is_unnamed(0) && expression.is_column(0, lhs) && expression.is_unnamed(1) && expression.is_column(1, rhs)) {
+    if (expression.is_unnamed(0) && expression.is_column(0, lhs) && lhs.is_trivial() && expression.is_unnamed(1) && expression.is_column(1, rhs) && rhs.is_trivial()) {
       return in_column_column(data, lhs, rhs, op);
     }
   }

--- a/inst/include/dplyr/hybrid/vector_result/lead_lag.h
+++ b/inst/include/dplyr/hybrid/vector_result/lead_lag.h
@@ -125,7 +125,7 @@ SEXP lead_lag_dispatch(const SlicedTibble& data, const Expression<SlicedTibble>&
   switch (expression.size()) {
   case 1:
     // lead( <column> )
-    if (expression.is_unnamed(0) && expression.is_column(0, x)) {
+    if (expression.is_unnamed(0) && expression.is_column(0, x) && x.is_trivial()) {
       return internal::lead_lag<SlicedTibble, Operation, Impl>(data, x, 1, op);
     }
     break;
@@ -134,7 +134,7 @@ SEXP lead_lag_dispatch(const SlicedTibble& data, const Expression<SlicedTibble>&
     // lead( <column>, n = <int> )
     int n;
 
-    if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols::n) && expression.is_scalar_int(1, n) && n >= 0) {
+    if (expression.is_unnamed(0) && expression.is_column(0, x) && x.is_trivial() && expression.is_named(1, symbols::n) && expression.is_scalar_int(1, n) && n >= 0) {
       return internal::lead_lag<SlicedTibble, Operation, Impl>(data, x, n, op);
     }
   default:

--- a/inst/include/dplyr/hybrid/vector_result/ntile.h
+++ b/inst/include/dplyr/hybrid/vector_result/ntile.h
@@ -127,7 +127,7 @@ SEXP ntile_dispatch(const SlicedTibble& data, const Expression<SlicedTibble>& ex
   case 2:
     // ntile( <column>, n = <int> )
     Column x;
-    if (expression.is_unnamed(0) && expression.is_column(0, x) && expression.is_named(1, symbols::n) && expression.is_scalar_int(1, n)) {
+    if (expression.is_unnamed(0) && expression.is_column(0, x) && x.is_trivial() && expression.is_named(1, symbols::n) && expression.is_scalar_int(1, n)) {
       return ntile_2(data, x, n, op);
     }
   default:

--- a/inst/include/dplyr/hybrid/vector_result/rank.h
+++ b/inst/include/dplyr/hybrid/vector_result/rank.h
@@ -225,7 +225,7 @@ inline SEXP rank_(const SlicedTibble& data, Column column, const Operation& op) 
 template <typename SlicedTibble, typename Operation, typename Increment>
 SEXP rank_dispatch(const SlicedTibble& data, const Expression<SlicedTibble>& expression, const Operation& op) {
   Column x;
-  if (expression.is_unnamed(0) && expression.is_column(0, x)) {
+  if (expression.is_unnamed(0) && expression.is_column(0, x) && x.is_trivial()) {
     return internal::rank_<SlicedTibble, Operation, Increment>(data, x, op);
   }
   return R_UnboundValue;

--- a/inst/include/dplyr/hybrid/vector_result/row_number.h
+++ b/inst/include/dplyr/hybrid/vector_result/row_number.h
@@ -101,7 +101,7 @@ SEXP row_number_dispatch(const SlicedTibble& data, const Expression<SlicedTibble
   case 1:
     // row_number( <column> )
     Column x;
-    if (expression.is_unnamed(0) && expression.is_column(0, x)) {
+    if (expression.is_unnamed(0) && expression.is_column(0, x) && x.is_trivial()) {
       return row_number_1(data, x, op);
     }
   default:

--- a/inst/include/dplyr/symbols.h
+++ b/inst/include/dplyr/symbols.h
@@ -83,6 +83,10 @@ struct strings {
   static SEXP Date;
 };
 
+struct vectors {
+  static SEXP factor;
+};
+
 } // namespace dplyr
 
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -24,6 +24,11 @@ SEXP get_time_classes() {
   return klasses;
 }
 
+SEXP get_factor_classes() {
+  static Rcpp::CharacterVector klasses(1, Rf_mkChar("factor"));
+  return klasses;
+}
+
 SEXP mark_precious(SEXP x) {
   R_PreserveObject(x);
   return x;
@@ -102,4 +107,6 @@ SEXP fns::quote = Rf_eval(Rf_install("quote"), R_BaseEnv);
 SEXP strings::POSIXct = STRING_ELT(get_time_classes(), 0);
 SEXP strings::POSIXt = STRING_ELT(get_time_classes(), 1);
 SEXP strings::Date = STRING_ELT(get_date_classes(), 0);
+
+SEXP vectors::factor = get_factor_classes();
 }


### PR DESCRIPTION
``` r
library(dplyr)

n = 1e5
dat = tibble(
  id  = sample(x = seq(1, n),    size = n, replace = TRUE),
  val = sample(x = letters[1:4], size = n, replace = TRUE) %>%
    factor(., levels = letters[1:4]))

f1 <- function(dat) {
  dat %>%
    group_by(id) %>%
    summarise(first_val = dplyr::first(val))
}

f2 <- function(dat) {
  dat %>%
    mutate(val = as.character(val)) %>%
    group_by(id) %>%
    summarise(first_val = dplyr::first(val)) %>%
    mutate(first_val = factor(first_val, levels = letters[1:4]))
}

bench::mark(f1(dat), f2(dat))
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 2 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 f1(dat)       235ms    251ms      3.98    1.76MB     3.98
#> 2 f2(dat)       251ms    256ms      3.91    2.71MB     3.91
```

<sup>Created on 2019-05-31 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>