### PR TITLE
`group_by()` puts NA groups last in character vectors.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,11 @@
 # dplyr 0.8.1.9000
 
+* `group_by()` puts NA groups last in character vectors (#4227).
+
 * Using quosures in colwise verbs is deprecated (#4330).
 
 * Updated `distinct_if()`, `distinct_at()` and `distinct_all()` to include `.keep_all` argument (@beansrowning, #4343).
+
 * `select.list()` method added so that `select()` does not dispatch on lists (#4279). 
 
 * Updated `distinct_if()`, `distinct_at()` and `distinct_all()` to include `.keep_all` argument (@beansrowning, #4343)

--- a/inst/include/dplyr/visitors/vector/VectorVisitorImpl.h
+++ b/inst/include/dplyr/visitors/vector/VectorVisitorImpl.h
@@ -115,6 +115,7 @@ protected:
 template <>
 class VectorVisitorImpl<STRSXP> : public VectorVisitor {
 public:
+  typedef comparisons<INTSXP> int_compare;
 
   VectorVisitorImpl(const Rcpp::CharacterVector& vec_) :
     vec(reencode_char(vec_)), has_orders(false)
@@ -129,7 +130,7 @@ public:
 
   inline bool less(int i, int j) const {
     provide_orders();
-    return orders[i] < orders[j];
+    return int_compare::is_less(orders[i], orders[j]);
   }
 
   inline bool equal_or_both_na(int i, int j) const {
@@ -138,7 +139,7 @@ public:
 
   inline bool greater(int i, int j) const {
     provide_orders();
-    return orders[i] > orders[j];
+    return int_compare::is_greater(orders[i], orders[j]);
   }
 
   int size() const {

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -519,3 +519,10 @@ test_that("group_by_drop_default() is forgiving about corrupt grouped df (#4306)
   expect_true(group_by_drop_default(df))
 })
 
+test_that("group_by() puts NA groups last in STRSXP (#4227)", {
+  res <- tibble(x = c("apple", NA, "banana"), y = 1:3) %>%
+    group_by(x) %>%
+    group_data()
+  expect_identical(res$x, c("apple", "banana", NA_character_))
+  expect_identical(res$.rows, list(1L, 3L, 2L))
+})


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)

tbl <- tibble(
  x = c("apple", NA, "banana"), 
  y = 1:3
)
tbl %>% 
  group_by(x) %>% 
  group_data()
#> # A tibble: 3 x 2
#>   x      .rows    
#>   <chr>  <list>   
#> 1 apple  <int [1]>
#> 2 banana <int [1]>
#> 3 <NA>   <int [1]>
```

<sup>Created on 2019-05-31 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>