### PR TITLE
extend funs() deprecation message.

### DIFF
--- a/R/funs.R
+++ b/R/funs.R
@@ -45,13 +45,16 @@
 funs <- function(..., .args = list()) {
   signal_soft_deprecated(paste_line(
     "funs() is soft deprecated as of dplyr 0.8.0",
-    "please use list() instead",
+    "please use a list of either functions or lambdas, some examples: ",
     "",
-    "  # Before:",
-    "  funs(name = f(.))",
+    "  # simple named list: ",
+    "  list(mean = mean, median = median)",
     "",
-    "  # After: ",
-    "  list(name = ~ f(.))"
+    "  # auto named with tibble::lst(): ",
+    "  tibble::lst(mean, median)",
+    "",
+    "  # using lambdas",
+    "  list(mean = ~mean(., trim = .2), median = ~median(., na.rm = TRUE))"
   ))
   dots <- enquos(...)
   default_env <- caller_env()

--- a/R/funs.R
+++ b/R/funs.R
@@ -45,16 +45,16 @@
 funs <- function(..., .args = list()) {
   signal_soft_deprecated(paste_line(
     "funs() is soft deprecated as of dplyr 0.8.0",
-    "please use a list of either functions or lambdas, some examples: ",
+    "Please use a list of either functions or lambdas: ",
     "",
-    "  # simple named list: ",
+    "  # Simple named list: ",
     "  list(mean = mean, median = median)",
     "",
-    "  # auto named with tibble::lst(): ",
+    "  # Auto named with `tibble::lst()`: ",
     "  tibble::lst(mean, median)",
     "",
-    "  # using lambdas",
-    "  list(mean = ~mean(., trim = .2), median = ~median(., na.rm = TRUE))"
+    "  # Using lambdas",
+    "  list(~ mean(., trim = .2), ~ median(., na.rm = TRUE))"
   ))
   dots <- enquos(...)
   default_env <- caller_env()


### PR DESCRIPTION
This does not mention `list2()` because it's not so easy to figure out a simple example that would benefit from splicing. 

``` r
library(dplyr, warn.conflicts = FALSE)
library(purrr)

p <- c(0.2, 0.5, 0.8)

p_names <- map_chr(p, ~paste0(.x*100, "%"))

p_funs <- map(p, ~partial(quantile, probs = .x, na.rm = TRUE)) %>% 
  set_names(nm = p_names) 

mtcars %>% 
  group_by(cyl) %>% 
  summarize_at(vars(mpg), funs(!!!p_funs))
#> Warning: funs() is soft deprecated as of dplyr 0.8.0
#> please use a list of either functions or lambdas, some examples: 
#> 
#>   # simple named list: 
#>   list(mean = mean, median = median)
#> 
#>   # auto named with tibble::lst(): 
#>   tibble::lst(mean, median)
#> 
#>   # using lambdas
#>   list(mean = ~mean(., trim = .2), median = ~median(., na.rm = TRUE))
#> This warning is displayed once per session.
#> # A tibble: 3 x 4
#>     cyl `20%` `50%` `80%`
#>   <dbl> <dbl> <dbl> <dbl>
#> 1     4  22.8  26    30.4
#> 2     6  18.3  19.7  21  
#> 3     8  13.9  15.2  16.8
```

So this is phrased not so much about which function you have to use, but rather what object you should be giving, i.e. in the example from #4302 there's no need for splicing because `p_funs` is already the thing we want: a list of functions. 

``` r
library(dplyr, warn.conflicts = FALSE)
library(purrr)

p <- c(0.2, 0.5, 0.8)

p_names <- map_chr(p, ~paste0(.x*100, "%"))

p_funs <- map(p, ~partial(quantile, probs = .x, na.rm = TRUE)) %>% 
  set_names(nm = p_names) 

mtcars %>% 
  group_by(cyl) %>% 
  summarize_at(vars(mpg), p_funs)
#> # A tibble: 3 x 4
#>     cyl `20%` `50%` `80%`
#>   <dbl> <dbl> <dbl> <dbl>
#> 1     4  22.8  26    30.4
#> 2     6  18.3  19.7  21  
#> 3     8  13.9  15.2  16.8
```


