### PR TITLE
Update progress.R

### DIFF
--- a/R/progress.R
+++ b/R/progress.R
@@ -77,8 +77,8 @@ Progress <- R6::R6Class("Progress",
       "Process one element"
       if (self$stopped) return(self)
 
-      if (self$i == self$n) abort("No more ticks")
-      self$i <- self$i + 1
+      if (self$i == self$n) warning("No more ticks")
+      else self$i <- self$i + 1
       self
     },
 


### PR DESCRIPTION
tick function aborts and throws an error if number of ticks is exceeded. For the user, it is not desired to abort a time consuming task just because the initialization of a user feedback was carried out wrong. Therefore, I propose to just throw a warning and proceed with the task even though the progress bar is not reliable anymore.