### PR TITLE
filter() gives more information on size mismatch errors

### DIFF
--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -16,9 +16,13 @@
 namespace dplyr {
 
 inline
-void check_result_length(const Rcpp::LogicalVector& test, int n) {
+void check_result_length(const Rcpp::LogicalVector& test, int n, const Quosure& quo) {
   if (test.size() != n) {
-    Rcpp::stop("Result must have length %d, not %d", n, test.size());
+    Rcpp::Shield<SEXP> expr(quo.expr());
+    Rcpp::Environment rlang = Rcpp::Environment::namespace_env("rlang");
+    Rcpp::Function as_label = rlang["as_label"];
+    Rcpp::CharacterVector label = as_label(quo);
+    Rcpp::stop("Result of `%s` must have length %d, not %d.", CHAR(label[0].get()), n, test.size());
   }
 }
 
@@ -256,7 +260,7 @@ SEXP filter_template(const SlicedTibble& gdf, const Quosure& quo) {
       }
     } else {
       // any other size, so we check that it is consistent with the group size
-      check_result_length(g_test, chunk_size);
+      check_result_length(g_test, chunk_size, quo);
       group_indices.add_group_lgl(i, g_test);
     }
   }

--- a/tests/testthat/test-filter.r
+++ b/tests/testthat/test-filter.r
@@ -3,12 +3,12 @@ context("Filter")
 test_that("filter fails if inputs incorrect length (#156)", {
   expect_error(
     filter(tbl_df(mtcars), c(F, T)),
-    "Result must have length 32, not 2",
+    "Result of `c(F, T)` must have length 32, not 2",
     fixed = TRUE
   )
   expect_error(
     filter(group_by(mtcars, am), c(F, T)),
-    "Result must have length 19, not 2",
+    "Result of `c(F, T)` must have length 19, not 2",
     fixed = TRUE
   )
 })


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)

starwars %>%
  mutate(age_bracket = case_when(
    birth_year < 21 ~ "kids",
    birth_year >= 18 & birth_year < 65 ~ "adults",
    TRUE ~ "Senior citizen discounts for Yoda & friends, woo"
  )) %>%
  filter(starwars$age_bracket == "kids")
#> Warning: Unknown or uninitialised column: 'age_bracket'.
#> Error: Result of `starwars$age_bracket == "kids"` must have length 87, not 0.
```

I realize @brooke-watson that it does not tell you the problem is because the `$` but I believe seeing the expression that generated the problem helps. 
