### PR TITLE
update some tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ jobs:
 
 matrix:
   fast_finish: true
+  allow_failures:
+  - env: DEVEL_PACKAGES=true
 
 env:
   global:

--- a/R/utils-expr.R
+++ b/R/utils-expr.R
@@ -22,7 +22,7 @@ node_walk_replace <- function(node, old, new) {
 }
 expr_substitute <- function(expr, old, new) {
   expr <- duplicate(expr)
-  switch_type(expr,
+  switch(typeof(expr),
     quosure = node_walk_replace(quo_get_expr(expr), old, new),
     formula = ,
     language = node_walk_replace(node_cdr(expr), old, new),

--- a/R/utils.r
+++ b/R/utils.r
@@ -21,7 +21,7 @@ any_apply <- function(xs, f) {
 }
 
 deparse_names <- function(x) {
-  x <- map_if(x, is_quosure, quo_expr)
+  x <- map_if(x, is_quosure, quo_squash)
   x <- map_if(x, is_bare_formula, f_rhs)
   map_chr(x, deparse)
 }

--- a/tests/testthat/test-colwise-filter.R
+++ b/tests/testthat/test-colwise-filter.R
@@ -29,8 +29,9 @@ test_that("aborts when supplied funs() or list", {
     "`.vars_predicate` must be a function or a call to `all_vars()` or `any_vars()`, not a list",
     fixed = TRUE
   )
+
   expect_error(
-    filter_all(mtcars, funs(. > 0)),
+    with_lifecycle_silence(filter_all(mtcars, funs(. > 0))),
     "`.vars_predicate` must be a function or a call to `all_vars()` or `any_vars()`, not a `fun_list` object",
     fixed = TRUE
   )

--- a/tests/testthat/test-colwise-mutate.R
+++ b/tests/testthat/test-colwise-mutate.R
@@ -4,7 +4,9 @@ test_that("funs found in current environment", {
   f <- function(x) 1
   df <- data.frame(x = c(2:10, 1000))
 
-  out <- summarise_all(df, funs(f, mean, median))
+  with_lifecycle_silence({
+    out <- summarise_all(df, funs(f, mean, median))
+  })
   expect_equal(out, data.frame(f = 1, mean = 105.4, median = 6.5))
 
   out <- summarise_all(df, list(f = f, mean = mean, median = median))
@@ -14,6 +16,7 @@ test_that("funs found in current environment", {
 
 test_that("can use character vectors", {
   df <- data.frame(x = 1:3)
+  scoped_lifecycle_silence()
 
   expect_equal(summarise_all(df, "mean"), summarise_all(df, funs(mean)))
   expect_equal(mutate_all(df, list(mean = "mean")), mutate_all(df, funs(mean = mean)))
@@ -24,6 +27,7 @@ test_that("can use character vectors", {
 
 test_that("can use bare functions", {
   df <- data.frame(x = 1:3)
+  scoped_lifecycle_silence()
 
   expect_equal(summarise_all(df, mean), summarise_all(df, funs(mean)))
   expect_equal(mutate_all(df, mean), mutate_all(df, funs(mean)))
@@ -34,6 +38,7 @@ test_that("can use bare functions", {
 
 test_that("default names are smallest unique set", {
   df <- data.frame(x = 1:3, y = 1:3)
+  scoped_lifecycle_silence()
 
   expect_named(summarise_at(df, vars(x:y), funs(mean)), c("x", "y"))
   expect_named(summarise_at(df, vars(x), funs(mean, sd)), c("mean", "sd"))
@@ -48,6 +53,7 @@ test_that("default names are smallest unique set", {
 })
 
 test_that("named arguments force complete named", {
+  scoped_lifecycle_silence()
   df <- data.frame(x = 1:3, y = 1:3)
   expect_named(summarise_at(df, vars(x:y), funs(mean = mean)), c("x_mean", "y_mean"))
   expect_named(summarise_at(df, vars(x = x), funs(mean = mean, sd = sd)), c("x_mean", "x_sd"))
@@ -112,6 +118,7 @@ test_that("predicate can be quoted", {
 })
 
 test_that("transmute verbs do not retain original variables", {
+  scoped_lifecycle_silence()
   expect_named(transmute_all(tibble(x = 1:3, y = 1:3), funs(mean, sd)), c("x_mean", "y_mean", "x_sd", "y_sd"))
   expect_named(transmute_if(tibble(x = 1:3, y = 1:3), is_integer, funs(mean, sd)), c("x_mean", "y_mean", "x_sd", "y_sd"))
   expect_named(transmute_at(tibble(x = 1:3, y = 1:3), vars(x:y), funs(mean, sd)), c("x_mean", "y_mean", "x_sd", "y_sd"))
@@ -131,6 +138,7 @@ test_that("selection works with grouped data frames (#2624)", {
 })
 
 test_that("at selection works even if not all ops are named (#2634)", {
+  scoped_lifecycle_silence()
   df <- tibble(x = 1, y = 2)
   expect_identical(mutate_at(df, vars(z = x, y), funs(. + 1)), tibble(x = 1, y = 3, z = 2))
   expect_identical(mutate_at(df, vars(z = x, y), list(~. + 1)), tibble(x = 1, y = 3, z = 2))
@@ -251,6 +259,7 @@ test_that("group_by_(at,all) handle utf-8 names (#3829)", {
 
 test_that("*_(all,at) handle utf-8 names (#2967)", {
   skip_if(getRversion() <= "3.4.0")
+  scoped_lifecycle_silence()
   withr::with_locale( c(LC_CTYPE = "C"), {
     name <- "\u4e2d"
     tbl <- tibble(a = 1) %>%

--- a/tests/testthat/test-colwise-select.R
+++ b/tests/testthat/test-colwise-select.R
@@ -27,6 +27,7 @@ test_that("can select/rename with predicate", {
 })
 
 test_that("can supply funs()", {
+  scoped_lifecycle_silence()
   expect_identical(select_if(df, funs(is_integerish(.)), funs(toupper(.))), set_names(df[c("x", "z")], c("X", "Z")))
   expect_identical(rename_if(df, funs(is_integerish(.)), funs(toupper(.))), set_names(df, c("X", "y", "Z")))
 
@@ -35,6 +36,7 @@ test_that("can supply funs()", {
 })
 
 test_that("fails when more than one renaming function is supplied", {
+  scoped_lifecycle_silence()
   expect_error(
     select_all(df, funs(tolower, toupper)),
     "`.funs` must contain one renaming function, not 2",

--- a/tests/testthat/test-colwise.R
+++ b/tests/testthat/test-colwise.R
@@ -17,6 +17,7 @@ test_that("tbl_at_vars() treats `NULL` as empty inputs", {
 })
 
 test_that("tbl_if_vars() errs on bad input", {
+  scoped_lifecycle_silence()
   expect_error(
     tbl_if_vars(iris, funs(identity, force), environment()),
     "`.predicate` must have length 1, not 2",

--- a/tests/testthat/test-funs.R
+++ b/tests/testthat/test-funs.R
@@ -1,30 +1,36 @@
 context("funs")
 
 test_that("fun_list is merged with new args", {
+  scoped_lifecycle_silence()
   funs <- funs(fn = bar)
   funs <- as_fun_list(funs, env(), baz = "baz")
   expect_identical(funs$fn, quo(bar(., baz = "baz")))
 })
 
 test_that("funs() works with namespaced calls", {
+  scoped_lifecycle_silence()
   expect_identical(summarise_all(mtcars, funs(base::mean(.))), summarise_all(mtcars, funs(mean(.))))
   expect_identical(summarise_all(mtcars, funs(base::mean)), summarise_all(mtcars, funs(mean(.))))
 })
 
 test_that("funs() accepts quoted functions", {
+  scoped_lifecycle_silence()
   expect_identical(funs(mean), funs("mean"))
 })
 
 test_that("funs() accepts unquoted functions", {
+  scoped_lifecycle_silence()
   funs <- funs(fn = !!mean)
   expect_identical(funs$fn, new_quosure(call2(base::mean, quote(.))))
 })
 
 test_that("funs() accepts quoted calls", {
+  scoped_lifecycle_silence()
   expect_identical(funs(mean), funs(mean(.)))
 })
 
 test_that("funs() gives a clear error message (#3368)", {
+  scoped_lifecycle_silence()
   expect_error(
     funs(function(si) { mp[si] }),
     glue("`function(si) {{
@@ -41,6 +47,7 @@ test_that("funs() gives a clear error message (#3368)", {
 })
 
 test_that("funs() can be merged with new arguments", {
+  scoped_lifecycle_silence()
   fns <- funs(foo(.))
   expect_identical(as_fun_list(fns, current_env(), foo = 1L), funs(foo(., foo = 1L)))
 })
@@ -63,6 +70,7 @@ test_that("can enfun() named functions by expression", {
 })
 
 test_that("local objects are not treated as symbols", {
+  scoped_lifecycle_silence()
   mean <- funs(my_mean(.))
   expect_identical(enfun(mean), mean)
 })

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -11,6 +11,7 @@ test_that("group_by with add = TRUE adds groups", {
 })
 
 test_that("group_by_ backwards compatibility with add = TRUE adds groups", {
+  scoped_lifecycle_silence()
   add_groups_extendedclass <- function(tbl) {
     grouped <- group_by(tbl, x)
     group_by.default(grouped, y, add = TRUE)

--- a/tests/testthat/test-group_data.R
+++ b/tests/testthat/test-group_data.R
@@ -83,8 +83,9 @@ test_that("old group format repair does not keep a vars attribute around", {
   attr(tbl, "vars") <- rlang::sym("x")
   class(tbl) <- c("grouped_df", "tbl_df", "tbl", "data.frame")
 
-  res <- tbl %>%
-    group_by(y)
+  expect_warning({
+    res <- tbl %>% group_by(y)
+  })
   expect_equal(group_vars(res), "y")
   expect_null(attr(res, " vars"))
   expect_null(attr(tbl, " vars"))

--- a/tests/testthat/test-hybrid-traverse.R
+++ b/tests/testthat/test-hybrid-traverse.R
@@ -469,6 +469,7 @@ test_hybrid <- function(grouping) {
         summarise_at(vars(env, data), list(mean))
     )
 
+    scoped_lifecycle_silence()
     expect_equal(
       conflict_data %>%
         grouping() %>%

--- a/tests/testthat/test-overscope.R
+++ b/tests/testthat/test-overscope.R
@@ -3,11 +3,13 @@ context("overscope")
 test_that(".data has strict matching semantics (#2591)", {
   expect_error(
     tibble(a = 1) %>% mutate(c = .data$b),
-    "data"
+    "data",
+    class = "rlang_data_pronoun_not_found"
   )
 
   expect_error(
     tibble(a = 1:3) %>% group_by(a) %>% mutate(c = .data$b),
-    "data"
+    "data",
+    class = "rlang_data_pronoun_not_found"
   )
 })

--- a/tests/testthat/test-overscope.R
+++ b/tests/testthat/test-overscope.R
@@ -1,15 +1,16 @@
 context("overscope")
 
 test_that(".data has strict matching semantics (#2591)", {
-  expect_error(
+  # testthat says to use class =
+  # but I guess older versions of R don't have the newest testthat
+  # because that gives me an error
+  suppressWarnings(expect_error(
     tibble(a = 1) %>% mutate(c = .data$b),
-    "data",
-    class = "rlang_data_pronoun_not_found"
-  )
+    "Column `b` not found in `.data`"
+  ))
 
-  expect_error(
+  suppressWarnings(expect_error(
     tibble(a = 1:3) %>% group_by(a) %>% mutate(c = .data$b),
-    "data",
-    class = "rlang_data_pronoun_not_found"
-  )
+    "Column `b` not found in `.data`"
+  ))
 })

--- a/tests/testthat/test-tbl-cube.R
+++ b/tests/testthat/test-tbl-cube.R
@@ -53,7 +53,7 @@ test_that("incomplete", {
 
   cube <- as.tbl_cube(d, met_name = "value")
   expect_true(is.na(as.data.frame(filter(cube, s == 1, j == 2))[["value"]]))
-  expect_equal(filter(as_data_frame(as.data.frame(cube)), s != 1 | j != 2), d)
+  expect_equal(filter(as_tibble(cube), s != 1 | j != 2), d)
 })
 
 test_that("duplicate", {
@@ -107,7 +107,7 @@ test_that("can coerce to data_frame", {
 
   expect_identical(
     tbl_df(as.data.frame(slice, stringsAsFactors = FALSE)),
-    as_data_frame(slice)
+    as_tibble(slice)
   )
 })
 


### PR DESCRIPTION
mostly so that I don't see the lifecycle warnings when testing e.g. `funs()` 

But maybe I don't do this correctly, wasn't there something to disable soft deprecation warnings from dplyr when testing dplyr ? @lionel- 