### PR TITLE
group_map() and group_modify() work with 0 groups grouped_df

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # dplyr 0.8.1.9000
 
+* `group_split()` always sets the `ptype` attribute. 
+
+* `group_map()` and `group_modify()` work in the 0 group edge case (#4421)
+
 * `view()` is reexported from tibble (#4423). 
 
 * `top_n()` quotes its `n` argument. 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -116,8 +116,8 @@ ungroup_grouped_df <- function(df) {
     .Call(`_dplyr_ungroup_grouped_df`, df)
 }
 
-group_split_impl <- function(gdf, keep, frame, ptype) {
-    .Call(`_dplyr_group_split_impl`, gdf, keep, frame, ptype)
+group_split_impl <- function(gdf, keep, frame) {
+    .Call(`_dplyr_group_split_impl`, gdf, keep, frame)
 }
 
 hybrids <- function() {

--- a/R/group_map.R
+++ b/R/group_map.R
@@ -163,7 +163,12 @@ group_modify.grouped_df <- function(.tbl, .f, ..., keep = FALSE) {
     }
     bind_cols(.y[rep(1L, nrow(res)), , drop = FALSE], res)
   }
-  res <- bind_rows(!!!group_map(.tbl, fun, ..., keep = keep))
+  chunks <- group_map(.tbl, fun, ..., keep = keep)
+  res <- if (length(chunks)) {
+    bind_rows(!!!chunks)
+  } else {
+    attr(chunks, "ptype")
+  }
   group_by(res, !!!groups(.tbl), .drop = group_by_drop_default(.tbl))
 }
 

--- a/R/group_map.R
+++ b/R/group_map.R
@@ -121,7 +121,7 @@ group_map <- function(.tbl, .f, ..., keep = FALSE) {
   .f <- as_group_map_function(.f)
 
   # call the function on each group
-  chunks <- group_split(.tbl, keep = keep)
+  chunks <- group_split(.tbl, keep = isTRUE(keep))
   keys  <- group_keys(.tbl)
   group_keys <- map(seq_len(nrow(keys)), function(i) keys[i, , drop = FALSE])
   map2(chunks, group_keys, .f, ...)

--- a/R/group_map.R
+++ b/R/group_map.R
@@ -164,7 +164,7 @@ group_modify.grouped_df <- function(.tbl, .f, ..., keep = FALSE) {
     bind_cols(.y[rep(1L, nrow(res)), , drop = FALSE], res)
   }
   chunks <- group_map(.tbl, fun, ..., keep = keep)
-  res <- if (length(chunks)) {
+  res <- if (length(chunks) > 0L) {
     bind_rows(!!!chunks)
   } else {
     attr(chunks, "ptype")

--- a/R/group_map.R
+++ b/R/group_map.R
@@ -124,7 +124,13 @@ group_map <- function(.tbl, .f, ..., keep = FALSE) {
   chunks <- group_split(.tbl, keep = isTRUE(keep))
   keys  <- group_keys(.tbl)
   group_keys <- map(seq_len(nrow(keys)), function(i) keys[i, , drop = FALSE])
-  map2(chunks, group_keys, .f, ...)
+
+  if (length(chunks)) {
+    map2(chunks, group_keys, .f, ...)
+  } else {
+    # calling .f with .x and .y set to prototypes
+    structure(list(), ptype = .f(attr(chunks, "ptype"), keys[integer(0L), ], ...))
+  }
 }
 
 #' @rdname group_map

--- a/R/group_nest.R
+++ b/R/group_nest.R
@@ -1,6 +1,6 @@
 
 group_nest_impl <- function(.tbl, .key, keep = FALSE){
-  mutate(group_keys(.tbl), !!.key := group_split_impl(.tbl, isTRUE(keep), environment(), TRUE))
+  mutate(group_keys(.tbl), !!.key := group_split_impl(.tbl, isTRUE(keep), environment()))
 }
 
 #' Nest a tibble using a grouping specification

--- a/R/group_split.R
+++ b/R/group_split.R
@@ -83,9 +83,9 @@ group_split <- function(.tbl, ..., keep = TRUE) {
 #' @export
 group_split.data.frame <- function(.tbl, ..., keep = TRUE) {
   if (dots_n(...)) {
-    group_split_impl(group_by(.tbl, ...), isTRUE(keep), environment(), FALSE)
+    group_split_impl(group_by(.tbl, ...), isTRUE(keep), environment())
   } else {
-    list(.tbl)
+    structure(list(.tbl), ptype = .tbl[integer(0L), ])
   }
 }
 
@@ -97,7 +97,7 @@ group_split.rowwise_df <- function(.tbl, ..., keep = TRUE) {
   if (!missing(keep)) {
     warn("keep is ignored in group_split(<rowwise_df>)")
   }
-  map(seq_len(nrow(.tbl)), function(i) .tbl[i, ])
+  structure(map(seq_len(nrow(.tbl)), function(i) .tbl[i, ]), ptype = .tbl[0L, ])
 }
 
 #' @export
@@ -105,5 +105,5 @@ group_split.grouped_df <- function(.tbl, ..., keep = TRUE) {
   if (dots_n(...)) {
     warn("... is ignored in group_split(<grouped_df>), please use group_by(..., add = TRUE) %>% group_split()")
   }
-  group_split_impl(.tbl, isTRUE(keep), environment(), FALSE)
+  group_split_impl(.tbl, isTRUE(keep), environment())
 }

--- a/R/group_split.R
+++ b/R/group_split.R
@@ -85,7 +85,7 @@ group_split.data.frame <- function(.tbl, ..., keep = TRUE) {
   if (dots_n(...)) {
     group_split_impl(group_by(.tbl, ...), isTRUE(keep), environment())
   } else {
-    structure(list(.tbl), ptype = .tbl[integer(0L), ])
+    structure(list(.tbl), ptype = .tbl[0L, ])
   }
 }
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -252,15 +252,14 @@ BEGIN_RCPP
 END_RCPP
 }
 // group_split_impl
-Rcpp::List group_split_impl(const dplyr::GroupedDataFrame& gdf, bool keep, SEXP frame, bool ptype);
-RcppExport SEXP _dplyr_group_split_impl(SEXP gdfSEXP, SEXP keepSEXP, SEXP frameSEXP, SEXP ptypeSEXP) {
+Rcpp::List group_split_impl(const dplyr::GroupedDataFrame& gdf, bool keep, SEXP frame);
+RcppExport SEXP _dplyr_group_split_impl(SEXP gdfSEXP, SEXP keepSEXP, SEXP frameSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< const dplyr::GroupedDataFrame& >::type gdf(gdfSEXP);
     Rcpp::traits::input_parameter< bool >::type keep(keepSEXP);
     Rcpp::traits::input_parameter< SEXP >::type frame(frameSEXP);
-    Rcpp::traits::input_parameter< bool >::type ptype(ptypeSEXP);
-    rcpp_result_gen = Rcpp::wrap(group_split_impl(gdf, keep, frame, ptype));
+    rcpp_result_gen = Rcpp::wrap(group_split_impl(gdf, keep, frame));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -659,7 +658,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dplyr_grouped_df_impl", (DL_FUNC) &_dplyr_grouped_df_impl, 3},
     {"_dplyr_group_data_grouped_df", (DL_FUNC) &_dplyr_group_data_grouped_df, 1},
     {"_dplyr_ungroup_grouped_df", (DL_FUNC) &_dplyr_ungroup_grouped_df, 1},
-    {"_dplyr_group_split_impl", (DL_FUNC) &_dplyr_group_split_impl, 4},
+    {"_dplyr_group_split_impl", (DL_FUNC) &_dplyr_group_split_impl, 3},
     {"_dplyr_hybrids", (DL_FUNC) &_dplyr_hybrids, 0},
     {"_dplyr_semi_join_impl", (DL_FUNC) &_dplyr_semi_join_impl, 6},
     {"_dplyr_anti_join_impl", (DL_FUNC) &_dplyr_anti_join_impl, 6},

--- a/src/group_indices.cpp
+++ b/src/group_indices.cpp
@@ -685,7 +685,7 @@ Rcpp::DataFrame ungroup_grouped_df(Rcpp::DataFrame df) {
 }
 
 // [[Rcpp::export(rng = false)]]
-Rcpp::List group_split_impl(const dplyr::GroupedDataFrame& gdf, bool keep, SEXP frame, bool ptype) {
+Rcpp::List group_split_impl(const dplyr::GroupedDataFrame& gdf, bool keep, SEXP frame) {
   Rcpp::ListView rows = gdf.indices();
   R_xlen_t n = rows.size();
 
@@ -724,11 +724,11 @@ Rcpp::List group_split_impl(const dplyr::GroupedDataFrame& gdf, bool keep, SEXP 
     dplyr::GroupedDataFrame::strip_groups(out_i);
     out[i] = out_i;
   }
-  if (ptype) {
-    Rf_setAttrib(
-      out, dplyr::symbols::ptype,
-      dplyr::dataframe_subset(data, Rcpp::IntegerVector(0), dplyr::NaturalDataFrame::classes(), frame)
-    );
-  }
+
+  Rf_setAttrib(
+    out, dplyr::symbols::ptype,
+    dplyr::dataframe_subset(data, Rcpp::IntegerVector(0), dplyr::NaturalDataFrame::classes(), frame)
+  );
+
   return out;
 }

--- a/tests/testthat/test-group_map.R
+++ b/tests/testthat/test-group_map.R
@@ -97,7 +97,7 @@ test_that("group_modify() works on ungrouped data frames (#4067)", {
   )
 })
 
-test_that("group_map() uses ptype on empty splits", {
+test_that("group_map() uses ptype on empty splits (#4421)", {
   res <- mtcars %>%
     group_by(cyl) %>%
     filter(hp > 1000) %>%
@@ -107,4 +107,12 @@ test_that("group_map() uses ptype on empty splits", {
   expect_equal(names(ptype), setdiff(names(mtcars), "cyl"))
   expect_equal(nrow(ptype), 0L)
   expect_is(ptype, "data.frame")
+})
+
+test_that("group_modify() uses ptype on empty splits (#4421)", {
+  res <- mtcars %>%
+    group_by(cyl) %>%
+    filter(hp > 1000) %>%
+    group_modify(~.x)
+  expect_equal(res, group_by(mtcars[integer(0L), ], cyl))
 })

--- a/tests/testthat/test-group_map.R
+++ b/tests/testthat/test-group_map.R
@@ -96,3 +96,15 @@ test_that("group_modify() works on ungrouped data frames (#4067)", {
     head(mtcars, 2L)
   )
 })
+
+test_that("group_map() uses ptype on empty splits", {
+  res <- mtcars %>%
+    group_by(cyl) %>%
+    filter(hp > 1000) %>%
+    group_map(~.x)
+  expect_equivalent(res, list())
+  ptype <- attr(res, "ptype")
+  expect_equal(names(ptype), setdiff(names(mtcars), "cyl"))
+  expect_equal(nrow(ptype), 0L)
+  expect_is(ptype, "data.frame")
+})

--- a/tests/testthat/test-group_split.R
+++ b/tests/testthat/test-group_split.R
@@ -3,22 +3,22 @@ context("group_split")
 test_that("group_split() keeps the grouping variables by default", {
   tbl <- tibble(x = 1:4, g = factor(rep(c("a", "b"), each = 2)))
   res <- group_split(tbl, g)
-  expect_equal(res, list(tbl[1:2,], tbl[3:4,]))
+  expect_equivalent(res, list(tbl[1:2,], tbl[3:4,]))
 })
 
 test_that("group_split() can discard the grouping variables with keep = FALSE", {
   tbl <- tibble(x = 1:4, g = factor(rep(c("a", "b"), each = 2)))
   res <- group_split(tbl, g, keep = FALSE)
-  expect_equal(res, list(tbl[1:2, 1, drop = FALSE], tbl[3:4,1, drop = FALSE]))
+  expect_equivalent(res, list(tbl[1:2, 1, drop = FALSE], tbl[3:4,1, drop = FALSE]))
 })
 
 test_that("group_split() respects empty groups", {
   tbl <- tibble(x = 1:4, g = factor(rep(c("a", "b"), each = 2), levels = c("a", "b", "c")))
   res <- group_split(tbl, g)
-  expect_equal(res, list(tbl[1:2,], tbl[3:4,]))
+  expect_equivalent(res, list(tbl[1:2,], tbl[3:4,]))
 
   res <- group_split(tbl, g, .drop = FALSE)
-  expect_equal(res, list(tbl[1:2,], tbl[3:4,], tbl[integer(), ]))
+  expect_equivalent(res, list(tbl[1:2,], tbl[3:4,], tbl[integer(), ]))
 })
 
 test_that("group_split.grouped_df() warns about ...", {
@@ -50,7 +50,7 @@ test_that("group_split / bind_rows round trip", {
 })
 
 test_that("group_split() works if no grouping column", {
-  expect_equal(group_split(iris), list(iris))
+  expect_equivalent(group_split(iris), list(iris))
 })
 
 test_that("group_split(keep=FALSE) does not try to remove virtual grouping columns (#4045)", {
@@ -62,7 +62,7 @@ test_that("group_split(keep=FALSE) does not try to remove virtual grouping colum
   )
   res <- group_split(df, keep = FALSE)
 
-  expect_equal(
+  expect_equivalent(
     res,
     list(iris3[rows[[1L]],], iris3[rows[[2L]],])
     )


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)

mtcars %>%
  group_by(cyl) %>%
  filter(hp > 1000) %>%
  group_map(~.x)
#> list()
#> attr(,"ptype")
#> # A tibble: 0 x 10
#> # … with 10 variables: mpg <dbl>, disp <dbl>, hp <dbl>, drat <dbl>,
#> #   wt <dbl>, qsec <dbl>, vs <dbl>, am <dbl>, gear <dbl>, carb <dbl>

mtcars %>%
  group_by(cyl) %>%
  filter(hp > 1000) %>%
  group_modify(~.x)
#> # A tibble: 0 x 11
#> # Groups:   cyl [0]
#> # … with 11 variables: cyl <dbl>, mpg <dbl>, disp <dbl>, hp <dbl>,
#> #   drat <dbl>, wt <dbl>, qsec <dbl>, vs <dbl>, am <dbl>, gear <dbl>,
#> #   carb <dbl>
```

<sup>Created on 2019-06-14 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>