### PR TITLE
Move responsibility of an eval_tidy() call

### DIFF
--- a/R/colwise.R
+++ b/R/colwise.R
@@ -241,5 +241,5 @@ as_inlined_function <- function(f, env, ...) {
     rlang::eval_tidy(rlang::eval_bare(`_quo`, base::parent.frame()))
   })
 
-  structure(fn, class = "inline_colwise_function", formula = f)
+  structure(fn, class = "dplyr_inline_colwise_function", formula = f)
 }

--- a/R/colwise.R
+++ b/R/colwise.R
@@ -205,7 +205,7 @@ tbl_if_vars <- function(.tbl, .p, .env, ..., .include_group_vars = FALSE) {
 
   for (i in seq_len(n)) {
     column <- .tbl[[tibble_vars[[i]]]]
-    selected[[i]] <- eval_tidy(.p(column, ...))
+    selected[[i]] <- .p(column, ...)
   }
 
   tibble_vars[selected]
@@ -237,8 +237,8 @@ as_inlined_function <- function(f, env, ...) {
     # from the execution environment
     `_quo` <- rlang::quo(!!body(fn))
 
-    # Evaluate the quosure in the mask
-    rlang::eval_bare(`_quo`, base::parent.frame())
+    # Construct the quosure in the mask, and then evaluate it
+    rlang::eval_tidy(rlang::eval_bare(`_quo`, base::parent.frame()))
   })
 
   structure(fn, class = "inline_colwise_function", formula = f)

--- a/inst/include/dplyr/hybrid/Expression.h
+++ b/inst/include/dplyr/hybrid/Expression.h
@@ -136,7 +136,7 @@ public:
 
     // when it's a inline_colwise_function, we use the formula attribute
     // to test for hybridability
-    if (TYPEOF(head) == CLOSXP && Rf_inherits(head, "inline_colwise_function")) {
+    if (TYPEOF(head) == CLOSXP && Rf_inherits(head, "dplyr_inline_colwise_function")) {
       dot_alias = CADR(expr);
       expr = CADR(Rf_getAttrib(head, symbols::formula));
       if (TYPEOF(expr) != LANGSXP) {


### PR DESCRIPTION
I was wondering about the `eval_tidy()` here: https://github.com/tidyverse/dplyr/pull/4382/files#diff-80918a3b3722d3c1bb88b2739d466cf0R208

Seems that inlined functions need to do both `eval_bare()` (to construct the quo) and `eval_tidy()` (to actually evaluate it).