### PR TITLE
Fix performance regression in dplyr 0.8.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr (development version)
 
+* Fixed performance regression introduced in version 0.8.2 (#4458). 
+
 # dplyr 0.8.2 (2019-06-28)
 
 ## New functions

--- a/inst/include/dplyr/data/DataMask.h
+++ b/inst/include/dplyr/data/DataMask.h
@@ -152,6 +152,9 @@ private:
                             );
     MARK_NOT_MUTABLE(value);
 
+    // store it in the mask_resolved environment
+    Rf_defineVar(symbol, value, mask_resolved);
+
     return value;
   }
 


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)
library(purrr)
library(rlang)
#> 
#> Attaching package: 'rlang'
#> The following objects are masked from 'package:purrr':
#> 
#>     %@%, as_function, flatten, flatten_chr, flatten_dbl,
#>     flatten_int, flatten_lgl, flatten_raw, invoke, list_along,
#>     modify, prepend, splice

df <- tibble(x = 1:50000)
system.time(df <- group_by(df, x))
#>    user  system elapsed 
#>   0.127   0.006   0.133
system.time(df %>% mutate(y = x + 1))
#>    user  system elapsed 
#>   0.287   0.025   0.311

# ideal situation where we don't need to do any data masking
df_x <- df$x
rows <- group_rows(df)
system.time(map(rows, ~.subset(df_x, .) + 1))
#>    user  system elapsed 
#>   0.060   0.003   0.063

# closer to what happens 
# just mimicking the data mask layout (but not using active bindings like what dplyr does)
mask_resolved <- child_env(empty_env())
mask_active <- child_env(mask_resolved)
data_mask <- new_data_mask(mask_active, mask_resolved)
quo <- quo(x + 1)
  
system.time(map(rows, ~ {
  assign("x", .subset(df_x, .), envir = mask_resolved)
  eval_tidy(quo, data = data_mask)
}))
#>    user  system elapsed 
#>   0.173   0.003   0.175

# approach in dance where the data masking
# is powered by formal arguments of the choreography
rows <- group_rows(df)
moves <- dance::choreography(df, y = ~ x + 1)
moves
#> function(`.::index::.`,
#>     x = <.subset>(<.tbl$x>, `.::index::.`)
#> ){
#>     list(y = x + 1)
#> }
system.time(map(rows, moves))
#>    user  system elapsed 
#>   0.053   0.001   0.055

# check = FALSE is fine here, it's just because how the result is structured 
# in dance before post-processing
bench::mark(
  purrr = map(rows, ~.subset(df_x, .) + 1), 
  dplyr = map(rows, ~ {
    assign("x", .subset(df_x, .), envir = mask_resolved)
    eval_tidy(quo, data = data_mask)
  }), 
  dance = map(rows, moves), 
  check = FALSE  
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 3 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 purrr        39.1ms   44.5ms     21.5      391KB     19.5
#> 2 dplyr       183.1ms    188ms      5.36     402KB     19.7
#> 3 dance        51.8ms   59.9ms     11.3      391KB     15.1
```

<sup>Created on 2019-07-03 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>