### PR TITLE
vars_select_syms() converts dplyr_sel_vars to character before callli…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,19 +25,19 @@ jobs:
   - r: 3.3
   - r: 3.2
     warnings_are_errors: false
-  - r: release
-    env:
-      - DEVEL_PACKAGES=true
-    r_github_packages:
-      - RcppCore/Rcpp
-      - r-lib/rlang
-      - tidyverse/tibble
-      - tidyverse/tidyselect
+  # - r: release
+  #   env:
+  #     - DEVEL_PACKAGES=true
+  #   r_github_packages:
+  #     - RcppCore/Rcpp
+  #     - r-lib/rlang
+  #     - tidyverse/tibble
+  #     - tidyverse/tidyselect
 
 matrix:
   fast_finish: true
-  allow_failures:
-  - env: DEVEL_PACKAGES=true
+  # allow_failures:
+  # - env: DEVEL_PACKAGES=true
 
 env:
   global:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr (development version)
 
+* `rename_at()` and `rename_all()` call the function with a simple character vector, not a `dplyr_sel_vars` (#4459). 
+
 # dplyr 0.8.3 (2019-07-04)
 
 * Fixed performance regression introduced in version 0.8.2 (#4458). 

--- a/R/colwise-select.R
+++ b/R/colwise-select.R
@@ -109,7 +109,7 @@ vars_select_syms <- function(vars, funs, tbl, strict = FALSE) {
       fun <- quo_as_function(fun)
     }
     syms <- if (length(vars)) {
-      set_names(syms(vars), fun(vars))
+      set_names(syms(vars), fun(as.character(vars)))
     } else {
       set_names(syms(vars))
     }

--- a/tests/testthat/test-colwise-select.R
+++ b/tests/testthat/test-colwise-select.R
@@ -190,3 +190,12 @@ test_that("rename_at() handles empty selection (#4324)", {
     mtcars
   )
 })
+
+test_that("rename_all/at() call the function with simple character vector (#4459)", {
+  fun <- function(x) case_when(x == 'mpg' ~ 'fuel_efficiency', TRUE ~ x)
+  out <- rename_all(mtcars,fun)
+  expect_equal(names(out)[1L], 'fuel_efficiency')
+
+  out <- rename_at(mtcars, vars(everything()), fun)
+  expect_equal(names(out)[1L], 'fuel_efficiency')
+})


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)

mtcars <- tibble::as_tibble(mtcars)
rename_all(mtcars,
  function(x) case_when(x == 'mpg' ~ 'fuel_efficiency',
    TRUE ~ x))
#> # A tibble: 32 x 11
#>    fuel_efficiency   cyl  disp    hp  drat    wt  qsec    vs    am  gear
#>              <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
#>  1            21       6  160    110  3.9   2.62  16.5     0     1     4
#>  2            21       6  160    110  3.9   2.88  17.0     0     1     4
#>  3            22.8     4  108     93  3.85  2.32  18.6     1     1     4
#>  4            21.4     6  258    110  3.08  3.22  19.4     1     0     3
#>  5            18.7     8  360    175  3.15  3.44  17.0     0     0     3
#>  6            18.1     6  225    105  2.76  3.46  20.2     1     0     3
#>  7            14.3     8  360    245  3.21  3.57  15.8     0     0     3
#>  8            24.4     4  147.    62  3.69  3.19  20       1     0     4
#>  9            22.8     4  141.    95  3.92  3.15  22.9     1     0     4
#> 10            19.2     6  168.   123  3.92  3.44  18.3     1     0     4
#> # … with 22 more rows, and 1 more variable: carb <dbl>
```

<sup>Created on 2019-07-05 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>