### PR TITLE
using expression instead of function in top_n()

### DIFF
--- a/R/top-n.R
+++ b/R/top-n.R
@@ -60,14 +60,14 @@ top_n <- function(x, n, wt) {
     wt <- sym(wt_name)
   }
 
-  filter(x, !!expr({
-    .n <- {{ n }}
-    if (.n > 0) {
-      min_rank(desc(!!wt)) <= .n
+  filter(x, {
+    `_n` <- {{ n }}
+    if (`_n` > 0) {
+      min_rank(desc(!!wt)) <= `_n`
     } else {
-      min_rank(!!wt) <= abs(.n)
+      min_rank(!!wt) <= abs(`_n`)
     }
-  }))
+  })
 }
 
 #' @export

--- a/R/top-n.R
+++ b/R/top-n.R
@@ -60,15 +60,14 @@ top_n <- function(x, n, wt) {
     wt <- sym(wt_name)
   }
 
-  filter(x, top_n_rank({{ n }}, !!wt))
-}
-
-top_n_rank <- function(n, wt) {
-  if (n > 0) {
-    min_rank(desc(wt)) <= n
-  } else {
-    min_rank(wt) <= abs(n)
-  }
+  filter(x, !!expr({
+    .n <- {{ n }}
+    if (.n > 0) {
+      min_rank(desc(!!wt)) <= .n
+    } else {
+      min_rank(!!wt) <= abs(.n)
+    }
+  }))
 }
 
 #' @export


### PR DESCRIPTION
Still does not fix the issue #4467: 

``` r
library(dplyr, warn.conflicts = FALSE)

dbplyr::memdb_frame(a = 1:3, b = 2:4) %>% count(a)  %>% top_n(2) 
#> Selecting by n
#> Error: Window function `RANK()` is not supported by this database
```
