### PR TITLE
Preserve generic chains in add_count() & add_tally()

### DIFF
--- a/R/count-tally.R
+++ b/R/count-tally.R
@@ -181,7 +181,7 @@ add_tally <- function(x, wt, sort = FALSE, name = "n") {
     out <- arrange(out, desc(!!sym(n_name)))
   }
 
-  grouped_df(out, group_vars(x), drop = group_by_drop_default(x))
+  out
 }
 #' @rdname se-deprecated
 #' @export
@@ -200,11 +200,9 @@ add_tally_ <- function(x, wt, sort = FALSE) {
 #' @rdname tally
 #' @export
 add_count <- function(x, ..., wt = NULL, sort = FALSE, name = "n") {
-  g <- group_vars(x)
   grouped <- group_by(x, ..., add = TRUE)
-
   out <- add_tally(grouped, wt = !!enquo(wt), sort = sort, name = name)
-  grouped_df(out, g, drop = group_by_drop_default(grouped))
+  group_by(out, !!!groups(x), .drop = group_by_drop_default(grouped))
 }
 #' @rdname se-deprecated
 #' @export

--- a/tests/testthat/test-count-tally.r
+++ b/tests/testthat/test-count-tally.r
@@ -103,6 +103,15 @@ test_that("returns error if user-defined name equals a grouped variable", {
   expect_error(df %>% add_count(g, name = "g"))
 })
 
+test_that("can add_count to a tbl_dbi", {
+  con <- DBI::dbConnect(RSQLite::SQLite())
+  tbl <- copy_to(con, mtcars)
+  tbl %>% add_count(gear)
+  tbl %>% add_count()
+  DBI::dbDisconnect(con)
+})
+
+
 # tally -------------------------------------------------------------------
 
 test_that("weighted tally drops NAs (#1145)", {


### PR DESCRIPTION
Fixes #3739.

Only touching the data with generic verbs allows preserving subclasses for the input.