### PR TITLE
Add example in recode about NA types

### DIFF
--- a/R/recode.R
+++ b/R/recode.R
@@ -56,7 +56,8 @@
 #' recode(char_vec, a = "Apple", b = "Banana")
 #'
 #' # Use .default as replacement for unmatched values. Note that NA and
-#' replacement values need to be of the same type.
+#' # replacement values need to be of the same type. For more information, see
+#' # https://adv-r.hadley.nz/vectors-chap.html#missing-values
 #' recode(char_vec, a = "Apple", b = "Banana", .default = NA_character_)
 #'
 #' # This throws an error as the NA type is of type logical, not character.

--- a/R/recode.R
+++ b/R/recode.R
@@ -60,7 +60,7 @@
 #' # https://adv-r.hadley.nz/vectors-chap.html#missing-values
 #' recode(char_vec, a = "Apple", b = "Banana", .default = NA_character_)
 #'
-#' # This throws an error as the NA type is of type logical, not character.
+#' # Throws an error as NA is logical, not character.
 #' \dontrun{
 #' recode(char_vec, a = "Apple", b = "Banana", .default = NA)
 #' }

--- a/R/recode.R
+++ b/R/recode.R
@@ -55,8 +55,14 @@
 #' recode(char_vec, a = "Apple")
 #' recode(char_vec, a = "Apple", b = "Banana")
 #'
-#' # Use .default as replacement for unmatched values
+#' # Use .default as replacement for unmatched values. Note that NA and
+#' replacement values need to be of the same type.
 #' recode(char_vec, a = "Apple", b = "Banana", .default = NA_character_)
+#'
+#' # This throws an error as the NA type is of type logical, not character.
+#' \dontrun{
+#' recode(char_vec, a = "Apple", b = "Banana", .default = NA)
+#' }
 #'
 #' # Use a named character vector for unquote splicing with !!!
 #' level_key <- c(a = "apple", b = "banana", c = "carrot")

--- a/man/recode.Rd
+++ b/man/recode.Rd
@@ -70,7 +70,8 @@ recode(char_vec, a = "Apple")
 recode(char_vec, a = "Apple", b = "Banana")
 
 # Use .default as replacement for unmatched values. Note that NA and
-replacement values need to be of the same type.
+# replacement values need to be of the same type. For more information, see
+# https://adv-r.hadley.nz/vectors-chap.html#missing-values
 recode(char_vec, a = "Apple", b = "Banana", .default = NA_character_)
 
 # This throws an error as the NA type is of type logical, not character.

--- a/man/recode.Rd
+++ b/man/recode.Rd
@@ -74,7 +74,7 @@ recode(char_vec, a = "Apple", b = "Banana")
 # https://adv-r.hadley.nz/vectors-chap.html#missing-values
 recode(char_vec, a = "Apple", b = "Banana", .default = NA_character_)
 
-# This throws an error as the NA type is of type logical, not character.
+# Throws an error as NA is logical, not character.
 \dontrun{
 recode(char_vec, a = "Apple", b = "Banana", .default = NA)
 }

--- a/man/recode.Rd
+++ b/man/recode.Rd
@@ -69,8 +69,14 @@ char_vec <- sample(c("a", "b", "c"), 10, replace = TRUE)
 recode(char_vec, a = "Apple")
 recode(char_vec, a = "Apple", b = "Banana")
 
-# Use .default as replacement for unmatched values
+# Use .default as replacement for unmatched values. Note that NA and
+replacement values need to be of the same type.
 recode(char_vec, a = "Apple", b = "Banana", .default = NA_character_)
+
+# This throws an error as the NA type is of type logical, not character.
+\dontrun{
+recode(char_vec, a = "Apple", b = "Banana", .default = NA)
+}
 
 # Use a named character vector for unquote splicing with !!!
 level_key <- c(a = "apple", b = "banana", c = "carrot")


### PR DESCRIPTION
Closes #3768 

I added an example and modified slightly the wording of another to make it clearer that NAs need to be of the same type as replacement values, similarly to what was done for `case_when` via https://github.com/tidyverse/dplyr/pull/3247