### PR TITLE
Rowwise() + do() questioning: propose alternatives

### DIFF
--- a/R/do.r
+++ b/R/do.r
@@ -2,6 +2,9 @@
 #'
 #' \Sexpr[results=rd, stage=render]{dplyr:::lifecycle("questioning")}
 #'
+#' `do()` is marked as questioning as of dplyr 0.8.0, and may be advantageously
+#' replaced by [group_modify()].
+#'
 #' @description This is a general purpose complement to the specialised
 #' manipulation functions [filter()], [select()], [mutate()],
 #' [summarise()] and [arrange()]. You can use `do()`
@@ -14,11 +17,6 @@
 #' For an empty data frame, the expressions will be evaluated once, even in the
 #' presence of a grouping.  This makes sure that the format of the resulting
 #' data frame is the same for both empty and non-empty input.
-#'
-#' @section Alternative:
-#'
-#' `do()` is marked as questioning as of dplyr 0.8.0, and may be advantageously
-#' replaced by [group_map()].
 #'
 #' @section Connection to plyr:
 #'

--- a/R/rowwise.r
+++ b/R/rowwise.r
@@ -3,7 +3,7 @@
 #' \Sexpr[results=rd, stage=render]{dplyr:::lifecycle("questioning")}
 #'
 #' See [this repository](https://github.com/jennybc/row-oriented-workflows)
-#' for alternative ways to perform row-wise operations
+#' for alternative ways to perform row-wise operations.
 #'
 #' `rowwise()` is used for the results of [do()] when you
 #' create list-variables. It is also useful to support arbitrary

--- a/man/do.Rd
+++ b/man/do.Rd
@@ -43,14 +43,10 @@ data frame is the same for both empty and non-empty input.
 }
 \details{
 \Sexpr[results=rd, stage=render]{dplyr:::lifecycle("questioning")}
-}
-\section{Alternative}{
-
 
 \code{do()} is marked as questioning as of dplyr 0.8.0, and may be advantageously
-replaced by \code{\link[=group_map]{group_map()}}.
+replaced by \code{\link[=group_modify]{group_modify()}}.
 }
-
 \section{Connection to plyr}{
 
 

--- a/man/rowwise.Rd
+++ b/man/rowwise.Rd
@@ -14,7 +14,7 @@ rowwise(data)
 }
 \details{
 See \href{https://github.com/jennybc/row-oriented-workflows}{this repository}
-for alternative ways to perform row-wise operations
+for alternative ways to perform row-wise operations.
 
 \code{rowwise()} is used for the results of \code{\link[=do]{do()}} when you
 create list-variables. It is also useful to support arbitrary


### PR DESCRIPTION
Both, `do.r` and `rowwise.r` are already marked as questioning and have proposed alternatives. 

Discussed with @romainfrancois. 

For consistency, I moved the `do()` alternative up to right after the badge + changed proposed alternative `group_map()` to `group_modify()`.

`rowwise.r` alternative got a dot added at the end of the sentence ;-). 

Closes #3494.