### PR TITLE
Less warnings in bind_rows(), and they mention the column. 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr (development version)
 
+* Improved errors and warnings in `bind_rows()` (#4489). 
+
 * `rbind_all()` and `rbind_list()` have been removed (@bjungbogati, #4433).
 
 * `dr_dplyr()` has been removed as it is no longer needed (#4433, @smwindecker).

--- a/inst/include/dplyr/Collecter.h
+++ b/inst/include/dplyr/Collecter.h
@@ -65,7 +65,7 @@ public:
   virtual std::string describe() const = 0;
 
   inline void Warn(std::string msg) {
-    Rf_warning(improve_message(msg, name).c_str());
+    Rf_warningcall(R_NilValue, improve_message(msg, name).c_str());
   }
 
   inline void Stop(std::string msg) {
@@ -91,10 +91,10 @@ private:
 static inline void warn_loss_attr(SEXP x, const SymbolString& name) {
   /* Attributes are lost with unknown classes */
   if (!is_class_known(x)) {
-    Rf_warning(Collecter::improve_message(
-                 tfm::format("Vectorizing '%s' elements may not preserve their attributes", CHAR(STRING_ELT(Rf_getAttrib(x, R_ClassSymbol), 0))),
-                 name
-               ).c_str());
+    Rf_warningcall(R_NilValue, Collecter::improve_message(
+                     tfm::format("Vectorizing '%s' elements may not preserve their attributes", CHAR(STRING_ELT(Rf_getAttrib(x, R_ClassSymbol), 0))),
+                     name
+                   ).c_str());
   }
 }
 
@@ -739,7 +739,7 @@ inline Collecter* promote_collecter(SEXP model, int n, Collecter* previous, cons
   // return a Collecter_Impl<STRSXP> because the factors don't have the
   // same levels
   if (Rf_inherits(model, "factor") && previous->is_factor_collecter()) {
-    Rf_warning(Collecter::improve_message("Unequal factor levels: coercing to character", name).c_str());
+    Rf_warningcall(R_NilValue, Collecter::improve_message("Unequal factor levels: coercing to character", name).c_str());
     return new Collecter_Impl<STRSXP>(name, n, true);
   }
 
@@ -767,7 +767,7 @@ inline Collecter* promote_collecter(SEXP model, int n, Collecter* previous, cons
     return new Collecter_Impl<LGLSXP>(name, n);
   case STRSXP:
     if (previous->is_factor_collecter()) {
-      Rf_warning(Collecter::improve_message("binding factor and character vector, coercing into character vector", name).c_str());
+      Rf_warningcall(R_NilValue, Collecter::improve_message("binding factor and character vector, coercing into character vector", name).c_str());
     }
     return new Collecter_Impl<STRSXP>(name, n, true);
   default:

--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -199,7 +199,7 @@ Rcpp::List rbind__impl(Rcpp::List dots, const dplyr::SymbolString& id) {
         }
       }
       if (!coll) {
-        coll = collecter(source, n);
+        coll = collecter(source, n, name);
         columns.push_back(coll);
         names.push_back(name);
       }
@@ -208,7 +208,7 @@ Rcpp::List rbind__impl(Rcpp::List dots, const dplyr::SymbolString& id) {
         coll->collect(OffsetSlicingIndex(k, nrows), source, offset);
       } else if (coll->can_promote(source)) {
         // setup a new Collecter
-        Collecter* new_collecter = promote_collecter(source, n, coll);
+        Collecter* new_collecter = promote_collecter(source, n, coll, name);
 
         // import data from this chunk
         new_collecter->collect(OffsetSlicingIndex(k, nrows), source, offset);
@@ -224,7 +224,7 @@ Rcpp::List rbind__impl(Rcpp::List dots, const dplyr::SymbolString& id) {
         // do nothing, the collecter already initialized data with the
         // right NA
       } else if (coll->is_logical_all_na()) {
-        Collecter* new_collecter = collecter(source, n);
+        Collecter* new_collecter = collecter(source, n, name);
         new_collecter->collect(OffsetSlicingIndex(k, nrows), source, offset);
         delete coll;
         columns[index] = new_collecter;
@@ -439,7 +439,8 @@ SEXP combine_all(Rcpp::List data) {
   if (i == nv) return Rcpp::LogicalVector();
 
   // collect
-  boost::scoped_ptr<dplyr::Collecter> coll(dplyr::collecter(data[i], n));
+  dplyr::SymbolString name;
+  boost::scoped_ptr<dplyr::Collecter> coll(dplyr::collecter(data[i], n, name));
   int k = Rf_length(data[i]);
   coll->collect(NaturalSlicingIndex(k), data[i]);
   i++;

--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -452,7 +452,7 @@ SEXP combine_all(Rcpp::List data) {
     if (coll->compatible(current)) {
       coll->collect(OffsetSlicingIndex(k, n_current), current);
     } else if (coll->can_promote(current)) {
-      dplyr::Collecter* new_coll = promote_collecter(current, n, coll.get());
+      dplyr::Collecter* new_coll = promote_collecter(current, n, coll.get(), name);
       new_coll->collect(OffsetSlicingIndex(k, n_current), current);
       new_coll->collect(NaturalSlicingIndex(k), coll->get());
       coll.reset(new_coll);

--- a/src/mutate.cpp
+++ b/src/mutate.cpp
@@ -252,7 +252,7 @@ public:
   ) :
     gdf(gdf_), proxy(proxy_), first_non_na(first_non_na_), name(name_)
   {
-    coll = collecter(first, gdf.nrows());
+    coll = collecter(first, gdf.nrows(), name);
     if (first_non_na < gdf.ngroups())
       grab(first, indices);
   }
@@ -303,7 +303,7 @@ private:
       coll->collect(indices, subset);
     } else if (coll->can_promote(subset)) {
       // setup a new Collecter
-      Collecter* new_collecter = promote_collecter(subset, gdf.nrows(), coll);
+      Collecter* new_collecter = promote_collecter(subset, gdf.nrows(), coll, name);
 
       // import data from previous collecter.
       new_collecter->collect(NaturalSlicingIndex(gdf.nrows()), coll->get());
@@ -315,7 +315,7 @@ private:
       delete coll;
       coll = new_collecter;
     } else if (coll->is_logical_all_na()) {
-      Collecter* new_collecter = collecter(subset, gdf.nrows());
+      Collecter* new_collecter = collecter(subset, gdf.nrows(), name);
       new_collecter->collect(indices, subset);
       delete coll;
       coll = new_collecter;


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)
a <- data.frame(x = "one")
b <- data.frame(x = "two")
bind_rows(a, b)
#> Warning: Column `x`: Unequal factor levels: coercing to character
#>     x
#> 1 one
#> 2 two

c <- data.frame(x = "three", stringsAsFactors = FALSE)
bind_rows(a, c)
#> Warning: Column `x`: binding factor and character vector, coercing into
#> character vector
#>       x
#> 1   one
#> 2 three
bind_rows(c, a)
#> Warning: Column `x`: binding character and factor vector, coercing into
#> character vector
#>       x
#> 1 three
#> 2   one
```
