### PR TITLE
select_if() discards column when predicate evaluates to NA.

### DIFF
--- a/R/colwise.R
+++ b/R/colwise.R
@@ -205,7 +205,7 @@ tbl_if_vars <- function(.tbl, .p, .env, ..., .include_group_vars = FALSE) {
 
   for (i in seq_len(n)) {
     column <- .tbl[[tibble_vars[[i]]]]
-    selected[[i]] <- eval_tidy(.p(column, ...))
+    selected[[i]] <- isTRUE(eval_tidy(.p(column, ...)))
   }
 
   tibble_vars[selected]

--- a/tests/testthat/test-colwise-select.R
+++ b/tests/testthat/test-colwise-select.R
@@ -199,3 +199,11 @@ test_that("rename_all/at() call the function with simple character vector (#4459
   out <- rename_at(mtcars, vars(everything()), fun)
   expect_equal(names(out)[1L], 'fuel_efficiency')
 })
+
+test_that("select_if() discards the column when predicate gives NA (#4486)", {
+  out <- tibble(mycol=c("","",NA)) %>% select_if(~!all(.==""))
+  expect_identical(
+    out,
+    tibble::new_tibble(list(), nrow = 3L)
+  )
+})


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)

tibble(mycol=c("","",NA)) %>% 
  select_if(~!all(.==""))
#> # A tibble: 3 x 0
```

<sup>Created on 2019-07-16 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>