### PR TITLE
`group_by()` does not create an arbitrary NA group 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr (development version)
 
+* `group_by()` does not create an arbitrary NA group when grouping by factors with `drop = TRUE` (#4460).
+
 * `rbind_all()` and `rbind_list()` have been removed (@bjungbogati, #4433).
 
 * `dr_dplyr()` has been removed as it is no longer needed (#4433, @smwindecker).

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -527,3 +527,12 @@ test_that("group_by() puts NA groups last in STRSXP (#4227)", {
   expect_identical(res$x, c("apple", "banana", NA_character_))
   expect_identical(res$.rows, list(1L, 3L, 2L))
 })
+
+test_that("group_by() does not create arbitrary NA groups for factors when drop = TRUE (#4460)", {
+  res <- expect_warning(group_data(group_by(iris, Species)[0, ]), NA)
+  expect_equal(nrow(res), 0L)
+
+  res <- expect_warning(group_data(group_by(iris[0, ], Species)), NA)
+  expect_equal(nrow(res), 0L)
+})
+


### PR DESCRIPTION
when grouping by factors with `drop = TRUE`.

closes #4460

``` r
library(dplyr, warn.conflicts = FALSE)
ig <- group_by(iris, Species)
group_data(ig[0,])
#> # A tibble: 0 x 2
#> # … with 2 variables: Species <fct>, .rows <list>
```

<sup>Created on 2019-07-17 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>