### PR TITLE
Better performance for slicing factors and ordered factors.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr (development version)
 
+* Better performance for extracting slices of factors and ordered factors (#4501).
+
 * `group_by()` does not create an arbitrary NA group when grouping by factors with `drop = TRUE` (#4460).
 
 * `rbind_all()` and `rbind_list()` have been removed (@bjungbogati, #4433).

--- a/inst/include/dplyr/symbols.h
+++ b/inst/include/dplyr/symbols.h
@@ -81,10 +81,13 @@ struct strings {
   static SEXP POSIXct;
   static SEXP POSIXt;
   static SEXP Date;
+  static SEXP factor;
+  static SEXP ordered;
 };
 
 struct vectors {
   static SEXP factor;
+  static SEXP ordered;
 };
 
 } // namespace dplyr

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -29,6 +29,14 @@ SEXP get_factor_classes() {
   return klasses;
 }
 
+SEXP get_ordered_classes() {
+  static Rcpp::CharacterVector klasses(2);
+  klasses[0] = "ordered";
+  klasses[1] = "factor";
+  return klasses;
+}
+
+
 SEXP mark_precious(SEXP x) {
   R_PreserveObject(x);
   return x;
@@ -104,9 +112,13 @@ SEXP symbols::names = R_NamesSymbol;
 SEXP symbols::formula = Rf_install("formula");
 SEXP fns::quote = Rf_eval(Rf_install("quote"), R_BaseEnv);
 
+SEXP vectors::factor = get_factor_classes();
+SEXP vectors::ordered = get_ordered_classes();
+
 SEXP strings::POSIXct = STRING_ELT(get_time_classes(), 0);
 SEXP strings::POSIXt = STRING_ELT(get_time_classes(), 1);
 SEXP strings::Date = STRING_ELT(get_date_classes(), 0);
+SEXP strings::factor = STRING_ELT(vectors::factor, 0);
+SEXP strings::ordered = STRING_ELT(vectors::ordered, 0);
 
-SEXP vectors::factor = get_factor_classes();
 }


### PR DESCRIPTION
closes #4501

``` r
library(dplyr, warn.conflicts = FALSE)

n <- 1e5
system.time(d <- tibble(
  x=sample(2000, n, TRUE),
  y=sample(800, n, TRUE),
  int=sample(5, n, TRUE),
  fac = factor(int), 
  ord = ordered(int, levels=c("4", "1", "3", "2", "5")),
  
  val=runif(n)
) 
)
#>    user  system elapsed 
#>   0.017   0.002   0.018
system.time(d <- d %>% group_by(x, y))
#>    user  system elapsed 
#>   0.259   0.010   0.270

system.time(d %>% summarize(w = val[which.max(ord)]))
#>    user  system elapsed 
#>   0.478   0.038   0.516
system.time(d %>% summarize(w = val[which.max(fac)]))
#>    user  system elapsed 
#>   0.467   0.036   0.503
system.time(d %>% summarize(w = val[which.max(int)]))
#>    user  system elapsed 
#>   0.429   0.038   0.467

system.time(d %>% summarize(w = {int; 1L}))
#>    user  system elapsed 
#>   0.337   0.036   0.374
system.time(d %>% summarize(w = {fac; 1L}))
#>    user  system elapsed 
#>   0.341   0.033   0.374
system.time(d %>% summarize(w = {ord; 1L}))
#>    user  system elapsed 
#>   0.351   0.034   0.385
```

<sup>Created on 2019-07-22 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>