### PR TITLE
Fix README dtplyr link

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -41,7 +41,7 @@ If you are new to dplyr, the best place to start is the [data import chapter](ht
 
 dplyr is designed to abstract over how the data is stored. Out of the box, dplyr works with data frames/tibbles; other packages provide alternative computational backends:
 
-* For large, in-memory datasets, try [dtplyr](http://dbplyr.tidyverse.org/)
+* For large, in-memory datasets, try [dtplyr](http://dtplyr.tidyverse.org/)
   to access the excellent performance of [data.table](http://r-datatable.com/).
   
 * For data in relational databases, [dbplyr](http://dbplyr.tidyverse.org/) 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ box, dplyr works with data frames/tibbles; other packages provide
 alternative computational backends:
 
   - For large, in-memory datasets, try
-    [dtplyr](http://dbplyr.tidyverse.org/) to access the excellent
+    [dtplyr](https://dtplyr.tidyverse.org/) to access the excellent
     performance of [data.table](http://r-datatable.com/).
 
   - For data in relational databases,


### PR DESCRIPTION
small typo in Backends. Url for dtplyr redirected to dbplyr