### PR TITLE
use n as default wt in tally

### DIFF
--- a/R/count-tally.R
+++ b/R/count-tally.R
@@ -72,7 +72,7 @@
 #' starwars %>%
 #'   add_count(species) %>%
 #'   filter(n == 1)
-tally <- function(x, wt = NULL, sort = FALSE, name = "n") {
+tally <- function(x, wt, sort = FALSE, name = "n") {
   wt <- enquo(wt)
 
   if (quo_is_missing(wt) && "n" %in% tbl_vars(x)) {

--- a/man/tally.Rd
+++ b/man/tally.Rd
@@ -7,7 +7,7 @@
 \alias{add_count}
 \title{Count/tally observations by group}
 \usage{
-tally(x, wt = NULL, sort = FALSE, name = "n")
+tally(x, wt, sort = FALSE, name = "n")
 
 count(x, ..., wt = NULL, sort = FALSE, name = "n",
   .drop = group_by_drop_default(x))

--- a/tests/testthat/test-count-tally.r
+++ b/tests/testthat/test-count-tally.r
@@ -134,6 +134,12 @@ test_that("returns error if user-defined name equals a grouped variable", {
   expect_error(df %>% group_by(g) %>% tally(name = name))
 })
 
+test_that("tally uses variable named n as default wt.", {
+  df <- tibble(n = 1:3)
+  expect_message(res <- df %>%  tally(), "Using `n` as weighting variable")
+  expect_equal(res$n, sum(1:3))
+})
+
 
 # add_tally ---------------------------------------------------------------
 


### PR DESCRIPTION
Fixes a bug introduced by 4408 - tally needs to differentiate between a missing `wt` and `wt = NULL`.

- `wt` is missing indicates that it should use a variable named `n` as `wt` by default (used by `tally()`)
- `wt = NULL` indicates that it should not use `n` (used by `count()`)