### PR TITLE
Document top_n() returns unsorted data frame

### DIFF
--- a/R/top-n.R
+++ b/R/top-n.R
@@ -2,7 +2,8 @@
 #'
 #' This is a convenient wrapper that uses [filter()] and
 #' [min_rank()] to select the top or bottom entries in each group,
-#' ordered by `wt`.
+#' with respect to `wt`. Note, the resulting data frame will not be
+#' ordered or sorted.
 #'
 #' @param x a [tbl()] to filter
 #' @param n number of rows to return for `top_n()`, fraction of rows to
@@ -25,7 +26,7 @@
 #'
 #' @export
 #' @examples
-#' df <- data.frame(x = c(10, 4, 1, 6, 3, 1, 1))
+#' df <- data.frame(x = c(6, 4, 1, 10, 3, 1, 1))
 #' df %>% top_n(2)
 #'
 #' # half the rows

--- a/man/top_n.Rd
+++ b/man/top_n.Rd
@@ -28,7 +28,8 @@ specified, defaults to the last variable in the tbl.}
 \description{
 This is a convenient wrapper that uses \code{\link[=filter]{filter()}} and
 \code{\link[=min_rank]{min_rank()}} to select the top or bottom entries in each group,
-ordered by \code{wt}.
+with respect to \code{wt}. Note, the resulting data frame will not be
+ordered or sorted.
 }
 \details{
 Both \code{n} and \code{wt} are automatically \link[rlang:enquo]{quoted} and later
@@ -36,7 +37,7 @@ Both \code{n} and \code{wt} are automatically \link[rlang:enquo]{quoted} and lat
 frame. It supports \link[rlang:quasiquotation]{unquoting}.
 }
 \examples{
-df <- data.frame(x = c(10, 4, 1, 6, 3, 1, 1))
+df <- data.frame(x = c(6, 4, 1, 10, 3, 1, 1))
 df \%>\% top_n(2)
 
 # half the rows


### PR DESCRIPTION
Made it clear in the documentation that top_n doesn't return an ordered data frame, because I found that surprising. Also changed the example code to show a case where the returned results are not ordered.

Modified the top-n.R and generated top_n.Rd with roxygen2.