### PR TITLE
group_split() returns a vctrs_list_of

### DIFF
--- a/R/group_split.R
+++ b/R/group_split.R
@@ -85,7 +85,7 @@ group_split.data.frame <- function(.tbl, ..., keep = TRUE) {
   if (dots_n(...)) {
     group_split(group_by(.tbl, ...), keep = keep)
   } else {
-    structure(list(.tbl), ptype = .tbl[0L, ])
+    new_list_of(list(.tbl), ptype = .tbl[0L, ])
   }
 }
 
@@ -97,7 +97,7 @@ group_split.rowwise_df <- function(.tbl, ..., keep = TRUE) {
   if (!missing(keep)) {
     warn("keep is ignored in group_split(<rowwise_df>)")
   }
-  structure(
+  new_list_of(
     map(seq_len(nrow(.tbl)), vec_slice, x = .tbl),
     ptype = vec_slice(.tbl, 0L)
   )
@@ -114,7 +114,7 @@ group_split.grouped_df <- function(.tbl, ..., keep = TRUE) {
     data <- data[, setdiff(names(data), group_vars(.tbl))]
   }
 
-  structure(
+  new_list_of(
     map(group_rows(.tbl), vec_slice, x = data),
     ptype = vec_slice(data, 0L)
   )

--- a/tests/testthat/test-group_nest.R
+++ b/tests/testthat/test-group_nest.R
@@ -6,6 +6,8 @@ test_that("group_nest() works", {
 
   res <- group_nest(starwars, species, homeworld)
   expect_is(pull(res), "list")
+  expect_is(pull(res), "vctrs_list_of")
+  expect_equal(attr(pull(res), "ptype"), vec_slice(select(starwars, -species, -homeworld), 0L))
   expect_equal(select(res, -last_col()), select(gdata, -last_col()))
 
   nested <- bind_rows(!!!res$data)
@@ -32,6 +34,9 @@ test_that("group_nest() works on grouped data frames", {
 
   res <- group_nest(grouped, keep = TRUE)
   expect_is(pull(res), "list")
+  expect_is(pull(res), "vctrs_list_of")
+  expect_equal(attr(pull(res), "ptype"), vec_slice(starwars, 0L))
+
   expect_equal(select(res, -last_col()), select(gdata, -last_col()))
   expect_equal(names(bind_rows(!!!res$data)), names(starwars))
 })

--- a/tests/testthat/test-group_split.R
+++ b/tests/testthat/test-group_split.R
@@ -4,18 +4,24 @@ test_that("group_split() keeps the grouping variables by default", {
   tbl <- tibble(x = 1:4, g = factor(rep(c("a", "b"), each = 2)))
   res <- group_split(tbl, g)
   expect_equivalent(res, list(tbl[1:2,], tbl[3:4,]))
+  expect_is(res, "vctrs_list_of")
+  expect_equal(attr(res, "ptype"), tibble(x = integer(), g = factor(levels = c("a", "b"))))
 })
 
 test_that("group_split() can discard the grouping variables with keep = FALSE", {
   tbl <- tibble(x = 1:4, g = factor(rep(c("a", "b"), each = 2)))
   res <- group_split(tbl, g, keep = FALSE)
   expect_equivalent(res, list(tbl[1:2, 1, drop = FALSE], tbl[3:4,1, drop = FALSE]))
+  expect_is(res, "vctrs_list_of")
+  expect_equal(attr(res, "ptype"), tibble(x = integer(), g = factor(levels = c("a", "b"))))
 })
 
 test_that("group_split() respects empty groups", {
   tbl <- tibble(x = 1:4, g = factor(rep(c("a", "b"), each = 2), levels = c("a", "b", "c")))
   res <- group_split(tbl, g)
   expect_equivalent(res, list(tbl[1:2,], tbl[3:4,]))
+  expect_is(res, "vctrs_list_of")
+  expect_equal(attr(res, "ptype"), tibble(x = integer(), g = factor(levels = c("a", "b", "c"))))
 
   res <- group_split(tbl, g, .drop = FALSE)
   expect_equivalent(res, list(tbl[1:2,], tbl[3:4,], tbl[integer(), ]))

--- a/tests/testthat/test-group_split.R
+++ b/tests/testthat/test-group_split.R
@@ -13,7 +13,7 @@ test_that("group_split() can discard the grouping variables with keep = FALSE", 
   res <- group_split(tbl, g, keep = FALSE)
   expect_equivalent(res, list(tbl[1:2, 1, drop = FALSE], tbl[3:4,1, drop = FALSE]))
   expect_is(res, "vctrs_list_of")
-  expect_equal(attr(res, "ptype"), tibble(x = integer(), g = factor(levels = c("a", "b"))))
+  expect_equal(attr(res, "ptype"), tibble(x = integer()))
 })
 
 test_that("group_split() respects empty groups", {


### PR DESCRIPTION
closes #4611

``` r
library(dplyr, warn.conflicts = FALSE)

iris %>% 
  group_by(Species) %>% 
  tidyr::nest()
#> # A tibble: 3 x 2
#> # Groups:   Species [3]
#>   Species              data
#>   <fct>      <list<df[,4]>>
#> 1 setosa           [50 × 4]
#> 2 versicolor       [50 × 4]
#> 3 virginica        [50 × 4]

iris %>% 
  group_nest(Species)
#> # A tibble: 3 x 2
#>   Species              data
#>   <fct>      <list<df[,4]>>
#> 1 setosa           [50 × 4]
#> 2 versicolor       [50 × 4]
#> 3 virginica        [50 × 4]
```

<sup>Created on 2019-11-18 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>