### PR TITLE
transmute() no longer warns when = NULL

### DIFF
--- a/R/manip.r
+++ b/R/manip.r
@@ -488,7 +488,7 @@ transmute.default <- function(.data, ...) {
   dots <- enquos(..., .named = TRUE)
   out <- mutate(.data, !!!dots)
 
-  keep <- names(dots)
+  keep <- intersect(names(dots), names(out))
   select(out, one_of(keep))
 }
 #' @export

--- a/tests/testthat/test-transmute.R
+++ b/tests/testthat/test-transmute.R
@@ -40,3 +40,8 @@ test_that("arguments to rename() don't match vars_rename() arguments (#2861)", {
 test_that("can transmute() with .data pronoun (#2715)", {
   expect_identical(transmute(mtcars, .data$cyl), transmute(mtcars, cyl))
 })
+
+test_that("transmute() does not warn when a variable is removed with = NULL (#4609)", {
+  df <- data.frame(x=1)
+  expect_warning(transmute(df, y =x+1, z=y*2, y = NULL), NA)
+})


### PR DESCRIPTION
closes #4609

``` r
library(dplyr, warn.conflicts = FALSE)

df <- data.frame(x=1)
transmute(df, y =x+1, z=y*2)
#>   y z
#> 1 2 4
```

<sup>Created on 2019-11-18 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>