### PR TITLE
bind_cols() handles packs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,7 +64,4 @@ RoxygenNote: 6.1.1
 Remotes:
     tidyverse/tibble,
     r-lib/pillar,
-    r-lib/vctrs
-    
-
-    
+    r-lib/vctrs#688

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,6 +63,8 @@ Roxygen: list(markdown = TRUE, roclets = c("rd", "namespace", "collate"))
 RoxygenNote: 6.1.1
 Remotes:
     tidyverse/tibble,
-    r-lib/vctrs, 
-    r-lib/pillar
+    r-lib/pillar,
+    r-lib/vctrs
+    
 
+    

--- a/R/bind.r
+++ b/R/bind.r
@@ -161,11 +161,11 @@ bind_cols <- function(...) {
     first <- dots[[1]][[1]]
   }
 
-  dots <- keep(squash_if(dots, is.list), not_null)
+  dots <- squash_if(dots, function(.x) is.list(.x) && !is.data.frame(.x))
+  dots <- keep(dots, not_null)
   if (!length(dots)) {
     return(tibble())
   }
-  dots <- tibble::repair_names(dots)
 
   res <- vec_cbind(!!!dots)
   if (length(dots)) {

--- a/tests/testthat/test-binds.R
+++ b/tests/testthat/test-binds.R
@@ -592,10 +592,10 @@ test_that("supports NULL values", {
   expect_identical(bind_cols(a = 1, NULL, b = 2, NULL), tibble(a = 1, b = 2))
 })
 
-test_that("bind_cols handles unnamed list (#3402)", {
+test_that("bind_cols() handles unnamed list with name repair (#3402)", {
   expect_identical(
     bind_cols(list(1, 2)),
-    bind_cols(list(V1 = 1, V2 = 2))
+    bind_cols(list(...1 = 1, ...2 = 2))
   )
 })
 


### PR DESCRIPTION
closes #4599

``` r
library(dplyr, warn.conflicts = FALSE)

tibble_1 <- tibble(col = "foo")
tibble_2 <- tibble(nested = tibble(bar = 33))

bind_cols(tibble_1, tibble_2)
#> # A tibble: 1 x 2
#>   col   nested$bar
#>   <chr>      <dbl>
#> 1 foo           33
```

<sup>Created on 2019-11-18 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>