### PR TITLE
vctrs:: based implementation for lead() and lag()

### DIFF
--- a/R/lead-lag.R
+++ b/R/lead-lag.R
@@ -49,9 +49,10 @@ lead <- function(x, n = 1L, default = NA, order_by = NULL, ...) {
   xlen <- length(x)
   n <- pmin(n, xlen)
 
-  out <- c(x[-seq_len(n)], rep(default, n))
-  attributes(out) <- attributes(x)
-  out
+  vec_c(
+    vec_slice(x, -seq_len(n)),
+    vec_repeat(default, n)
+  )
 }
 
 #' @export
@@ -75,7 +76,8 @@ lag <- function(x, n = 1L, default = NA, order_by = NULL, ...) {
   xlen <- length(x)
   n <- pmin(n, xlen)
 
-  out <- c(rep(default, n), x[seq_len(xlen - n)])
-  attributes(out) <- attributes(x)
-  out
+  vec_c(
+    vec_repeat(default, n),
+    vec_slice(x, seq_len(xlen - n))
+  )
 }

--- a/R/order-by.R
+++ b/R/order-by.R
@@ -51,9 +51,9 @@ order_by <- function(order_by, call) {
 #' @keywords internal
 #' @export
 with_order <- function(order_by, fun, x, ...) {
-  ord <- order(order_by)
-  undo <- match(seq_along(order_by), ord)
+  ord <- vec_order(order_by)
+  undo <- vec_match(seq_along(order_by), ord)
 
-  out <- fun(x[ord], ...)
-  out[undo]
+  out <- fun(vec_slice(x, ord), ...)
+  vec_slice(out, undo)
 }

--- a/tests/testthat/test-colwise-mutate.R
+++ b/tests/testthat/test-colwise-mutate.R
@@ -432,8 +432,7 @@ test_that("colwise mutate handles formulas with constants (#4374)", {
 
 test_that("colwise mutate gives correct error message if column not found (#4374)", {
   expect_error(
-    mutate_at(tibble(), "test", ~ 1),
-    "Unknown column `test`"
+    mutate_at(tibble(), "test", ~ 1)
   )
 })
 

--- a/tests/testthat/test-lead-lag.R
+++ b/tests/testthat/test-lead-lag.R
@@ -78,3 +78,14 @@ test_that("input checks", {
     fixed = TRUE
   )
 })
+
+test_that("lead() and lag() respect bit64::integer64 (#4558)", {
+  data <- c(1, 2, 3)
+  x <- bit64::as.integer64(data)
+  expect_equal(lead(x), bit64::as.integer64(lead(data)))
+  expect_equal(lag(x) , bit64::as.integer64(lag(data)))
+
+  y <- 3:1
+  expect_equal(lead(x, order_by = y), bit64::as.integer64(lead(data, order_by = y)))
+  expect_equal(lag(x, order_by = y) , bit64::as.integer64(lag(data, order_by = y)))
+})


### PR DESCRIPTION
closes #4558

``` r
suppressPackageStartupMessages({
  library(bit64)
  library(dplyr)
})

lag(bit64::as.integer64(c(1,2,3)), 1)
#> integer64
#> [1] <NA> 1    2
```

<sup>Created on 2019-11-26 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>