### PR TITLE
Tiny clarification for example for summarise_at

### DIFF
--- a/R/colwise-mutate.R
+++ b/R/colwise-mutate.R
@@ -38,7 +38,7 @@
 #'
 #'   ```
 #'   nms <- setdiff(nms, group_vars(data))
-#'   data %>% summarise_at(vars, myoperation)
+#'   data %>% summarise_at(nms, myoperation)
 #'   ```
 #'
 #' * Grouping variables covered by implicit selections are silently

--- a/man/summarise_all.Rd
+++ b/man/summarise_all.Rd
@@ -73,7 +73,7 @@ selection is \strong{implicit} (\code{all} and \code{if} selections) or
 }
 
 Or remove \code{group_vars()} from the character vector of column names:\preformatted{nms <- setdiff(nms, group_vars(data))
-data \%>\% summarise_at(vars, myoperation)
+data \%>\% summarise_at(nms, myoperation)
 }
 \item Grouping variables covered by implicit selections are silently
 ignored by \code{summarise_all()} and \code{summarise_if()}.


### PR DESCRIPTION
In the examples for summarise_at, a selection of variables called nms is created but not used.

This also demonstrates that you can pass a character vector directly to .vars without the need of the vars(one_of(...)) pattern.