### PR TITLE
internal implementation for validate_grouped_df

### DIFF
--- a/man/new_grouped_df.Rd
+++ b/man/new_grouped_df.Rd
@@ -7,7 +7,7 @@
 \usage{
 new_grouped_df(x, groups, ..., class = character())
 
-validate_grouped_df(x)
+validate_grouped_df(x, check_bounds = FALSE)
 }
 \arguments{
 \item{x}{A data frame}
@@ -19,6 +19,8 @@ a list of 1 based integer vectors that all are between 1 and the number of rows 
 \item{...}{additional attributes}
 
 \item{class}{additional class, will be prepended to canonical classes of a grouped data frame.}
+
+\item{check_bounds}{whether to check all indices for out of bounds problems in grouped_df objects}
 }
 \description{
 \code{new_grouped_df()} is a constructor designed to be high-performance so only

--- a/src/dplyr/symbols.h
+++ b/src/dplyr/symbols.h
@@ -4,44 +4,15 @@
 namespace dplyr {
 
 struct symbols {
+  static SEXP groups;
   static SEXP levels;
   static SEXP ptype;
-  static SEXP names;
-  static SEXP formula;
-  static SEXP envir;
-  static SEXP getNamespace;
-  static SEXP dot_dot_group_size;
-  static SEXP dot_dot_group_number;
-};
-
-struct fns {
-  static SEXP quote;
-  static SEXP rm;
-};
-
-struct strings {
-  static SEXP POSIXct;
-  static SEXP POSIXt;
-  static SEXP Date;
-  static SEXP factor;
-  static SEXP ordered;
+  static SEXP vars;
 };
 
 struct vectors {
-  static SEXP factor;
-  static SEXP ordered;
-  static SEXP unbound_sentinel;
   static SEXP classes_vctrs_list_of;
   static SEXP empty_int_vector;
-
-};
-
-struct envs {
-  static SEXP ns_dplyr;
-  static SEXP ns_rlang;
-  static SEXP ns_stats;
-
-  static SEXP context_env;
 };
 
 } // namespace dplyr

--- a/tests/testthat/test-group_data.R
+++ b/tests/testthat/test-group_data.R
@@ -53,19 +53,19 @@ test_that("GroupDataFrame checks the structure of the groups attribute", {
   groups <- attr(df, "groups")
   groups[[2]] <- 1:2
   attr(df, "groups") <- groups
-  expect_error(group_data(df), "The `groups` attribute is not a data frame with its last column called `.rows`")
+  expect_error(group_data(df), "The `groups` attribute is not a data frame with its last column called `.rows`", class = "dplyr_grouped_df_corrupt")
 
   df <- group_by(tibble(x = 1:4, g = rep(1:2, each = 2)), g)
   groups <- attr(df, "groups")
   names(groups) <- c("g", "not.rows")
   attr(df, "groups") <- groups
-  expect_error(group_data(df), "The `groups` attribute is not a data frame with its last column called `.rows`")
+  expect_error(group_data(df), "The `groups` attribute is not a data frame with its last column called `.rows`", class = "dplyr_grouped_df_corrupt")
 
   attr(df, "groups") <- tibble()
-  expect_error(group_data(df), "The `groups` attribute is not a data frame with its last column called `.rows`")
+  expect_error(group_data(df), "The `groups` attribute is not a data frame with its last column called `.rows`", class = "dplyr_grouped_df_corrupt")
 
   attr(df, "groups") <- NA
-  expect_error(group_data(df), "The `groups` attribute is not a data frame with its last column called `.rows`")
+  expect_error(group_data(df), "The `groups` attribute is not a data frame with its last column called `.rows`", class = "dplyr_grouped_df_corrupt")
 })
 
 test_that("older style grouped_df is no longer supported", {

--- a/tests/testthat/test-new_grouped_df.R
+++ b/tests/testthat/test-new_grouped_df.R
@@ -19,22 +19,22 @@ test_that("validate_grouped_df (#3837)", {
     tibble(x = 1:10),
     groups = tibble(".rows" := list(1:5, -1L))
   )
-  expect_error(validate_grouped_df(df), "indices of group 2 are out of bounds")
+  expect_error(validate_grouped_df(df, check_bounds = TRUE), "out of bounds indices", class = "dplyr_grouped_df_corrupt")
 
   attr(df, "groups")$.rows <- list(11L)
-  expect_error(validate_grouped_df(df), "indices of group 1 are out of bounds")
+  expect_error(validate_grouped_df(df, check_bounds = TRUE), "out of bounds indices", class = "dplyr_grouped_df_corrupt")
 
   attr(df, "groups")$.rows <- list(0L)
-  expect_error(validate_grouped_df(df), "indices of group 1 are out of bounds")
+  expect_error(validate_grouped_df(df, check_bounds = TRUE), "out of bounds indices", class = "dplyr_grouped_df_corrupt")
 
   attr(df, "groups")$.rows <- list(1)
-  expect_error(validate_grouped_df(df), "`.rows` column is not a list of one-based integer vectors")
+  expect_error(validate_grouped_df(df), "`.rows` column is not a list of one-based integer vectors", class = "dplyr_grouped_df_corrupt")
 
   attr(df, "groups") <- tibble()
-  expect_error(validate_grouped_df(df), "The `groups` attribute is not a data frame with its last column called `.rows`")
+  expect_error(validate_grouped_df(df), "The `groups` attribute is not a data frame with its last column called `.rows`", class = "dplyr_grouped_df_corrupt")
 
   attr(df, "groups") <- NULL
-  expect_error(validate_grouped_df(df), "The `groups` attribute is not a data frame with its last column called `.rows`")
+  expect_error(validate_grouped_df(df), "The `groups` attribute is not a data frame with its last column called `.rows`", class = "dplyr_grouped_df_corrupt")
 })
 
 test_that("new_grouped_df does not have rownames (#4173)", {


### PR DESCRIPTION
The R implementation was fairly slow, and this is not something we need vctrs for

```
[validate_grouped_df*] 282.4 MiB ❯ callr::r(function() {
+   library(dplyr, warn.conflicts = FALSE)
+   df <- tibble(x = rnorm(1e4), g = sample(rep(1:1e2, 100))) %>% group_by(g)
+   bench::mark(summarise(df, n = 0 + 0))
+ }, lib = "bench-libs/master")
# A tibble: 1 x 13
  expression                    min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result             memory               time     gc               
  <bch:expr>               <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list>             <list>               <list>   <list>           
1 summarise(df, n = 0 + 0)     22ms   26.7ms      36.3    1.54MB     61.2    19    32      523ms <tibble [100 × 2]> <df[,3] [1,720 × 3]> <bch:tm> <tibble [19 × 3]>


[validate_grouped_df*] 282.4 MiB ❯ callr::r(function() {
+   library(dplyr, warn.conflicts = FALSE)
+   df <- tibble(x = rnorm(1e4), g = sample(rep(1:1e2, 100))) %>% group_by(g)
+   bench::mark(summarise(df, n = 0 + 0))
+ }, lib = "bench-libs/validate_grouped_df")
# A tibble: 1 x 13
  expression                    min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result             memory             time     gc               
  <bch:expr>               <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list>             <list>             <list>   <list>           
1 summarise(df, n = 0 + 0)   4.99ms   5.81ms      170.    1.01MB     86.7    49    25      288ms <tibble [100 × 2]> <df[,3] [504 × 3]> <bch:tm> <tibble [74 × 3]>
```