### PR TITLE
faster internal group_keys()

### DIFF
--- a/R/group_keys.R
+++ b/R/group_keys.R
@@ -1,10 +1,3 @@
-group_keys_impl <- function(.data) {
-  structure(
-    select(group_data(.data), -last_col()),
-    .drop = NULL
-  )
-}
-
 #' @rdname group_split
 #' @export
 group_keys <- function(.tbl, ...) {
@@ -13,7 +6,7 @@ group_keys <- function(.tbl, ...) {
 
 #' @export
 group_keys.data.frame <- function(.tbl, ...){
-  group_keys_impl(group_by(.tbl, ...))
+  .Call(`dplyr_group_keys_impl`, group_by(.tbl, ...))
 }
 
 #' @export
@@ -21,7 +14,7 @@ group_keys.grouped_df <- function(.tbl, ...) {
   if (dots_n(...)) {
     warn("... is ignored in group_keys(<grouped_df>), please use group_by(..., add = TRUE) %>% group_keys()")
   }
-  group_keys_impl(.tbl)
+  .Call(`dplyr_group_keys_impl`, .tbl)
 }
 
 #' @export

--- a/inst/bench/bench.R
+++ b/inst/bench/bench.R
@@ -44,7 +44,7 @@ summarise_hybrid <- benchs(
   libs = libs,
 
   setup = {
-    df <- tibble(x = rnorm(1e4), g = sample(rep(1:1e2, 100))) %>% group_by(g)
+    df <- tibble(x = rnorm(1e5), g = sample(rep(1:1e3, 100))) %>% group_by(g)
   },
 
   summarise(df, n = n()),

--- a/src/dplyr/symbols.h
+++ b/src/dplyr/symbols.h
@@ -12,6 +12,7 @@ struct symbols {
 
 struct vectors {
   static SEXP classes_vctrs_list_of;
+  static SEXP classes_tbl_df;
   static SEXP empty_int_vector;
 };
 


### PR DESCRIPTION
``` r
library(bench)
library(dplyr)

callr::r(function(){
  library(dplyr)
  df <- tibble(x = rnorm(1e6), g = sample(rep(1:1e4, 100))) %>% group_by(g)
  bench::mark(a = group_keys(df))
}, lib = "/Users/romainfrancois/git/tidyverse/dplyr/bench-libs/0.8.3")
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 a             721µs    774µs     1217.     515KB     51.2

callr::r(function(){
  library(dplyr)
  df <- tibble(x = rnorm(1e6), g = sample(rep(1:1e4, 100))) %>% group_by(g)
  bench::mark(a = group_keys(df))
}, lib = "/Users/romainfrancois/git/tidyverse/dplyr/bench-libs/master")
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 a             1.3ms   1.44ms      663.    70.8KB     50.7

callr::r(function(){
  library(dplyr)
  df <- tibble(x = rnorm(1e6), g = sample(rep(1:1e4, 100))) %>% group_by(g)
  bench::mark(group_keys(df))
})
#> # A tibble: 1 x 6
#>   expression          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 group_keys(df)   2.18µs   2.55µs   375549.    7.22KB     75.1
```

<sup>Created on 2019-12-04 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>