### PR TITLE
WIP: Use as_label() for determining name of RHS table after nest_join()

### DIFF
--- a/R/tbl-df.r
+++ b/R/tbl-df.r
@@ -707,7 +707,7 @@ inner_join.tbl_df <- function(x, y, by = NULL, copy = FALSE,
 #' @export
 #' @rdname join.tbl_df
 nest_join.tbl_df <- function(x, y, by = NULL, copy = FALSE, keep = FALSE, name = NULL, ...) {
-  name_var <- name %||% expr_name(enexpr(y))
+  name_var <- name %||% as_label(enexpr(y))
 
   check_valid_names(tbl_vars(x))
   check_valid_names(tbl_vars(y))


### PR DESCRIPTION
Closes #4571.

With this PR:

``` r
library(dplyr)
library(nycflights13)

flights_var <- quo(flights)
rlang::eval_tidy(rlang::quo(nest_join(airlines[1:3, ], !!flights_var)))
#> Joining, by = "carrier"
#> # A tibble: 3 x 3
#>   carrier name                   flights               
#>   <chr>   <chr>                  <list>                
#> 1 9E      Endeavor Air Inc.      <tibble [18,460 × 18]>
#> 2 AA      American Airlines Inc. <tibble [32,729 × 18]>
#> 3 AS      Alaska Airlines Inc.   <tibble [714 × 18]>
```

<sup>Created on 2019-12-10 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>