### PR TITLE
internalize calculation of chunks in mutate()

### DIFF
--- a/src/dplyr.cpp
+++ b/src/dplyr.cpp
@@ -419,7 +419,7 @@ SEXP dplyr_mask_eval(SEXP quo, SEXP group, SEXP env_private, SEXP env_context) {
   return result;
 }
 
-SEXP dplyr_mask_eval_all(SEXP quo, SEXP env_private, SEXP env_context, SEXP dots_names, SEXP sexp_i) {
+SEXP dplyr_mask_eval_all_summarise(SEXP quo, SEXP env_private, SEXP env_context, SEXP dots_names, SEXP sexp_i) {
   SEXP rows = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::rows));
   R_xlen_t ngroups = XLENGTH(rows);
 
@@ -454,6 +454,73 @@ SEXP dplyr_mask_eval_all(SEXP quo, SEXP env_private, SEXP env_context, SEXP dots
 
   UNPROTECT(4);
   return chunks;
+}
+
+SEXP dplyr_mask_eval_all_mutate(SEXP quo, SEXP env_private, SEXP env_context, SEXP dots_names, SEXP sexp_i) {
+  SEXP rows = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::rows));
+  R_xlen_t ngroups = XLENGTH(rows);
+
+  SEXP mask = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::mask));
+  SEXP caller = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::caller));
+
+  SEXP res = PROTECT(Rf_allocVector(VECSXP, 2));
+  SEXP chunks = PROTECT(Rf_allocVector(VECSXP, ngroups));
+  bool seen_vec = false;
+  bool needs_recycle = false;
+
+  for (R_xlen_t i = 0; i < ngroups; i++) {
+    SEXP rows_i = VECTOR_ELT(rows, i);
+    R_xlen_t n_i = XLENGTH(rows_i);
+    SEXP current_group = PROTECT(Rf_ScalarInteger(i + 1));
+    Rf_defineVar(dplyr::symbols::current_group, current_group, env_private);
+    Rf_defineVar(dplyr::symbols::dot_dot_group_size, Rf_ScalarInteger(n_i), env_context);
+    Rf_defineVar(dplyr::symbols::dot_dot_group_number, current_group, env_context);
+
+    SEXP result_i = PROTECT(rlang::eval_tidy(quo, mask, caller));
+    if (Rf_isNull(result_i)) {
+      if (seen_vec) {
+        // the current chunk is NULL but there were some non NULL
+        // chunks, so this is an error
+        Rf_error("incompatible results for mutate(), some results are NULL");
+      } else {
+        UNPROTECT(2);
+        continue;
+      }
+    } else {
+      seen_vec = true;
+    }
+
+    if (!vctrs::vec_is_vector(result_i)) {
+      if (!Rf_isNull(dots_names)) {
+        SEXP name = STRING_ELT(dots_names, i);
+        if (XLENGTH(name) > 0) {
+          Rf_error("Unsupported type for result `%s`", CHAR(name));
+        }
+      }
+      int i = INTEGER(sexp_i)[0];
+      Rf_error("Unsupported type at index %d", i);
+    }
+
+    if (!needs_recycle && vctrs::short_vec_size(result_i) != n_i) {
+      needs_recycle = true;
+    }
+
+    SET_VECTOR_ELT(chunks, i, result_i);
+
+    UNPROTECT(2);
+  }
+
+
+  // there was only NULL results
+  if (ngroups > 0 && !seen_vec) {
+    chunks = R_NilValue;
+  }
+  SET_VECTOR_ELT(res, 0, chunks);
+  SET_VECTOR_ELT(res, 1, Rf_ScalarLogical(needs_recycle));
+
+  UNPROTECT(5);
+
+  return res;
 }
 
 SEXP dplyr_vec_sizes(SEXP chunks) {
@@ -758,7 +825,8 @@ static const R_CallMethodDef CallEntries[] = {
   {"dplyr_validate_grouped_df", (DL_FUNC)& dplyr_validate_grouped_df, 3},
   {"dplyr_group_keys_impl", (DL_FUNC)& dplyr_group_keys_impl, 1},
   {"dplyr_mask_eval", (DL_FUNC)& dplyr_mask_eval, 4},
-  {"dplyr_mask_eval_all", (DL_FUNC)& dplyr_mask_eval_all, 5},
+  {"dplyr_mask_eval_all_summarise", (DL_FUNC)& dplyr_mask_eval_all_summarise, 5},
+  {"dplyr_mask_eval_all_mutate", (DL_FUNC)& dplyr_mask_eval_all_mutate, 5},
   {"dplyr_vec_sizes", (DL_FUNC)& dplyr_vec_sizes, 1},
   {"dplyr_validate_summarise_sizes", (DL_FUNC)& dplyr_validate_summarise_sizes, 2},
   {"dplyr_group_indices", (DL_FUNC)& dplyr_group_indices, 2},

--- a/tests/testthat/test-filter.r
+++ b/tests/testthat/test-filter.r
@@ -2,12 +2,14 @@ context("Filter")
 
 test_that("filter fails if inputs incorrect length (#156)", {
   expect_error(
-    filter(tbl_df(mtcars), c(F, T)),
-    class = "vctrs_error_recycle_incompatible_size"
+    filter(tbl_df(mtcars), c(FALSE, TRUE)),
+    "filter() expressions should return logical vectors of the same size as the group",
+    fixed = TRUE
   )
   expect_error(
-    filter(group_by(mtcars, am), c(F, T)),
-    class  = "vctrs_error_recycle_incompatible_size"
+    filter(group_by(mtcars, am), c(FALSE, TRUE)),
+    "filter() expressions should return logical vectors of the same size as the group",
+    fixed = TRUE
   )
 })
 
@@ -18,8 +20,6 @@ test_that("filter gives useful error message when given incorrect input", {
     fixed = TRUE
   )
 })
-
-
 
 test_that("filter complains if inputs are named", {
   expect_known_output(
@@ -98,11 +98,13 @@ test_that("filter propagates attributes", {
 test_that("filter fails on integer indices", {
   expect_error(
     filter(mtcars, 1:2),
-    class = "dplyr_filter_wrong_result"
+    "filter() expressions should return logical vectors of the same size as the group",
+    fixed = TRUE
   )
   expect_error(
     filter(group_by(mtcars, cyl), 1:2),
-    class = "dplyr_filter_wrong_result"
+    "filter() expressions should return logical vectors of the same size as the group",
+    fixed = TRUE
   )
 })
 

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -507,17 +507,7 @@ test_that("mutate works on empty data frames (#1142)", {
 })
 
 test_that("mutate handles 0 rows rowwise (#1300)", {
-  a <- tibble(x = 1)
-  b <- tibble(y = character())
-
-  g <- function(y) {
-    1
-  }
-  f <- function() {
-    b %>% rowwise() %>% mutate(z = g(y))
-  }
-
-  res <- f()
+  res <- tibble(y = character()) %>% rowwise() %>% mutate(z = 1)
   expect_equal(nrow(res), 0L)
 })
 
@@ -743,13 +733,13 @@ test_that("mutate() supports unquoted values", {
   expect_identical(mutate(df, out = !!(1:5)), mutate(df, out = 1:5))
   expect_identical(mutate(df, out = !!quote(1:5)), mutate(df, out = 1:5))
   expect_error(mutate(df, out = !!(1:2)), class = "vctrs_error_recycle_incompatible_size")
-  expect_error(mutate(df, out = !!env(a = 1)), class = "vctrs_error_scalar_type")
+  expect_error(mutate(df, out = !!env(a = 1)), "Unsupported type for result `out`")
 
   gdf <- group_by(df, g)
   expect_identical(mutate(gdf, out = !!1), mutate(gdf, out = 1))
   expect_error(mutate(gdf, out = !!quote(1:5)), class = "vctrs_error_recycle_incompatible_size")
   expect_error(mutate(gdf, out = !!(1:2)), class = "vctrs_error_recycle_incompatible_size")
-  expect_error(mutate(gdf, out = !!env(a = 1)), class = "vctrs_error_scalar_type")
+  expect_error(mutate(gdf, out = !!env(a = 1)), "Unsupported type for result `out`")
 })
 
 test_that("auto-splicing for tibbles", {
@@ -784,11 +774,11 @@ test_that("mutate handles raw vectors in columns (#1803)", {
 test_that("grouped mutate errors on incompatible column type (#1641)", {
   expect_error(
     tibble(x = 1) %>% mutate(y = mean),
-    class = "vctrs_error_scalar_type"
+    "Unsupported type for result `y`"
   )
   expect_error(
     tibble(x = 1) %>% mutate(y = quote(a)),
-    class = "vctrs_error_scalar_type"
+    "Unsupported type for result `y`"
   )
 })
 


### PR DESCRIPTION
Similar to #4646 but for mutate()

With profile code: 

```r
library(dplyr, warn.conflicts = FALSE)
df <- tibble(x = rnorm(1e6), g = sample(rep(1:1e4, 100))) %>% group_by(g)
profvis::profvis(for (i in 1:100) out <- mutate(df, a = rep(+1L, n())))
```

We start at: 

![image](https://user-images.githubusercontent.com/2625526/70791992-92011380-1d98-11ea-9600-b6415512d967.png)

after internalizing the loop that makes the chunks: 

![image](https://user-images.githubusercontent.com/2625526/70792042-af35e200-1d98-11ea-9706-450c2b604123.png)


