### PR TITLE
Update NEWS.md for already merged PR #4102

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dplyr 0.9.0 (in development)
 
+* `pull()` can now return named vectors by specifying an additional column name
+  (@ilarischeinin, #4102).
+
 * dplyr no longer provides a `all.equal.tbl_df()` method. It never should have
   done so in the first place because it owns neither the generic nor the class.
   It also provided a problematic implementation because, by default, it 


### PR DESCRIPTION
Pull request #4102 has already been merged, but it did not contain a corresponding update to `NEWS.md`. This PR does.

The reason is that when I submitted the PR, `NEWS.md` was still at 0.8.0 for the then upcoming release: 

> I didn't yet make any changes to `NEWS` (or `DESCRIPTION`) as in branch master they are still at 0.8.0 for the upcoming release. I'm happy to add to this PR later to add an item to `NEWS`, but thought I'd leave it out for now to not cause any extra work for maintainers, in case a number of PRs go about bumping the version number and adding a new header to `NEWS`.

