### PR TITLE
row order for left_join() and right_join()

### DIFF
--- a/R/tbl-df.r
+++ b/R/tbl-df.r
@@ -717,18 +717,14 @@ left_join.tbl_df <- function(x, y, by = NULL, copy = FALSE,
   aux_y <- vars$idx$y$aux
 
   # unique values and where they are in each
-  x_split <- vec_group_pos(x[, by_x, drop = FALSE])
   y_split <- vec_group_pos(y[, by_y, drop = FALSE])
 
   # matching uniques in x with uniques in y
-  matches <- vec_match(
-    x_split$key,
-    set_names(y_split$key, names(x_split$key))
-  )
+  matches <- vec_match(x[, by_x, drop = FALSE], set_names(y_split$key, names(x)[by_x]))
 
   # for each unique value in x, expand the ids according to the number
   # of matches in y
-  x_indices <- vec_c(!!!map2(matches, x_split$pos, function(match, ids, rhs_id) {
+  x_indices <- vec_c(!!!map2(matches, seq_along(matches), function(match, ids, rhs_id) {
     if (is.na(match)) {
       ids
     } else {
@@ -737,11 +733,11 @@ left_join.tbl_df <- function(x, y, by = NULL, copy = FALSE,
   }, rhs_id = y_split$pos), .ptype = integer())
 
   # same for ids of y
-  y_indices <- vec_c(!!!map2(matches, x_split$pos, function(match, ids, rhs_id) {
+  y_indices <- vec_c(!!!map2(matches, seq_along(matches), function(match, ids, rhs_id) {
     if (is.na(match)) {
-      vec_repeat(NA_integer_, length(ids))
+      NA_integer_
     } else {
-      vec_repeat(rhs_id[[match]], times = length(ids))
+      rhs_id[[match]]
     }
   }, rhs_id = y_split$pos), .ptype = integer())
 

--- a/R/tbl-df.r
+++ b/R/tbl-df.r
@@ -900,7 +900,7 @@ full_join.tbl_df <- function(x, y, by = NULL, copy = FALSE,
 
 #' @export
 #' @rdname join.tbl_df
-semi_join.tbl_df <- function(x, y, by = NULL, copy = FALSE, ..., suffix = c(".x", ".y"),
+semi_join.tbl_df <- function(x, y, by = NULL, copy = FALSE, ...,
                              na_matches = pkgconfig::get_config("dplyr::na_matches")) {
   check_valid_names(tbl_vars(x))
   check_valid_names(tbl_vars(y))
@@ -908,7 +908,7 @@ semi_join.tbl_df <- function(x, y, by = NULL, copy = FALSE, ..., suffix = c(".x"
   by <- common_by(by, x, y)
   by_x <- check_by_x(by$x)
   y <- auto_copy(x, y, copy = copy)
-  suffix <- check_suffix(suffix)
+  suffix <- check_suffix(c(".x", ".y"))
   na_matches <- check_na_matches(na_matches)
 
   y <- auto_copy(x, y, copy = copy)
@@ -936,7 +936,7 @@ semi_join.tbl_df <- function(x, y, by = NULL, copy = FALSE, ..., suffix = c(".x"
 
 #' @export
 #' @rdname join.tbl_df
-anti_join.tbl_df <- function(x, y, by = NULL, copy = FALSE, ..., suffix = c(".x", ".y"),
+anti_join.tbl_df <- function(x, y, by = NULL, copy = FALSE, ...,
                              na_matches = pkgconfig::get_config("dplyr::na_matches")) {
   check_valid_names(tbl_vars(x))
   check_valid_names(tbl_vars(y))
@@ -944,7 +944,7 @@ anti_join.tbl_df <- function(x, y, by = NULL, copy = FALSE, ..., suffix = c(".x"
   by <- common_by(by, x, y)
   by_x <- check_by_x(by$x)
   y <- auto_copy(x, y, copy = copy)
-  suffix <- check_suffix(suffix)
+  suffix <- check_suffix(c(".x", ".y"))
   na_matches <- check_na_matches(na_matches)
 
   y <- auto_copy(x, y, copy = copy)

--- a/R/tbl-df.r
+++ b/R/tbl-df.r
@@ -779,30 +779,29 @@ right_join.tbl_df <- function(x, y, by = NULL, copy = FALSE,
 
   # unique values and where they are in each
   x_split <- vec_group_pos(x[, by_x, drop = FALSE])
-  y_split <- vec_group_pos(y[, by_y, drop = FALSE])
 
   # matching uniques in x with uniques in y
   matches <- vec_match(
-    y_split$key,
-    set_names(x_split$key, names(y_split$key))
+    y[, by_y, drop = FALSE],
+    set_names(x_split$key, names(y)[by_y])
   )
 
   # for each unique value in y, expand the ids according to the number
   # of matches in x
-  y_indices <- vec_c(!!!map2(matches, y_split$pos, function(match, ids, lhs_id) {
+  y_indices <- vec_c(!!!map2(matches, seq_along(matches), function(match, id, lhs_id) {
     if (is.na(match)) {
-      ids
+      id
     } else {
-      vec_repeat(ids, each = length(lhs_id[[match]]))
+      vec_repeat(id, each = length(lhs_id[[match]]))
     }
   }, lhs_id = x_split$pos), .ptype = integer())
 
   # same for ids of x
-  x_indices <- vec_c(!!!map2(matches, y_split$pos, function(match, ids, lhs_id) {
+  x_indices <- vec_c(!!!map2(matches, seq_along(matches), function(match, id, lhs_id) {
     if (is.na(match)) {
-      vec_repeat(NA_integer_, length(ids))
+      NA_integer_
     } else {
-      vec_repeat(lhs_id[[match]], times = length(ids))
+      vec_repeat(lhs_id[[match]], times = length(id))
     }
   }, lhs_id = x_split$pos), .ptype = integer())
 

--- a/tests/testthat/test-joins.r
+++ b/tests/testthat/test-joins.r
@@ -1037,14 +1037,9 @@ test_that("joins reject data frames with duplicate columns (#3243)", {
     class = "tibble_error_column_names_must_be_unique"
   )
 
-  # FIXME: Compatibility, should throw an error eventually
-  expect_warning(
-    expect_equal(
-      semi_join(df2, df1, by = c("x", "y")),
-      data.frame(x = 2:3, y = 2:3)
-    ),
-    "Column `x` must have a unique name",
-    fixed = TRUE
+  expect_error(
+    semi_join(df2, df1, by = c("x", "y")),
+    "Column `x` must have a unique name", fixed = TRUE
   )
 
   expect_error(
@@ -1052,12 +1047,8 @@ test_that("joins reject data frames with duplicate columns (#3243)", {
     class = "tibble_error_column_names_must_be_unique"
   )
 
-  # FIXME: Compatibility, should throw an error eventually
-  expect_warning(
-    expect_equal(
-      anti_join(df2, df1, by = c("x", "y")),
-      data.frame(x = 4L, y = 4L)
-    ),
+  expect_error(
+    anti_join(df2, df1, by = c("x", "y")),
     "Column `x` must have a unique name",
     fixed = TRUE
   )
@@ -1136,33 +1127,33 @@ test_that("joins reject data frames with NA columns (#3417)", {
     fixed = TRUE
   )
 
-  expect_warning(
+  expect_error(
     semi_join(df_aa, df_b),
     "Column `1` cannot have NA as name",
     fixed = TRUE
   )
-  expect_warning(
+  expect_error(
     semi_join(df_aa, df_ba),
     "Column `1` cannot have NA as name",
     fixed = TRUE
   )
-  expect_warning(
+  expect_error(
     semi_join(df_a, df_ba),
     "Column `2` cannot have NA as name",
     fixed = TRUE
   )
 
-  expect_warning(
+  expect_error(
     anti_join(df_aa, df_b),
     "Column `1` cannot have NA as name",
     fixed = TRUE
   )
-  expect_warning(
+  expect_error(
     anti_join(df_aa, df_ba),
     "Column `1` cannot have NA as name",
     fixed = TRUE
   )
-  expect_warning(
+  expect_error(
     anti_join(df_a, df_ba),
     "Column `2` cannot have NA as name",
     fixed = TRUE

--- a/tests/testthat/test-joins.r
+++ b/tests/testthat/test-joins.r
@@ -1169,7 +1169,7 @@ test_that("joins reject data frames with NA columns (#3417)", {
   )
 })
 
-test_that("left_join() respects original row orders (#4639)", {
+test_that("left_join() respects original row orders of x (#4639)", {
   d1 <- tibble(a = c(1:3, 3:1))
   d2 <- tibble(a = 3:1, b = 1:3)
 
@@ -1183,4 +1183,13 @@ test_that("left_join() respects original row orders (#4639)", {
   res <- left_join(d1, d2, by = "a")
   expect_equal(res$a, c(1, 1:3, 3:1, 1))
   expect_equal(res$b, c(3:4, 2:1, 1:2, 3:4))
+})
+
+test_that("right_join() respects original row orders of y (#4639)", {
+  d1 <- tibble(a = c(3:1))
+  d2 <- tibble(a = c(1:3, 3:1), b = 1:6)
+
+  res <- right_join(d1, d2)
+  expect_equal(res$a, d2$a)
+  expect_equal(res$b, 1:6)
 })

--- a/tests/testthat/test-joins.r
+++ b/tests/testthat/test-joins.r
@@ -1168,3 +1168,19 @@ test_that("joins reject data frames with NA columns (#3417)", {
     fixed = TRUE
   )
 })
+
+test_that("left_join() respects original row orders (#4639)", {
+  d1 <- tibble(a = c(1:3, 3:1))
+  d2 <- tibble(a = 3:1, b = 1:3)
+
+  res <- left_join(d1, d2, by = "a")
+  expect_equal(res$a, d1$a)
+  expect_equal(res$b, c(3:1, 1:3))
+
+  d1 <- tibble(a = c(1:3, 3:1))
+  d2 <- tibble(a = c(3:1, 1), b = 1:4)
+
+  res <- left_join(d1, d2, by = "a")
+  expect_equal(res$a, c(1, 1:3, 3:1, 1))
+  expect_equal(res$b, c(3:4, 2:1, 1:2, 3:4))
+})


### PR DESCRIPTION
``` r
library(tidyverse)
left_join(tibble(a = c(1:3, 3:1)), tibble(a = 3:1, b = 1:3))
#> Joining, by = "a"
#> # A tibble: 6 x 2
#>       a     b
#>   <int> <int>
#> 1     1     3
#> 2     2     2
#> 3     3     1
#> 4     3     1
#> 5     2     2
#> 6     1     3
```

<sup>Created on 2019-12-19 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>