### PR TITLE
group_by() and distinct() understands auto splicing

### DIFF
--- a/R/distinct.R
+++ b/R/distinct.R
@@ -73,19 +73,18 @@ distinct_prepare <- function(.data, vars, group_vars = character(), .keep_all = 
   }
 
   # If any calls, use mutate to add new columns, then distinct on those
-  .data <- add_computed_columns(.data, vars)$data
-  vars <- exprs_auto_name(vars)
+  c(.data, distinct_vars) %<-% add_computed_columns(.data, vars)
 
   # Once we've done the mutate, we no longer need lazy objects, and
   # can instead just use their names
-  missing_vars <- setdiff(names(vars), names(.data))
+  missing_vars <- setdiff(distinct_vars, names(.data))
 
   if (length(missing_vars) > 0) {
     missing_items <- fmt_items(fmt_obj(missing_vars))
-    vars <- vars[names(vars) %in% names(.data)]
-    if (length(vars) > 0) {
+    distinct_vars <- distinct_vars[distinct_vars %in% names(.data)]
+    if (length(distinct_vars) > 0) {
       true_vars <- glue("The following variables will be used:
-                        {fmt_items(names(vars))}")
+                        {fmt_items(distinct_vars)}")
     } else {
       true_vars <- "The operation will return the input unchanged."
     }
@@ -97,7 +96,7 @@ distinct_prepare <- function(.data, vars, group_vars = character(), .keep_all = 
     warn(msg)
   }
 
-  new_vars <- unique(c(names(vars), group_vars))
+  new_vars <- unique(c(distinct_vars, group_vars))
 
   # Keep the order of the variables
   out_vars <- intersect(new_vars, names(.data))

--- a/R/distinct.R
+++ b/R/distinct.R
@@ -73,7 +73,7 @@ distinct_prepare <- function(.data, vars, group_vars = character(), .keep_all = 
   }
 
   # If any calls, use mutate to add new columns, then distinct on those
-  .data <- add_computed_columns(.data, vars)
+  .data <- add_computed_columns(.data, vars)$data
   vars <- exprs_auto_name(vars)
 
   # Once we've done the mutate, we no longer need lazy objects, and

--- a/R/tbl-df.r
+++ b/R/tbl-df.r
@@ -337,10 +337,7 @@ mutate_new_columns <- function(.data, ...) {
   new_columns
 }
 
-
-#' @export
-mutate.tbl_df <- function(.data, ...) {
-  new_columns <- mutate_new_columns(.data, ...)
+mutate_finish <- function(.data, new_columns) {
   if (!length(new_columns)) {
     return(.data)
   }
@@ -360,6 +357,13 @@ mutate.tbl_df <- function(.data, ...) {
   }
 
   out
+}
+
+
+#' @export
+mutate.tbl_df <- function(.data, ...) {
+  new_columns <- mutate_new_columns(.data, ...)
+  mutate_finish(.data, new_columns)
 }
 
 #' @export

--- a/tests/testthat/test-distinct.R
+++ b/tests/testthat/test-distinct.R
@@ -210,3 +210,20 @@ test_that("distinct() understands both NA variants (#4516)", {
   df_1$col_a[2] <- NA
   expect_equal(nrow(setdiff(df_1, df_2)), 0L)
 })
+
+test_that("distinct() handles auto splicing", {
+  expect_equal(
+    iris %>% distinct(Species),
+    iris %>% distinct(data.frame(Species=Species))
+  )
+
+  expect_equal(
+    iris %>% distinct(Species),
+    iris %>% distinct(across(Species))
+  )
+
+  expect_equal(
+    iris %>% mutate(across(starts_with("Sepal"), round)) %>% distinct(Sepal.Length, Sepal.Width),
+    iris %>% distinct(across(starts_with("Sepal"), round))
+  )
+})

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -535,3 +535,32 @@ test_that("group_by() does not create arbitrary NA groups for factors when drop 
   expect_equal(nrow(res), 0L)
 })
 
+test_that("group_by() can handle auto splicing in the mutate() step", {
+  expect_identical(
+    iris %>% group_by(Species),
+    iris %>% group_by(data.frame(Species = Species))
+  )
+
+  expect_identical(
+    iris %>% group_by(Species),
+    iris %>% group_by(across(Species))
+  )
+
+  expect_identical(
+    iris %>% mutate(across(starts_with("Sepal"), round)) %>% group_by(Sepal.Length, Sepal.Width),
+    iris %>% group_by(across(starts_with("Sepal"), round))
+  )
+
+})
+
+test_that("group_by() can combine usual spec and auto-splicing-mutate() step", {
+  expect_identical(
+    iris %>% mutate(across(starts_with("Sepal"), round)) %>% group_by(Sepal.Length, Sepal.Width, Species),
+    iris %>% group_by(across(starts_with("Sepal"), round), Species)
+  )
+
+  expect_identical(
+    iris %>% mutate(across(starts_with("Sepal"), round)) %>% group_by(Species, Sepal.Length, Sepal.Width),
+    iris %>% group_by(Species, across(starts_with("Sepal"), round))
+  )
+})


### PR DESCRIPTION
~This needs some testing I guess, but~ `group_by()` gets somewhat smarter about its implicit `mutate()` step, in particular this means we can use `across()` in `group_by()` : 

``` r
library(dplyr, warn.conflicts = FALSE)

iris %>% 
  group_by(data.frame(Species = Species))
#> # A tibble: 150 x 5
#> # Groups:   Species [3]
#>    Sepal.Length Sepal.Width Petal.Length Petal.Width Species
#>           <dbl>       <dbl>        <dbl>       <dbl> <fct>  
#>  1          5.1         3.5          1.4         0.2 setosa 
#>  2          4.9         3            1.4         0.2 setosa 
#>  3          4.7         3.2          1.3         0.2 setosa 
#>  4          4.6         3.1          1.5         0.2 setosa 
#>  5          5           3.6          1.4         0.2 setosa 
#>  6          5.4         3.9          1.7         0.4 setosa 
#>  7          4.6         3.4          1.4         0.3 setosa 
#>  8          5           3.4          1.5         0.2 setosa 
#>  9          4.4         2.9          1.4         0.2 setosa 
#> 10          4.9         3.1          1.5         0.1 setosa 
#> # … with 140 more rows

input <- list(vars = "Species")
iris %>% 
  group_by(across(input$vars))
#> # A tibble: 150 x 5
#> # Groups:   Species [3]
#>    Sepal.Length Sepal.Width Petal.Length Petal.Width Species
#>           <dbl>       <dbl>        <dbl>       <dbl> <fct>  
#>  1          5.1         3.5          1.4         0.2 setosa 
#>  2          4.9         3            1.4         0.2 setosa 
#>  3          4.7         3.2          1.3         0.2 setosa 
#>  4          4.6         3.1          1.5         0.2 setosa 
#>  5          5           3.6          1.4         0.2 setosa 
#>  6          5.4         3.9          1.7         0.4 setosa 
#>  7          4.6         3.4          1.4         0.3 setosa 
#>  8          5           3.4          1.5         0.2 setosa 
#>  9          4.4         2.9          1.4         0.2 setosa 
#> 10          4.9         3.1          1.5         0.1 setosa 
#> # … with 140 more rows

iris %>% 
  group_by(across(starts_with("Sepal"), round))
#> # A tibble: 150 x 5
#> # Groups:   Sepal.Length, Sepal.Width [13]
#>    Sepal.Length Sepal.Width Petal.Length Petal.Width Species
#>           <dbl>       <dbl>        <dbl>       <dbl> <fct>  
#>  1            5           4          1.4         0.2 setosa 
#>  2            5           3          1.4         0.2 setosa 
#>  3            5           3          1.3         0.2 setosa 
#>  4            5           3          1.5         0.2 setosa 
#>  5            5           4          1.4         0.2 setosa 
#>  6            5           4          1.7         0.4 setosa 
#>  7            5           3          1.4         0.3 setosa 
#>  8            5           3          1.5         0.2 setosa 
#>  9            4           3          1.4         0.2 setosa 
#> 10            5           3          1.5         0.1 setosa 
#> # … with 140 more rows
```

<sup>Created on 2019-12-27 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>