### PR TITLE
across() selection does not include grouping variables

### DIFF
--- a/R/across.R
+++ b/R/across.R
@@ -70,7 +70,12 @@ current_column <- function() {
 #' @export
 across <- function(select, fns = identity) {
   mask <- peek_mask()
-  vars <- eval_select(expr({{select}}), mask$full_data())
+  data <- mask$full_data()
+
+  vars <- eval_select(
+    expr({{select}}),
+    data[, setdiff(names(data), group_vars(data))]
+  )
   data <- mask$pick(names(vars))
 
   single_function <- is.function(fns) || is_formula(fns)

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -1124,3 +1124,10 @@ test_that("summarise() packs named tibble results (#2326)", {
   expect_is(res$out, "data.frame")
   expect_equal(nrow(res$out), 3L)
 })
+
+test_that("across() does not select grouping variables", {
+  expect_identical(
+    iris %>% group_by(Species) %>% summarise(across(is.numeric, mean)),
+    iris %>% group_by(Species) %>% summarise(across(everything(), mean))
+  )
+})


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)

iris %>% group_by(Species) %>% summarise(across(is.numeric, mean))
#> # A tibble: 3 x 5
#>   Species    Sepal.Length Sepal.Width Petal.Length Petal.Width
#>   <fct>             <dbl>       <dbl>        <dbl>       <dbl>
#> 1 setosa             5.01        3.43         1.46       0.246
#> 2 versicolor         5.94        2.77         4.26       1.33 
#> 3 virginica          6.59        2.97         5.55       2.03
iris %>% group_by(Species) %>% summarise(across(everything(), mean))
#> # A tibble: 3 x 5
#>   Species    Sepal.Length Sepal.Width Petal.Length Petal.Width
#>   <fct>             <dbl>       <dbl>        <dbl>       <dbl>
#> 1 setosa             5.01        3.43         1.46       0.246
#> 2 versicolor         5.94        2.77         4.26       1.33 
#> 3 virginica          6.59        2.97         5.55       2.03
```

<sup>Created on 2020-01-06 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>