### PR TITLE
rename before vec_rbind() for the by_x part of the full join

### DIFF
--- a/R/join.r
+++ b/R/join.r
@@ -532,7 +532,7 @@ full_join.tbl_df <- function(x, y, by = NULL, copy = FALSE,
 
   out[by_x] <- vec_rbind(
     vec_slice(x[, by_x, drop = FALSE], x_indices_one),
-    vec_slice(y[, by_y, drop = FALSE], y_indices_two)
+    set_names(vec_slice(y[, by_y, drop = FALSE], y_indices_two), names(x)[by_x])
   )
 
   # other colums from x

--- a/tests/testthat/test-join.r
+++ b/tests/testthat/test-join.r
@@ -1151,3 +1151,12 @@ test_that("right_join() respects original row orders of y (#4639)", {
   expect_equal(res$a, d2$a)
   expect_equal(res$b, 1:6)
 })
+
+test_that("full_join() correctly restores columns (#4649)", {
+  df1 <- tibble(x = "x", by = 1)
+  df2 <- tibble(y = "y", by = 1)
+  res <- tibble(x = "x", by = 1, y = "y")
+
+  expect_equal(res, full_join(df1, df2, by = "by"))
+  expect_equal(res, right_join(df1, df2, by ="by"))
+})

--- a/tests/testthat/test-join.r
+++ b/tests/testthat/test-join.r
@@ -1152,11 +1152,21 @@ test_that("right_join() respects original row orders of y (#4639)", {
   expect_equal(res$b, 1:6)
 })
 
-test_that("full_join() correctly restores columns (#4649)", {
+test_that("full_join() and right_join() correctly restores columns (#4649)", {
   df1 <- tibble(x = "x", by = 1)
   df2 <- tibble(y = "y", by = 1)
   res <- tibble(x = "x", by = 1, y = "y")
 
   expect_equal(res, full_join(df1, df2, by = "by"))
   expect_equal(res, right_join(df1, df2, by ="by"))
+})
+
+test_that("full_join() correctly binds the by part", {
+  df1 <- tibble(x = "x", a = 1)
+  df2 <- tibble(y = "y", b = 1)
+
+  expect_equal(
+    full_join(df1, df2, by = c("x" = "y")),
+    tibble(x = c("x", "y"), a = c(1, NA), b = c(NA, 1))
+  )
 })


### PR DESCRIPTION
before: 

``` r
library(dplyr, warn.conflicts = FALSE)

e <- data.frame(x = c(1, 1, 2, 3), z = 1:4)
f <- data.frame(x = c(1, 2, 2, 4), z = 1:4)
full_join(e, f, by = c("x" = "z"))
#> Warning in out[by_x] <- vec_rbind(vec_slice(x[, by_x, drop = FALSE],
#> x_indices_one), : number of items to replace is not a multiple of
#> replacement length
#>    x  z x.y
#> 1  1  1   1
#> 2  1  2   1
#> 3  2  3   2
#> 4  3  4   2
#> 5 NA NA   4
```

after: 

``` r
library(dplyr, warn.conflicts = FALSE)

e <- data.frame(x = c(1, 1, 2, 3), z = 1:4)
f <- data.frame(x = c(1, 2, 2, 4), z = 1:4)
full_join(e, f, by = c("x" = "z"))
#>   x  z x.y
#> 1 1  1   1
#> 2 1  2   1
#> 3 2  3   2
#> 4 3  4   2
#> 5 4 NA   4
```

<sup>Created on 2020-01-07 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>