### PR TITLE
argument across(.including_grouping=)

### DIFF
--- a/R/across.R
+++ b/R/across.R
@@ -46,14 +46,14 @@
 #'   group_by(Species) %>%
 #'   summarise(across(starts_with("Sepal"), list(mean = mean, sd = sd)))
 #' @export
-across <- function(cols, fns = NULL) {
+across <- function(cols, fns = NULL, .including_grouping = FALSE) {
   mask <- peek_mask()
   data <- mask$full_data()
+  if (!isTRUE(.including_grouping)) {
+    data <- data[, setdiff(names(data), group_vars(data))]
+  }
 
-  vars <- tidyselect::eval_select(
-    expr({{ cols }}),
-    data[, setdiff(names(data), group_vars(data))]
-  )
+  vars <- tidyselect::eval_select(expr({{ cols }}), data)
   data <- mask$pick(names(vars))
 
   if (is.null(fns)) {


### PR DESCRIPTION
``` r
library(tidyverse)

df <- tibble(
  foo = c("a", "a", "a", "b", "b", "b"),
  yo = c(1, NA, 1, 1, 1, 2),
  bar = c(1:4, NA, 6)
)

(df_grouped <- df %>% 
    group_by(foo, yo))
#> # A tibble: 6 x 3
#> # Groups:   foo, yo [4]
#>   foo      yo   bar
#>   <chr> <dbl> <dbl>
#> 1 a         1     1
#> 2 a        NA     2
#> 3 a         1     3
#> 4 b         1     4
#> 5 b         1    NA
#> 6 b         2     6

(df_nested <- df_grouped %>%
    nest())
#> # A tibble: 4 x 3
#> # Groups:   foo, yo [4]
#>   foo      yo data            
#>   <chr> <dbl> <list>          
#> 1 a         1 <tibble [2 × 1]>
#> 2 a        NA <tibble [1 × 1]>
#> 3 b         1 <tibble [2 × 1]>
#> 4 b         2 <tibble [1 × 1]>

df_nested %>% 
  filter(complete.cases(across(c(foo, yo), .including_grouping = TRUE)))
#> # A tibble: 3 x 3
#> # Groups:   foo, yo [3]
#>   foo      yo data            
#>   <chr> <dbl> <list>          
#> 1 a         1 <tibble [2 × 1]>
#> 2 b         1 <tibble [2 × 1]>
#> 3 b         2 <tibble [1 × 1]>
```

<sup>Created on 2020-01-08 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>

This would need to reopen #4692 somehow, 