### PR TITLE
summarise() tidy recycling

### DIFF
--- a/src/summarise.cpp
+++ b/src/summarise.cpp
@@ -89,8 +89,9 @@ SEXP dplyr_validate_summarise_sizes(SEXP size, SEXP chunks) {
     // matches
     int* p_size = INTEGER(size);
     for (R_xlen_t i = 0; i < nchunks; i++, ++p_size) {
-      if (*p_size != vctrs::short_vec_size(VECTOR_ELT(chunks, i))) {
-        Rf_errorcall(R_NilValue, "Result does not respect vec_size() == .size");
+      int new_size = vctrs::short_vec_size(VECTOR_ELT(chunks, i));
+      if (new_size != *p_size && new_size != 1) {
+        Rf_errorcall(R_NilValue, "Result does not respect vec_size() == .size or vec_size() == 1");
       }
     }
     return size;

--- a/src/summarise.cpp
+++ b/src/summarise.cpp
@@ -89,8 +89,8 @@ SEXP dplyr_validate_summarise_sizes(SEXP size, SEXP chunks) {
     // matches
     int* p_size = INTEGER(size);
     for (R_xlen_t i = 0; i < nchunks; i++, ++p_size) {
-      int new_size = vctrs::short_vec_size(VECTOR_ELT(chunks, i));
-      if (new_size != *p_size && new_size != 1) {
+      int size_i = vctrs::short_vec_size(VECTOR_ELT(chunks, i));
+      if (size_i != *p_size && size_i != 1) {
         Rf_errorcall(R_NilValue, "Result does not respect vec_size() == .size or vec_size() == 1");
       }
     }

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -1024,6 +1024,12 @@ test_that("summarise() recycles", {
     tibble(a = 1:2) %>% group_by(a) %>% summarise(x = 1, y = 1:3, z = 1),
     tibble(a = rep(1:2, each = 3), x = 1, y = c(1:3, 1:3), z = 1)
   )
+  expect_equal(
+    tibble(a = 1:2) %>%
+      group_by(a) %>%
+      summarise(x = seq_len(a), y = 1),
+    tibble(a = c(1L, 2L, 2L), x = c(1L, 1L, 2L), y = 1)
+  )
 })
 
 test_that("summarise() give meaningful errors", {

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -1014,6 +1014,18 @@ test_that("summarise() keeps class, but not attributes", {
   expect_equal(attr(out, "res"), NULL)
 })
 
+test_that("summarise() recycles", {
+  expect_equal(
+    tibble() %>% summarise(x = 1, y = 1:3, z = 1),
+    tibble(x = 1, y = 1:3, z = 1)
+  )
+
+  expect_equal(
+    tibble(a = 1:2) %>% group_by(a) %>% summarise(x = 1, y = 1:3, z = 1),
+    tibble(a = rep(1:2, each = 3), x = 1, y = c(1:3, 1:3), z = 1)
+  )
+})
+
 test_that("summarise() give meaningful errors", {
   verify_output(test_path("test-summarise-errors.txt"), {
     "# unsupported type"


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)

tibble(a = 1:2) %>% group_by(a) %>% summarise(x = 1, y = 1:3, z = 1)
#> # A tibble: 6 x 4
#>       a     x     y     z
#>   <int> <dbl> <int> <dbl>
#> 1     1     1     1     1
#> 2     1     1     2     1
#> 3     1     1     3     1
#> 4     2     1     1     1
#> 5     2     1     2     1
#> 6     2     1     3     1
```

<sup>Created on 2020-01-12 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>