### PR TITLE
[.grouped_df should not keep the groups attribute when it does not ma…

### DIFF
--- a/R/grouped-df.r
+++ b/R/grouped-df.r
@@ -15,7 +15,7 @@
 #' @export
 grouped_df <- function(data, vars, drop = FALSE) {
   if (length(vars) == 0) {
-    as_tibble(data)
+    `attr<-`(as_tibble(data), "groups", NULL)
   } else {
     groups <- compute_groups(data, vars, drop = drop)
     new_grouped_df(data, groups)


### PR DESCRIPTION
…ke a grouped_df 

closes #4738 

``` r
library(dplyr, warn.conflicts = FALSE)

str(group_by(tibble(x = 1, z = 2), x)[2])
#> tibble [1 × 1] (S3: tbl_df/tbl/data.frame)
#>  $ z: num 2
```

<sup>Created on 2020-01-12 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>