### PR TITLE
investigating relationship between summarise() and do()

### DIFF
--- a/R/summarise.R
+++ b/R/summarise.R
@@ -122,7 +122,7 @@ summarise_cols <- function(.data, ...) {
   cols <- list()
 
   .size <- 1L
-  chunks <- vector("list", length(dots))
+  # chunks <- vector("list", length(dots))
 
   tryCatch({
 
@@ -134,41 +134,27 @@ summarise_cols <- function(.data, ...) {
       # evaluating the quosure in the "sliced data mask"
       #
       # TODO: reinject hybrid evaluation at the R level
-      chunks[[i]] <- mask$eval_all_summarise(quo, dots_names, i)
+      c(chunks_i, scalar_list) %<-% mask$eval_all_summarise(quo, dots_names, i)
 
-      # check that vec_size() of chunks is compatible with .size
-      # and maybe update .size
-      .size <- .Call(`dplyr_validate_summarise_sizes`, .size, chunks[[i]])
-
-      result_type <- vec_ptype_common(!!!chunks[[i]])
-
-      if ((is.null(dots_names) || dots_names[i] == "") && is.data.frame(result_type)) {
-        # remember each result separately
-        map2(seq_along(result_type), names(result_type), function(j, nm) {
-          mask$add(nm, pluck(chunks[[i]], j))
-        })
+      if (scalar_list) {
+        mask$add(auto_named_dots[i], chunks_i)
+        cols[[ auto_named_dots[i] ]] <- chunks_i
       } else {
-        # remember
-        mask$add(auto_named_dots[i], chunks[[i]])
-      }
-    }
+        result <- vec_c(!!!chunks_i)
 
-    # materialize columns
-    for (i in seq_along(dots)) {
-      if (!identical(.size, 1L)) {
-        sizes <- .Call(`dplyr_vec_sizes`, chunks[[i]])
-        if (!identical(sizes, .size)) {
-          chunks[[i]] <- map2(chunks[[i]], .size, vec_recycle, x_arg = glue("..{i}"))
+        if ((is.null(dots_names) || dots_names[i] == "") && is.data.frame(result)) {
+          # remember each result separately
+          map2(seq_along(result), names(result), function(j, nm) {
+            mask$add(nm, pluck(chunks_i, j))
+          })
+          cols[names(result)] <- result
+        } else {
+          # remember
+          mask$add(auto_named_dots[i], chunks_i)
+          cols[[ auto_named_dots[i] ]] <-  result
         }
       }
 
-      result <- vec_c(!!!chunks[[i]])
-
-      if ((is.null(dots_names) || dots_names[i] == "") && is.data.frame(result)) {
-        cols[names(result)] <- result
-      } else {
-        cols[[ auto_named_dots[i] ]] <-  result
-      }
     }
 
   },
@@ -177,12 +163,6 @@ summarise_cols <- function(.data, ...) {
   },
   simpleError = function(e) {
     stop_eval_tidy(e, index = i, dots = dots, fn = "summarise")
-  },
-  dplyr_summarise_unsupported_type = function(cnd) {
-    stop_summarise_unsupported_type(result = cnd$result, index = i, dots = dots)
-  },
-  dplyr_summarise_incompatible_size = function(cnd) {
-    stop_incompatible_size(size = cnd$size, group = cnd$group, index = i, expected_sizes = .size, dots = dots)
   })
 
   list(new = cols, size = .size)

--- a/tests/testthat/test-summarise-errors.txt
+++ b/tests/testthat/test-summarise-errors.txt
@@ -1,20 +1,4 @@
 
-unsupported type
-================
-
-> tibble(x = 1, y = c(1, 2, 2), z = runif(3)) %>% summarise(a = env(a = 1))
-Error: `summarise()` argument `a` must be a vector
-x Result should be a vector, not a environment
-i `a` is env(a = 1)
-
-> tibble(x = 1, y = c(1, 2, 2), z = runif(3)) %>% group_by(x, y) %>% summarise(a = env(
-+   a = 1))
-Error: `summarise()` argument `a` must be a vector
-x Result should be a vector, not a environment
-i `a` is env(a = 1)
-i The error occured in group 1
-
-
 mixed types
 ===========
 
@@ -27,30 +11,6 @@ i `a` is a[[1]]
 Error: `summarise()` argument `a` must return compatible vectors across groups
 x Error from vec_c() : No common type for `..1` <double> and `..2` <character>.
 i `a` is a[[1]]
-
-
-incompatible size
-=================
-
-> tibble(z = 1) %>% summarise(x = 1:3, y = 1:2)
-Error: `summarise()` argument `y` must be recyclable
-x Result should be size 3 or 1, not 2
-i `y` is 1:2
-i An earlier column had size 3
-
-> tibble(z = 1:2) %>% group_by(z) %>% summarise(x = 1:3, y = 1:2)
-Error: `summarise()` argument `y` must be recyclable
-x Result should be size 3 or 1, not 2
-i `y` is 1:2
-i The error occured in group 1
-i An earlier column had size 3 for the group 1
-
-> tibble(z = 2:1) %>% group_by(z) %>% summarise(x = seq_len(z), y = 1:2)
-Error: `summarise()` argument `y` must be recyclable
-x Result should be size 1, not 2
-i `y` is 1:2
-i The error occured in group 1
-i An earlier column had size 1 for the group 1
 
 
 Missing variable


### PR DESCRIPTION
This plays with the idea of rolling back to the previous constraint that `summarise()` had before, i.e. that its result must be size 1. 

 - vectors that are size 1 (including data frames) are combined with `vec_c(!!!)`
 - other things are just stuffed into a standard list

This gives that we don't need to add a `list()` here: 

```r
library(dplyr, warn.conflicts = FALSE)

mtcars %>%
  group_by(cyl) %>%
  summarise(
    fit = lm(gear ~ carb)
  )
```

where it previously had to be 

```r
mtcars %>%
  group_by(cyl) %>%
  summarise(
    fit = list(lm(gear ~ carb))
  )
```

This also means that, for free, within the same summaries, we may refer to `fit` without having to `[[1]]` : 

``` r
library(dplyr, warn.conflicts = FALSE)

mtcars %>%
  group_by(cyl) %>%
  summarise(
    fit = lm(gear ~ carb), 
    models = broom::tidy(fit)
  )
#> # A tibble: 3 x 3
#>     cyl fit    models          
#>   <dbl> <list> <list>          
#> 1     4 <lm>   <tibble [2 × 5]>
#> 2     6 <lm>   <tibble [2 × 5]>
#> 3     8 <lm>   <tibble [2 × 5]>
```

models gives size 2 data frames, so these are wrapped into a list column, if it had been size 1, it would have been combined and auto spliced: 

``` r
library(dplyr, warn.conflicts = FALSE)

mtcars %>%
  group_by(cyl) %>%
  summarise(
    fit = lm(gear ~ carb), 
    broom::tidy(fit)[1, ]
  )
#> # A tibble: 3 x 7
#>     cyl fit    term        estimate std.error statistic    p.value
#>   <dbl> <list> <chr>          <dbl>     <dbl>     <dbl>      <dbl>
#> 1     4 <lm>   (Intercept)     3.27    0.479       6.82 0.0000769 
#> 2     6 <lm>   (Intercept)     2.57    0.0926     27.7  0.00000115
#> 3     8 <lm>   (Intercept)     2.17    0.376       5.79 0.0000866
```

Perhaps size != 1 vectors should be an error instead of automatic enlisting. 

