### PR TITLE
Fix cur_group()

### DIFF
--- a/R/tbl-df.r
+++ b/R/tbl-df.r
@@ -92,7 +92,7 @@ DataMask <- R6Class("DataMask",
     },
 
     current_key = function() {
-      vec_slice(keys, private$current_group)
+      vec_slice(private$keys, private$current_group)
     },
 
     get_current_group = function() {

--- a/tests/testthat/test-context.R
+++ b/tests/testthat/test-context.R
@@ -1,3 +1,26 @@
+test_that("cur_group() works", {
+  df <- tibble(g = 1, x = 1)
+  gf <- group_by(df, g)
+
+  expect_equal(
+    df %>% summarise(cur_group()),
+    group_keys(df)
+  )
+  expect_equal(
+    gf %>% summarise(cur_group()),
+    group_keys(gf)
+  )
+
+  expect_equal(
+    df %>% mutate(key = cur_group()) %>% pull(key),
+    group_keys(df)
+  )
+  expect_equal(
+    gf %>% mutate(key = cur_group()) %>% pull(key),
+    group_keys(gf)
+  )
+})
+
 test_that("cur_group_idx() gives unique id", {
   df <- tibble(x = c("b", "a", "b"))
   gf <- group_by(df, x)

--- a/tests/testthat/test-context.R
+++ b/tests/testthat/test-context.R
@@ -3,22 +3,14 @@ test_that("cur_group() works", {
   gf <- group_by(df, g)
 
   expect_equal(
-    df %>% summarise(cur_group()),
-    group_keys(df)
+    df %>% summarise(key = list(cur_group())) %>% pull(key),
+    list(tibble(.rows = 1L))
   )
   expect_equal(
-    gf %>% summarise(cur_group()),
-    group_keys(gf)
+    gf %>% summarise(key = list(cur_group())) %>% pull(key),
+    list(tibble(g = 1))
   )
 
-  expect_equal(
-    df %>% mutate(key = cur_group()) %>% pull(key),
-    group_keys(df)
-  )
-  expect_equal(
-    gf %>% mutate(key = cur_group()) %>% pull(key),
-    group_keys(gf)
-  )
 })
 
 test_that("cur_group_idx() gives unique id", {


### PR DESCRIPTION
I'll probably also tackle here that there are for no apparent good reasons two ways to get to the current group: https://github.com/tidyverse/dplyr/blob/master/src/dplyr.h#L78

```c
#define DPLYR_MASK_SET_GROUP(INDEX)                                                  \
SEXP rows_i = VECTOR_ELT(rows, i);                                                   \
R_xlen_t n_i = XLENGTH(rows_i);                                                      \
SEXP current_group = PROTECT(Rf_ScalarInteger(i + 1));                               \
Rf_defineVar(dplyr::symbols::current_group, current_group, env_private);             \
Rf_defineVar(dplyr::symbols::dot_dot_group_size, Rf_ScalarInteger(n_i), env_context);\
Rf_defineVar(dplyr::symbols::dot_dot_group_number, current_group, env_context) ;     \
UNPROTECT(1)
```

We maintain stacks for: 
 - the `DataMask` instance 
 - the current column name, for the benefit of `across()`
 - the current group id
 - the current group size

We can probably only maintain the `DataMask` instance stack and get the other things via `peek_mask()$<...>`
