### PR TITLE
Implement keep = T in left_join(), right_join()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,9 +23,9 @@
 * `add_count(drop = )` is deprecated because it didn't actually affect
   the output.
 
-* `full_join()` gains keep argument so that you can optionally choose to 
-  keep both sets of join keys (#4589). This is useful when you want to
-  figure out which rows were missing from either side.
+* `left_join()`, `right_join()`, and `full_join()` gain a `keep` argument so
+  that you can optionally choose to keep both sets of join keys (#4589). This is
+  useful when you want to figure out which rows were missing from either side.
 
 * Join functions can now perform a cross-join by specifying `by = character()`
   (#4206.)

--- a/R/join-cols.R
+++ b/R/join-cols.R
@@ -1,4 +1,4 @@
-join_cols <- function(x_names, y_names, by = NULL, suffix = c(".x", ".y"), keep_y = FALSE) {
+join_cols <- function(x_names, y_names, by = NULL, suffix = c(".x", ".y"), keep = FALSE) {
   check_duplicate_vars(x_names, "x")
   check_duplicate_vars(y_names, "y")
 
@@ -11,14 +11,18 @@ join_cols <- function(x_names, y_names, by = NULL, suffix = c(".x", ".y"), keep_
   # In x_out, key variables from need to keep the same name; aux variables
   # need suffixes for duplicates that appear in y_out
   x_loc <- seq_along(x_names)
-  y_aux <- setdiff(y_names, c(by$x, if (!keep_y) by$y))
-  x_is_aux <- !x_names %in% by$x
   names(x_loc) <- x_names
-  names(x_loc)[x_is_aux] <- add_suffixes(x_names[x_is_aux], c(by$x, y_aux), suffix$x)
+  if (!keep) {
+    y_aux <- setdiff(y_names, c(by$x, if (!keep) by$y))
+    x_is_aux <- !x_names %in% by$x
+    names(x_loc)[x_is_aux] <- add_suffixes(x_names[x_is_aux], c(by$x, y_aux), suffix$x)
+  } else {
+    names(x_loc) <- add_suffixes(x_names, y_names, suffix$x)
+  }
 
   y_loc <- seq_along(y_names)
   names(y_loc) <- add_suffixes(y_names, x_names, suffix$y)
-  if (!keep_y) {
+  if (!keep) {
     y_loc <- y_loc[!y_names %in% by$y]
   }
 

--- a/R/join-cols.R
+++ b/R/join-cols.R
@@ -8,15 +8,17 @@ join_cols <- function(x_names, y_names, by = NULL, suffix = c(".x", ".y"), keep 
   x_by <- set_names(match(by$x, x_names), by$x)
   y_by <- set_names(match(by$y, y_names), by$x)
 
-  # In x_out, key variables from need to keep the same name; aux variables
-  # need suffixes for duplicates that appear in y_out
   x_loc <- seq_along(x_names)
   names(x_loc) <- x_names
   if (!keep) {
+    # in x_out, key variables need to keep the same name, and aux
+    # variables need suffixes for duplicates that appear in y_out
     y_aux <- setdiff(y_names, c(by$x, if (!keep) by$y))
     x_is_aux <- !x_names %in% by$x
     names(x_loc)[x_is_aux] <- add_suffixes(x_names[x_is_aux], c(by$x, y_aux), suffix$x)
   } else {
+    # in x_out, key variables and aux variables need suffixes
+    # for duplicates that appear in y_out
     names(x_loc) <- add_suffixes(x_names, y_names, suffix$x)
   }
 

--- a/R/join.r
+++ b/R/join.r
@@ -84,7 +84,7 @@
 #' # Use a named `by` if the join variables have different names
 #' band_members %>% full_join(band_instruments2, by = c("name" = "artist"))
 #' # By default, the join keys from `x` and `y` are coalesced in the output; use
-#' # `keep = TRUE` # to keep the join keys from both `x` and `y`
+#' # `keep = TRUE` to keep the join keys from both `x` and `y`
 #' band_members %>%
 #'   full_join(band_instruments2, by = c("name" = "artist"), keep = TRUE)
 #'

--- a/man/mutate-joins.Rd
+++ b/man/mutate-joins.Rd
@@ -26,7 +26,15 @@ inner_join(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ...)
   na_matches = NULL
 )
 
-left_join(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ...)
+left_join(
+  x,
+  y,
+  by = NULL,
+  copy = FALSE,
+  suffix = c(".x", ".y"),
+  ...,
+  keep = FALSE
+)
 
 \method{left_join}{data.frame}(
   x,
@@ -35,10 +43,19 @@ left_join(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ...)
   copy = FALSE,
   suffix = c(".x", ".y"),
   ...,
+  keep = FALSE,
   na_matches = NULL
 )
 
-right_join(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ...)
+right_join(
+  x,
+  y,
+  by = NULL,
+  copy = FALSE,
+  suffix = c(".x", ".y"),
+  ...,
+  keep = FALSE
+)
 
 \method{right_join}{data.frame}(
   x,
@@ -47,6 +64,7 @@ right_join(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y"), ...)
   copy = FALSE,
   suffix = c(".x", ".y"),
   ...,
+  keep = FALSE,
   na_matches = NULL
 )
 
@@ -106,8 +124,9 @@ joins for database sources, similarly to \code{merge(incomparables = FALSE)}.
 The default, \code{"na"}, always treats two \code{NA} or \code{NaN} values as equal,
 like \code{\%in\%}, \code{\link[=match]{match()}}, \code{\link[=merge]{merge()}}.}
 
-\item{keep}{Should the join keys from \code{y} be preserved in the output?
-Only applies to \code{nest_join()} and \code{full_join()}.}
+\item{keep}{Should the join keys from both \code{x} and \code{y} be preserved in the
+output? Only applies to \code{nest_join()}, \code{left_join()}, \code{right_join()}, and
+\code{full_join()}.}
 }
 \value{
 An object of the same type as \code{x}. The order of the rows and columns of \code{x}
@@ -167,8 +186,8 @@ band_members \%>\% inner_join(band_instruments, by = "name")
 
 # Use a named `by` if the join variables have different names
 band_members \%>\% full_join(band_instruments2, by = c("name" = "artist"))
-# By default only the join keys from `x` are kept; use `keep = TRUE`
-# to keep both
+# By default, the join keys from `x` and `y` are coalesced in the output; use
+# `keep = TRUE` # to keep the join keys from both `x` and `y`
 band_members \%>\%
   full_join(band_instruments2, by = c("name" = "artist"), keep = TRUE)
 

--- a/man/nest_join.Rd
+++ b/man/nest_join.Rd
@@ -31,8 +31,9 @@ and \code{copy} is \code{TRUE}, then \code{y} will be copied into the
 same src as \code{x}.  This allows you to join tables across srcs, but
 it is a potentially expensive operation so you must opt into it.}
 
-\item{keep}{Should the join keys from \code{y} be preserved in the output?
-Only applies to \code{nest_join()} and \code{full_join()}.}
+\item{keep}{Should the join keys from both \code{x} and \code{y} be preserved in the
+output? Only applies to \code{nest_join()}, \code{left_join()}, \code{right_join()}, and
+\code{full_join()}.}
 
 \item{name}{The name of the list column nesting joins create.
 If \code{NULL} the name of \code{y} is used.}

--- a/tests/testthat/test-join-cols.R
+++ b/tests/testthat/test-join-cols.R
@@ -29,6 +29,11 @@ test_that("duplicate column names are given suffixes", {
   expect_equal(vars$x$out, c("x" = 1, "y.x" = 2))
   expect_equal(vars$y$out, c("y.y" = 2))
 
+  # including join vars when keep = TRUE
+  vars <- join_cols(c("x", "y"), c("x", "y"), by = "x", keep = TRUE)
+  expect_equal(vars$x$out, c("x.x" = 1, "y.x" = 2))
+  expect_equal(vars$y$out, c("x.y" = 1, "y.y" = 2))
+
   # suffixes don't create duplicates
   vars <- join_cols(c("x", "y", "y.x"), c("x", "y"), by = "x")
   expect_equal(vars$x$out, c("x" = 1, "y.x" = 2, "y.x.x" = 3))

--- a/tests/testthat/test-join-cols.R
+++ b/tests/testthat/test-join-cols.R
@@ -60,8 +60,9 @@ test_that("by columns omited from y" , {
   expect_equal(vars$y$out, c("x.y" = 1))
 
   # unless specifically requested
-  vars <- join_cols(c("x", "y"), c("x", "y"), by = c("x" = "y"), keep_y = TRUE)
-  expect_equal(vars$x$out, c("x" = 1, "y.x" = 2))
+  # TBD: fix this test!
+  vars <- join_cols(c("x", "y"), c("x", "y"), by = c("x" = "y"), keep = TRUE)
+  expect_equal(vars$x$out, c("x.x" = 1, "y.x" = 2))
   expect_equal(vars$y$out, c("x.y" = 1, "y.y" = 2))
 })
 

--- a/tests/testthat/test-join-cols.R
+++ b/tests/testthat/test-join-cols.R
@@ -60,7 +60,6 @@ test_that("by columns omited from y" , {
   expect_equal(vars$y$out, c("x.y" = 1))
 
   # unless specifically requested
-  # TBD: fix this test!
   vars <- join_cols(c("x", "y"), c("x", "y"), by = c("x" = "y"), keep = TRUE)
   expect_equal(vars$x$out, c("x.x" = 1, "y.x" = 2))
   expect_equal(vars$y$out, c("x.y" = 1, "y.y" = 2))

--- a/tests/testthat/test-join.r
+++ b/tests/testthat/test-join.r
@@ -59,12 +59,52 @@ test_that("keys are coerced to symmetric type", {
   expect_type(inner_join(bar, foo, by = "id")$id, "character")
 })
 
+test_that("when keep = TRUE, left_join() preserves both sets of keys", {
+  # when keys have different names
+  df1 <- tibble(a = c(2, 3), b = c(1, 2))
+  df2 <- tibble(x = c(3, 4), y = c(3, 4))
+  out <- left_join(df1, df2, by = c("a" = "x"), keep = TRUE)
+  expect_equal(out$a, c(2, 3))
+  expect_equal(out$x, c(NA, 3))
+
+  # when keys have same name
+  df1 <- tibble(a = c(2, 3), b = c(1, 2))
+  df2 <- tibble(a = c(3, 4), y = c(3, 4))
+  out <- left_join(df1, df2, by = c("a"), keep = TRUE)
+  expect_equal(out$a.x, c(2, 3))
+  expect_equal(out$a.y, c(NA, 3))
+})
+
+test_that("when keep = TRUE, right_join() preserves both sets of keys", {
+  # when keys have different names
+  df1 <- tibble(a = c(2, 3), b = c(1, 2))
+  df2 <- tibble(x = c(3, 4), y = c(3, 4))
+  out <- right_join(df1, df2, by = c("a" = "x"), keep = TRUE)
+  expect_equal(out$a, c(3, NA))
+  expect_equal(out$x, c(3, 4))
+
+  # when keys have same name
+  df1 <- tibble(a = c(2, 3), b = c(1, 2))
+  df2 <- tibble(a = c(3, 4), y = c(3, 4))
+  out <- right_join(df1, df2, by = c("a"), keep = TRUE)
+  expect_equal(out$a.x, c(3, NA))
+  expect_equal(out$a.y, c(3, 4))
+})
+
 test_that("when keep = TRUE, full_join() preserves both sets of keys", {
+  # when keys have different names
   df1 <- tibble(a = c(2, 3), b = c(1, 2))
   df2 <- tibble(x = c(3, 4), y = c(3, 4))
   out <- full_join(df1, df2, by = c("a" = "x"), keep = TRUE)
   expect_equal(out$a, c(2, 3, NA))
   expect_equal(out$x, c(NA, 3, 4))
+
+  # when keys have same name
+  df1 <- tibble(a = c(2, 3), b = c(1, 2))
+  df2 <- tibble(a = c(3, 4), y = c(3, 4))
+  out <- full_join(df1, df2, by = c("a"), keep = TRUE)
+  expect_equal(out$a.x, c(2, 3, NA))
+  expect_equal(out$a.y, c(NA, 3, 4))
 })
 
 test_that("joins matches NAs by default (#892, #2033)", {


### PR DESCRIPTION
@hadley as discussed in #4589, this is a quick first attempt to implement `keep = TRUE` for `left_join()` and `right_join()` in the same way as `full_join()` in 1e76e8a. It also keeps the suffix on the join column from the left table when `keep = TRUE`. No new examples or tests added yet.

I'll use these examples to add tests in a later commit:
```
band_members %>% left_join(band_instruments, by = c("name"), keep = TRUE)
band_members %>% right_join(band_instruments, by = c("name"), keep = TRUE)
band_members %>% full_join(band_instruments, by = c("name"), keep = TRUE)

band_members %>% left_join(band_instruments2, by = c("name" = "artist"), keep = TRUE)
band_members %>% right_join(band_instruments2, by = c("name" = "artist"), keep = TRUE)
band_members %>% full_join(band_instruments2, by = c("name" = "artist"), keep = TRUE)
```

Two questions before I go any further:
- In `right_join()`, when `keep = FALSE` and when the join key columns do not have the same names in the right and left columns, the output really should use the join key column names from the _right_ table, not the left table—because that's where they come from. But this would be a breaking change for existing dplyr code. What are your thoughts about this?
- It would be better to refactor `join_cols()` in a symmetrical way instead of treating the left table as more special than the right table. But that's a bigger endeavor than I have time for right now. Is this something you want to do?