### PR TITLE
row wise specific error bullets

### DIFF
--- a/R/conditions.R
+++ b/R/conditions.R
@@ -105,7 +105,7 @@ stop_filter_incompatible_size <- function(index_expression, size, expected_size)
   abort(glue_c(
     "`filter()` argument `..{index_expression}` is incorrect.",
     cnd_bullet_cur_group_label(),
-    x = "It must be of size {or_1(expected_size)}, not size {size}."
+    x = "`..{index_expression}` must be of size {or_1(expected_size)}, not size {size}."
   ))
 }
 

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -25,6 +25,13 @@ cnd_bullet_cur_group_label <- function() {
   }
 }
 
+cnd_bullet_rowwise_unlist <- function() {
+  data <- peek_mask()$full_data()
+  if (inherits(data, "rowwise_df")) {
+    c(i = "Did you mean: `{error_name} = list({error_expression})` ?")
+  }
+}
+
 or_1 <- function(x) {
   if(x == 1L) {
     "1"
@@ -138,12 +145,9 @@ stop_summarise_unsupported_type <- function(result, index, dots) {
     abort(class = "dplyr_summarise_unsupported_type", result = result)
   }
 
-  data <- peek_mask()$full_data()
   stop_dplyr(index, dots, "summarise", "must be a vector",
     x = "`{error_name}` must be a vector, not {as_friendly_type(typeof(result))}.",
-    if (inherits(data, "rowwise_df")) {
-      c(i = "Did you mean: `{error_name} = list({error_expression})` ?")
-    }
+    cnd_bullet_rowwise_unlist()
   )
 }
 
@@ -157,7 +161,8 @@ stop_mutate_mixed_NULL <- function(index, dots) {
 
   stop_dplyr(index, dots, "mutate", "must return compatible vectors across groups",
     i = "Cannot combine NULL and non NULL results.",
-    .show_group_details = FALSE
+    .show_group_details = FALSE,
+    cnd_bullet_rowwise_unlist()
   )
 }
 
@@ -169,18 +174,16 @@ stop_mutate_not_vector <- function(result, index, dots) {
   }
 
   stop_dplyr(index, dots, "mutate", "must be a vector",
-    x = "`{error_name}` must be a vector, not {as_friendly_type(typeof(result))}."
+    x = "`{error_name}` must be a vector, not {as_friendly_type(typeof(result))}.",
+    cnd_bullet_rowwise_unlist()
   )
 }
 
 stop_mutate_recycle_incompatible_size <- function(cnd, index, dots) {
-  data <- peek_mask()$full_data()
   stop_dplyr(index, dots, "mutate", "must be recyclable",
     x = "`{error_name}` can't be recycled to size {cnd$size}.",
     i = "`{error_name}` must be size {or_1(cnd$size)}, not {cnd$x_size}.",
-    if (inherits(data, "rowwise_df")) {
-      c(i = "Did you mean: `{error_name} = list({error_expression})` ?")
-    }
+    cnd_bullet_rowwise_unlist()
   )
 }
 

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -146,7 +146,7 @@ stop_summarise_unsupported_type <- function(result, index, dots) {
   }
 
   stop_dplyr(index, dots, "summarise", "must be a vector",
-    x = "`{error_name}` must be a vector, not {as_friendly_type(typeof(result))}.",
+    x = "`{error_name}` must be a vector, not {friendly_type_of(result)}.",
     cnd_bullet_rowwise_unlist()
   )
 }
@@ -174,7 +174,7 @@ stop_mutate_not_vector <- function(result, index, dots) {
   }
 
   stop_dplyr(index, dots, "mutate", "must be a vector",
-    x = "`{error_name}` must be a vector, not {as_friendly_type(typeof(result))}.",
+    x = "`{error_name}` must be a vector, not {friendly_type_of(result)}.",
     cnd_bullet_rowwise_unlist()
   )
 }

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -170,9 +170,13 @@ stop_mutate_not_vector <- function(result, index, dots) {
 }
 
 stop_mutate_recycle_incompatible_size <- function(cnd, index, dots) {
+  data <- peek_mask()$full_data()
   stop_dplyr(index, dots, "mutate", "must be recyclable",
     x = "`{error_name}` can't be recycled to size {cnd$size}.",
-    i = "`{error_name}` must be size {or_1(cnd$size)}, not {cnd$x_size}."
+    i = "`{error_name}` must be size {or_1(cnd$size)}, not {cnd$x_size}.",
+    if (inherits(data, "rowwise_df")) {
+      c(i = "Did you mean: `{error_name} = list({error_expression})` ?")
+    }
   )
 }
 

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -138,8 +138,12 @@ stop_summarise_unsupported_type <- function(result, index, dots) {
     abort(class = "dplyr_summarise_unsupported_type", result = result)
   }
 
+  data <- peek_mask()$full_data()
   stop_dplyr(index, dots, "summarise", "must be a vector",
-    x = "`{error_name}` must be a vector, not {as_friendly_type(typeof(result))}."
+    x = "`{error_name}` must be a vector, not {as_friendly_type(typeof(result))}.",
+    if (inherits(data, "rowwise_df")) {
+      c(i = "Did you mean: `{error_name} = list({error_expression})` ?")
+    }
   )
 }
 

--- a/tests/testthat/test-colwise-mutate-errors.txt
+++ b/tests/testthat/test-colwise-mutate-errors.txt
@@ -3,8 +3,8 @@ column not found
 ================
 
 > mutate_at(tibble(), "test", ~1)
-Error: Must select existing columns.
-x Can't subset element with unknown name `test`.
+Error: Can't subset columns that don't exist.
+x The column `test` doesn't exist.
 
 
 not summarising grouping variables
@@ -13,8 +13,8 @@ not summarising grouping variables
 > tbl <- tibble(gr1 = rep(1:2, 4), gr2 = rep(1:2, each = 4), x = 1:8)
 > tbl <- group_by(tbl, gr1)
 > summarise_at(tbl, vars(gr1), mean)
-Error: Must select existing columns.
-x Can't subset element with unknown name `gr1`.
+Error: Can't subset columns that don't exist.
+x The column `gr1` doesn't exist.
 
 
 improper additional arguments

--- a/tests/testthat/test-filter-errors.txt
+++ b/tests/testthat/test-filter-errors.txt
@@ -18,11 +18,16 @@ wrong size
 > iris %>% group_by(Species) %>% filter(c(TRUE, FALSE))
 Error: `filter()` argument `..1` is incorrect.
 i The error occured in group 1: Species = "setosa".
-x It must be of size 50 or 1, not size 2.
+x `..1` must be of size 50 or 1, not size 2.
+
+> iris %>% rowwise(Species) %>% filter(c(TRUE, FALSE))
+Error: `filter()` argument `..1` is incorrect.
+i The error occured in row 1.
+x `..1` must be of size 1, not size 2.
 
 > iris %>% filter(c(TRUE, FALSE))
 Error: `filter()` argument `..1` is incorrect.
-x It must be of size 150 or 1, not size 2.
+x `..1` must be of size 150 or 1, not size 2.
 
 
 wrong size in column
@@ -31,15 +36,20 @@ wrong size in column
 > iris %>% group_by(Species) %>% filter(data.frame(c(TRUE, FALSE)))
 Error: `filter()` argument `..1` is incorrect.
 i The error occured in group 1: Species = "setosa".
-x It must be of size 50 or 1, not size 2.
+x `..1` must be of size 50 or 1, not size 2.
+
+> iris %>% rowwise() %>% filter(data.frame(c(TRUE, FALSE)))
+Error: `filter()` argument `..1` is incorrect.
+i The error occured in row 1.
+x `..1` must be of size 1, not size 2.
 
 > iris %>% filter(data.frame(c(TRUE, FALSE)))
 Error: `filter()` argument `..1` is incorrect.
-x It must be of size 150 or 1, not size 2.
+x `..1` must be of size 150 or 1, not size 2.
 
 > tibble(x = 1) %>% filter(c(TRUE, TRUE))
 Error: `filter()` argument `..1` is incorrect.
-x It must be of size 1, not size 2.
+x `..1` must be of size 1, not size 2.
 
 
 wrong type in column

--- a/tests/testthat/test-filter.r
+++ b/tests/testthat/test-filter.r
@@ -413,11 +413,17 @@ test_that("filter() gives useful error messages", {
       group_by(Species) %>%
       filter(c(TRUE, FALSE))
     iris %>%
+      rowwise(Species) %>%
+      filter(c(TRUE, FALSE))
+    iris %>%
       filter(c(TRUE, FALSE))
 
     "# wrong size in column"
     iris %>%
       group_by(Species) %>%
+      filter(data.frame(c(TRUE, FALSE)))
+    iris %>%
+      rowwise() %>%
       filter(data.frame(c(TRUE, FALSE)))
     iris %>%
       filter(data.frame(c(TRUE, FALSE)))

--- a/tests/testthat/test-group-by-errors.txt
+++ b/tests/testthat/test-group-by-errors.txt
@@ -13,6 +13,6 @@ These dots only exist to allow future extensions and should be empty.
 Did you misspecify an argument?
 
 > df %>% group_by(x, y) %>% ungroup(z)
-Error: Must select existing columns.
-x Can't subset element with unknown name `z`.
+Error: Can't subset columns that don't exist.
+x The column `z` doesn't exist.
 

--- a/tests/testthat/test-mutate-errors.txt
+++ b/tests/testthat/test-mutate-errors.txt
@@ -39,6 +39,13 @@ i `out` is `env(a = 1)`.
 i The error occured in group 1: g = 1.
 x `out` must be a vector, not an environment.
 
+> df %>% rowwise() %>% mutate(out = rnorm)
+Error: `mutate()` argument `out` must be a vector.
+i `out` is `rnorm`.
+i The error occured in row 1.
+x `out` must be a vector, not a function.
+i Did you mean: `out = list(rnorm)` ?
+
 
 incompatible types across groups
 ================================

--- a/tests/testthat/test-mutate-errors.txt
+++ b/tests/testthat/test-mutate-errors.txt
@@ -79,6 +79,14 @@ i The error occured in group 1: x = 2.
 x `int` can't be recycled to size 1.
 i `int` must be size 1, not 5.
 
+> data.frame(x = c(2, 2, 3, 3)) %>% rowwise() %>% mutate(int = 1:5)
+Error: `mutate()` argument `int` must be recyclable.
+i `int` is `1:5`.
+i The error occured in row 1.
+x `int` can't be recycled to size 1.
+i `int` must be size 1, not 5.
+i Did you mean: `int = list(1:5)` ?
+
 
 .data pronoun
 =============

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -264,6 +264,9 @@ test_that("mutate() give meaningful errors", {
     df %>%
       group_by(g) %>%
       mutate(out = env(a = 1))
+    df %>%
+      rowwise() %>%
+      mutate(out = rnorm)
 
     "# incompatible types across groups"
     data.frame(x = rep(1:5, each = 3)) %>%

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -283,6 +283,9 @@ test_that("mutate() give meaningful errors", {
     data.frame(x = c(2, 3, 3)) %>%
       group_by(x) %>%
       mutate(int = 1:5)
+    data.frame(x = c(2, 2, 3, 3)) %>%
+      rowwise() %>%
+      mutate(int = 1:5)
 
     "# .data pronoun"
     tibble(a = 1) %>%

--- a/tests/testthat/test-summarise-errors.txt
+++ b/tests/testthat/test-summarise-errors.txt
@@ -14,6 +14,14 @@ i `a` is `env(a = 1)`.
 i The error occured in group 1: x = 1, y = 1.
 x `a` must be a vector, not an environment.
 
+> tibble(x = 1, y = c(1, 2, 2), z = runif(3)) %>% rowwise() %>% summarise(a = lm(
++   y ~ x))
+Error: `summarise()` argument `a` must be a vector.
+i `a` is `lm(y ~ x)`.
+i The error occured in row 1.
+x `a` must be a vector, not a list.
+i Did you mean: `a = list(lm(y ~ x))` ?
+
 
 mixed types
 ===========

--- a/tests/testthat/test-summarise-errors.txt
+++ b/tests/testthat/test-summarise-errors.txt
@@ -19,7 +19,7 @@ x `a` must be a vector, not an environment.
 Error: `summarise()` argument `a` must be a vector.
 i `a` is `lm(y ~ x)`.
 i The error occured in row 1.
-x `a` must be a vector, not a list.
+x `a` must be a vector, not a `lm` object.
 i Did you mean: `a = list(lm(y ~ x))` ?
 
 

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -1041,6 +1041,9 @@ test_that("summarise() give meaningful errors", {
     tibble(x = 1, y = c(1, 2, 2), z = runif(3)) %>%
       group_by(x, y) %>%
       summarise(a = env(a = 1))
+    tibble(x = 1, y = c(1, 2, 2), z = runif(3)) %>%
+      rowwise() %>%
+      summarise(a = lm(y ~ x))
 
     "# mixed types"
     tibble(id = 1:2, a = list(1, "2")) %>%


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)

tibble(x = 1, y = c(1, 2, 2), z = runif(3)) %>%
  rowwise() %>%
  summarise(a = lm(y ~ x))
#> Error: `summarise()` argument `a` must be a vector.
#> ℹ `a` is `lm(y ~ x)`.
#> ℹ The error occured in row 1.
#> x `a` must be a vector, not a list.
#> ℹ Did you mean: `a = list(lm(y ~ x))` ?

data.frame(x = c(2, 2, 3, 3)) %>%
  rowwise() %>%
  mutate(int = 1:5)
#> Error: `mutate()` argument `int` must be recyclable.
#> ℹ `int` is `1:5`.
#> ℹ The error occured in row 1.
#> x `int` can't be recycled to size 1.
#> ℹ `int` must be size 1, not 5.
#> ℹ Did you mean: `int = list(1:5)` ?
```

<sup>Created on 2020-01-20 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>