### PR TITLE
Compute groups from existing grouping data

### DIFF
--- a/R/summarise.R
+++ b/R/summarise.R
@@ -153,7 +153,7 @@ summarise.grouped_df <- function(.data, ...) {
   out_groups <- loc$key
   out_groups$.rows <- as_list_of(lapply(loc$loc, function(i) unlist(rows[i])) %||% integer(), .ptype = integer())
 
-  new_grouped_df(out, out_groups)
+  new_grouped_df(out, out_groups, drop = group_by_drop_default(.data))
 }
 
 #' @export

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -137,13 +137,13 @@ summarise.grouped_df <- function(.data, ...) {
   }
 
   # Figure out rows of old groups
-  if (identical(cols$size, 1)) {
+  if (identical(cols$size, 1L)) {
     rows <- as.list(1:nrow(out))
   } else {
     breaks <- cumsum(c(1L, cols$size))
     start <- breaks[-length(breaks)]
     end <- breaks[-1] - 1L
-    rows <- map2(start, end, `:`)
+    rows <- map2(start, end, seq2)
   }
   # If needed, collapse old groups into new groups
   groups <- group_keys(.data)

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -132,7 +132,7 @@ summarise.grouped_df <- function(.data, ...) {
 
   group_vars <- group_vars(.data)
   n <- length(group_vars)
-  if (n == 1) {
+  if (n <= 1) {
     return(out)
   }
 

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -93,10 +93,20 @@ test_that("peels off a single layer of grouping", {
 })
 
 test_that("correctly reconstructs groups", {
-  d <- tibble(x = 1:4, g1 = rep(1:2, 2), g2 = 1:4) %>%
-    group_by(g1, g2) %>%
-    summarise(x = x + 1)
-  expect_equal(group_rows(d), list_of(1:2, 3:4))
+  gf <- group_by(tibble(x = 1:4, g1 = rep(1:2, 2), g2 = 1:4), g1, g2)
+  out <- summarise(gf, x = x + 1)
+  expect_equal(group_rows(out), list_of(1:2, 3:4))
+
+  # even when an input group is empty
+  f <- factor(c("a", "a", "b"), levels = letters[1:3])
+  gf <- group_by(tibble(x = f, y = 1), x, y, .drop = FALSE)
+  out <- summarise(gf, z = n())
+  expect_equal(group_rows(out), list_of(1, 2, 3))
+
+  # or when an output creates an empty group
+  gf <- group_by(tibble(x = 0:2, y = 1), x, y)
+  out <- summarise(gf, z = seq_len(x))
+  expect_equal(group_rows(out), list_of(integer(), 1L, 2:3))
 })
 
 test_that("can modify grouping variables", {
@@ -104,7 +114,7 @@ test_that("can modify grouping variables", {
   gf <- group_by(df, a, b)
 
   i <- count_regroups(out <- summarise(gf, a = a + 1))
-  expect_equal(i, 1)
+  expect_equal(i, 0)
   expect_equal(out$a, c(2, 2, 3, 3))
 })
 


### PR DESCRIPTION
Now that I've implemented it, I'm not 100% sure it's worth it, since this code is effectively doing the same thing as `compute_groups()`, and it's not like you can't regroup afterwards since it is always contains `group_keys()`.

If we do decide to merge it, I think this it needs more testing for the case where `summarise()` modifies the grouping variables, particularly when it creates more groups.