### PR TITLE
tweaks to arrange() errors

### DIFF
--- a/R/arrange.R
+++ b/R/arrange.R
@@ -100,7 +100,11 @@ arrange_rows <- function(.data, ..., .by_group = FALSE) {
   #
   #       revisit when we have something like mutate_one() to
   #       evaluate one quosure in the data mask
-  data <- transmute(ungroup(.data), !!!quosures)
+  tryCatch({
+    data <- transmute(ungroup(.data), !!!quosures)
+  }, error = function(cnd) {
+    stop_arrange_transmute(cnd)
+  })
 
   # we can't just use vec_compare_proxy(data) because we need to apply
   # direction for each column, so we get a list of proxies instead

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -214,7 +214,7 @@ stop_arrange_transmute <- function(cnd) {
     error_expression <- context_env[["error_expression"]]
 
     bullets <- c(
-      i = glue("Could not create a temporary column with `..{index}`."),
+      i = glue("Could not create a temporary column for `..{index}`."),
       i = glue("`..{index}` is `{error_expression}`.")
     )
   } else {

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -200,5 +200,30 @@ stop_summarise_incompatible_size <- function(size, group, index, expected_sizes,
     x = "`{error_name}` must be size {or_1(expected_sizes[group])}, not {size}.",
     i = "An earlier column had size {expected_sizes[group]}."
   )
+}
+
+
+# arrange() ---------------------------------------------------------------
+
+stop_arrange_transmute <- function(cnd) {
+  name <- context_env[["error_name"]]
+
+  if (!is.null(name)) {
+    # error caught by mutate_cols()
+    index <- sub("^.*_", "", name)
+    error_expression <- context_env[["error_expression"]]
+
+    bullets <- c(
+      i = glue("Could not create a temporary column with `..{index}`."),
+      i = glue("`..{index}` is `{error_expression}`.")
+    )
+  } else {
+    bullets <- c(x = conditionMessage(cnd))
+  }
+
+  abort(c(
+    "arrange() failed at implicit mutate() step. ",
+    bullets
+  ))
 
 }

--- a/tests/testthat/test-arrange-errors.txt
+++ b/tests/testthat/test-arrange-errors.txt
@@ -2,13 +2,21 @@
 duplicated column name
 ======================
 
-> df <- data.frame(x = 1:10, x = 1:10)
-> names(df) <- c("x", "x")
-> df %>% arrange(x)
-Error: Can't bind data because some arguments have the same name
+> tibble(x = 1, x = 1, .name_repair = "minimal") %>% arrange(x)
+Error: arrange() failed at implicit mutate() step. 
+x Can't bind data because some arguments have the same name
 
-> df <- data.frame(x = 1:10, x = 1:10, y = 1:10, y = 1:10)
-> names(df) <- c("x", "x", "y", "y")
-> df %>% arrange(x)
-Error: Can't bind data because some arguments have the same name
+
+error in mutate() step
+======================
+
+> tibble(x = 1) %>% arrange(y)
+Error: arrange() failed at implicit mutate() step. 
+i Could not create a temporary column with `..1`.
+i `..1` is `y`.
+
+> tibble(x = 1) %>% arrange(rep(x, 2))
+Error: arrange() failed at implicit mutate() step. 
+i Could not create a temporary column with `..1`.
+i `..1` is `rep(x, 2)`.
 

--- a/tests/testthat/test-arrange-errors.txt
+++ b/tests/testthat/test-arrange-errors.txt
@@ -12,11 +12,11 @@ error in mutate() step
 
 > tibble(x = 1) %>% arrange(y)
 Error: arrange() failed at implicit mutate() step. 
-i Could not create a temporary column with `..1`.
+i Could not create a temporary column for `..1`.
 i `..1` is `y`.
 
 > tibble(x = 1) %>% arrange(rep(x, 2))
 Error: arrange() failed at implicit mutate() step. 
-i Could not create a temporary column with `..1`.
+i Could not create a temporary column for `..1`.
 i `..1` is `rep(x, 2)`.
 

--- a/tests/testthat/test-arrange.r
+++ b/tests/testthat/test-arrange.r
@@ -21,13 +21,14 @@ test_that("local arrange sorts missing values to end", {
 test_that("arrange() gives meaningful errors", {
   verify_output(test_path("test-arrange-errors.txt"), {
     "# duplicated column name"
-    df <- data.frame(x = 1:10, x = 1:10)
-    names(df) <- c("x", "x")
-    df %>% arrange(x)
+    tibble(x = 1, x = 1, .name_repair = "minimal") %>%
+      arrange(x)
 
-    df <- data.frame(x = 1:10, x = 1:10, y = 1:10, y = 1:10)
-    names(df) <- c("x", "x", "y", "y")
-    df %>% arrange(x)
+    "# error in mutate() step"
+    tibble(x = 1) %>%
+      arrange(y)
+    tibble(x = 1) %>%
+      arrange(rep(x, 2))
   })
 })
 


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)

tibble(x = 1, x = 2, .name_repair = "minimal") %>% arrange(x) 
#> Error: arrange() failed at implicit mutate() step. 
#> x Can't bind data because some arguments have the same name
tibble(x = 1) %>% arrange(y)
#> Error: arrange() failed at implicit mutate() step. 
#> ℹ Could not create a temporary column with `..1`.
#> ℹ `..1` is `y`.
tibble(x = 1) %>% arrange(c(x, x))
#> Error: arrange() failed at implicit mutate() step. 
#> ℹ Could not create a temporary column with `..1`.
#> ℹ `..1` is `c(x, x)`.
```

<sup>Created on 2020-01-27 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>