### PR TITLE
Using promises instead of active bindings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,4 +65,4 @@ RoxygenNote: 7.0.2
 Remotes:
     tidyverse/tibble,
     r-lib/pillar, 
-    r-lib/rlang#910
+    r-lib/rlang

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,4 +64,5 @@ Roxygen: list(markdown = TRUE, roclets = c("rd", "namespace", "collate"))
 RoxygenNote: 7.0.2
 Remotes:
     tidyverse/tibble,
-    r-lib/pillar
+    r-lib/pillar, 
+    r-lib/rlang#910

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -67,4 +67,4 @@ Remotes:
     r-lib/pillar,
     r-lib/vctrs, 
     r-lib/tidyselect,
-    r-lib/rlang
+    r-lib/rlang#910

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,4 +65,4 @@ RoxygenNote: 7.0.2
 Remotes:
     tidyverse/tibble,
     r-lib/pillar, 
-    r-lib/rlang
+    r-lib/rlang#910

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -36,6 +36,7 @@ DataMask <- R6Class("DataMask",
           # track
           private$used[[index]] <- TRUE
           private$resolved[[index]] <- chunks
+          private$which_used <- c(private$which_used, index)
 
           # return result for current slice
           res
@@ -50,11 +51,19 @@ DataMask <- R6Class("DataMask",
     },
 
     add = function(name, chunks) {
+      pos <- which(names(private$resolved) == name)
+      if (length(pos) == 0L) {
+        pos <- length(private$resolved) + 1L
+        private$used[[pos]] <- TRUE
+        private$which_used <- c(private$which_used, pos)
+      }
       private$resolved[[name]] <- chunks
     },
 
     remove = function(name) {
+      pos <- which(names(private$resolved) == name)
       private$resolved[[name]] <- NULL
+      private$which_used <- setdiff(private$which_used, pos)
       rm(list = name, envir = private$bindings)
     },
 
@@ -110,6 +119,7 @@ DataMask <- R6Class("DataMask",
     old_vars = character(),
     used = logical(),
     resolved = list(),
+    which_used = integer(),
     rows = NULL,
     keys = NULL,
     bindings = NULL,

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -1,6 +1,6 @@
 DataMask <- R6Class("DataMask",
   public = list(
-    initialize = function(data, caller, rows = group_rows(data), track_usage = FALSE) {
+    initialize = function(data, caller, rows = group_rows(data)) {
       frame <- caller_env(n = 2)
       local_mask(self, frame)
 

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -35,7 +35,7 @@ DataMask <- R6Class("DataMask",
 
       promise_fn <- function(index, chunks = resolve_chunks(index)) {
           # resolve the chunks and hold the slice for current group
-          res <- .subset2(chunks, private$get_current_group())
+          res <- .subset2(chunks, self$get_current_group())
 
           # track
           private$used[[index]] <- TRUE

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -15,13 +15,13 @@ DataMask <- R6Class("DataMask",
         function(index) {
           col <- .subset2(data, index)
           if (is_list(col) && !is.data.frame(col)) {
-            map(rows, function(row) vec_slice(col, row)[[1L]])
+            map(vec_chop(col, rows), `[[`, 1L)
           } else {
-            map(rows, vec_slice, x = col)
+            vec_chop(col, rows)
           }
         }
       } else if (is_grouped_df(data)) {
-        function(index) map(rows, vec_slice, x = .subset2(data, index))
+        function(index) vec_chop(.subset2(data, index), rows)
       } else {
         # for ungrouped data frames, there is only one chunk that
         # is made of the full column

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -166,7 +166,7 @@ mutate.data.frame <- function(.data, ...,
                               .before = NULL, .after = NULL) {
   keep <- arg_match(.keep)
 
-  cols <- mutate_cols(.data, ..., .track_usage = keep %in% c("used", "unused"))
+  cols <- mutate_cols(.data, ...)
   out <- dplyr_col_modify(.data, cols)
 
   .before <- enquo(.before)
@@ -211,7 +211,7 @@ transmute.data.frame <- function(.data, ...) {
 
 # Helpers -----------------------------------------------------------------
 
-mutate_cols <- function(.data, ..., .track_usage = FALSE) {
+mutate_cols <- function(.data, ...) {
   rows <- group_rows(.data)
   # workaround when there are 0 groups
   if (length(rows) == 0L) {
@@ -220,7 +220,7 @@ mutate_cols <- function(.data, ..., .track_usage = FALSE) {
   rows_lengths <- .Call(`dplyr_vec_sizes`, rows)
 
   o_rows <- vec_order(vec_c(!!!rows, .ptype = integer()))
-  mask <- DataMask$new(.data, caller_env(), rows, track_usage = .track_usage)
+  mask <- DataMask$new(.data, caller_env(), rows)
 
   dots <- enquos(...)
   dots_names <- names(dots)

--- a/src/dplyr.h
+++ b/src/dplyr.h
@@ -79,7 +79,7 @@ Rf_defineVar(dplyr::symbols::current_group, Rf_ScalarInteger(i + 1), env_private
 SEXP resolved = Rf_findVarInFrame(env_private, dplyr::symbols::resolved);            \
 SEXP names_resolved = Rf_getAttrib(resolved, R_NamesSymbol);       \
 R_xlen_t n_resolved = XLENGTH(resolved);                           \
-for (R_xlen_t i_resolved=0; i_resolved<n_resolved; i_resolved++) { \
+for (R_xlen_t i_resolved = 0; i_resolved < n_resolved; i_resolved++) { \
   SEXP x_resolved = VECTOR_ELT(resolved, i_resolved);              \
   if (!Rf_isNull(x_resolved)) {                                \
     Rf_defineVar(Rf_installChar(STRING_ELT(names_resolved, i_resolved)), VECTOR_ELT(x_resolved, i), bindings); \

--- a/src/dplyr.h
+++ b/src/dplyr.h
@@ -74,7 +74,7 @@ SEXP current_group = PROTECT(Rf_ScalarInteger(NA_INTEGER));                    \
 Rf_defineVar(dplyr::symbols::current_group, current_group, env_private);       \
 int* p_current_group = INTEGER(current_group)
 
-#define DPLYR_MASK_FINALISE() UNPROTECT(4);
+#define DPLYR_MASK_FINALISE() UNPROTECT(5);
 
 #define DPLYR_MASK_SET_GROUP(INDEX)                                                  \
 *p_current_group = INDEX + 1;   \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -37,6 +37,8 @@ SEXP symbols::current_expression = Rf_install("current_expression");
 SEXP symbols::rows = Rf_install("rows");
 SEXP symbols::mask = Rf_install("mask");
 SEXP symbols::caller = Rf_install("caller");
+SEXP symbols::resolved = Rf_install("resolved");
+SEXP symbols::bindings = Rf_install("bindings");
 
 SEXP vectors::classes_vctrs_list_of = get_classes_vctrs_list_of();
 SEXP vectors::classes_tbl_df = get_classes_tbl_df();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -39,6 +39,7 @@ SEXP symbols::mask = Rf_install("mask");
 SEXP symbols::caller = Rf_install("caller");
 SEXP symbols::resolved = Rf_install("resolved");
 SEXP symbols::bindings = Rf_install("bindings");
+SEXP symbols::which_used = Rf_install("which_used");
 
 SEXP vectors::classes_vctrs_list_of = get_classes_vctrs_list_of();
 SEXP vectors::classes_tbl_df = get_classes_tbl_df();


### PR DESCRIPTION
Based on looking at some profvis results, we were still paying unnecessary price for active bindings, even though the slices were materialized only once, i.e. this was still somewhat expensive `.subset2(chunks, private$current_group)` when we actually go through groups one by one predictably. 

We still need some laziness, because the first time a variable from the data is used causes lots of slicing, but once we know we need it, we can just install it instead of relying on another form of lazyness. 

So for each column from the data, we either need to materialize slices 0 or 1 times. Therefore switching to promises instead of active bindings. This needs this though. https://github.com/r-lib/rlang/pull/910

