### PR TITLE
Updates documentation to filter()

### DIFF
--- a/R/filter.R
+++ b/R/filter.R
@@ -1,6 +1,6 @@
 #' Return all rows that satisfy conditions
 #'
-#' The `filter()` function is used to create a subset of a tibble or data frame,
+#' The `filter()` function is used to subset a data set,
 #' retaining all rows that satisfy user-specified conditions.
 #' To be retained, the row must produce a value of `TRUE` for all conditions.
 #' An important difference between `filter()` and base subsetting with `[`, any

--- a/R/filter.R
+++ b/R/filter.R
@@ -97,7 +97,7 @@
 #' starwars %>% group_by(gender) %>% filter(mass > mean(mass, na.rm = TRUE))
 #'
 #'
-#' # To refer to column names stored as strings, use the `.data` pronoun:
+#' # To refer to column names that are stored as strings, use the `.data` pronoun:
 #' vars <- c("mass", "height")
 #' cond <- c(80, 150)
 #' starwars %>%

--- a/R/filter.R
+++ b/R/filter.R
@@ -60,7 +60,6 @@
 #'
 #' The following methods are currently available in loaded packages:
 #' \Sexpr[stage=render,results=rd]{dplyr:::methods_rd("filter")}.
-#' @seealso [filter_all()], [filter_if()] and [filter_at()].
 #' @export
 #' @examples
 #' filter(starwars, species == "Human")

--- a/R/filter.R
+++ b/R/filter.R
@@ -1,6 +1,6 @@
-#' Return all rows that satisfy conditions
+#' Subset rows using column values
 #'
-#' The `filter()` function is used to subset a data object,
+#' The `filter()` function is used to subset a data frame,
 #' retaining all rows that satisfy your conditions.
 #' To be retained, the row must produce a value of `TRUE` for all conditions.
 #' An important difference between `filter()` and base subsetting with `[`, any
@@ -48,11 +48,10 @@
 #'
 #' @family single table verbs
 #' @inheritParams arrange
-#' @param ... Expressions that return a
+#' @param ... <[`data-masking`][dplyr_data_masking]> Expressions that return a
 #'   logical value, and are defined in terms of the variables in `.data`.
 #'   If multiple expressions are included, they are combined with the `&` operator.
-#'   Only rows for which all conditions evaluate to `TRUE` are kept. Note that
-#'   <[`data-masking`][dplyr_data_masking]> applies here.
+#'   Only rows for which all conditions evaluate to `TRUE` are kept.
 #' @param .preserve Relevant when the `.data` input is grouped.
 #'   If `.preserve = FALSE` (the default), the grouping structure
 #'   is recalculated based on the resulting data, otherwise the grouping is kept as is.

--- a/R/filter.R
+++ b/R/filter.R
@@ -97,7 +97,7 @@
 #' starwars %>% group_by(gender) %>% filter(mass > mean(mass, na.rm = TRUE))
 #'
 #'
-#' # To refer to column names that are as strings, use the `.data` pronoun:
+#' # To refer to column names stored as strings, use the `.data` pronoun:
 #' vars <- c("mass", "height")
 #' cond <- c(80, 150)
 #' starwars %>%

--- a/R/filter.R
+++ b/R/filter.R
@@ -40,10 +40,12 @@
 #' starwars %>% group_by(gender) %>% filter(mass > mean(mass, na.rm = TRUE))
 #' ```
 #'
-#' The former keeps rows with `mass` greater than the global average
-#' whereas the latter keeps rows with `mass` greater than the gender
+#' In the ungrouped version, `filter()` compares the value of `mass` in each row to
+#' the global average (taken over the whole data set), keeping only the rows with
+#' `mass` greater than this global average. In contrast, the grouped version calculates
+#' the average mass separately for each `gender` group, and keeps rows with `mass` greater
+#' than the relevant within-gender average.
 #'
-#' average.
 #' @family single table verbs
 #' @inheritParams arrange
 #' @param ... Expressions that return a

--- a/R/filter.R
+++ b/R/filter.R
@@ -1,8 +1,10 @@
-#' Subset rows using column values
+#' Return all rows that satisfy conditions
 #'
-#' `filter()` retains the rows where the conditions you provide a `TRUE`. Note
-#' that, unlike base subsetting with `[`, rows where the condition evaluates
-#' to `NA` are dropped.
+#' The `filter()` function is used to create a subset of a tibble or data frame,
+#' retaining all rows that satisfy user-specified conditions.
+#' To be retained, the row must produce a value of `TRUE` for all conditions.
+#' An important difference between `filter()` and base subsetting with `[`, any
+#' row for which a condition evaluates to `NA` is dropped.
 #'
 #' dplyr is not yet smart enough to optimise filtering optimisation
 #' on grouped datasets that don't need grouped calculations. For this reason,

--- a/R/filter.R
+++ b/R/filter.R
@@ -45,8 +45,9 @@
 #'   If multiple expressions are included, they are combined with the `&` operator.
 #'   Only rows for which all conditions evaluate to `TRUE` are kept. Note that
 #'   <[`data-masking`][dplyr_data_masking]> applies here.
-#' @param .preserve when `FALSE` (the default), the grouping structure
-#'   is recalculated based on the resulting data, otherwise it is kept as is.
+#' @param .preserve Relevant when the `.data` input is grouped.
+#'   If `.preserve = FALSE` (the default), the grouping structure
+#'   is recalculated based on the resulting data, otherwise the grouping is kept as is.
 #' @return
 #' An object of the same type as `.data`. The output has the following properties:
 #'

--- a/R/filter.R
+++ b/R/filter.R
@@ -15,6 +15,9 @@
 #'
 #' @section Useful filter functions:
 #'
+#' There are many functions and operators that are useful when constructing the
+#' expressions used to filter the data:
+#'
 #' * [`==`], [`>`], [`>=`] etc
 #' * [`&`], [`|`], [`!`], [xor()]
 #' * [is.na()]

--- a/R/filter.R
+++ b/R/filter.R
@@ -40,10 +40,11 @@
 #' average.
 #' @family single table verbs
 #' @inheritParams arrange
-#' @param ... <[`data-masking`][dplyr_data_masking]> Logical predicates defined
-#'   in terms of the variables in `.data`.
-#'   Multiple conditions are combined with `&`. Only rows where the
-#'   condition evaluates to `TRUE` are kept.
+#' @param ... Expressions that return a
+#'   logical value, and are defined in terms of the variables in `.data`.
+#'   If multiple expressions are included, they are combined with the `&` operator.
+#'   Only rows for which all conditions evaluate to `TRUE` are kept. Note that
+#'   <[`data-masking`][dplyr_data_masking]> applies here.
 #' @param .preserve when `FALSE` (the default), the grouping structure
 #'   is recalculated based on the resulting data, otherwise it is kept as is.
 #' @return

--- a/R/filter.R
+++ b/R/filter.R
@@ -73,14 +73,15 @@
 #' \Sexpr[stage=render,results=rd]{dplyr:::methods_rd("filter")}.
 #' @export
 #' @examples
+#' # Filtering by one criterion
 #' filter(starwars, species == "Human")
 #' filter(starwars, mass > 1000)
 #'
-#' # Multiple criteria
+#' # Filtering by multiple criteria within a single logical expression
 #' filter(starwars, hair_color == "none" & eye_color == "black")
 #' filter(starwars, hair_color == "none" | eye_color == "black")
 #'
-#' # Multiple arguments are equivalent to and
+#' # When multiple expressions are used, they are combined using &
 #' filter(starwars, hair_color == "none", eye_color == "black")
 #'
 #'
@@ -96,7 +97,7 @@
 #' starwars %>% group_by(gender) %>% filter(mass > mean(mass, na.rm = TRUE))
 #'
 #'
-#' # Refer to column names stored as strings with the `.data` pronoun:
+#' # To refer to column names that are as strings, use the `.data` pronoun:
 #' vars <- c("mass", "height")
 #' cond <- c(80, 150)
 #' starwars %>%

--- a/R/filter.R
+++ b/R/filter.R
@@ -3,8 +3,8 @@
 #' The `filter()` function is used to subset a data frame,
 #' retaining all rows that satisfy your conditions.
 #' To be retained, the row must produce a value of `TRUE` for all conditions.
-#' An important difference between `filter()` and base subsetting with `[`, any
-#' row for which a condition evaluates to `NA` is dropped.
+#' Note that when a condition evaluates to `NA`
+#' the row will be dropped, unlike base subsetting with `[`.
 #'
 #' The `filter()` function is used to subset the rows of
 #' `.data`, applying the expressions in `...` to the column values to determine which

--- a/R/filter.R
+++ b/R/filter.R
@@ -1,6 +1,6 @@
 #' Return all rows that satisfy conditions
 #'
-#' The `filter()` function is used to subset a data set,
+#' The `filter()` function is used to subset a data object,
 #' retaining all rows that satisfy user-specified conditions.
 #' To be retained, the row must produce a value of `TRUE` for all conditions.
 #' An important difference between `filter()` and base subsetting with `[`, any

--- a/R/filter.R
+++ b/R/filter.R
@@ -47,12 +47,13 @@
 #' @param .preserve when `FALSE` (the default), the grouping structure
 #'   is recalculated based on the resulting data, otherwise it is kept as is.
 #' @return
-#' An object of the same type as `.data`.
+#' An object of the same type as `.data`. The output has the following properties:
 #'
 #' * Rows are a subset of the input, but appear in the same order.
 #' * Columns are not modified.
 #' * The number of groups may be reduced (if `.preserve` is not `TRUE`).
 #' * Data frame attributes are preserved.
+#'
 #' @section Methods:
 #' This function is a **generic**, which means that packages can provide
 #' implementations (methods) for other classes. See the documentation of

--- a/R/filter.R
+++ b/R/filter.R
@@ -6,9 +6,12 @@
 #' An important difference between `filter()` and base subsetting with `[`, any
 #' row for which a condition evaluates to `NA` is dropped.
 #'
-#' dplyr is not yet smart enough to optimise filtering optimisation
-#' on grouped datasets that don't need grouped calculations. For this reason,
-#' filtering is often considerably faster on [ungroup()]ed data.
+#' The `filter()` function is used to subset the rows of
+#' `.data`, applying the expressions in `...` to the column values to determine which
+#' rows should be retained. It can be applied to both grouped and ungrouped data (see [group_by()] and
+#' [ungroup()]). However, dplyr is not yet smart enough to optimise the filtering
+#' operation on grouped datasets that do not need grouped calculations. For this
+#' reason, filtering is often considerably faster on ungrouped data.
 #'
 #' @section Useful filter functions:
 #'

--- a/R/filter.R
+++ b/R/filter.R
@@ -1,7 +1,7 @@
 #' Return all rows that satisfy conditions
 #'
 #' The `filter()` function is used to subset a data object,
-#' retaining all rows that satisfy user-specified conditions.
+#' retaining all rows that satisfy your conditions.
 #' To be retained, the row must produce a value of `TRUE` for all conditions.
 #' An important difference between `filter()` and base subsetting with `[`, any
 #' row for which a condition evaluates to `NA` is dropped.

--- a/man/filter.Rd
+++ b/man/filter.Rd
@@ -33,8 +33,8 @@ An object of the same type as \code{.data}. The output has the following propert
 The \code{filter()} function is used to subset a data frame,
 retaining all rows that satisfy your conditions.
 To be retained, the row must produce a value of \code{TRUE} for all conditions.
-An important difference between \code{filter()} and base subsetting with \code{[}, any
-row for which a condition evaluates to \code{NA} is dropped.
+Note that when a condition evaluates to \code{NA}
+the row will be dropped, unlike base subsetting with \code{[}.
 }
 \details{
 The \code{filter()} function is used to subset the rows of

--- a/man/filter.Rd
+++ b/man/filter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/filter.R
 \name{filter}
 \alias{filter}
-\title{Return all rows that satisfy conditions}
+\title{Subset rows using column values}
 \usage{
 filter(.data, ..., .preserve = FALSE)
 }
@@ -11,11 +11,10 @@ filter(.data, ..., .preserve = FALSE)
 lazy data frame (e.g. from dbplyr or dtplyr). See \emph{Methods}, below, for
 more details.}
 
-\item{...}{Expressions that return a
+\item{...}{<\code{\link[=dplyr_data_masking]{data-masking}}> Expressions that return a
 logical value, and are defined in terms of the variables in \code{.data}.
 If multiple expressions are included, they are combined with the \code{&} operator.
-Only rows for which all conditions evaluate to \code{TRUE} are kept. Note that
-<\code{\link[=dplyr_data_masking]{data-masking}}> applies here.}
+Only rows for which all conditions evaluate to \code{TRUE} are kept.}
 
 \item{.preserve}{Relevant when the \code{.data} input is grouped.
 If \code{.preserve = FALSE} (the default), the grouping structure
@@ -31,8 +30,8 @@ An object of the same type as \code{.data}. The output has the following propert
 }
 }
 \description{
-The \code{filter()} function is used to subset a data object,
-retaining all rows that satisfy user-specified conditions.
+The \code{filter()} function is used to subset a data frame,
+retaining all rows that satisfy your conditions.
 To be retained, the row must produce a value of \code{TRUE} for all conditions.
 An important difference between \code{filter()} and base subsetting with \code{[}, any
 row for which a condition evaluates to \code{NA} is dropped.

--- a/man/filter.Rd
+++ b/man/filter.Rd
@@ -47,6 +47,9 @@ reason, filtering is often considerably faster on ungrouped data.
 }
 \section{Useful filter functions}{
 
+
+There are many functions and operators that are useful when constructing the
+expressions used to filter the data:
 \itemize{
 \item \code{\link{==}}, \code{\link{>}}, \code{\link{>=}} etc
 \item \code{\link{&}}, \code{\link{|}}, \code{\link{!}}, \code{\link[=xor]{xor()}}

--- a/man/filter.Rd
+++ b/man/filter.Rd
@@ -70,10 +70,11 @@ involved. Compare this ungrouped filtering:\preformatted{starwars \%>\% filter(m
 With the grouped equivalent:\preformatted{starwars \%>\% group_by(gender) \%>\% filter(mass > mean(mass, na.rm = TRUE))
 }
 
-The former keeps rows with \code{mass} greater than the global average
-whereas the latter keeps rows with \code{mass} greater than the gender
-
-average.
+In the ungrouped version, \code{filter()} compares the value of \code{mass} in each row to
+the global average (taken over the whole data set), keeping only the rows with
+\code{mass} greater than this global average. In contrast, the grouped version calculates
+the average mass separately for each \code{gender} group, and keeps rows with \code{mass} greater
+than the relevant within-gender average.
 }
 
 \section{Methods}{

--- a/man/filter.Rd
+++ b/man/filter.Rd
@@ -113,8 +113,6 @@ starwars \%>\%
 # Learn more in ?dplyr_data_masking
 }
 \seealso{
-\code{\link[=filter_all]{filter_all()}}, \code{\link[=filter_if]{filter_if()}} and \code{\link[=filter_at]{filter_at()}}.
-
 Other single table verbs: 
 \code{\link{arrange}()},
 \code{\link{mutate}()},

--- a/man/filter.Rd
+++ b/man/filter.Rd
@@ -112,7 +112,7 @@ starwars \%>\% filter(mass > mean(mass, na.rm = TRUE))
 starwars \%>\% group_by(gender) \%>\% filter(mass > mean(mass, na.rm = TRUE))
 
 
-# To refer to column names that are as strings, use the `.data` pronoun:
+# To refer to column names stored as strings, use the `.data` pronoun:
 vars <- c("mass", "height")
 cond <- c(80, 150)
 starwars \%>\%

--- a/man/filter.Rd
+++ b/man/filter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/filter.R
 \name{filter}
 \alias{filter}
-\title{Subset rows using column values}
+\title{Return all rows that satisfy conditions}
 \usage{
 filter(.data, ..., .preserve = FALSE)
 }
@@ -29,9 +29,11 @@ An object of the same type as \code{.data}.
 }
 }
 \description{
-\code{filter()} retains the rows where the conditions you provide a \code{TRUE}. Note
-that, unlike base subsetting with \code{[}, rows where the condition evaluates
-to \code{NA} are dropped.
+The \code{filter()} function is used to create a subset of a tibble or data frame,
+retaining all rows that satisfy user-specified conditions.
+To be retained, the row must produce a value of \code{TRUE} for all conditions.
+An important difference between \code{filter()} and base subsetting with \code{[}, any
+row for which a condition evaluates to \code{NA} is dropped.
 }
 \details{
 dplyr is not yet smart enough to optimise filtering optimisation

--- a/man/filter.Rd
+++ b/man/filter.Rd
@@ -88,14 +88,15 @@ The following methods are currently available in loaded packages:
 }
 
 \examples{
+# Filtering by one criterion
 filter(starwars, species == "Human")
 filter(starwars, mass > 1000)
 
-# Multiple criteria
+# Filtering by multiple criteria within a single logical expression
 filter(starwars, hair_color == "none" & eye_color == "black")
 filter(starwars, hair_color == "none" | eye_color == "black")
 
-# Multiple arguments are equivalent to and
+# When multiple expressions are used, they are combined using &
 filter(starwars, hair_color == "none", eye_color == "black")
 
 
@@ -111,7 +112,7 @@ starwars \%>\% filter(mass > mean(mass, na.rm = TRUE))
 starwars \%>\% group_by(gender) \%>\% filter(mass > mean(mass, na.rm = TRUE))
 
 
-# Refer to column names stored as strings with the `.data` pronoun:
+# To refer to column names that are as strings, use the `.data` pronoun:
 vars <- c("mass", "height")
 cond <- c(80, 150)
 starwars \%>\%

--- a/man/filter.Rd
+++ b/man/filter.Rd
@@ -112,7 +112,7 @@ starwars \%>\% filter(mass > mean(mass, na.rm = TRUE))
 starwars \%>\% group_by(gender) \%>\% filter(mass > mean(mass, na.rm = TRUE))
 
 
-# To refer to column names stored as strings, use the `.data` pronoun:
+# To refer to column names that are stored as strings, use the `.data` pronoun:
 vars <- c("mass", "height")
 cond <- c(80, 150)
 starwars \%>\%

--- a/man/filter.Rd
+++ b/man/filter.Rd
@@ -31,7 +31,7 @@ An object of the same type as \code{.data}. The output has the following propert
 }
 }
 \description{
-The \code{filter()} function is used to subset a data set,
+The \code{filter()} function is used to subset a data object,
 retaining all rows that satisfy user-specified conditions.
 To be retained, the row must produce a value of \code{TRUE} for all conditions.
 An important difference between \code{filter()} and base subsetting with \code{[}, any

--- a/man/filter.Rd
+++ b/man/filter.Rd
@@ -11,10 +11,11 @@ filter(.data, ..., .preserve = FALSE)
 lazy data frame (e.g. from dbplyr or dtplyr). See \emph{Methods}, below, for
 more details.}
 
-\item{...}{<\code{\link[=dplyr_data_masking]{data-masking}}> Logical predicates defined
-in terms of the variables in \code{.data}.
-Multiple conditions are combined with \code{&}. Only rows where the
-condition evaluates to \code{TRUE} are kept.}
+\item{...}{Expressions that return a
+logical value, and are defined in terms of the variables in \code{.data}.
+If multiple expressions are included, they are combined with the \code{&} operator.
+Only rows for which all conditions evaluate to \code{TRUE} are kept. Note that
+<\code{\link[=dplyr_data_masking]{data-masking}}> applies here.}
 
 \item{.preserve}{when \code{FALSE} (the default), the grouping structure
 is recalculated based on the resulting data, otherwise it is kept as is.}

--- a/man/filter.Rd
+++ b/man/filter.Rd
@@ -38,9 +38,12 @@ An important difference between \code{filter()} and base subsetting with \code{[
 row for which a condition evaluates to \code{NA} is dropped.
 }
 \details{
-dplyr is not yet smart enough to optimise filtering optimisation
-on grouped datasets that don't need grouped calculations. For this reason,
-filtering is often considerably faster on \code{\link[=ungroup]{ungroup()}}ed data.
+The \code{filter()} function is used to subset the rows of
+\code{.data}, applying the expressions in \code{...} to the column values to determine which
+rows should be retained. It can be applied to both grouped and ungrouped data (see \code{\link[=group_by]{group_by()}} and
+\code{\link[=ungroup]{ungroup()}}). However, dplyr is not yet smart enough to optimise the filtering
+operation on grouped datasets that do not need grouped calculations. For this
+reason, filtering is often considerably faster on ungrouped data.
 }
 \section{Useful filter functions}{
 

--- a/man/filter.Rd
+++ b/man/filter.Rd
@@ -17,8 +17,9 @@ If multiple expressions are included, they are combined with the \code{&} operat
 Only rows for which all conditions evaluate to \code{TRUE} are kept. Note that
 <\code{\link[=dplyr_data_masking]{data-masking}}> applies here.}
 
-\item{.preserve}{when \code{FALSE} (the default), the grouping structure
-is recalculated based on the resulting data, otherwise it is kept as is.}
+\item{.preserve}{Relevant when the \code{.data} input is grouped.
+If \code{.preserve = FALSE} (the default), the grouping structure
+is recalculated based on the resulting data, otherwise the grouping is kept as is.}
 }
 \value{
 An object of the same type as \code{.data}. The output has the following properties:

--- a/man/filter.Rd
+++ b/man/filter.Rd
@@ -29,7 +29,7 @@ An object of the same type as \code{.data}.
 }
 }
 \description{
-The \code{filter()} function is used to create a subset of a tibble or data frame,
+The \code{filter()} function is used to subset a data set,
 retaining all rows that satisfy user-specified conditions.
 To be retained, the row must produce a value of \code{TRUE} for all conditions.
 An important difference between \code{filter()} and base subsetting with \code{[}, any

--- a/man/filter.Rd
+++ b/man/filter.Rd
@@ -20,7 +20,7 @@ condition evaluates to \code{TRUE} are kept.}
 is recalculated based on the resulting data, otherwise it is kept as is.}
 }
 \value{
-An object of the same type as \code{.data}.
+An object of the same type as \code{.data}. The output has the following properties:
 \itemize{
 \item Rows are a subset of the input, but appear in the same order.
 \item Columns are not modified.

--- a/man/slice.Rd
+++ b/man/slice.Rd
@@ -35,8 +35,9 @@ Indices beyond the number of rows in the input are silently ignored.
 
 For \code{slice_helpers()}, these arguments are passed on to methods.}
 
-\item{.preserve}{when \code{FALSE} (the default), the grouping structure
-is recalculated based on the resulting data, otherwise it is kept as is.}
+\item{.preserve}{Relevant when the \code{.data} input is grouped.
+If \code{.preserve = FALSE} (the default), the grouping structure
+is recalculated based on the resulting data, otherwise the grouping is kept as is.}
 
 \item{n, prop}{Provide either \code{n}, the number of rows, or \code{prop}, the
 proportion of rows to select. If \code{n} is greater than the number of


### PR DESCRIPTION
Various updates to the filter() documentation. 

- Adds brief introduction to make the "details" section less jarring
- Minor tidying to text to improve readability
- Attempts to describe the arguments more clearly
- Removes "see alsos" that will be redundant in an `across()` workflow

Closes #4791. I hope :slightly_smiling_face: 