### PR TITLE
oversight in example text

### DIFF
--- a/R/all-equal.r
+++ b/R/all-equal.r
@@ -28,7 +28,7 @@
 #' all_equal(mtcars, scramble(mtcars), ignore_row_order = FALSE)
 #'
 #' # By default all_equal is sensitive to variable differences
-#' df1 <- data.frame(x = "a")
+#' df1 <- data.frame(x = "a", stringsAsFactors = FALSE)
 #' df2 <- data.frame(x = factor("a"))
 #' all_equal(df1, df2)
 #' # But you can request dplyr convert similar types


### PR DESCRIPTION
i think this block might have an oversight?  `x=` in both cases is a factor, so `convert = FALSE` gives the same result as `convert = TRUE`

	# By default all_equal is sensitive to variable differences
	df1 <- data.frame(x = "a")
	df2 <- data.frame(x = factor("a"))
	all_equal(df1, df2)
	# But you can request dplyr convert similar types
	all_equal(df1, df2, convert = TRUE)


if you don't want to add stringsAsFactors = FALSE here, another easy edit would be

	# By default all_equal is sensitive to variable differences
	df1 <- data.frame(x = 1L)
	df2 <- data.frame(x = 1.0)
	all_equal(df1, df2)
	# But you can request dplyr convert similar types
	all_equal(df1, df2, convert = TRUE)