### PR TITLE
Only one defineVar for current_group

### DIFF
--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -33,7 +33,7 @@ DataMask <- R6Class("DataMask",
         binding_fn <- function(index, chunks = resolve_chunks(index)) {
           function() {
             private$used[[index]] <- TRUE
-            .subset2(chunks, private$current_group)
+            .subset2(chunks, self$get_current_group())
           }
         }
       } else {
@@ -41,7 +41,7 @@ DataMask <- R6Class("DataMask",
           # chunks is a promise of the list of all chunks for the column
           # at this index, so resolve_chunks() is only called when
           # the active binding is touched
-          function() .subset2(chunks, private$current_group)
+          function() .subset2(chunks, self$get_current_group())
         }
       }
 
@@ -54,7 +54,7 @@ DataMask <- R6Class("DataMask",
     add = function(name, chunks) {
       force(chunks)
       env_bind_active(private$bindings, !!name := function() {
-        .subset2(chunks, private$current_group)
+        .subset2(chunks, self$get_current_group())
       })
     },
 
@@ -83,15 +83,18 @@ DataMask <- R6Class("DataMask",
     },
 
     current_rows = function() {
-      private$rows[[private$current_group]]
+      private$rows[[self$get_current_group()]]
     },
 
     current_key = function() {
-      vec_slice(private$keys, private$current_group)
+      vec_slice(private$keys, self$get_current_group())
     },
 
     get_current_group = function() {
-      private$current_group
+      # The [] is so that we get a copy, which is important for how
+      # current_group is dealt with internally, to avoid defining it at each
+      # iteration of the dplyr_mask_eval_*() loops.
+      private$current_group[]
     },
 
     set_current_group = function(group) {

--- a/src/dplyr.h
+++ b/src/dplyr.h
@@ -65,12 +65,14 @@ SEXP dplyr_group_indices(SEXP data, SEXP s_nr);
 SEXP rows = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::rows)); \
 R_xlen_t ngroups = XLENGTH(rows);                                          \
 SEXP mask = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::mask)); \
-SEXP caller = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::caller))
+SEXP caller = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::caller)); \
+SEXP current_group = PROTECT(Rf_ScalarInteger(NA_INTEGER));    \
+Rf_defineVar(dplyr::symbols::current_group, current_group, env_private); \
+int* p_current_group = INTEGER(current_group)
 
-#define DPLYR_MASK_FINALISE() UNPROTECT(3);
+#define DPLYR_MASK_FINALISE() UNPROTECT(4);
 
-#define DPLYR_MASK_SET_GROUP(INDEX)                                                  \
-Rf_defineVar(dplyr::symbols::current_group, Rf_ScalarInteger(INDEX + 1), env_private);
+#define DPLYR_MASK_SET_GROUP(INDEX) *p_current_group = INDEX + 1
 
 #define DPLYR_MASK_EVAL(quo) rlang::eval_tidy(quo, mask, caller)
 


### PR DESCRIPTION
Instead of calling `Rf_defineVar()` over and over again, we define the `private$current_group` once and then update the value, the R side of the code that access it makes a copy. 

This is a minor performance fix. 