### PR TITLE
Additional rowwise() magic within the same mutate() call.

### DIFF
--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -61,6 +61,14 @@ DataMask <- R6Class("DataMask",
         private$used[[pos]] <- TRUE
         private$which_used <- c(private$which_used, pos)
       }
+      if (inherits(private$data, "rowwise_df")){
+        is_scalar_list <- function(.x) {
+          is.list(.x) && !is.data.frame(.x) && length(.x) == 1L
+        }
+        if (all(map_lgl(chunks, is_scalar_list))) {
+          chunks <- map(chunks, `[[`, 1L)
+        }
+      }
       private$resolved[[name]] <- chunks
     },
 

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -170,6 +170,17 @@ test_that("grouped mutate does not drop grouping attributes (#1020)", {
   expect_equal(setdiff(a1, a2), character(0))
 })
 
+test_that("mutate() hands list columns with rowwise magic to follow up expressions (#4845)", {
+  test <- rowwise(tibble(x = 1:2))
+
+  expect_identical(
+    test %>%
+      mutate(a = list(1)) %>%
+      mutate(b = list(a + 1)),
+    test %>%
+      mutate(a = list(1), b = list(a + 1))
+  )
+})
 
 
 # other -------------------------------------------------------------------


### PR DESCRIPTION
closes #4845

``` r
library(dplyr, warn.conflicts = FALSE)

test <- tibble(x = 1:2)

test %>%
  rowwise() %>%
  mutate(a = list(1)) %>%
  mutate(b = list(a + 1))
#> # A tibble: 2 x 3
#> # Rowwise: 
#>       x a         b        
#>   <int> <list>    <list>   
#> 1     1 <dbl [1]> <dbl [1]>
#> 2     2 <dbl [1]> <dbl [1]>

test %>%
  rowwise() %>%
  mutate(a = list(1),
    b = list(a + 1))
#> # A tibble: 2 x 3
#> # Rowwise: 
#>       x a         b        
#>   <int> <list>    <list>   
#> 1     1 <dbl [1]> <dbl [1]>
#> 2     2 <dbl [1]> <dbl [1]>
```

<sup>Created on 2020-02-10 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>