### PR TITLE
Faster internal group_keys implementation

### DIFF
--- a/R/group_data.R
+++ b/R/group_data.R
@@ -73,10 +73,8 @@ group_keys.data.frame <- function(.tbl, ...) {
     )
     .tbl <- group_by(.tbl, ...)
   }
-
   out <- group_data(.tbl)
-  attr(out, ".drop") <- NULL
-  out[-length(out)]
+  .Call(`dplyr_group_keys`, out)
 }
 #' @rdname group_data
 #' @export

--- a/R/grouped-df.r
+++ b/R/grouped-df.r
@@ -163,7 +163,7 @@ new_grouped_df <- function(x, groups, ..., class = character()) {
 #' @rdname new_grouped_df
 #' @export
 validate_grouped_df <- function(x, check_bounds = FALSE) {
-  result <- .Call(`dplyr_validate_grouped_df`, x, nrow(x), check_bounds)
+  result <- .Call(`dplyr_validate_grouped_df`, x, check_bounds)
   if (!is.null(result)) {
     abort(result, class = "dplyr_grouped_df_corrupt")
   }

--- a/src/dplyr.h
+++ b/src/dplyr.h
@@ -25,6 +25,7 @@ struct symbols {
   static SEXP resolved;
   static SEXP bindings;
   static SEXP which_used;
+  static SEXP dot_drop;
 };
 
 struct vectors {
@@ -55,7 +56,7 @@ SEXP dplyr_between(SEXP x, SEXP s_left, SEXP s_right);
 SEXP dplyr_cumall(SEXP x);
 SEXP dplyr_cumany(SEXP x);
 SEXP dplyr_cummean(SEXP x);
-SEXP dplyr_validate_grouped_df(SEXP df, SEXP s_nr_df, SEXP s_check_bounds);
+SEXP dplyr_validate_grouped_df(SEXP df, SEXP s_check_bounds);
 SEXP dplyr_mask_eval_all(SEXP quo, SEXP env_private);
 SEXP dplyr_mask_eval_all_summarise(SEXP quo, SEXP env_private);
 SEXP dplyr_mask_eval_all_mutate(SEXP quo, SEXP env_private);
@@ -63,6 +64,7 @@ SEXP dplyr_mask_eval_all_filter(SEXP quos, SEXP env_private, SEXP s_n, SEXP env_
 SEXP dplyr_vec_sizes(SEXP chunks);
 SEXP dplyr_validate_summarise_sizes(SEXP size, SEXP chunks);
 SEXP dplyr_group_indices(SEXP data, SEXP s_nr);
+SEXP dplyr_group_keys(SEXP group_data);
 
 #define DPLYR_MASK_INIT()                                                  \
 SEXP rows = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::rows)); \

--- a/src/group_data.cpp
+++ b/src/group_data.cpp
@@ -18,3 +18,19 @@ SEXP dplyr_group_indices(SEXP rows, SEXP s_nr) {
   UNPROTECT(1);
   return indices;
 }
+
+SEXP dplyr_group_keys(SEXP group_data) {
+  R_xlen_t n = XLENGTH(group_data) - 1;
+  SEXP old_names = Rf_getAttrib(group_data, R_NamesSymbol);
+  SEXP new_names = PROTECT(Rf_allocVector(STRSXP, n));
+  SEXP keys = PROTECT(Rf_allocVector(VECSXP, n));
+  for (R_xlen_t i=0; i<n; i++){
+    SET_STRING_ELT(new_names, i, STRING_ELT(old_names, i));
+    SET_VECTOR_ELT(keys, i, VECTOR_ELT(group_data, i));
+  }
+  Rf_copyMostAttrib(group_data, keys);
+  Rf_setAttrib(keys, R_NamesSymbol, new_names);
+  Rf_setAttrib(keys, dplyr::symbols::dot_drop, R_NilValue);
+  UNPROTECT(2);
+  return keys;
+}

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -40,6 +40,7 @@ SEXP symbols::caller = Rf_install("caller");
 SEXP symbols::resolved = Rf_install("resolved");
 SEXP symbols::bindings = Rf_install("bindings");
 SEXP symbols::which_used = Rf_install("which_used");
+SEXP symbols::dot_drop = Rf_install(".drop");
 
 SEXP vectors::classes_vctrs_list_of = get_classes_vctrs_list_of();
 SEXP vectors::classes_tbl_df = get_classes_tbl_df();
@@ -60,7 +61,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"dplyr_cumall", (DL_FUNC)& dplyr_cumall, 1},
   {"dplyr_cumany", (DL_FUNC)& dplyr_cumany, 1},
   {"dplyr_cummean", (DL_FUNC)& dplyr_cummean, 1},
-  {"dplyr_validate_grouped_df", (DL_FUNC)& dplyr_validate_grouped_df, 3},
+  {"dplyr_validate_grouped_df", (DL_FUNC)& dplyr_validate_grouped_df, 2},
 
   {"dplyr_mask_eval_all", (DL_FUNC)& dplyr_mask_eval_all, 2},
   {"dplyr_mask_eval_all_summarise", (DL_FUNC)& dplyr_mask_eval_all_summarise, 2},
@@ -70,6 +71,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"dplyr_vec_sizes", (DL_FUNC)& dplyr_vec_sizes, 1},
   {"dplyr_validate_summarise_sizes", (DL_FUNC)& dplyr_validate_summarise_sizes, 2},
   {"dplyr_group_indices", (DL_FUNC)& dplyr_group_indices, 2},
+  {"dplyr_group_keys", (DL_FUNC)& dplyr_group_keys, 1},
 
   {NULL, NULL, 0}
 };

--- a/tests/testthat/test-group_data-errors.txt
+++ b/tests/testthat/test-group_data-errors.txt
@@ -42,9 +42,6 @@ Error: out of bounds indices
 > validate_grouped_df(df8, check_bounds = TRUE)
 Error: out of bounds indices
 
-> validate_grouped_df(df9)
-Error: `.rows` column is not a list of one-based integer vectors
-
 > validate_grouped_df(df10)
 Error: The `groups` attribute is not a data frame with its last column called `.rows`
 

--- a/tests/testthat/test-group_data.R
+++ b/tests/testthat/test-group_data.R
@@ -129,9 +129,6 @@ test_that("group_data() give meaningful errors", {
   df8 <- df6
   attr(df8, "groups")$.rows <- list(0L)
 
-  df9 <- df6
-  attr(df9, "groups")$.rows <- list(1)
-
   df10 <- df6
   attr(df10, "groups") <- tibble()
 
@@ -158,7 +155,6 @@ test_that("group_data() give meaningful errors", {
     validate_grouped_df(df6, check_bounds = TRUE)
     validate_grouped_df(df7, check_bounds = TRUE)
     validate_grouped_df(df8, check_bounds = TRUE)
-    validate_grouped_df(df9)
     validate_grouped_df(df10)
     validate_grouped_df(df11)
   })


### PR DESCRIPTION
This appeared to be taking unnecessary time, presumably because of the infamous `row.names` handling in R, so I worked out it. 

``` r
library(dplyr)

df <- tibble(x = rnorm(1e6), g = sample(rep(1:1e4, 100))) %>% group_by(g)

bench::mark(
  group_keys(df), 
  group_data(df)[-2], 
  
  check = FALSE # not exactly the same because `group_keys()` also removes the .drop attribute
)
#> # A tibble: 2 x 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 group_keys(df)       4.37µs   4.97µs   171603.    27.6KB     17.2
#> 2 group_data(df)[-2] 345.28µs  413.9µs     2482.    41.3KB     14.6
```


