### PR TITLE
Prevent slice_min/max from crashing when there are NA's

### DIFF
--- a/R/slice.R
+++ b/R/slice.R
@@ -170,8 +170,8 @@ slice_min.data.frame <- function(.data, order_by, ..., n, prop, with_ties = TRUE
   size <- check_slice_size(n, prop)
   if (with_ties) {
     idx <- switch(size$type,
-      n =    function(x, n) head(order(x), sum(min_rank(x) <= size$n, na.rm = TRUE)),
-      prop = function(x, n) head(order(x), sum(min_rank(x) <= size$prop * n, na.rm = TRUE))
+      n =    function(x, n) head(order(x), nr_ranks_lesser_or_equal_to(x, size$n)),
+      prop = function(x, n) head(order(x), nr_ranks_lesser_or_equal_to(x, size$prop * n))
     )
   } else {
     idx <- switch(size$type,
@@ -198,12 +198,10 @@ slice_max.data.frame <- function(.data, order_by, ..., n, prop, with_ties = TRUE
   if (with_ties) {
     idx <- switch(size$type,
       n =    function(x, n) head(
-          order(x, decreasing = TRUE),
-          sum(min_rank(desc(x)) <= size$n, na.rm = TRUE)
-        ),
+        order(x, decreasing = TRUE), nr_ranks_lesser_or_equal_to(desc(x), size$n)
+      ),
       prop = function(x, n) head(
-        order(x, decreasing = TRUE),
-        sum(min_rank(desc(x)) <= size$prop * n, na.rm = TRUE)
+        order(x, decreasing = TRUE), nr_ranks_lesser_or_equal_to(desc(x), size$prop)
       )
     )
   } else {
@@ -318,5 +316,9 @@ sample_int <- function(n, size, replace = FALSE, wt = NULL) {
   } else {
     sample.int(n, min(size, n), prob = wt)
   }
+}
+
+nr_ranks_lesser_or_equal_to <- function(x, y) {
+  sum(min_rank(x) <= y, na.rm = TRUE)
 }
 

--- a/R/slice.R
+++ b/R/slice.R
@@ -170,8 +170,8 @@ slice_min.data.frame <- function(.data, order_by, ..., n, prop, with_ties = TRUE
   size <- check_slice_size(n, prop)
   if (with_ties) {
     idx <- switch(size$type,
-      n =    function(x, n) head(order(x), nr_ranks_lesser_or_equal_to(x, size$n)),
-      prop = function(x, n) head(order(x), nr_ranks_lesser_or_equal_to(x, size$prop * n))
+      n =    function(x, n) head(order(x), smaller_ranks(x, size$n)),
+      prop = function(x, n) head(order(x), smaller_ranks(x, size$prop * n))
     )
   } else {
     idx <- switch(size$type,
@@ -198,10 +198,10 @@ slice_max.data.frame <- function(.data, order_by, ..., n, prop, with_ties = TRUE
   if (with_ties) {
     idx <- switch(size$type,
       n =    function(x, n) head(
-        order(x, decreasing = TRUE), nr_ranks_lesser_or_equal_to(desc(x), size$n)
+        order(x, decreasing = TRUE), smaller_ranks(desc(x), size$n)
       ),
       prop = function(x, n) head(
-        order(x, decreasing = TRUE), nr_ranks_lesser_or_equal_to(desc(x), size$prop)
+        order(x, decreasing = TRUE), smaller_ranks(desc(x), size$prop)
       )
     )
   } else {
@@ -318,7 +318,7 @@ sample_int <- function(n, size, replace = FALSE, wt = NULL) {
   }
 }
 
-nr_ranks_lesser_or_equal_to <- function(x, y) {
+smaller_ranks <- function(x, y) {
   sum(min_rank(x) <= y, na.rm = TRUE)
 }
 

--- a/R/slice.R
+++ b/R/slice.R
@@ -170,8 +170,8 @@ slice_min.data.frame <- function(.data, order_by, ..., n, prop, with_ties = TRUE
   size <- check_slice_size(n, prop)
   if (with_ties) {
     idx <- switch(size$type,
-      n =    function(x, n) head(order(x), sum(min_rank(x) <= size$n)),
-      prop = function(x, n) head(order(x), sum(min_rank(x) <= size$prop * n)),
+      n =    function(x, n) head(order(x), sum(min_rank(x) <= size$n, na.rm = TRUE)),
+      prop = function(x, n) head(order(x), sum(min_rank(x) <= size$prop * n, na.rm = TRUE))
     )
   } else {
     idx <- switch(size$type,
@@ -197,8 +197,14 @@ slice_max.data.frame <- function(.data, order_by, ..., n, prop, with_ties = TRUE
   size <- check_slice_size(n, prop)
   if (with_ties) {
     idx <- switch(size$type,
-      n =    function(x, n) head(order(x, decreasing = TRUE), sum(min_rank(desc(x)) <= size$n)),
-      prop = function(x, n) head(order(x, decreasing = TRUE), sum(min_rank(desc(x)) <= size$prop * n))
+      n =    function(x, n) head(
+          order(x, decreasing = TRUE),
+          sum(min_rank(desc(x)) <= size$n, na.rm = TRUE)
+        ),
+      prop = function(x, n) head(
+        order(x, decreasing = TRUE),
+        sum(min_rank(desc(x)) <= size$prop * n, na.rm = TRUE)
+      )
     )
   } else {
     idx <- switch(size$type,

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -219,12 +219,23 @@ test_that("min and max reorder results", {
   expect_equal(df %>% slice_max(x, n = 2, with_ties = FALSE) %>% pull(id), c(2, 1))
 })
 
+test_that("min and max ignore NA's (#4826)", {
+  df <- data.frame(id = 1:4, x = c(2, NA, 1, 2), y = c(NA, NA, NA, NA))
+
+  expect_equal(df %>% slice_min(x, n = 2) %>% pull(id), c(3, 1, 4))
+  expect_equal(df %>% slice_min(y, n = 2) %>% nrow(), 0)
+  expect_equal(df %>% slice_max(x, n = 2) %>% pull(id), c(1, 4))
+  expect_equal(df %>% slice_max(y, n = 2) %>% nrow(), 0)
+})
+
 test_that("arguments to sample are passed along", {
   df <- data.frame(x = 1:100, wt = c(1, rep(0, 99)))
 
   expect_equal(df %>% slice_sample(n = 1, weight_by = wt) %>% pull(x), 1)
   expect_equal(df %>% slice_sample(n = 2, weight_by = wt, replace = TRUE) %>% pull(x), c(1, 1))
 })
+
+
 
 # Errors ------------------------------------------------------------------
 

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -235,8 +235,6 @@ test_that("arguments to sample are passed along", {
   expect_equal(df %>% slice_sample(n = 2, weight_by = wt, replace = TRUE) %>% pull(x), c(1, 1))
 })
 
-
-
 # Errors ------------------------------------------------------------------
 
 test_that("rename errors with invalid grouped data frame (#640)", {


### PR DESCRIPTION
Removes `NA`'s from the columns.

Closes https://github.com/tidyverse/dplyr/issues/4826