### PR TITLE
join_mutate() using vec_ptype_common() instead of vec_ptype2()

### DIFF
--- a/R/join.r
+++ b/R/join.r
@@ -330,10 +330,8 @@ join_mutate <- function(x, y, by, type,
 
   if (!keep) {
     out[names(x_key)] <- vec_cast(out[names(x_key)], vec_ptype_common(x_key, y_key))
-    if (length(rows$y_extra)) {
-      new_rows <- length(rows$x) + seq_along(rows$y_extra)
-      out[new_rows, names(y_key)] <- vec_slice(y_key, rows$y_extra)
-    }
+    new_rows <- length(rows$x) + seq_along(rows$y_extra)
+    out[new_rows, names(y_key)] <- vec_slice(y_key, rows$y_extra)
   }
 
   out[names(y_out)] <- vec_slice(y_out, c(rows$y, rows$y_extra))

--- a/R/join.r
+++ b/R/join.r
@@ -329,7 +329,7 @@ join_mutate <- function(x, y, by, type,
   out <- vec_slice(out, c(rows$x, rep_along(rows$y_extra, NA_integer_)))
 
   if (!keep) {
-    out[names(x_key)] <- vec_cast(out[names(x_key)], vec_ptype2(x_key, y_key))
+    out[names(x_key)] <- vec_cast(out[names(x_key)], vec_ptype_common(x_key, y_key))
     if (length(rows$y_extra)) {
       new_rows <- length(rows$x) + seq_along(rows$y_extra)
       out[new_rows, names(y_key)] <- vec_slice(y_key, rows$y_extra)

--- a/R/join.r
+++ b/R/join.r
@@ -330,8 +330,10 @@ join_mutate <- function(x, y, by, type,
 
   if (!keep) {
     out[names(x_key)] <- vec_cast(out[names(x_key)], vec_ptype2(x_key, y_key))
-    new_rows <- length(rows$x) + seq_along(rows$y_extra)
-    out[new_rows, names(y_key)] <- vec_slice(y_key, rows$y_extra)
+    if (length(rows$y_extra)) {
+      new_rows <- length(rows$x) + seq_along(rows$y_extra)
+      out[new_rows, names(y_key)] <- vec_slice(y_key, rows$y_extra)
+    }
   }
 
   out[names(y_out)] <- vec_slice(y_out, c(rows$y, rows$y_extra))

--- a/tests/testthat/test-join.r
+++ b/tests/testthat/test-join.r
@@ -119,8 +119,6 @@ test_that("joins don't match NA when na_matches = 'never' (#2033)", {
   df1 <- tibble(a = NA)
   df2 <- tibble(a = NA, b = 1:3)
   expect_warning(left_join(df1, df2, by = "a", na_matches = "never"))
-
-  skip("until https://github.com/r-lib/vctrs/issues/718")
 })
 
 # nest_join ---------------------------------------------------------------


### PR DESCRIPTION
This is just avoiding the problem, which I think is related to https://github.com/r-lib/vctrs/issues/807

``` r
library(vctrs)
library(tibble)
df <- tibble(x = NA)
vec_ptype(df)$x
#> logical(0)
vec_ptype2(df, df)$x
#> <unspecified> [0]
```

<sup>Created on 2020-02-17 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>