### PR TITLE
Prevent collapse of data.frame to vector in across (#4867)

### DIFF
--- a/R/across.R
+++ b/R/across.R
@@ -63,7 +63,7 @@ across <- function(cols = everything(), fns = NULL, names = NULL) {
 
   vars <- tidyselect::eval_select(
     expr({{ cols }}),
-    data[, setdiff(names(data), group_vars(data))]
+    data[, setdiff(names(data), group_vars(data)), drop = FALSE]
   )
   data <- mask$pick(names(vars))
 

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -1,8 +1,8 @@
 test_that("across() works on one column data.frame", {
   df <- data.frame(x = 1)
 
-  out <- df %>% mutate(across(x, identity))
-  expect_equal(dim(out), c(1, 1))
+  out <- df %>% mutate(across())
+  expect_equal(out, df)
 })
 
 test_that("across() does not select grouping variables", {

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -1,3 +1,10 @@
+test_that("across() works on one column data.frame", {
+  df <- data.frame(x = 1)
+
+  out <- df %>% mutate(across(x, identity))
+  expect_equal(dim(out), c(1, 1))
+})
+
 test_that("across() does not select grouping variables", {
   df <- data.frame(g = 1, x = 1)
 


### PR DESCRIPTION
Fixes #4867: across() did not work on one column data.frame because a call to `[` was made without setting `drop = FALSE`.