### PR TITLE
More efficient replacement of `NULL` with `NA_integer` in `join_rows()`

### DIFF
--- a/R/join-rows.R
+++ b/R/join-rows.R
@@ -7,7 +7,7 @@ join_rows <- function(x_key, y_key, type = c("inner", "left", "right", "full")) 
   y_loc <- y_split$loc[matches]
 
   if (type == "left" || type == "full") {
-    y_loc <- map(y_loc, function(x) if (is.null(x)) NA_integer_ else x)
+    y_loc <- vec_assign(y_loc, vec_equal_na(matches), list(NA_integer_))
   }
 
   x_loc <- seq_len(vec_size(x_key))


### PR DESCRIPTION
Part of #4873 

This uses `vec_assign()` and `vec_equal_na()` to detect and replace `NULL` values with `NA_integer`, rather than `map()`

This only affects `left_join()` and `full_join()`, but I've included benchmarks for `right_join()` and `inner_join()` to note the previous performance difference between those and `left/full_join()` because of this `map()` call.

``` r
library(dplyr, warn.conflicts = FALSE)
library(bench)
set.seed(342)

df1 <- tibble(x = rnorm(1e5), a = sample(1:10, 1e5, replace = TRUE))
df2 <- tibble(y = rnorm(1e3), a = sample(1:10, 1e3, replace = TRUE))
df3 <- tibble(x = rnorm(1e5), a = sample(1:10, 1e5, replace = TRUE), b = sample(1:5, 1e5, replace = TRUE))
df4 <- tibble(y = rnorm(1e3), a = sample(1:10, 1e3, replace = TRUE), b = sample(1:5, 1e3, replace = TRUE))
```


```r
bench::mark(
  inner_join(df1, df2, by = "a"),
  left_join(df1, df2, by = "a"),
  right_join(df1, df2, by = "a"),
  full_join(df1, df2, by = "a"),
  
  check = FALSE,
  iterations = 30
)

# master
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 4 x 6
#>   expression                          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 inner_join(df1, df2, by = "a")    210ms    241ms      3.99     424MB     4.26
#> 2 left_join(df1, df2, by = "a")     237ms    313ms      3.09     424MB     4.43
#> 3 right_join(df1, df2, by = "a")    208ms    250ms      3.94     424MB     3.94
#> 4 full_join(df1, df2, by = "a")     244ms    303ms      3.23     425MB     4.73

# this PR
#> # A tibble: 4 x 6
#>   expression                          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 inner_join(df1, df2, by = "a")    235ms    235ms      4.26     424MB    145. 
#> 2 left_join(df1, df2, by = "a")     198ms    208ms      4.82     424MB     36.2
#> 3 right_join(df1, df2, by = "a")    195ms    207ms      4.86     424MB     18.2
#> 4 full_join(df1, df2, by = "a")     218ms    232ms      4.30     425MB     14.7
```

```r
bench::mark(
  inner_join(df3, df4, by = c("a", "b")),
  left_join(df3, df4, by = c("a", "b")),
  right_join(df3, df4, by = c("a", "b")),
  full_join(df3, df4, by = c("a", "b")),
  
  check = FALSE,
  iterations = 30
)

# master
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 4 x 6
#>   expression                                 min  median `itr/sec` mem_alloc
#>   <bch:expr>                             <bch:t> <bch:t>     <dbl> <bch:byt>
#> 1 inner_join(df3, df4, by = c("a", "b"))  65.3ms  80.2ms     11.2      103MB
#> 2 left_join(df3, df4, by = c("a", "b"))  106.5ms 118.4ms      7.84     103MB
#> 3 right_join(df3, df4, by = c("a", "b"))  70.5ms  78.8ms     11.6      104MB
#> 4 full_join(df3, df4, by = c("a", "b"))  111.1ms 125.8ms      7.39     104MB
#> # … with 1 more variable: `gc/sec` <dbl>

# this PR
#> # A tibble: 4 x 6
#>   expression                                min median `itr/sec` mem_alloc
#>   <bch:expr>                             <bch:> <bch:>     <dbl> <bch:byt>
#> 1 inner_join(df3, df4, by = c("a", "b")) 70.9ms 90.9ms      11.1     103MB
#> 2 left_join(df3, df4, by = c("a", "b"))  69.6ms 76.1ms      12.8     104MB
#> 3 right_join(df3, df4, by = c("a", "b")) 70.2ms 88.7ms      11.2     104MB
#> 4 full_join(df3, df4, by = c("a", "b"))  70.2ms 79.1ms      12.3     105MB
#> # … with 1 more variable: `gc/sec` <dbl>
```