### PR TITLE
Avoid `c()` calls when only `x` rows are required

### DIFF
--- a/R/join.r
+++ b/R/join.r
@@ -331,16 +331,27 @@ join_mutate <- function(x, y, by, type,
   x_out <- set_names(x[vars$x$out], names(vars$x$out))
   y_out <- set_names(y[vars$y$out], names(vars$y$out))
 
+  if (type == "right" || type == "full") {
+    x_slicer <- c(rows$x, rep_along(rows$y_extra, NA_integer_))
+    y_slicer <- c(rows$y, rows$y_extra)
+  } else {
+    x_slicer <- rows$x
+    y_slicer <- rows$y
+  }
+
   out <- as_tibble(x_out)
-  out <- vec_slice(out, c(rows$x, rep_along(rows$y_extra, NA_integer_)))
+  out <- vec_slice(out, x_slicer)
+  out[names(y_out)] <- vec_slice(y_out, y_slicer)
 
   if (!keep) {
     out[names(x_key)] <- vec_cast(out[names(x_key)], vec_ptype_common(x_key, y_key))
-    new_rows <- length(rows$x) + seq_along(rows$y_extra)
-    out[new_rows, names(y_key)] <- vec_slice(y_key, rows$y_extra)
+
+    if (type == "right" || type == "full") {
+      new_rows <- length(rows$x) + seq_along(rows$y_extra)
+      out[new_rows, names(y_key)] <- vec_slice(y_key, rows$y_extra)
+    }
   }
 
-  out[names(y_out)] <- vec_slice(y_out, c(rows$y, rows$y_extra))
   dplyr_reconstruct(out, x_out)
 }
 


### PR DESCRIPTION
Part of #4873 

This only affects left and inner joins

In `join_mutate()`, `y_extra` only contains data on a right or full join. We are paying for extra copies of `rows$x` and `rows$y` in a few cases for left and inner joins, and we can avoid the updating of `new_rows` when `keep = TRUE` altogether, because we know there aren't any new rows

https://github.com/tidyverse/dplyr/blob/c6522a15bd7e37d4d760415af3e93c889d1a9b5f/R/join.r#L337-L341

Note the memory difference as well as the times in the benchmarks below

```r
library(dplyr, warn.conflicts = FALSE)
library(bench)
set.seed(342)

df1 <- tibble(x = rnorm(1e5), a = sample(1:10, 1e5, replace = TRUE))
df2 <- tibble(y = rnorm(1e3), a = sample(1:10, 1e3, replace = TRUE))
df3 <- tibble(x = rnorm(1e5), a = sample(1:10, 1e5, replace = TRUE), b = sample(1:5, 1e5, replace = TRUE))
df4 <- tibble(y = rnorm(1e3), a = sample(1:10, 1e3, replace = TRUE), b = sample(1:5, 1e3, replace = TRUE))
```

```r
bench::mark(
  inner_join(df1, df2, by = "a"),
  left_join(df1, df2, by = "a"),
  
  check = FALSE,
  iterations = 50
)

# master
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 x 6
#>   expression                          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 inner_join(df1, df2, by = "a")    200ms    235ms      4.08     424MB     4.32
#> 2 left_join(df1, df2, by = "a")     237ms    285ms      3.37     424MB     5.99

# this PR
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 x 6
#>   expression                          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 inner_join(df1, df2, by = "a")    156ms    217ms      4.50     310MB     5.76
#> 2 left_join(df1, df2, by = "a")     188ms    216ms      4.36     309MB     7.07
```

```r
bench::mark(
  inner_join(df3, df4, by = c("a", "b")),
  left_join(df3, df4, by = c("a", "b")),
  
  check = FALSE,
  iterations = 50
)

# master
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 x 6
#>   expression                                 min  median `itr/sec` mem_alloc
#>   <bch:expr>                             <bch:t> <bch:t>     <dbl> <bch:byt>
#> 1 inner_join(df3, df4, by = c("a", "b"))  65.3ms  83.8ms     10.6      103MB
#> 2 left_join(df3, df4, by = c("a", "b"))  100.9ms   127ms      7.58     103MB
#> # … with 1 more variable: `gc/sec` <dbl>

# this PR
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 x 6
#>   expression                                min median `itr/sec` mem_alloc
#>   <bch:expr>                             <bch:> <bch:>     <dbl> <bch:byt>
#> 1 inner_join(df3, df4, by = c("a", "b")) 52.7ms 63.9ms     14.1     72.1MB
#> 2 left_join(df3, df4, by = c("a", "b"))    84ms 99.2ms      9.59    72.9MB
#> # … with 1 more variable: `gc/sec` <dbl>
```