### PR TITLE
Use `new_data_frame()` in `dplyr_reconstruct()` to avoid materializing row names

### DIFF
--- a/R/generics.R
+++ b/R/generics.R
@@ -143,7 +143,16 @@ dplyr_reconstruct.data.frame <- function(data, template) {
   to_copy <- setdiff(names(attr_old), c("row.names", "names", ".drop"))
   attr_new[to_copy] <- attr_old[to_copy]
 
-  attributes(data) <- attr_new
+  class <- attr_new[["class"]]
+  attr_new[["class"]] <- NULL
+
+  # `new_data_frame()` will add the `"data.frame"` class
+  class <- setdiff(class, "data.frame")
+
+  size <- vec_size(data)
+
+  data <- exec(new_data_frame, x = data, n = size, class = class, !!! attr_new)
+
   data
 }
 

--- a/R/generics.R
+++ b/R/generics.R
@@ -140,14 +140,12 @@ dplyr_reconstruct.data.frame <- function(data, template) {
   attr_old <- attributes(template)
   attr_new <- attributes(data)
 
-  to_copy <- setdiff(names(attr_old), c("row.names", "names", ".drop"))
+  to_copy <- setdiff(names(attr_old), c("class", "row.names", "names", ".drop"))
   attr_new[to_copy] <- attr_old[to_copy]
 
-  class <- attr_new[["class"]]
-  attr_new[["class"]] <- NULL
-
   # `new_data_frame()` will add the `"data.frame"` class
-  class <- setdiff(class, "data.frame")
+  class <- setdiff(class(template), "data.frame")
+  attr_new[["class"]] <- NULL
 
   size <- vec_size(data)
 


### PR DESCRIPTION
Part of #4873 

This benefits all joins, plus any function that calls `dplyr_reconstruct()` with a data frame.

As shown in https://github.com/tidyverse/dplyr/issues/4873#issuecomment-590067757, `attributes()<-` materializes compact row names (which is rather unfortunate).

`new_data_frame()` does not, which makes it much cheaper. It doesn't allow `!!!` in the `...` right now, but maybe we should consider that.

Note both the time and memory in the benchmarks below.

``` r
library(dplyr, warn.conflicts = FALSE)
library(bench)
set.seed(342)

df1 <- tibble(x = rnorm(1e5), a = sample(1:10, 1e5, replace = TRUE))
df2 <- tibble(y = rnorm(1e3), a = sample(1:10, 1e3, replace = TRUE))
df3 <- tibble(x = rnorm(1e5), a = sample(1:10, 1e5, replace = TRUE), b = sample(1:5, 1e5, replace = TRUE))
df4 <- tibble(y = rnorm(1e3), a = sample(1:10, 1e3, replace = TRUE), b = sample(1:5, 1e3, replace = TRUE))
```

```r
bench::mark(
  inner_join(df1, df2, by = "a"),
  left_join(df1, df2, by = "a"),
  right_join(df1, df2, by = "a"),
  full_join(df1, df2, by = "a"),
  
  check = FALSE,
  iterations = 50
)

# master
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 4 x 6
#>   expression                          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 inner_join(df1, df2, by = "a")    213ms    251ms      3.89     424MB     4.13
#> 2 left_join(df1, df2, by = "a")     243ms    310ms      3.11     424MB     4.30
#> 3 right_join(df1, df2, by = "a")    195ms    245ms      3.96     424MB     3.49
#> 4 full_join(df1, df2, by = "a")     244ms    296ms      3.32     425MB     4.38

# this PR
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 4 x 6
#>   expression                          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 inner_join(df1, df2, by = "a")    159ms    205ms      4.61     386MB     4.88
#> 2 left_join(df1, df2, by = "a")     202ms    254ms      3.97     386MB     5.48
#> 3 right_join(df1, df2, by = "a")    158ms    205ms      4.81     386MB     3.66
#> 4 full_join(df1, df2, by = "a")     194ms    251ms      3.87     386MB     5.11
```