### PR TITLE
Generalize avoidance of `c()` calls to right and full joins

### DIFF
--- a/R/join-rows.R
+++ b/R/join-rows.R
@@ -16,17 +16,15 @@ join_rows <- function(x_key, y_key, type = c("inner", "left", "right", "full")) 
   x_loc <- rep(x_loc, lengths(y_loc))
   y_loc <- vec_c(!!!y_loc, .ptype = integer())
 
-  y_extra <- integer()
-  any_y_extra <- FALSE
-
   if (type == "right" || type == "full") {
     miss_x <- !vec_in(y_key, x_key)
-    any_y_extra <- any(miss_x)
 
-    if (any_y_extra) {
+    if (any(miss_x)) {
       y_extra <- seq_len(vec_size(y_key))[miss_x]
     }
+  } else {
+    y_extra <- integer()
   }
 
-  list(x = x_loc, y = y_loc, y_extra = y_extra, any_y_extra = any_y_extra)
+  list(x = x_loc, y = y_loc, y_extra = y_extra)
 }

--- a/R/join-rows.R
+++ b/R/join-rows.R
@@ -16,14 +16,14 @@ join_rows <- function(x_key, y_key, type = c("inner", "left", "right", "full")) 
   x_loc <- rep(x_loc, lengths(y_loc))
   y_loc <- vec_c(!!!y_loc, .ptype = integer())
 
+  y_extra <- integer()
+
   if (type == "right" || type == "full") {
     miss_x <- !vec_in(y_key, x_key)
 
     if (any(miss_x)) {
       y_extra <- seq_len(vec_size(y_key))[miss_x]
     }
-  } else {
-    y_extra <- integer()
   }
 
   list(x = x_loc, y = y_loc, y_extra = y_extra)

--- a/R/join-rows.R
+++ b/R/join-rows.R
@@ -16,12 +16,17 @@ join_rows <- function(x_key, y_key, type = c("inner", "left", "right", "full")) 
   x_loc <- rep(x_loc, lengths(y_loc))
   y_loc <- vec_c(!!!y_loc, .ptype = integer())
 
+  y_extra <- integer()
+  any_y_extra <- FALSE
+
   if (type == "right" || type == "full") {
     miss_x <- !vec_in(y_key, x_key)
-    y_extra <- seq_len(vec_size(y_key))[miss_x]
-  } else {
-    y_extra <- integer()
+    any_y_extra <- any(miss_x)
+
+    if (any_y_extra) {
+      y_extra <- seq_len(vec_size(y_key))[miss_x]
+    }
   }
 
-  list(x = x_loc, y = y_loc, y_extra = y_extra)
+  list(x = x_loc, y = y_loc, y_extra = y_extra, any_y_extra = any_y_extra)
 }

--- a/R/join.r
+++ b/R/join.r
@@ -331,7 +331,7 @@ join_mutate <- function(x, y, by, type,
   x_out <- set_names(x[vars$x$out], names(vars$x$out))
   y_out <- set_names(y[vars$y$out], names(vars$y$out))
 
-  if (rows$any_y_extra) {
+  if (length(rows$y_extra) > 0L) {
     x_slicer <- c(rows$x, rep_along(rows$y_extra, NA_integer_))
     y_slicer <- c(rows$y, rows$y_extra)
   } else {
@@ -346,7 +346,7 @@ join_mutate <- function(x, y, by, type,
   if (!keep) {
     out[names(x_key)] <- vec_cast(out[names(x_key)], vec_ptype_common(x_key, y_key))
 
-    if (rows$any_y_extra) {
+    if (length(rows$y_extra) > 0L) {
       new_rows <- length(rows$x) + seq_along(rows$y_extra)
       out[new_rows, names(y_key)] <- vec_slice(y_key, rows$y_extra)
     }

--- a/R/join.r
+++ b/R/join.r
@@ -331,7 +331,7 @@ join_mutate <- function(x, y, by, type,
   x_out <- set_names(x[vars$x$out], names(vars$x$out))
   y_out <- set_names(y[vars$y$out], names(vars$y$out))
 
-  if (type == "right" || type == "full") {
+  if (rows$any_y_extra) {
     x_slicer <- c(rows$x, rep_along(rows$y_extra, NA_integer_))
     y_slicer <- c(rows$y, rows$y_extra)
   } else {
@@ -346,7 +346,7 @@ join_mutate <- function(x, y, by, type,
   if (!keep) {
     out[names(x_key)] <- vec_cast(out[names(x_key)], vec_ptype_common(x_key, y_key))
 
-    if (type == "right" || type == "full") {
+    if (rows$any_y_extra) {
       new_rows <- length(rows$x) + seq_along(rows$y_extra)
       out[new_rows, names(y_key)] <- vec_slice(y_key, rows$y_extra)
     }


### PR DESCRIPTION
Part of #4873 

I realized that right and full joins could also take advantage of avoiding `c()` calls in the cases where they don't have any extra `y` rows. I'm not sure how common this is in practice, but it was the case in the two examples.

I mainly like that it again encapsulates the use of `type` to be purely in `join_rows()`.

``` r
library(dplyr, warn.conflicts = FALSE)
library(bench)
set.seed(342)

df1 <- tibble(x = rnorm(1e5), a = sample(1:10, 1e5, replace = TRUE))
df2 <- tibble(y = rnorm(1e3), a = sample(1:10, 1e3, replace = TRUE))
df3 <- tibble(x = rnorm(1e5), a = sample(1:10, 1e5, replace = TRUE), b = sample(1:5, 1e5, replace = TRUE))
df4 <- tibble(y = rnorm(1e3), a = sample(1:10, 1e3, replace = TRUE), b = sample(1:5, 1e3, replace = TRUE))
```

```r
bench::mark(
  right_join(df1, df2, by = "a"),
  full_join(df1, df2, by = "a"),
  
  check = FALSE,
  iterations = 50
)

# master
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 x 6
#>   expression                          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 right_join(df1, df2, by = "a")    220ms    253ms      3.83     387MB     3.99
#> 2 full_join(df1, df2, by = "a")     226ms    245ms      4.02     387MB     4.02

# this PR
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 x 6
#>   expression                          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 right_join(df1, df2, by = "a")    180ms    207ms      4.84     273MB     4.84
#> 2 full_join(df1, df2, by = "a")     151ms    195ms      5.13     272MB     5.13
```

```r
bench::mark(
  right_join(df3, df4, by = c("a", "b")),
  full_join(df3, df4, by = c("a", "b")),
  
  check = FALSE,
  iterations = 50
)

# master
#> # A tibble: 2 x 6
#>   expression                                min median `itr/sec` mem_alloc
#>   <bch:expr>                             <bch:> <bch:>     <dbl> <bch:byt>
#> 1 right_join(df3, df4, by = c("a", "b")) 61.1ms   76ms      12.9    95.9MB
#> 2 full_join(df3, df4, by = c("a", "b"))  60.3ms 71.3ms      13.7    97.1MB
#> # … with 1 more variable: `gc/sec` <dbl>

# this PR
#> # A tibble: 2 x 6
#>   expression                                min median `itr/sec` mem_alloc
#>   <bch:expr>                             <bch:> <bch:>     <dbl> <bch:byt>
#> 1 right_join(df3, df4, by = c("a", "b"))   53ms 62.7ms      15.8    65.4MB
#> 2 full_join(df3, df4, by = c("a", "b"))  54.8ms 64.8ms      15.2    66.5MB
#> # … with 1 more variable: `gc/sec` <dbl>
```