### PR TITLE
Implement fast `rep_int()` for use in joins

### DIFF
--- a/R/join-rows.R
+++ b/R/join-rows.R
@@ -13,7 +13,7 @@ join_rows <- function(x_key, y_key, type = c("inner", "left", "right", "full")) 
   x_loc <- seq_len(vec_size(x_key))
 
   # flatten index list
-  x_loc <- rep(x_loc, lengths(y_loc))
+  x_loc <- rep_int(x_loc, lengths(y_loc))
   y_loc <- vec_c(!!!y_loc, .ptype = integer())
 
   y_extra <- integer()
@@ -27,4 +27,9 @@ join_rows <- function(x_key, y_key, type = c("inner", "left", "right", "full")) 
   }
 
   list(x = x_loc, y = y_loc, y_extra = y_extra)
+}
+
+# A faster version of `rep.int(x, times)`
+rep_int <- function(x, times) {
+  .Call(dplyr_rep_int, x, times)
 }

--- a/src/dplyr.h
+++ b/src/dplyr.h
@@ -66,6 +66,7 @@ SEXP dplyr_vec_sizes(SEXP chunks);
 SEXP dplyr_summarise_recycle_chunks(SEXP chunks);
 SEXP dplyr_group_indices(SEXP data, SEXP s_nr);
 SEXP dplyr_group_keys(SEXP group_data);
+SEXP dplyr_rep_int(SEXP x, SEXP times);
 
 #define DPLYR_MASK_INIT()                                                  \
 SEXP rows = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::rows)); \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -74,6 +74,8 @@ static const R_CallMethodDef CallEntries[] = {
   {"dplyr_group_indices", (DL_FUNC)& dplyr_group_indices, 2},
   {"dplyr_group_keys", (DL_FUNC)& dplyr_group_keys, 1},
 
+  {"dplyr_rep_int", (DL_FUNC)& dplyr_rep_int, 2},
+
   {NULL, NULL, 0}
 };
 

--- a/src/join-rows.cpp
+++ b/src/join-rows.cpp
@@ -1,0 +1,109 @@
+#include "dplyr.h"
+
+#define DPLYR_REP_INT_OUT_SIZE(CTYPE, DEREF, ELT_INVALID) do { \
+  CTYPE* p_times = DEREF(times);                               \
+                                                               \
+  for (R_xlen_t i = 0; i < size_times; ++i) {                  \
+    CTYPE elt = p_times[i];                                    \
+                                                               \
+    if (ELT_INVALID) {                                         \
+      Rf_errorcall(R_NilValue, "Invalid `times` value");       \
+    }                                                          \
+                                                               \
+    size_out_dbl += elt;                                       \
+  }                                                            \
+} while(0)
+
+#define DPLYR_REP_INT_LOOP(CTYPE, DEREF) do {                  \
+  CTYPE* p_times = DEREF(times);                               \
+                                                               \
+  for (R_xlen_t i = 0; i < size_times; ++i) {                  \
+    int x_elt = p_x[i];                                        \
+    R_xlen_t times_elt = (R_xlen_t) p_times[i];                \
+                                                               \
+    for (R_xlen_t j = 0; j < times_elt; ++j, ++k) {            \
+      p_out[k] = x_elt;                                        \
+    }                                                          \
+  }                                                            \
+} while(0)
+
+/*
+ * Repeat an integer vector a number of times
+ *
+ * The purpose of this helper is as a faster version of `rep.int()`. It is
+ * very slow in R 3.6 and below, because it repeatedly accesses elements of
+ * each array when it doesn't need to.
+ *
+ * @param x An integer vector to repeat.
+ * @param times Generally, an integer vector of times to repeat each element
+ *   of `x`. Can be a double vector to generate long vectors.
+ *
+ * The size of `times` must match the size of `x`. Neither are recycled.
+ */
+SEXP dplyr_rep_int(SEXP x, SEXP times) {
+  if (TYPEOF(x) != INTSXP) {
+    Rf_errorcall(R_NilValue, "`x` must be an integer vector");
+  }
+
+  SEXPTYPE type_times = TYPEOF(times);
+
+  // Allow double `times` for long vectors
+  switch (type_times) {
+  case INTSXP: break;
+#ifdef LONG_VECTOR_SUPPORT
+  case REALSXP: break;
+#endif
+  default:
+    Rf_errorcall(
+      R_NilValue,
+      "`times` has unknown type %s", Rf_type2char(TYPEOF(times))
+    );
+  }
+
+  R_xlen_t size_times = Rf_xlength(times);
+
+  // For internal use we don't allow any recycling
+  if (size_times != Rf_xlength(x)) {
+    Rf_errorcall(R_NilValue, "Internal error: `x` and `times` should have equal lengths");
+  }
+
+  // Hold the output size in a double at first, so we can check if we go
+  // above the maximum xlen size with less chance of overflow
+  double size_out_dbl = 0;
+
+  switch (type_times) {
+  case INTSXP: DPLYR_REP_INT_OUT_SIZE(int, INTEGER, elt < 0); break;
+  case REALSXP: DPLYR_REP_INT_OUT_SIZE(double, REAL, ISNAN(elt) || elt < 0 || elt > R_XLEN_T_MAX); break;
+  default: Rf_errorcall(R_NilValue, "Internal error: Should never get here");
+  }
+
+  if (size_out_dbl > R_XLEN_T_MAX) {
+    Rf_errorcall(
+      R_NilValue,
+      "Invalid `times`. Total number of `times` is greater than "
+      "the maximum allowed vector length."
+    );
+  }
+
+  R_xlen_t size_out = (R_xlen_t) size_out_dbl;
+
+  const int* p_x = INTEGER(x);
+
+  SEXP out = PROTECT(Rf_allocVector(INTSXP, size_out));
+  int* p_out = INTEGER(out);
+
+  // Keep track of element index in `out`
+  R_xlen_t k = 0;
+
+  switch (type_times) {
+  case INTSXP: DPLYR_REP_INT_LOOP(int, INTEGER); break;
+  case REALSXP: DPLYR_REP_INT_LOOP(double, REAL); break;
+  default: Rf_errorcall(R_NilValue, "Internal error: Should never get here");
+  }
+
+  UNPROTECT(1);
+  return out;
+}
+
+#undef DPLYR_REP_INT_OUT_SIZE
+#undef DPLYR_REP_INT_LOOP


### PR DESCRIPTION
Part of #4873 

Looking at benchmarks of join performance, I was very surprised at the time `rep(x_loc, lengths(y_loc))` takes. Even switching to `rep.int()` doesn't help. It turns out that these functions are surprisingly inefficient. Looking at the C code, they repeatedly access elements when they should just store them once.

The following links to `rep2()`, used in `rep.int()`. Both `it[i]` and `INTEGER(s)[i]` could be stored in the outer loop, and reused in the inner loop.
https://github.com/wch/r-source/blob/20f40d8ecb517e47caa9931b9def6dc690124c00/src/main/seq.c#L189-L192

Here is another part of `rep2()` where the total output size is computed. `INTEGER(t)[i]` is accessed 3 times when it only really needed to be accessed once.
https://github.com/wch/r-source/blob/20f40d8ecb517e47caa9931b9def6dc690124c00/src/main/seq.c#L256-L260

I'll probably try and submit a patch to R to fix this, but for now I rewrote it (this could move to vctrs), and now we have:

```r
rep_int <- dplyr:::rep_int

set.seed(123)

x <- 1:1e3 + 0L
times <- sample(1e3, replace = TRUE) + 0L

bench::mark(
  rep(x, times),
  rep.int(x, times),
  rep_int(x, times),
  iterations = 1000
)
#> # A tibble: 3 x 6
#>   expression             min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>        <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 rep(x, times)        640µs    891µs     1051.     1.9MB     41.5
#> 2 rep.int(x, times)    512µs    751µs     1317.    1.91MB     53.4
#> 3 rep_int(x, times)    165µs    298µs     3312.     1.9MB    131.

x <- 1:1e4 + 0L
times <- sample(1e4, replace = TRUE) + 0L

bench::mark(
  rep(x, times),
  rep.int(x, times),
  rep_int(x, times),
  iterations = 20
)
#> # A tibble: 3 x 6
#>   expression             min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>        <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 rep(x, times)      120.8ms  131.1ms      7.58     191MB     4.08
#> 2 rep.int(x, times)  115.2ms  121.8ms      8.15     191MB     4.39
#> 3 rep_int(x, times)   74.5ms   80.5ms     12.5      191MB     5.36
```

And our benchmarks:

``` r
library(dplyr, warn.conflicts = FALSE)
library(bench)
set.seed(342)

df1 <- tibble(x = rnorm(1e5), a = sample(1:10, 1e5, replace = TRUE))
df2 <- tibble(y = rnorm(1e3), a = sample(1:10, 1e3, replace = TRUE))
df3 <- tibble(x = rnorm(1e5), a = sample(1:10, 1e5, replace = TRUE), b = sample(1:5, 1e5, replace = TRUE))
df4 <- tibble(y = rnorm(1e3), a = sample(1:10, 1e3, replace = TRUE), b = sample(1:5, 1e3, replace = TRUE))
```

```r
bench::mark(
  inner_join(df1, df2, by = "a"),
  left_join(df1, df2, by = "a"),
  right_join(df1, df2, by = "a"),
  full_join(df1, df2, by = "a"),
  
  check = FALSE,
  iterations = 50
)

# master
#> # A tibble: 4 x 6
#>   expression                          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 inner_join(df1, df2, by = "a")    122ms    142ms      7.15     272MB     15.6
#> 2 left_join(df1, df2, by = "a")     122ms    129ms      7.58     272MB     14.7
#> 3 right_join(df1, df2, by = "a")    157ms    164ms      6.06     386MB     27.5
#> 4 full_join(df1, df2, by = "a")     163ms    168ms      5.95     387MB     27.4

# this PR
#> # A tibble: 4 x 6
#>   expression                          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 inner_join(df1, df2, by = "a")   82.3ms   93.8ms     10.7      272MB     23.5
#> 2 left_join(df1, df2, by = "a")    80.4ms   89.1ms     11.1      272MB     21.5
#> 3 right_join(df1, df2, by = "a")  113.5ms    121ms      8.11     386MB     36.8
#> 4 full_join(df1, df2, by = "a")   110.4ms  118.6ms      8.36     387MB     38.6
```

```r
bench::mark(
  inner_join(df3, df4, by = c("a", "b")),
  left_join(df3, df4, by = c("a", "b")),
  right_join(df3, df4, by = c("a", "b")),
  full_join(df3, df4, by = c("a", "b")),
  
  check = FALSE,
  iterations = 50
)

# master
#> # A tibble: 4 x 6
#>   expression                                min median `itr/sec` mem_alloc
#>   <bch:expr>                             <bch:> <bch:>     <dbl> <bch:byt>
#> 1 inner_join(df3, df4, by = c("a", "b")) 46.4ms 55.2ms      17.9    64.5MB
#> 2 left_join(df3, df4, by = c("a", "b"))  47.3ms 53.7ms      18.2    65.6MB
#> 3 right_join(df3, df4, by = c("a", "b")) 59.6ms 68.7ms      14.5    95.9MB
#> 4 full_join(df3, df4, by = c("a", "b"))  61.1ms 69.6ms      14.2    97.1MB
#> # … with 1 more variable: `gc/sec` <dbl>

# this PR
#> # A tibble: 4 x 6
#>   expression                                min median `itr/sec` mem_alloc
#>   <bch:expr>                             <bch:> <bch:>     <dbl> <bch:byt>
#> 1 inner_join(df3, df4, by = c("a", "b")) 38.6ms 48.8ms      20.3    64.5MB
#> 2 left_join(df3, df4, by = c("a", "b"))  37.4ms 45.6ms      21.5    65.6MB
#> 3 right_join(df3, df4, by = c("a", "b")) 49.7ms 61.4ms      16.2    95.9MB
#> 4 full_join(df3, df4, by = c("a", "b"))  53.5ms 64.8ms      15.3    97.1MB
#> # … with 1 more variable: `gc/sec` <dbl>
```

<sup>Created on 2020-02-24 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>