### PR TITLE
Fix sequential updating

### DIFF
--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -61,12 +61,6 @@ DataMask <- R6Class("DataMask",
     },
 
     add = function(name, chunks) {
-      pos <- which(names(private$resolved) == name)
-      if (length(pos) == 0L) {
-        pos <- length(private$resolved) + 1L
-        private$used[[pos]] <- TRUE
-        private$which_used <- c(private$which_used, pos)
-      }
       if (inherits(private$data, "rowwise_df")){
         is_scalar_list <- function(.x) {
           is.list(.x) && !is.data.frame(.x) && length(.x) == 1L
@@ -75,6 +69,22 @@ DataMask <- R6Class("DataMask",
           chunks <- map(chunks, `[[`, 1L)
         }
       }
+
+      pos <- which(names(private$resolved) == name)
+      is_new_column <- length(pos) == 0L
+
+      if (is_new_column) {
+        pos <- length(private$resolved) + 1L
+        used <- FALSE
+      } else {
+        used <- private$used[[pos]]
+      }
+
+      if (!used) {
+        private$used[[pos]] <- TRUE
+        private$which_used <- c(private$which_used, pos)
+      }
+
       private$resolved[[name]] <- chunks
     },
 

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -12,6 +12,7 @@ test_that("mutations applied progressively", {
   df <- tibble(x = 1)
   expect_equal(df %>% mutate(y = x + 1, z = y + 1), tibble(x = 1, y = 2, z = 3))
   expect_equal(df %>% mutate(x = x + 1, x = x + 1), tibble(x = 3))
+  expect_equal(df %>% mutate(x = 2, y = x), tibble(x = 2, y = 2))
 })
 
 test_that("length-1 vectors are recycled (#152)", {


### PR DESCRIPTION
Closes #4893 

When the column to be updated exists in the data already, but is not actually used in the expression that does the updating, then it does not currently get marked as `used`. This means that further usage of that column refers to the old version before it was updated. This PR fixes that.