### PR TITLE
Use `names2()` to guard against `NULL` column names

### DIFF
--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -36,7 +36,7 @@ DataMask <- R6Class("DataMask",
 
       private$used <- rep(FALSE, ncol(data))
 
-      names_bindings <- chr_unserialise_unicode(names(data))
+      names_bindings <- chr_unserialise_unicode(names2(data))
       private$resolved <- set_names(vector(mode = "list", length = ncol(data)), names_bindings)
 
       promise_fn <- function(index, chunks = resolve_chunks(index)) {

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -54,6 +54,12 @@ test_that("assignments don't overwrite variables (#315)", {
   expect_equal(out, tibble(x = 1, y = 2, z = 10))
 })
 
+test_that("can mutate a data frame with zero columns and `NULL` column names", {
+  df <- new_data_frame(n = 2L)
+  colnames(df) <- NULL
+  expect_equal(mutate(df, x = 1), data.frame(x = c(1, 1)))
+})
+
 # column types ------------------------------------------------------------
 
 test_that("mutate disambiguates NA and NaN (#1448)", {


### PR DESCRIPTION
Broke {d3r} and likely {ushr}

Previously:

```r
library(dplyr, warn.conflicts = FALSE)
library(vctrs)

df <- new_data_frame(n = 5L)
colnames(df) <- NULL

mutate(df, x = 4)
#> Error in chr_unserialise_unicode(names(data)): is_character(chr) is not TRUE
```

Now:

``` r
library(dplyr, warn.conflicts = FALSE)
library(vctrs)

df <- new_data_frame(n = 5L)
colnames(df) <- NULL

mutate(df, x = 4)
#>   x
#> 1 4
#> 2 4
#> 3 4
#> 4 4
#> 5 4
```

<sup>Created on 2020-02-26 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>