### PR TITLE
Use `new_tibble()` in `$pick()` for faster construction

### DIFF
--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -113,15 +113,8 @@ DataMask <- R6Class("DataMask",
 
     pick = function(vars) {
       cols <- eval_tidy(expr(list(!!!syms(vars))), private$mask)
-
       names(cols) <- vars
-
-      if (length(cols) == 0L) {
-        nrow <- 0L
-      } else {
-        nrow <- vec_size(cols[[1L]])
-      }
-
+      nrow <- length(self$current_rows())
       new_tibble(cols, nrow = nrow)
     },
 

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -112,7 +112,17 @@ DataMask <- R6Class("DataMask",
     },
 
     pick = function(vars) {
-      eval_tidy(quo(tibble(!!!syms(vars))), private$mask)
+      cols <- eval_tidy(expr(list(!!!syms(vars))), private$mask)
+
+      names(cols) <- vars
+
+      if (length(cols) == 0L) {
+        nrow <- 0L
+      } else {
+        nrow <- vec_size(cols[[1L]])
+      }
+
+      new_tibble(cols, nrow = nrow)
     },
 
     current_rows = function() {


### PR DESCRIPTION
``` r
library(dplyr)

r_iris <- rowwise(iris)

bench::mark(
  mutate(r_iris, x = across(Sepal.Width)),
  iterations = 50
)

# master
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 x 6
#>   expression                                min median `itr/sec` mem_alloc
#>   <bch:expr>                              <bch> <bch:>     <dbl> <bch:byt>
#> 1 mutate(r_iris, x = across(Sepal.Width)) 276ms  318ms      3.09     3.4MB
#> # … with 1 more variable: `gc/sec` <dbl>

# this PR
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 x 6
#>   expression                                min median `itr/sec` mem_alloc
#>   <bch:expr>                              <bch> <bch:>     <dbl> <bch:byt>
#> 1 mutate(r_iris, x = across(Sepal.Width)) 218ms  258ms      3.72    2.87MB
#> # … with 1 more variable: `gc/sec` <dbl>
```

<sup>Created on 2020-02-27 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>