### PR TITLE
workaround for n() when dplyr is not loaded

### DIFF
--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -13,10 +13,7 @@ DataMask <- R6Class("DataMask",
 
       private$data <- data
       private$caller <- caller
-      helpers <- env(empty_env())
-      if (!dplyr_state$attached) {
-        helpers$n <- n
-      }
+      helpers <- env(empty_env(), n = n)
       private$bindings <- env(helpers)
       private$keys <- group_keys(data)
 

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -1,3 +1,16 @@
+quo_disguise <- function(quo) {
+  if (!.dplyr_attached) {
+    n <- get0("n", envir = quo_get_env(quo), inherits = TRUE, mode = "function")
+    if (is.null(n)) {
+      quo <- new_quosure(
+        quo_get_expr(quo),
+        env(quo_get_env(quo), n = dplyr::n)
+      )
+    }
+  }
+  quo
+}
+
 DataMask <- R6Class("DataMask",
   public = list(
     initialize = function(data, caller) {
@@ -96,18 +109,19 @@ DataMask <- R6Class("DataMask",
     },
 
     eval_all = function(quo) {
-      .Call(`dplyr_mask_eval_all`, quo, private)
+      .Call(`dplyr_mask_eval_all`, quo_disguise(quo), private)
     },
 
     eval_all_summarise = function(quo) {
-      .Call(`dplyr_mask_eval_all_summarise`, quo, private)
+      .Call(`dplyr_mask_eval_all_summarise`, quo_disguise(quo), private)
     },
 
     eval_all_mutate = function(quo) {
-      .Call(`dplyr_mask_eval_all_mutate`, quo, private)
+      .Call(`dplyr_mask_eval_all_mutate`, quo_disguise(quo), private)
     },
 
     eval_all_filter = function(quos, env_filter) {
+      quos <- map(quos, quo_disguise)
       .Call(`dplyr_mask_eval_all_filter`, quos, private, nrow(private$data), env_filter)
     },
 

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -14,7 +14,7 @@ DataMask <- R6Class("DataMask",
       private$data <- data
       private$caller <- caller
       helpers <- env(empty_env())
-      if (!.dplyr_attached) {
+      if (!dplyr_state$attached) {
         helpers$n <- n
       }
       private$bindings <- env(helpers)

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -13,7 +13,10 @@ DataMask <- R6Class("DataMask",
 
       private$data <- data
       private$caller <- caller
-      helpers <- env(n = dplyr::n, empty_env())
+      helpers <- env(empty_env())
+      if (!.dplyr_attached) {
+        helpers[["n"]] = dplyr::n
+      }
       private$bindings <- env(helpers)
       private$keys <- group_keys(data)
 

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -15,7 +15,7 @@ DataMask <- R6Class("DataMask",
       private$caller <- caller
       helpers <- env(empty_env())
       if (!.dplyr_attached) {
-        helpers[["n"]] = dplyr::n
+        helpers$n <- n
       }
       private$bindings <- env(helpers)
       private$keys <- group_keys(data)

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -1,3 +1,5 @@
+.dplyr_attached <- FALSE
+
 .onLoad <- function(libname, pkgname) {
   op <- options()
   op.dplyr <- list(
@@ -6,12 +8,16 @@
   toset <- !(names(op.dplyr) %in% names(op))
   if (any(toset)) options(op.dplyr[toset])
 
-  ns <- ns_env("dplyr")
   .Call(dplyr_init_library, ns_env())
   invisible()
 }
 
 .onAttach <- function(libname, pkgname) {
+  ns <- ns_env()
+  unlockBinding(".dplyr_attached", ns)
+  assign(".dplyr_attached", TRUE, env = ns)
+  lockBinding(".dplyr_attached", env = ns)
+
   setHook(packageEvent("plyr", "attach"), function(...) {
     packageStartupMessage(rule())
     packageStartupMessage(

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -1,5 +1,3 @@
-dplyr_state <- env(attached = FALSE)
-
 .onLoad <- function(libname, pkgname) {
   op <- options()
   op.dplyr <- list(
@@ -13,8 +11,6 @@ dplyr_state <- env(attached = FALSE)
 }
 
 .onAttach <- function(libname, pkgname) {
-  dplyr_state$attached <- TRUE
-
   setHook(packageEvent("plyr", "attach"), function(...) {
     packageStartupMessage(rule())
     packageStartupMessage(

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -15,7 +15,7 @@
 .onAttach <- function(libname, pkgname) {
   ns <- ns_env()
   unlockBinding(".dplyr_attached", ns)
-  assign(".dplyr_attached", TRUE, env = ns)
+  assign(".dplyr_attached", TRUE, envir = ns)
   lockBinding(".dplyr_attached", env = ns)
 
   setHook(packageEvent("plyr", "attach"), function(...) {

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -1,4 +1,4 @@
-.dplyr_attached <- FALSE
+dplyr_state <- env(attached = FALSE)
 
 .onLoad <- function(libname, pkgname) {
   op <- options()
@@ -13,11 +13,7 @@
 }
 
 .onAttach <- function(libname, pkgname) {
-  ns <- ns_env()
-
-  exec("unlockBinding", ".dplyr_attached", ns)
-  assign(".dplyr_attached", TRUE, envir = ns)
-  lockBinding(".dplyr_attached", env = ns)
+  dplyr_state$attached <- TRUE
 
   setHook(packageEvent("plyr", "attach"), function(...) {
     packageStartupMessage(rule())

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -14,7 +14,8 @@
 
 .onAttach <- function(libname, pkgname) {
   ns <- ns_env()
-  unlockBinding(".dplyr_attached", ns)
+
+  exec("unlockBinding", ".dplyr_attached", ns)
   assign(".dplyr_attached", TRUE, envir = ns)
   lockBinding(".dplyr_attached", env = ns)
 

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -64,17 +64,11 @@ test_that("can mutate a data frame with zero columns and `NULL` column names", {
 test_that("n() can be used without loading dplyr", {
   skip_if_not_installed("callr")
 
-  df <- callr::r(function(){
+  res <- callr::r(function(){
+    # n() can be used without dplyr loaded
     dplyr::mutate(data.frame(x = 1), n = n())
   })
-  expect_equal(df$n, 1)
-
-  # but can be overwritten
-  df <- callr::r(function(){
-    n <- function() 42
-    dplyr::mutate(data.frame(x = 1), n = n())
-  })
-  expect_equal(df$n, 42)
+  expect_equal(res$n, 1)
 })
 
 # column types ------------------------------------------------------------

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -66,9 +66,13 @@ test_that("n() can be used without loading dplyr", {
 
   res <- callr::r(function(){
     # n() can be used without dplyr loaded
-    dplyr::mutate(data.frame(x = 1), n = n())
+    list(
+      dplyr::mutate(data.frame(x = 1), n = n()),
+      dplyr::mutate(data.frame(n = 3), m = n)
+    )
   })
-  expect_equal(res$n, 1)
+  expect_equal(res[[1]]$n, 1L)
+  expect_equal(res[[2]]$m, 3)
 })
 
 # column types ------------------------------------------------------------

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -61,6 +61,22 @@ test_that("can mutate a data frame with zero columns and `NULL` column names", {
   expect_equal(mutate(df, x = 1), data.frame(x = c(1, 1)))
 })
 
+test_that("n() can be used without loading dplyr", {
+  skip_if_not_installed("callr")
+
+  df <- callr::r(function(){
+    dplyr::mutate(data.frame(x = 1), n = n())
+  })
+  expect_equal(df$n, 1)
+
+  # but can be overwritten
+  df <- callr::r(function(){
+    n <- function() 42
+    dplyr::mutate(data.frame(x = 1), n = n())
+  })
+  expect_equal(df$n, 42)
+})
+
 # column types ------------------------------------------------------------
 
 test_that("mutate disambiguates NA and NaN (#1448)", {


### PR DESCRIPTION
``` r
dplyr::mutate(data.frame(x = 1), n = n())
#>   x n
#> 1 1 1

n <- function() 42
dplyr::mutate(data.frame(x = 1), n = n())
#>   x  n
#> 1 1 42
```

<sup>Created on 2020-02-28 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>

closes #4895 