### PR TITLE
Swap `eval_tidy()` for `env_get_list()`

### DIFF
--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -112,8 +112,7 @@ DataMask <- R6Class("DataMask",
     },
 
     pick = function(vars) {
-      cols <- eval_tidy(expr(list(!!!syms(vars))), private$mask)
-      names(cols) <- vars
+      cols <- env_get_list(private$bindings, vars)
       nrow <- length(self$current_rows())
       new_tibble(cols, nrow = nrow)
     },


### PR DESCRIPTION
This simplifies `$pick()` further by using `env_get_list()`. This is also slightly faster, but I'm mainly interested in how it simplifies the code

I don't think there is any reason we need to use the mask vs what I do here with the bindings

``` r
library(rlang)

env <- environment()
env$x <- 1
env$y <- 2

mask <- new_data_mask(env)
mask$.data <- as_data_pronoun(mask)

vars <- c("x", "y")

bench::mark(
  eval_tidy = {
    cols <- eval_tidy(expr(list(!!!syms(vars))), mask)
    names(cols) <- vars
    cols
  },
  get_list = env_get_list(env, vars),
  iterations = 100000
)
#> # A tibble: 2 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 eval_tidy   10.74µs  12.73µs    74228.    38.7KB     84.7
#> 2 get_list     7.51µs   8.46µs   107744.    32.8KB     25.9
```

<sup>Created on 2020-02-28 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>