### PR TITLE
Cache `eval_select()` results in `across()` on a per expression basis

### DIFF
--- a/R/across.R
+++ b/R/across.R
@@ -129,7 +129,7 @@ across_select <- function(cols) {
   cols <- enquo(cols)
 
   key <- quo_get_expr(cols)
-  key <- expr_text(key, width = 500L)
+  key <- key_deparse(key)
 
   cache <- mask$across_cache_get()
   value <- cache[[key]]
@@ -146,4 +146,8 @@ across_select <- function(cols) {
   mask$across_cache_add(key, value)
 
   value
+}
+
+key_deparse <- function(key) {
+  deparse(key, width.cutoff = 500L, backtick = TRUE, nlines = 1L, control = NULL)
 }

--- a/R/across.R
+++ b/R/across.R
@@ -118,6 +118,11 @@ across <- function(cols = everything(), fns = NULL, names = NULL, ...) {
   as_tibble(cols)
 }
 
+# TODO: The usage of a cache in `across_select()` is a stopgap solution, and
+# this idea should not be used anywhere else. This should be replaced by the
+# next version of hybrid evaluation, which should offer a way for any function
+# to do any required "set up" work (like the `eval_select()` call) a single
+# time per top-level call, rather than once per group.
 across_select <- function(cols) {
   mask <- peek_mask()
 

--- a/R/condense.r
+++ b/R/condense.r
@@ -77,6 +77,7 @@ condense_cols <- function(.data, ...) {
   tryCatch({
     for (i in seq_along(dots)) {
       chunks[[i]] <- mask$eval_all(dots[[i]])
+      mask$across_cache_reset()
       mask$add(dots_names[i], chunks[[i]])
     }
 

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -191,6 +191,18 @@ DataMask <- R6Class("DataMask",
       cols <- cols[across_vars]
 
       cols
+    },
+
+    across_cache_get = function() {
+      private$across_cache
+    },
+
+    across_cache_add = function(key, value) {
+      private$across_cache[[key]] <- value
+    },
+
+    across_cache_reset = function() {
+      private$across_cache <- list()
     }
 
   ),
@@ -207,6 +219,7 @@ DataMask <- R6Class("DataMask",
     keys = NULL,
     bindings = NULL,
     current_group = 0L,
-    caller = NULL
+    caller = NULL,
+    across_cache = list()
   )
 )

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -237,6 +237,8 @@ mutate_cols <- function(.data, ...) {
       # TODO: reinject hybrid evaluation at the R level
       chunks <- mask$eval_all_mutate(dots[[i]])
 
+      mask$across_cache_reset()
+
       if (is.null(chunks)) {
         if (!is.null(dots_names) && dots_names[i] != "") {
           new_columns[[dots_names[i]]] <- zap()

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -163,6 +163,8 @@ summarise_cols <- function(.data, ...) {
       # TODO: reinject hybrid evaluation at the R level
       chunks[[i]] <- mask$eval_all_summarise(quo)
 
+      mask$across_cache_reset()
+
       result_type <- vec_ptype_common(!!!chunks[[i]])
 
       if ((is.null(dots_names) || dots_names[i] == "") && is.data.frame(result_type)) {

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -92,3 +92,19 @@ test_that("across() gives meaningful messages", {
       summarise(res = across(is.numeric, 42))
   })
 })
+
+test_that("monitoring cache - across() can be used twice in the same expression", {
+  df <- tibble(a = 1, b = 2)
+  expect_equal(
+    mutate(df, x = ncol(across(is.numeric)) + ncol(across(a))),
+    tibble(a = 1, b = 2, x = 3)
+  )
+})
+
+test_that("monitoring cache - across() can be used in separate expressions", {
+  df <- tibble(a = 1, b = 2)
+  expect_equal(
+    mutate(df, x = ncol(across(is.numeric)), y = ncol(across(a))),
+    tibble(a = 1, b = 2, x = 2, y = 1)
+  )
+})

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -108,3 +108,20 @@ test_that("monitoring cache - across() can be used in separate expressions", {
     tibble(a = 1, b = 2, x = 2, y = 1)
   )
 })
+
+test_that("monitoring cache - across() usage can depend on the group id", {
+  df <- tibble(g = 1:2, a = 1:2, b = 3:4)
+  df <- group_by(df, g)
+
+  switcher <- function() {
+    if_else(cur_group_id() == 1L, across(a)$a, across(b)$b)
+  }
+
+  expect <- df
+  expect$x <- c(1L, 4L)
+
+  expect_equal(
+    mutate(df, x = switcher()),
+    expect
+  )
+})


### PR DESCRIPTION
This PR implements a caching system for the results of `eval_select()` when called from `across()`. The same cache could be used for `c_across()`.

The cache is a named list. The names are the deparsed expressions that a user provides when calling `across()`. The values are the results of `eval_select()`.

For any verbs that evaluate multiple expressions in a loop, the cache is reset between expressions (`mutate()`, `summarise()`, `condense()`). This should allow a `across(is.numeric)` call in one expression to be different from an `across(is.numeric)` call in another expression, but right now #4907 keeps that from working. This "reset" could move to the C code if it seems out of place.

``` r
library(dplyr, warn.conflicts = FALSE)

iris2 <- bind_rows(!!!rep_len(list(iris), 10))
rowwise_iris2 <- rowwise(iris2)
nrow(rowwise_iris2)
#> [1] 1500

bench::mark(
  across = mutate(rowwise_iris2, x = across(Sepal.Width:Species)),
  iterations = 5
)

# master (with master rlang and master vctrs too!)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 across        1.71s    1.77s     0.568    83.8MB     20.4

# This PR
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 across        166ms    169ms      5.81    10.5MB     16.3
```

<sup>Created on 2020-02-28 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>


This does not fix #4907. Here are a few tests examples that are wrong because of it. These should become tests.

``` r
library(dplyr, warn.conflicts = FALSE)

df <- tibble(a = 1, b = 2)

# wrong because of #4907
mutate(df, x = ncol(across(is.numeric)), y = ncol(across(is.numeric)))
#> # A tibble: 1 x 4
#>       a     b     x     y
#>   <dbl> <dbl> <int> <int>
#> 1     1     2     2     2

# wrong because of #4907
mutate(df, across(is.numeric, as.character), y = ncol(across(is.numeric)))
#> # A tibble: 1 x 3
#>   a     b         y
#>   <chr> <chr> <int>
#> 1 1     2         2
```

<sup>Created on 2020-02-28 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>