### PR TITLE
Have group_modify accept additional function arguments as group_map does

### DIFF
--- a/R/group_map.R
+++ b/R/group_map.R
@@ -153,7 +153,7 @@ group_modify.grouped_df <- function(.data, .f, ..., keep = FALSE) {
   tbl_group_vars <- group_vars(.data)
 
   .f <- as_group_map_function(.f)
-  fun <- function(.x, .y){
+  fun <- function(.x, .y, ...){
     res <- .f(.x, .y, ...)
     if (!inherits(res, "data.frame")) {
       abort("The result of .f should be a data frame")
@@ -166,7 +166,7 @@ group_modify.grouped_df <- function(.data, .f, ..., keep = FALSE) {
     }
     bind_cols(.y[rep(1L, nrow(res)), , drop = FALSE], res)
   }
-  chunks <- group_map(.data, fun, keep = keep)
+  chunks <- group_map(.data, fun, ..., keep = keep)
   res <- if (length(chunks) > 0L) {
     bind_rows(!!!chunks)
   } else {


### PR DESCRIPTION
Looking at the docs, I thought `group_modify` should work with this:

```
tibble (a = 1:3) %>% group_by (a) %>% group_modify (function (data, key, extra) { print (key) ; return (tibble (x = extra)) }, 8)
```
