### PR TITLE
Fix `across()` and `cur_data()` to work sequentially

### DIFF
--- a/R/across.R
+++ b/R/across.R
@@ -62,15 +62,49 @@
 #' @export
 across <- function(cols = everything(), fns = NULL, names = NULL, ...) {
   mask <- peek_mask()
-  data <- mask$full_data()
 
-  vars <- tidyselect::eval_select(
-    expr({{ cols }}),
-    data[, setdiff(names(data), group_vars(data)), drop = FALSE]
-  )
-  data <- mask$pick(names(vars))
+  original_data <- mask$full_data()
+  group_vars <- group_vars(original_data)
+  original_data <- unclass(original_data)
+  original_vars <- names(original_data)
+
+  current_vars <- mask$current_vars()
+
+  # Allowed columns are any non-group columns in the current data
+  allowed_vars <- setdiff(current_vars, group_vars)
+
+  # Locate unused columns. These always exist in the original data, but
+  # we subset against `current_vars` because `get_used()` tracks new
+  # columns as well.
+  used <- mask$get_used()
+  unused_vars <- current_vars[!used]
+
+  # Split the allowed columns into:
+  # - old: non-group cols in the original data that are unused
+  # - new: non-group cols in the current data that are used
+  old_vars <- intersect(allowed_vars, unused_vars)
+  new_vars <- setdiff(allowed_vars, old_vars)
+
+  # Pull unused columns from the original data to avoid
+  # resolving / marking them as used. If the data is grouped,
+  # lengths will be different but names and types will be correct
+  old_data <- original_data[old_vars]
+  new_data <- mask$current_cols(new_vars)
+
+  data <- vec_c(old_data, new_data)
+
+  # Retain the original ordering
+  data <- data[allowed_vars]
+
+  vars <- tidyselect::eval_select(expr({{ cols }}), data)
+  vars <- names(vars)
+
+  data <- mask$current_cols(vars)
 
   if (is.null(fns)) {
+    nrow <- length(mask$current_rows())
+    data <- new_tibble(data, nrow = nrow)
+
     if (is.null(names)) {
       return(data)
     } else {
@@ -100,7 +134,6 @@ across <- function(cols = everything(), fns = NULL, names = NULL, ...) {
       names_fns[empties] <- empties
     }
   }
-  names_data <- names(data)
 
   # handle formulas
   fns <- map(fns, as_function)
@@ -109,13 +142,13 @@ across <- function(cols = everything(), fns = NULL, names = NULL, ...) {
   cols <- pmap(
     expand.grid(i = seq_along(data), fn = fns),
     function(i, fn) {
-      local_column(names_data[i])
+      local_column(vars[i])
       fn(data[[i]], ...)
     }
   )
   names(cols) <- glue(names,
-    col = rep(names_data, each = length(fns)),
-    fn  = rep(names_fns, ncol(data))
+    col = rep(vars, each = length(fns)),
+    fn  = rep(names_fns, length(data))
   )
   as_tibble(cols)
 }

--- a/R/across.R
+++ b/R/across.R
@@ -63,40 +63,9 @@
 across <- function(cols = everything(), fns = NULL, names = NULL, ...) {
   mask <- peek_mask()
 
-  original_data <- mask$full_data()
-  group_vars <- group_vars(original_data)
-  original_data <- unclass(original_data)
-  original_vars <- names(original_data)
+  across_cols <- mask$across_cols()
 
-  current_vars <- mask$current_vars()
-
-  # Allowed columns are any non-group columns in the current data
-  allowed_vars <- setdiff(current_vars, group_vars)
-
-  # Locate unused columns. These always exist in the original data, but
-  # we subset against `current_vars` because `get_used()` tracks new
-  # columns as well.
-  used <- mask$get_used()
-  unused_vars <- current_vars[!used]
-
-  # Split the allowed columns into:
-  # - old: non-group cols in the original data that are unused
-  # - new: non-group cols in the current data that are used
-  old_vars <- intersect(allowed_vars, unused_vars)
-  new_vars <- setdiff(allowed_vars, old_vars)
-
-  # Pull unused columns from the original data to avoid
-  # resolving / marking them as used. If the data is grouped,
-  # lengths will be different but names and types will be correct
-  old_data <- original_data[old_vars]
-  new_data <- mask$current_cols(new_vars)
-
-  data <- vec_c(old_data, new_data)
-
-  # Retain the original ordering
-  data <- data[allowed_vars]
-
-  vars <- tidyselect::eval_select(expr({{ cols }}), data)
+  vars <- tidyselect::eval_select(expr({{ cols }}), across_cols)
   vars <- names(vars)
 
   data <- mask$current_cols(vars)

--- a/R/context.R
+++ b/R/context.R
@@ -54,7 +54,11 @@ n <- function() {
 cur_data <- function() {
   mask <- peek_mask("cur_data()")
   data <- mask$full_data()
-  mask$pick(setdiff(names(data), group_vars(data)))
+
+  current_vars <- mask$current_vars()
+  group_vars <- group_vars(data)
+
+  mask$pick(setdiff(current_vars, group_vars))
 }
 
 #' @rdname context

--- a/R/context.R
+++ b/R/context.R
@@ -53,12 +53,8 @@ n <- function() {
 #' @export
 cur_data <- function() {
   mask <- peek_mask("cur_data()")
-  data <- mask$full_data()
-
-  current_vars <- mask$current_vars()
-  group_vars <- group_vars(data)
-
-  mask$pick(setdiff(current_vars, group_vars))
+  vars <- mask$current_non_group_vars()
+  mask$pick(vars)
 }
 
 #' @rdname context

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -126,7 +126,7 @@ DataMask <- R6Class("DataMask",
     },
 
     current_vars = function() {
-      env_names(private$bindings)
+      names(private$resolved)
     },
 
     get_current_group = function() {

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -112,9 +112,13 @@ DataMask <- R6Class("DataMask",
     },
 
     pick = function(vars) {
-      cols <- env_get_list(private$bindings, vars)
+      cols <- self$current_cols(vars)
       nrow <- length(self$current_rows())
       new_tibble(cols, nrow = nrow)
+    },
+
+    current_cols = function(vars) {
+      env_get_list(private$bindings, vars)
     },
 
     current_rows = function() {

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -125,6 +125,10 @@ DataMask <- R6Class("DataMask",
       vec_slice(private$keys, self$get_current_group())
     },
 
+    current_vars = function() {
+      env_names(private$bindings)
+    },
+
     get_current_group = function() {
       # The [] is so that we get a copy, which is important for how
       # current_group is dealt with internally, to avoid defining it at each

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -180,7 +180,8 @@ DataMask <- R6Class("DataMask",
 
       # Pull unused vars from original data to keep from marking them as used.
       # Column lengths will not match if `original_data` is grouped, but for
-      # across we only need the column names and types to be correct.
+      # the usage of tidyselect in `across()` we only need the column names
+      # and types to be correct.
       cols_unused <- original_data[across_vars_unused]
       cols_used <- self$current_cols(across_vars_used)
 

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -65,6 +65,27 @@ test_that("across() passes ... to functions", {
   )
 })
 
+test_that("across() works sequentially (#4907)", {
+  df <- tibble(a = 1)
+  expect_equal(
+    mutate(df, x = ncol(across(is.numeric)), y = ncol(across(is.numeric))),
+    tibble(a = 1, x = 1L, y = 2L)
+  )
+  expect_equal(
+    mutate(df, a = "x", y = ncol(across(is.numeric))),
+    tibble(a = "x", y = 0L)
+  )
+  expect_equal(
+    mutate(df, x = 1, y = ncol(across(is.numeric))),
+    tibble(a = 1, x = 1, y = 2L)
+  )
+})
+
+test_that("across() retains original ordering", {
+  df <- tibble(a = 1, b = 2)
+  expect_named(mutate(df, a = 2, x = across())$x, c("a", "b"))
+})
+
 test_that("across() gives meaningful messages", {
   verify_output(test_path("test-across-errors.txt"), {
     tibble(x = 1) %>%

--- a/tests/testthat/test-context.R
+++ b/tests/testthat/test-context.R
@@ -58,6 +58,14 @@ test_that("cur_group_rows() retrieves row position in original data", {
   )
 })
 
+test_that("cur_data() works sequentially", {
+  df <- tibble(a = 1)
+  expect_equal(
+    mutate(df, x = ncol(cur_data()), y = ncol(cur_data())),
+    tibble(a = 1, x = 1, y = 2)
+  )
+})
+
 test_that("give useful error messages when not applicable", {
   verify_output(test_path("test-context-error.txt"), {
     n()


### PR DESCRIPTION
Closes #4907 

This PR fixes both `across()` and `cur_data()` when used in sequential expressions.

This was actually incredibly hard to get right. This is complicated by the fact that we don't want to resolve "unused" columns, which would mark them as "used", but we still have to check their types in `eval_select()` if something like `across(is.numeric)` is called.

The idea here is to separate the non-group columns that are currently present in the data into two groups. The first group are unused columns, which we pull from the original data. The second are used columns, which we pull from the current bindings.

The good news is that, even though this is more expensive, it is part of the "set up" work that gets cached in #4909. I'll rework that PR on top of this