### PR TITLE
Restore compatibility with CRAN tibble

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Imports:
     pkgconfig,
     R6,
     rlang (>= 0.4.5),
-    tibble (>= 2.99.99.9014),
+    tibble (>= 2.1.3),
     tidyselect (>= 1.0.0),
     utils,
     vctrs (>= 0.2.99.9005)

--- a/R/generics.R
+++ b/R/generics.R
@@ -113,7 +113,6 @@ dplyr_col_modify.data.frame <- function(data, cols) {
 
   # - Issues with UTF-8 names
   names(data) <- as_utf8_character(names2(data))
-  names(cols) <- as_utf8_character(names2(cols))
 
   # - Removal of inner names by [<-.data.frame
   cols_null <- map_lgl(cols, is.null)

--- a/tests/testthat/test-arrange.r
+++ b/tests/testthat/test-arrange.r
@@ -55,7 +55,7 @@ test_that("arrange handles matrix columns", {
 
 test_that("arrange handles data.frame columns (#3153)", {
   df <- tibble(x = 1:3, y = data.frame(z = 3:1))
-  expect_equal(arrange(df, y), df[3:1, ])
+  expect_equal(arrange(df, y), tibble(x = 3:1, y = data.frame(z = 1:3)))
 })
 
 test_that("arrange handles complex columns", {

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -98,6 +98,8 @@ test_that("group_by orders by groups. #242", {
 })
 
 test_that("Can group_by() a POSIXlt", {
+  skip_if_not_installed("tibble", "2.99.99.9014")
+
   df <- data.frame(times = 1:5, x = 1:5)
   df$times <- as.POSIXlt(seq.Date(Sys.Date(), length.out = 5, by = "day"))
   g <- group_by(df, times)

--- a/tests/testthat/test-n-distinct-errors.txt
+++ b/tests/testthat/test-n-distinct-errors.txt
@@ -1,5 +1,5 @@
 > n_distinct(1:2, 1:3)
-Error: Tibble columns must have consistent sizes, only values of size one are recycled:
-* Size 2: Existing data
-* Size 3: Column at position 2
+Error: Tibble columns must have consistent lengths, only values of length one are recycled:
+* Length 2: Column `1:2`
+* Length 3: Column `1:3`
 


### PR DESCRIPTION
Most issues arise because `[<-.data.frame()` doesn't support all corner cases that we do. Merging thisallows us to isolate "our" downstream failures from tibble's.