### PR TITLE
Add section on breaking changes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,9 +2,11 @@
 
 ## Breaking changes
 
-* `bind_cols()` no longer forces tibbles.
+* `bind_cols()` no longer converts to a tibble, returns a data frame if the input is a data frame.
 
 * `bind_rows()` and `combine()` use vctrs coercion rules.
+
+    * Combining factor and character creates a character without warning, combining factors creates a factor with levels combined.
 
     * For time columns, the time zone of the first argument is used.
     
@@ -12,9 +14,13 @@
 
 * `bind_rows()` and other functions use vctrs name repair, see `?vctrs::vec_as_names`.
 
-* `count()` no longer removes the last level of grouping.
+* `all.equal.tbl_df()` removed.
 
-* `all.equal.tbl_df()` removed, equality checks for data frames no longer ignore row order or groupings.
+    * Data frames, tibbles and grouped data frames are no longer considered equal, even if the data is the same.
+    
+    * Equality checks for data frames no longer ignore row order or groupings.
+
+    * `expect_equal()` uses `all.equal()` internally. When comparing data frames, tests that used to pass may now fail.
 
 * `distinct()` keeps the original column order.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,30 @@
 # dplyr 1.0.0 (in development)
 
+## Breaking changes
+
+* `bind_cols()` no longer forces tibbles.
+
+* `bind_rows()` and `combine()` use vctrs coercion rules.
+
+    * For time columns, the time zone of the first argument is used.
+    
+    * Classed atomic vectors are no longer accepted, `vctrs::vec_is()` is required for all inputs.
+
+* `bind_rows()` and other functions use vctrs name repair, see `?vctrs::vec_as_names`.
+
+* `count()` no longer removes the last level of grouping.
+
+* `all.equal.tbl_df()` removed, equality checks for data frames no longer ignore row order or groupings.
+
+* `distinct()` keeps the original column order.
+
+* `distinct()` on missing columns now raises an error, it has been a compatibility warning for a long time.
+
+* `group_modify()` puts the grouping variable to the front.
+
+* The old data format for `grouped_df` is no longer supported. This may affect you if you have serialized grouped data frames to disk, e.g. with `saveRDS()` or when using knitr caching.
+
+
 ## New features
 
 * The `cur_` functions (`cur_data()`, `cur_group()`, `cur_group_id()`, 


### PR DESCRIPTION
to NEWS.

I'm aware of the "Lifecycle changes" section. The new text highlights behavior changes that break tests that worked in dplyr 0.8.4.