### PR TITLE
Remove `struct vctrs_arg*` argument from `short_vec_recycle()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,7 @@ Imports:
     tibble (>= 2.99.99.9014),
     tidyselect (>= 1.0.0),
     utils,
-    vctrs (>= 0.2.99.9005)
+    vctrs (>= 0.2.99.9008)
 Suggests: 
     bench,
     broom,

--- a/src/imports.cpp
+++ b/src/imports.cpp
@@ -29,12 +29,12 @@ namespace vctrs {
 struct vctrs_api_ptrs_t {
   bool (*vec_is_vector)(SEXP x);
   R_len_t (*short_vec_size)(SEXP x);
-  SEXP (*short_vec_recycle)(SEXP, R_len_t, struct vctrs_arg*);
+  SEXP (*short_vec_recycle)(SEXP, R_len_t);
 
   vctrs_api_ptrs_t() {
     vec_is_vector =         (bool (*)(SEXP)) R_GetCCallable("vctrs", "vec_is_vector");
     short_vec_size  =         (R_len_t (*)(SEXP)) R_GetCCallable("vctrs", "short_vec_size");
-    short_vec_recycle = (SEXP (*)(SEXP, R_len_t, struct vctrs_arg*)) R_GetCCallable("vctrs", "short_vec_recycle");
+    short_vec_recycle = (SEXP (*)(SEXP, R_len_t)) R_GetCCallable("vctrs", "short_vec_recycle");
   }
 };
 // *INDENT-ON*
@@ -53,7 +53,7 @@ R_len_t short_vec_size(SEXP x) {
 }
 
 SEXP short_vec_recycle(SEXP x, R_len_t n) {
-  return vctrs_api().short_vec_recycle(x, n, NULL);
+  return vctrs_api().short_vec_recycle(x, n);
 }
 
 }


### PR DESCRIPTION
Surprisingly tests pass fine even without this change, but this is more correct.

This is a minimal change, eventually we can use the fact that the 3 vctrs functions used here are actually in a public header file provided by vctrs, rather than calling `R_GetCCallable()`