### PR TITLE
Fix misplaced `)` programming vignette

### DIFF
--- a/vignettes/programming.Rmd
+++ b/vignettes/programming.Rmd
@@ -319,7 +319,7 @@ Use the `names` argument to `across()` to control the names of the output.
 my_summarise <- function(data, group_by, summarise_by) {
   data %>%
     group_by(across({{ group_by }})) %>% 
-    summarise(across({{ summarise_by }}, mean), names = "mean_{col}")
+    summarise(across({{ summarise_by }}, mean, names = "mean_{col}"))
 }
 ```
 


### PR DESCRIPTION
* Partially addresses #4970

Function still doesn't work if `group_by` is used as the variable name. I didn't change this, since this must have worked at some point.

If I'm wrong, ignore this PR, and use #4972 instead.