### PR TITLE
Use `group_var` instead of `group_by` as arg name

### DIFF
--- a/vignettes/programming.Rmd
+++ b/vignettes/programming.Rmd
@@ -306,9 +306,9 @@ starwars %>%
 You can use this same idea for multiple sets of input data-variables:
 
 ```{r}
-my_summarise <- function(data, group_by, summarise_by) {
+my_summarise <- function(data, group_var, summarise_by) {
   data %>%
-    group_by(across({{ group_by }})) %>% 
+    group_by(across({{ group_var }})) %>% 
     summarise(across({{ summarise_by }}, mean))
 }
 ```
@@ -316,9 +316,9 @@ my_summarise <- function(data, group_by, summarise_by) {
 Use the `names` argument to `across()` to control the names of the output.
 
 ```{r}
-my_summarise <- function(data, group_by, summarise_by) {
+my_summarise <- function(data, group_var, summarise_by) {
   data %>%
-    group_by(across({{ group_by }})) %>% 
+    group_by(across({{ group_var }})) %>% 
     summarise(across({{ summarise_by }}, mean, names = "mean_{col}"))
 }
 ```

--- a/vignettes/programming.Rmd
+++ b/vignettes/programming.Rmd
@@ -319,7 +319,7 @@ Use the `names` argument to `across()` to control the names of the output.
 my_summarise <- function(data, group_by, summarise_by) {
   data %>%
     group_by(across({{ group_by }})) %>% 
-    summarise(across({{ summarise_by }}, mean), names = "mean_{col}")
+    summarise(across({{ summarise_by }}, mean, names = "mean_{col}"))
 }
 ```
 


### PR DESCRIPTION
If we _should_ avoid using a function name as an arg name, this fixes the use of `group_by` as an arg name in the programming vignette.
* Fixes #4970 