### PR TITLE
mutate() skips chop/unchop with symbol expressions

### DIFF
--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -64,6 +64,16 @@ test_that("can mutate a data frame with zero columns and `NULL` column names", {
   expect_equal(mutate(df, x = 1), data.frame(x = c(1, 1)))
 })
 
+test_that("mutate() handles symbol expressions", {
+  df <- tibble(x = structure(1, class = "alien"))
+  res <- mutate(df, y = x)
+  expect_identical(df$x, res$y)
+
+  gf <- group_by(df, x)
+  res <- mutate(df, y = x)
+  expect_identical(df$x, res$y)
+})
+
 # column types ------------------------------------------------------------
 
 test_that("glue() is supported", {


### PR DESCRIPTION
This was breaking `ggperiodic` on revdep checks. 

``` r
library(dplyr, warn.conflicts = FALSE)
df <- tibble(x = structure(1, class = "foo"))
arrange(df, x)
#> Error: arrange() failed at implicit mutate() step. 
#> ℹ Could not create a temporary column for `..1`.
#> ℹ `..1` is `x`.
```

<sup>Created on 2020-03-11 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

with this pr: 

``` r
library(dplyr, warn.conflicts = FALSE)
df <- tibble(x = structure(1, class = "foo"))
arrange(df, x)
#> # A tibble: 1 x 1
#>       x
#>   <dbl>
#> 1     1
```

<sup>Created on 2020-03-11 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

We can later revisit as part of hybrid 2.0 but for now this just avoids the chop/unchop 💃 
