### PR TITLE
Use `unlist()` in `join_rows()` until `vec_c()` performance improves

### DIFF
--- a/R/join-rows.R
+++ b/R/join-rows.R
@@ -14,7 +14,7 @@ join_rows <- function(x_key, y_key, type = c("inner", "left", "right", "full"), 
 
   # flatten index list
   x_loc <- rep(x_loc, lengths(y_loc))
-  y_loc <- vec_c(!!!y_loc, .ptype = integer())
+  y_loc <- index_flatten(y_loc)
 
   y_extra <- integer()
 
@@ -27,4 +27,10 @@ join_rows <- function(x_key, y_key, type = c("inner", "left", "right", "full"), 
   }
 
   list(x = x_loc, y = y_loc, y_extra = y_extra)
+}
+
+# TODO: Replace with `vec_unchop(x, ptype = integer())`
+# once performance of `vec_c()` matches `unlist()`. See #4964.
+index_flatten <- function(x) {
+  unlist(x, recursive = FALSE, use.names = FALSE)
 }


### PR DESCRIPTION
Closes #4964 
Also related to #4873, particularly https://github.com/tidyverse/dplyr/issues/4873#issuecomment-590232679

Unfortunately `vec_c()` is currently much slower than `unlist()`. It is much safer though, so I'm not sure we will ever be able to fully match the speed of `unlist()`. I'm sure we can make improvements in some way though.

Until then, I think we might have to fall back to `unlist()` in `join_rows()`. It should be safe, as `y_loc` is always a list of integers.

``` r
library(dplyr, warn.conflicts = FALSE)
library(bench)

data_size <- 1000000

left_df <- tibble(
  a = sample(1:7, data_size, TRUE),
  b = sample(c("a","a","b","c","d"), data_size, TRUE)
)

right_df1 <- tibble(
  b = c("a","b","c","d"),
  c = 1:4
)

right_df2 <- tibble(
  b = c("a","b","c"),
  c = 1:3
)
```

```r
bench::mark(
  left_join = left_join(left_df, right_df1, by = "b"),
  inner_join = inner_join(left_df, right_df2, by = "b"),
  check = FALSE,
  iterations = 100
)

# dplyr 0.8.5
#> # A tibble: 2 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 left_join    40.3ms   49.6ms      20.3    23.2MB     53.9
#> 2 inner_join   35.8ms   38.8ms      25.0    18.3MB     17.4

# Master
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 left_join     186ms    241ms      4.19    85.3MB     12.6
#> 2 inner_join    164ms    187ms      4.94    61.8MB     12.3

# This PR
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 left_join    65.7ms   77.7ms      11.5    73.9MB     19.6
#> 2 inner_join   59.6ms   69.8ms      13.3    50.4MB     11.2
```