### PR TITLE
Avoid `vec_assign()` call when all rows match

### DIFF
--- a/R/join-rows.R
+++ b/R/join-rows.R
@@ -7,7 +7,9 @@ join_rows <- function(x_key, y_key, type = c("inner", "left", "right", "full"), 
   y_loc <- y_split$loc[matches]
 
   if (type == "left" || type == "full") {
-    y_loc <- vec_assign(y_loc, vec_equal_na(matches), list(NA_integer_))
+    if (anyNA(matches)) {
+      y_loc <- vec_assign(y_loc, vec_equal_na(matches), list(NA_integer_))
+    }
   }
 
   x_loc <- seq_len(vec_size(x_key))


### PR DESCRIPTION
For left and full joins, we can often avoid a `vec_assign()` call if all rows in `x` have a match in `y`. This helps performance in these cases.

These benchmarks are on top of #4975 

``` r
library(dplyr, warn.conflicts = FALSE)
library(bench)

data_size <- 1000000

left_df <- tibble(
  a = sample(1:7, data_size, TRUE),
  b = sample(c("a","a","b","c","d"), data_size, TRUE)
)

right_df <- tibble(
  b = c("a","b","c", "d"),
  c = 1:4
)

bench::mark(
  left_join = left_join(left_df, right_df, by = "b"),
  check = FALSE,
  iterations = 100
)

# This PR + #4975 
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 left_join    46.2ms   50.5ms      19.2    58.5MB     158.

# Just #4975 
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 left_join    55.7ms   73.9ms      11.8    73.9MB     23.7
```

<sup>Created on 2020-03-11 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>