### PR TITLE
Use a double loop to apply functions in `across()`

### DIFF
--- a/R/across.R
+++ b/R/across.R
@@ -118,19 +118,39 @@ across <- function(cols = everything(), fns = NULL, names = NULL, ...) {
   # handle formulas
   fns <- map(fns, as_function)
 
-  # main loop
-  cols <- pmap(
-    expand.grid(i = seq_along(data), fn = fns),
-    function(i, fn) {
-      local_column(vars[i])
-      fn(data[[i]], ...)
+  n_cols <- length(data)
+  n_fns <- length(fns)
+
+  seq_n_cols <- seq_len(n_cols)
+  seq_fns <- seq_len(n_fns)
+
+  k <- 1L
+  out <- vector("list", n_cols * n_fns)
+
+  # Loop in such an order that all functions are applied
+  # to a single column before moving on to the next column
+  for (i in seq_n_cols) {
+    var <- vars[[i]]
+    col <- data[[i]]
+
+    for (j in seq_fns) {
+      fn <- fns[[j]]
+      out[[k]] <- across_apply(var, col, fn, ...)
+      k <- k + 1L
     }
-  )
-  names(cols) <- glue(names,
+  }
+
+  names(out) <- glue(names,
     col = rep(vars, each = length(fns)),
     fn  = rep(names_fns, length(data))
   )
-  as_tibble(cols)
+
+  as_tibble(out)
+}
+
+across_apply <- function(var, col, fn, ...) {
+  local_column(var)
+  fn(col, ...)
 }
 
 #' @export

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -55,6 +55,25 @@ test_that("across() correctly names output columns", {
   )
 })
 
+test_that("across() result locations are aligned with column names (#4967)", {
+  df <- tibble(x = 1:2, y = c("a", "b"))
+
+  x <- df %>% summarise(
+    across(
+      everything(),
+      list(cls = class, type = is.numeric),
+      names = "{col}_{fn}"
+    )
+  )
+
+  expect_named(x, c("x_cls", "x_type", "y_cls", "y_type"))
+
+  expect_identical(x$x_cls, "integer")
+  expect_identical(x$x_type, TRUE)
+  expect_identical(x$y_cls, "character")
+  expect_identical(x$y_type, FALSE)
+})
+
 test_that("across() passes ... to functions", {
   df <- tibble(x = c(1, NA))
   expect_equal(

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -58,13 +58,14 @@ test_that("across() correctly names output columns", {
 test_that("across() result locations are aligned with column names (#4967)", {
   df <- tibble(x = 1:2, y = c("a", "b"))
 
-  x <- df %>% summarise(
-    across(
-      everything(),
-      list(cls = class, type = is.numeric),
-      names = "{col}_{fn}"
+  x <- df %>%
+    summarise(
+      across(
+        everything(),
+        list(cls = class, type = is.numeric),
+        names = "{col}_{fn}"
+      )
     )
-  )
 
   expect_named(x, c("x_cls", "x_type", "y_cls", "y_type"))
 

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -57,22 +57,11 @@ test_that("across() correctly names output columns", {
 
 test_that("across() result locations are aligned with column names (#4967)", {
   df <- tibble(x = 1:2, y = c("a", "b"))
+  expect <- tibble(x_cls = "integer", x_type = TRUE, y_cls = "character", y_type = FALSE)
 
-  x <- df %>%
-    summarise(
-      across(
-        everything(),
-        list(cls = class, type = is.numeric),
-        names = "{col}_{fn}"
-      )
-    )
+  x <- summarise(df, across(everything(), list(cls = class, type = is.numeric)))
 
-  expect_named(x, c("x_cls", "x_type", "y_cls", "y_type"))
-
-  expect_identical(x$x_cls, "integer")
-  expect_identical(x$x_type, TRUE)
-  expect_identical(x$y_cls, "character")
-  expect_identical(x$y_type, FALSE)
+  expect_identical(x, expect)
 })
 
 test_that("across() passes ... to functions", {


### PR DESCRIPTION
Closes #4967 
Part of #4953 

A chunk of the time in `across()` comes from compat-`pmap()` applying checks that we don't need here (like arg recycling).

Also, using `expand.grid()` is probably more work than we need to do vs using a double loop. I think that the use of `expand.grid()` was also the cause of #4967, because it varies the first input fastest (the columns).

```r
library(dplyr, warn.conflicts = FALSE)

n_cols <- 5
n_rows <- 400
split <- 4

df <- tibble(
  g1 = rep(seq_len(n_rows / split), each = split),
  g2 = rep(seq_len(split), times = n_rows / split),
  x1 = rnorm(n_rows),
  x2 = rnorm(n_rows),
  x3 = rnorm(n_rows),
  x4 = rnorm(n_rows),
  x5 = rnorm(n_rows)
)

gdf <- group_by(df, g1, g2)

bench::mark(
  summarize(gdf, across(is.numeric, diff)),
  summarize_if(gdf, is.numeric, diff),
  iterations = 50
)

# master
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 x 6
#>   expression                                   min  median `itr/sec` mem_alloc
#>   <bch:expr>                               <bch:t> <bch:t>     <dbl> <bch:byt>
#> 1 summarize(gdf, across(is.numeric, diff)) 205.8ms 245.1ms      4.07    8.04MB
#> 2 summarize_if(gdf, is.numeric, diff)       10.2ms  11.3ms     84.5   659.23KB
#> # … with 1 more variable: `gc/sec` <dbl>

# This PR
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 x 6
#>   expression                                   min  median `itr/sec` mem_alloc
#>   <bch:expr>                               <bch:t> <bch:t>     <dbl> <bch:byt>
#> 1 summarize(gdf, across(is.numeric, diff)) 156.3ms 185.7ms      5.38    7.61MB
#> 2 summarize_if(gdf, is.numeric, diff)       10.9ms  12.9ms     72.5   659.23KB
#> # … with 1 more variable: `gc/sec` <dbl>
```

Column names and `across()` results now line up:

``` r
library(dplyr, warn.conflicts = FALSE)

df <- tibble(x = 1:2, y = c("a", "b"))

df %>% 
  summarise(
    across(
      everything(), 
      list(cls = class, type = is.numeric), 
      names = "{col}_{fn}"
    )
  )
#> # A tibble: 1 x 4
#>   x_cls   x_type y_cls     y_type
#>   <chr>   <lgl>  <chr>     <lgl> 
#> 1 integer TRUE   character FALSE
```

This is not a fix for #4953, as there is still a lot of work going on in `across()`. Much of the rest of the time is split between `as_tibble()` and `glue()`. I'm fairly certain the `glue()` calls are repeated between each call to `across()`, and are part of the "up front" work that could be done.

<img width="595" alt="Screen Shot 2020-03-11 at 2 10 42 PM" src="https://user-images.githubusercontent.com/19150088/76449801-161c6480-63a3-11ea-8284-5ed16696db5d.png">
