### PR TITLE
Prefix across() args with dots and pass ellipsis after .fns

### DIFF
--- a/R/across.R
+++ b/R/across.R
@@ -27,7 +27,7 @@
 #'
 #'   Within these functions you can use [cur_column()] and [cur_group()]
 #'   to access the current column and grouping keys respectively.
-#' @param names A glue specification that describes how to name the output
+#' @param .names A glue specification that describes how to name the output
 #'   columns. This can use `{col}` to stand for the selected column name, and
 #'   `{fn}` to stand for the name of the function being applied. The default
 #'   (`NULL`) is equivalent to `"{col}"` for the single function case and
@@ -55,16 +55,16 @@
 #'   group_by(Species) %>%
 #'   summarise(across(starts_with("Sepal"), list(mean = mean, sd = sd)))
 #'
-#' # Use the names argument to control the output names
+#' # Use the .names argument to control the output names
 #' iris %>%
 #'   group_by(Species) %>%
-#'   summarise(across(starts_with("Sepal"), mean, names = "mean_{col}"))
+#'   summarise(across(starts_with("Sepal"), mean, .names = "mean_{col}"))
 #' iris %>%
 #'   group_by(Species) %>%
-#'   summarise(across(starts_with("Sepal"), list(mean = mean, sd = sd), names = "{col}.{fn}"))
+#'   summarise(across(starts_with("Sepal"), list(mean = mean, sd = sd), .names = "{col}.{fn}"))
 #' iris %>%
 #'   group_by(Species) %>%
-#'   summarise(across(starts_with("Sepal"), list(mean, sd), names = "{col}.fn{fn}"))
+#'   summarise(across(starts_with("Sepal"), list(mean, sd), .names = "{col}.fn{fn}"))
 #'
 #' # c_across() ---------------------------------------------------------------
 #' df <- tibble(id = 1:4, w = runif(4), x = runif(4), y = runif(4), z = runif(4))
@@ -75,7 +75,7 @@
 #'     sd = sd(c_across(w:z))
 #'  )
 #' @export
-across <- function(.cols = everything(), .fns = NULL, names = NULL, ...) {
+across <- function(.cols = everything(), .fns = NULL, .names = NULL, ...) {
   vars <- across_select({{ .cols }})
 
   mask <- peek_mask()
@@ -85,19 +85,19 @@ across <- function(.cols = everything(), .fns = NULL, names = NULL, ...) {
     nrow <- length(mask$current_rows())
     data <- new_tibble(data, nrow = nrow)
 
-    if (is.null(names)) {
+    if (is.null(.names)) {
       return(data)
     } else {
-      return(set_names(data, glue(names, col = names(data), fn = "1")))
+      return(set_names(data, glue(.names, col = names(data), fn = "1")))
     }
   }
 
-  # apply `names` smart default
+  # apply `.names` smart default
   if (is.function(.fns) || is_formula(.fns)) {
-    names <- names %||% "{col}"
+    .names <- .names %||% "{col}"
     .fns <- list("1" = .fns)
   } else {
-    names <- names %||% "{col}_{fn}"
+    .names <- .names %||% "{col}_{fn}"
   }
 
   if (!is.list(.fns)) {
@@ -126,7 +126,7 @@ across <- function(.cols = everything(), .fns = NULL, names = NULL, ...) {
       fn(data[[i]], ...)
     }
   )
-  names(.cols) <- glue(names,
+  names(.cols) <- glue(.names,
     col = rep(vars, each = length(.fns)),
     fn  = rep(names_fns, length(data))
   )

--- a/R/across.R
+++ b/R/across.R
@@ -135,7 +135,7 @@ across <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
 
 #' @export
 #' @rdname across
-c_across <- function(cols = everything()) {
+c_across <- function(.cols = everything()) {
   vars <- across_select({{ cols }})
 
   mask <- peek_mask()

--- a/R/across.R
+++ b/R/across.R
@@ -13,7 +13,7 @@
 #' semantics so you can easily select multiple variables. See
 #' `vignette("rowwise")` for more details.
 #'
-#' @param cols <[`tidy-select`][dplyr_tidy_select]> Columns to transform.
+#' @param .cols <[`tidy-select`][dplyr_tidy_select]> Columns to transform.
 #'   Because `across()` is used within functions like `summarise()` and
 #'   `mutate()`, you can't select or compute upon grouping variables.
 #' @param fns Functions to apply to each of the selected columns.
@@ -35,7 +35,7 @@
 #' @param ... Additional arguments for the function calls in `fns`.
 #'
 #' @returns
-#' A tibble with one column for each column in `cols` and each function in `fns`.
+#' A tibble with one column for each column in `.cols` and each function in `fns`.
 #' @examples
 #' # across() -----------------------------------------------------------------
 #' iris %>%
@@ -75,8 +75,8 @@
 #'     sd = sd(c_across(w:z))
 #'  )
 #' @export
-across <- function(cols = everything(), fns = NULL, names = NULL, ...) {
-  vars <- across_select({{ cols }})
+across <- function(.cols = everything(), fns = NULL, names = NULL, ...) {
+  vars <- across_select({{ .cols }})
 
   mask <- peek_mask()
   data <- mask$current_cols(vars)
@@ -119,18 +119,18 @@ across <- function(cols = everything(), fns = NULL, names = NULL, ...) {
   fns <- map(fns, as_function)
 
   # main loop
-  cols <- pmap(
+  .cols <- pmap(
     expand.grid(i = seq_along(data), fn = fns),
     function(i, fn) {
       local_column(vars[i])
       fn(data[[i]], ...)
     }
   )
-  names(cols) <- glue(names,
+  names(.cols) <- glue(names,
     col = rep(vars, each = length(fns)),
     fn  = rep(names_fns, length(data))
   )
-  as_tibble(cols)
+  as_tibble(.cols)
 }
 
 #' @export

--- a/R/across.R
+++ b/R/across.R
@@ -27,12 +27,12 @@
 #'
 #'   Within these functions you can use [cur_column()] and [cur_group()]
 #'   to access the current column and grouping keys respectively.
+#' @param ... Additional arguments for the function calls in `.fns`.
 #' @param .names A glue specification that describes how to name the output
 #'   columns. This can use `{col}` to stand for the selected column name, and
 #'   `{fn}` to stand for the name of the function being applied. The default
 #'   (`NULL`) is equivalent to `"{col}"` for the single function case and
 #'   `"{col}_{fn}"` for the case where a list is used for `.fns`.
-#' @param ... Additional arguments for the function calls in `.fns`.
 #'
 #' @returns
 #' A tibble with one column for each column in `.cols` and each function in `.fns`.
@@ -75,7 +75,7 @@
 #'     sd = sd(c_across(w:z))
 #'  )
 #' @export
-across <- function(.cols = everything(), .fns = NULL, .names = NULL, ...) {
+across <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
   vars <- across_select({{ .cols }})
 
   mask <- peek_mask()

--- a/R/across.R
+++ b/R/across.R
@@ -136,14 +136,14 @@ across <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
 #' @export
 #' @rdname across
 c_across <- function(.cols = everything()) {
-  vars <- across_select({{ cols }})
+  vars <- across_select({{ .cols }})
 
   mask <- peek_mask()
 
-  cols <- mask$current_cols(vars)
-  cols <- unname(cols)
+  .cols <- mask$current_cols(vars)
+  .cols <- unname(.cols)
 
-  vec_c(!!!cols)
+  vec_c(!!!.cols)
 }
 
 # TODO: The usage of a cache in `across_select()` is a stopgap solution, and

--- a/R/select.R
+++ b/R/select.R
@@ -81,7 +81,7 @@
 #' starwars %>% group_by(gender, eye_color) %>% select(group_cols())
 #'
 #' # Using select() semantics in across()
-#' starwars %>% summarise(across(cols = height:mass, fns = ~mean(.x, na.rm = TRUE)))
+#' starwars %>% summarise(across(.cols = height:mass, .fns = ~mean(.x, na.rm = TRUE)))
 #'
 #' # Use `{{ }}` inside functions to tunnel data-variables through
 #' # function arguments. See ?dplyr_tidy_eval for more information.

--- a/man/across.Rd
+++ b/man/across.Rd
@@ -7,7 +7,7 @@
 \usage{
 across(.cols = everything(), .fns = NULL, ..., .names = NULL)
 
-c_across(cols = everything())
+c_across(.cols = everything())
 }
 \arguments{
 \item{.cols}{<\code{\link[=dplyr_tidy_select]{tidy-select}}> Columns to transform.

--- a/man/across.Rd
+++ b/man/across.Rd
@@ -5,16 +5,16 @@
 \alias{c_across}
 \title{Apply a function (or a set of functions) to a set of columns}
 \usage{
-across(cols = everything(), fns = NULL, names = NULL, ...)
+across(.cols = everything(), .fns = NULL, ..., .names = NULL)
 
 c_across(cols = everything())
 }
 \arguments{
-\item{cols}{<\code{\link[=dplyr_tidy_select]{tidy-select}}> Columns to transform.
+\item{.cols}{<\code{\link[=dplyr_tidy_select]{tidy-select}}> Columns to transform.
 Because \code{across()} is used within functions like \code{summarise()} and
 \code{mutate()}, you can't select or compute upon grouping variables.}
 
-\item{fns}{Functions to apply to each of the selected columns.
+\item{.fns}{Functions to apply to each of the selected columns.
 Possible values are:
 \itemize{
 \item \code{NULL}, to returns the columns untransformed.
@@ -27,16 +27,16 @@ Possible values are:
 Within these functions you can use \code{\link[=cur_column]{cur_column()}} and \code{\link[=cur_group]{cur_group()}}
 to access the current column and grouping keys respectively.}
 
-\item{names}{A glue specification that describes how to name the output
+\item{...}{Additional arguments for the function calls in \code{.fns}.}
+
+\item{.names}{A glue specification that describes how to name the output
 columns. This can use \code{{col}} to stand for the selected column name, and
 \code{{fn}} to stand for the name of the function being applied. The default
 (\code{NULL}) is equivalent to \code{"{col}"} for the single function case and
-\code{"{col}_{fn}"} for the case where a list is used for \code{fns}.}
-
-\item{...}{Additional arguments for the function calls in \code{fns}.}
+\code{"{col}_{fn}"} for the case where a list is used for \code{.fns}.}
 }
 \value{
-A tibble with one column for each column in \code{cols} and each function in \code{fns}.
+A tibble with one column for each column in \code{.cols} and each function in \code{.fns}.
 }
 \description{
 \code{across()} makes it easy to apply the same transformation to multiple
@@ -70,16 +70,16 @@ iris \%>\%
   group_by(Species) \%>\%
   summarise(across(starts_with("Sepal"), list(mean = mean, sd = sd)))
 
-# Use the names argument to control the output names
+# Use the .names argument to control the output names
 iris \%>\%
   group_by(Species) \%>\%
-  summarise(across(starts_with("Sepal"), mean, names = "mean_{col}"))
+  summarise(across(starts_with("Sepal"), mean, .names = "mean_{col}"))
 iris \%>\%
   group_by(Species) \%>\%
-  summarise(across(starts_with("Sepal"), list(mean = mean, sd = sd), names = "{col}.{fn}"))
+  summarise(across(starts_with("Sepal"), list(mean = mean, sd = sd), .names = "{col}.{fn}"))
 iris \%>\%
   group_by(Species) \%>\%
-  summarise(across(starts_with("Sepal"), list(mean, sd), names = "{col}.fn{fn}"))
+  summarise(across(starts_with("Sepal"), list(mean, sd), .names = "{col}.fn{fn}"))
 
 # c_across() ---------------------------------------------------------------
 df <- tibble(id = 1:4, w = runif(4), x = runif(4), y = runif(4), z = runif(4))

--- a/man/select.Rd
+++ b/man/select.Rd
@@ -102,7 +102,7 @@ select(df, num_range(prefix = "V", range = 4:6)) # Or, specify the prefix used o
 starwars \%>\% group_by(gender, eye_color) \%>\% select(group_cols())
 
 # Using select() semantics in across()
-starwars \%>\% summarise(across(cols = height:mass, fns = ~mean(.x, na.rm = TRUE)))
+starwars \%>\% summarise(across(.cols = height:mass, .fns = ~mean(.x, na.rm = TRUE)))
 
 # Use `{{ }}` inside functions to tunnel data-variables through
 # function arguments. See ?dplyr_tidy_eval for more information.

--- a/tests/testthat/test-across-errors.txt
+++ b/tests/testthat/test-across-errors.txt
@@ -1,3 +1,3 @@
 > tibble(x = 1) %>% summarise(res = across(is.numeric, 42))
-Error: `fns` must be NULL, a function, a formula, or a list of functions/formulas
+Error: `.fns` must be NULL, a function, a formula, or a list of functions/formulas
 

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -22,7 +22,7 @@ test_that("across() correctly names output columns", {
     c("x", "y", "z", "s")
   )
   expect_named(
-    summarise(gf, across(names = "id_{col}")),
+    summarise(gf, across(.names = "id_{col}")),
     c("x", "id_y", "id_z", "id_s")
   )
   expect_named(
@@ -30,7 +30,7 @@ test_that("across() correctly names output columns", {
     c("x", "y", "z")
   )
   expect_named(
-    summarise(gf, across(is.numeric, mean, names = "mean_{col}")),
+    summarise(gf, across(is.numeric, mean, .names = "mean_{col}")),
     c("x", "mean_y", "mean_z")
   )
   expect_named(
@@ -50,7 +50,7 @@ test_that("across() correctly names output columns", {
     c("x", "y_1", "y_2", "z_1", "z_2")
   )
   expect_named(
-    summarise(gf, across(is.numeric, list(mean = mean, sum = sum), names = "{fn}_{col}")),
+    summarise(gf, across(is.numeric, list(mean = mean, sum = sum), .names = "{fn}_{col}")),
     c("x", "mean_y", "sum_y", "mean_z", "sum_z")
   )
 })

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -67,6 +67,16 @@ test_that("across() passes ... to functions", {
   )
 })
 
+test_that("across() passes unnamed arguments following .fns as ... (#4965)", {
+  df <- tibble(x = 1)
+  expect_equal(mutate(df, across(x, `+`, 1)), tibble(x = 2))
+})
+
+test_that("across() avoids simple argument name collisions with ... (#4965)", {
+  df <- tibble(x = c(1, 2))
+  expect_equal(summarize(df, across(x, tail, n = 1)), tibble(x = 2))
+})
+
 test_that("across() works sequentially (#4907)", {
   df <- tibble(a = 1)
   expect_equal(

--- a/tests/testthat/test-arrange.r
+++ b/tests/testthat/test-arrange.r
@@ -120,7 +120,7 @@ test_that("arrange() supports across() (#4679)", {
     df %>% arrange(x, y)
   )
   expect_identical(
-    df %>% arrange(across(fns = desc)),
+    df %>% arrange(across(.fns = desc)),
     df %>% arrange(desc(x), desc(y))
   )
   expect_identical(

--- a/vignettes/colwise.Rmd
+++ b/vignettes/colwise.Rmd
@@ -41,11 +41,11 @@ library(dplyr, warn.conflicts = FALSE)
 
 `across()` has two primary arguments:
 
-* The first argument, `cols`, selects the columns you want to operate on.
+* The first argument, `.cols`, selects the columns you want to operate on.
   It uses tidy selection (like `select()`) so you can pick variables by 
   position, name, and type.
 
-* The second argument, `fns`, is a function or list of functions to apply to
+* The second argument, `.fns`, is a function or list of functions to apply to
   each column. This can also be a purrr style formula (or list of formulas)
   like `~ .x / 2`. (This argument is optional, and you can omit it if you just want
   to get the underlying data; you'll see that technique used in
@@ -89,18 +89,18 @@ min_max <- list(
 starwars %>% summarise(across(is.numeric, min_max))
 ```
 
-Control how the names are created with the `names` argument which takes a [glue](http://glue.tidyverse.org/) spec:
+Control how the names are created with the `.names` argument which takes a [glue](http://glue.tidyverse.org/) spec:
 
 ```{r}
-starwars %>% summarise(across(is.numeric, min_max, names = "{fn}.{col}"))
+starwars %>% summarise(across(is.numeric, min_max, .names = "{fn}.{col}"))
 ```
 
 If you'd prefer all summaries with the same function to be grouped together, you'll have to expand the calls yourself:
 
 ```{r}
 starwars %>% summarise(
-  across(is.numeric, ~min(.x, na.rm = TRUE), names = "min_{col}"),
-  across(is.numeric, ~max(.x, na.rm = TRUE), names = "max_{col}")
+  across(is.numeric, ~min(.x, na.rm = TRUE), .names = "min_{col}"),
+  across(is.numeric, ~max(.x, na.rm = TRUE), .names = "max_{col}")
 )
 ```
 

--- a/vignettes/programming.Rmd
+++ b/vignettes/programming.Rmd
@@ -313,13 +313,13 @@ my_summarise <- function(data, group_var, summarise_var) {
 }
 ```
 
-Use the `names` argument to `across()` to control the names of the output.
+Use the `.names` argument to `across()` to control the names of the output.
 
 ```{r}
 my_summarise <- function(data, group_var, summarise_var) {
   data %>%
     group_by(across({{ group_var }})) %>% 
-    summarise(across({{ summarise_var }}, mean, names = "mean_{col}"))
+    summarise(across({{ summarise_var }}, mean, .names = "mean_{col}"))
 }
 ```
 


### PR DESCRIPTION
Closes #4965.

- Prefixed argument names with dots to avoid argument name collisions with `...` args.
- Moved `.names` after `...` so that ellipsis gets passed directly after `.fns` for consistency with other functionals.

I think I managed to get all of the arguments sorted in the callers, too. I grepped for `across\(.*(?<!\.)(cols|fns|names) *=` without anything more coming up.