### PR TITLE
recalculate which_used on removes.

### DIFF
--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -92,7 +92,8 @@ DataMask <- R6Class("DataMask",
     remove = function(name) {
       pos <- which(names(private$resolved) == name)
       private$resolved[[name]] <- NULL
-      private$which_used <- which(!map_lgl(private$resolved, is.null))
+      private$used <- !map_lgl(private$resolved, is.null)
+      private$which_used <- which(private$used)
       rm(list = name, envir = private$bindings)
     },
 

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -92,7 +92,7 @@ DataMask <- R6Class("DataMask",
     remove = function(name) {
       pos <- which(names(private$resolved) == name)
       private$resolved[[name]] <- NULL
-      private$which_used <- setdiff(private$which_used, pos)
+      private$which_used <- which(!map_lgl(private$resolved, is.null))
       rm(list = name, envir = private$bindings)
     },
 

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -87,12 +87,6 @@ DataMask <- R6Class("DataMask",
       private$resolved[[name]] <- chunks
     },
 
-    set = function(name, chunks) {
-      private$resolved[[name]] <- chunks
-      private$used <- !map_lgl(private$resolved, is.null)
-      private$which_used <- which(private$used)
-    },
-
     remove = function(name) {
       private$set(name, NULL)
       rm(list = name, envir = private$bindings)
@@ -222,6 +216,12 @@ DataMask <- R6Class("DataMask",
     bindings = NULL,
     current_group = 0L,
     caller = NULL,
-    across_cache = list()
+    across_cache = list(),
+
+    set = function(name, chunks) {
+      private$resolved[[name]] <- chunks
+      private$used <- !map_lgl(private$resolved, is.null)
+      private$which_used <- which(private$used)
+    }
   )
 )

--- a/src/dplyr.h
+++ b/src/dplyr.h
@@ -70,31 +70,31 @@ SEXP dplyr_summarise_recycle_chunks(SEXP chunks);
 SEXP dplyr_group_indices(SEXP data, SEXP s_nr);
 SEXP dplyr_group_keys(SEXP group_data);
 
-#define DPLYR_MASK_INIT()                                                  \
-SEXP rows = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::rows)); \
-R_xlen_t ngroups = XLENGTH(rows);                                          \
-SEXP mask = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::mask)); \
-SEXP caller = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::caller)); \
+#define DPLYR_MASK_INIT()                                                          \
+SEXP rows = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::rows));         \
+R_xlen_t ngroups = XLENGTH(rows);                                                  \
+SEXP mask = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::mask));         \
+SEXP caller = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::caller));     \
 SEXP bindings = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::bindings)); \
-SEXP current_group = PROTECT(Rf_ScalarInteger(NA_INTEGER));                    \
-Rf_defineVar(dplyr::symbols::current_group, current_group, env_private);       \
+SEXP current_group = PROTECT(Rf_ScalarInteger(NA_INTEGER));                        \
+Rf_defineVar(dplyr::symbols::current_group, current_group, env_private);           \
 int* p_current_group = INTEGER(current_group)
 
 #define DPLYR_MASK_FINALISE() UNPROTECT(5);
 
 #define DPLYR_MASK_SET_GROUP(INDEX)                                                  \
-*p_current_group = INDEX + 1;   \
+*p_current_group = INDEX + 1;                                                        \
 SEXP resolved = Rf_findVarInFrame(env_private, dplyr::symbols::resolved);            \
-SEXP which_used = Rf_findVarInFrame(env_private, dplyr::symbols::which_used); \
-int* p_which_used = INTEGER(which_used);                       \
-SEXP names_resolved = Rf_getAttrib(resolved, R_NamesSymbol);       \
-R_xlen_t n_resolved = XLENGTH(which_used);                           \
-for (R_xlen_t i_resolved = 0; i_resolved < n_resolved; i_resolved++) { \
-  int idx_promise = p_which_used[i_resolved] - 1;              \
-  Rf_defineVar( \
-    Rf_installChar(STRING_ELT(names_resolved, idx_promise)), \
-    VECTOR_ELT(VECTOR_ELT(resolved, idx_promise), i), bindings \
-  ); \
+SEXP which_used = Rf_findVarInFrame(env_private, dplyr::symbols::which_used);        \
+int* p_which_used = INTEGER(which_used);                                             \
+SEXP names_resolved = Rf_getAttrib(resolved, R_NamesSymbol);                         \
+R_xlen_t n_resolved = XLENGTH(which_used);                                           \
+for (R_xlen_t i_resolved = 0; i_resolved < n_resolved; i_resolved++) {               \
+  int idx_promise = p_which_used[i_resolved] - 1;                                    \
+  Rf_defineVar(                                                                      \
+    Rf_installChar(STRING_ELT(names_resolved, idx_promise)),                         \
+    VECTOR_ELT(VECTOR_ELT(resolved, idx_promise), i), bindings                       \
+  );                                                                                 \
 }
 
 

--- a/src/mutate.cpp
+++ b/src/mutate.cpp
@@ -30,7 +30,6 @@ SEXP dplyr_mask_eval_all_mutate(SEXP quo, SEXP env_private) {
   for (R_xlen_t i = 0; i < ngroups; i++) {
     DPLYR_MASK_SET_GROUP(i);
     R_xlen_t n_i = XLENGTH(VECTOR_ELT(rows, i));
-
     SEXP result_i = PROTECT(DPLYR_MASK_EVAL(quo));
     SET_VECTOR_ELT(chunks, i, result_i);
 

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -35,6 +35,12 @@ test_that("can remove variables with NULL (#462)", {
   expect_equal(df %>% mutate(z = NULL), df)
   # or was just created
   expect_equal(df %>% mutate(z = 1, z = NULL), df)
+
+  # regression test for https://github.com/tidyverse/dplyr/issues/4974
+  expect_equal(
+    mutate(data.frame(x = 1, y = 1), z = 1, x = NULL, y = NULL),
+    data.frame(z = 1)
+  )
 })
 
 test_that("mutate() names pronouns correctly (#2686)", {


### PR DESCRIPTION
closes #4974

`which_used` is maintained so that the internal loop in this macro is performant: 

```c
#define DPLYR_MASK_SET_GROUP(INDEX)                                                  \
*p_current_group = INDEX + 1;                                                        \
SEXP resolved = Rf_findVarInFrame(env_private, dplyr::symbols::resolved);            \
SEXP which_used = Rf_findVarInFrame(env_private, dplyr::symbols::which_used);        \
int* p_which_used = INTEGER(which_used);                                             \
SEXP names_resolved = Rf_getAttrib(resolved, R_NamesSymbol);                         \
R_xlen_t n_resolved = XLENGTH(which_used);                                           \
for (R_xlen_t i_resolved = 0; i_resolved < n_resolved; i_resolved++) {               \
  int idx_promise = p_which_used[i_resolved] - 1;                                    \
  Rf_defineVar(                                                                      \
    Rf_installChar(STRING_ELT(names_resolved, idx_promise)),                         \
    VECTOR_ELT(VECTOR_ELT(resolved, idx_promise), i), bindings                       \
  );                                                                                 \
}
```

The alternative would be to drop `which_used` totally and just rely on `resolved` 