### PR TITLE
cache more in across_setup()

### DIFF
--- a/R/across.R
+++ b/R/across.R
@@ -214,13 +214,12 @@ across_setup <- function(cols, fns, names, key) {
 c_across_setup <- function(cols, key) {
   mask <- peek_mask()
 
-  cols <- enquo(cols)
-
   value <- mask$across_cache_get(key)
   if (!is.null(value)) {
     return(value)
   }
 
+  cols <- enquo(cols)
   across_cols <- mask$across_cols()
 
   vars <- tidyselect::eval_select(expr(!!cols), across_cols)

--- a/R/across.R
+++ b/R/across.R
@@ -149,13 +149,12 @@ c_across <- function(.cols = everything()) {
 across_setup <- function(.cols = everything(), .fns = NULL, .names = NULL, .key) {
   mask <- peek_mask()
 
-  .cols <- enquo(.cols)
-
   value <- mask$across_cache_get(.key)
   if (!is.null(value)) {
     return(value)
   }
 
+  .cols <- enquo(.cols)
   across_cols <- mask$across_cols()
 
   vars <- tidyselect::eval_select(expr(!!.cols), across_cols)

--- a/R/across.R
+++ b/R/across.R
@@ -76,7 +76,7 @@
 #'  )
 #' @export
 across <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
-  key <- key_deparse(match.call())
+  key <- key_deparse(sys.call())
   setup <- across_setup({{ .cols }}, fns = .fns, names = .names, key = key)
 
   vars <- setup$vars
@@ -133,7 +133,7 @@ across_apply <- function(var, col, fn, ...) {
 #' @export
 #' @rdname across
 c_across <- function(.cols = everything()) {
-  key <- key_deparse(match.call())
+  key <- key_deparse(sys.call())
   vars <- c_across_setup({{ .cols }}, key = key)
 
   mask <- peek_mask()

--- a/R/across.R
+++ b/R/across.R
@@ -125,9 +125,10 @@ across <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
     }
   }
 
+  size <- vec_size_common(!!!out)
+  out <- vec_recycle_common(!!!out, .size = size)
   names(out) <- names
-
-  as_tibble(out)
+  new_tibble(out, nrow = size)
 }
 
 #' @export
@@ -165,7 +166,7 @@ across_setup <- function(cols, fns, names, key) {
 
   if (is.null(fns)) {
     if (!is.null(names)) {
-      names <- glue(names, col = vars, fn = "1")
+      names <- vec_as_names(glue(names, col = vars, fn = "1"), repair = "check_unique")
     }
 
     value <- list(vars = vars, fns = fns, names = names)
@@ -200,10 +201,10 @@ across_setup <- function(cols, fns, names, key) {
     }
   }
 
-  names <- glue(names,
+  names <- vec_as_names(glue(names,
     col = rep(vars, each = length(fns)),
     fn  = rep(names_fns, length(vars))
-  )
+  ), repair = "check_unique")
 
   value <- list(vars = vars, fns = fns, names = names)
   mask$across_cache_add(key, value)

--- a/R/across.R
+++ b/R/across.R
@@ -124,7 +124,8 @@ across <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
 }
 
 across_apply <- function(var, col, fn, ...) {
-  local_column(var)
+  old_var <- context_poke("column", var)
+  on.exit(context_poke("column", old_var))
   fn(col, ...)
 }
 

--- a/R/across.R
+++ b/R/across.R
@@ -76,7 +76,8 @@
 #'  )
 #' @export
 across <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
-  setup <- across_setup({{ .cols }}, fns = .fns, names = .names, key = key_deparse(match.call()))
+  key <- key_deparse(match.call())
+  setup <- across_setup({{ .cols }}, fns = .fns, names = .names, key = key)
 
   vars <- setup$vars
   fns <- setup$fns
@@ -132,7 +133,8 @@ across_apply <- function(var, col, fn, ...) {
 #' @export
 #' @rdname across
 c_across <- function(.cols = everything()) {
-  vars <- c_across_setup({{ .cols }}, key = key_deparse(match.call()))
+  key <- key_deparse(match.call())
+  vars <- c_across_setup({{ .cols }}, key = key)
 
   mask <- peek_mask()
 

--- a/R/across.R
+++ b/R/across.R
@@ -170,6 +170,7 @@ across_setup <- function(cols, fns, names, key) {
 
     value <- list(vars = vars, fns = fns, names = names)
     mask$across_cache_add(key, value)
+
     return(value)
   }
 
@@ -204,12 +205,9 @@ across_setup <- function(cols, fns, names, key) {
     fn  = rep(names_fns, length(vars))
   )
 
-  value <- list(
-    vars = vars,
-    fns = fns,
-    names = names
-  )
+  value <- list(vars = vars, fns = fns, names = names)
   mask$across_cache_add(key, value)
+
   value
 }
 

--- a/R/across.R
+++ b/R/across.R
@@ -106,15 +106,21 @@ across <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
   k <- 1L
   out <- vector("list", n_cols * n_fns)
 
+  # Reset `cur_column()` info on exit
+  old_var <- context_peek_bare("column")
+  on.exit(context_poke("column", old_var), add = TRUE)
+
   # Loop in such an order that all functions are applied
   # to a single column before moving on to the next column
   for (i in seq_n_cols) {
     var <- vars[[i]]
     col <- data[[i]]
 
+    context_poke("column", var)
+
     for (j in seq_fns) {
       fn <- fns[[j]]
-      out[[k]] <- across_apply(var, col, fn, ...)
+      out[[k]] <- fn(col, ...)
       k <- k + 1L
     }
   }
@@ -122,12 +128,6 @@ across <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
   names(out) <- names
 
   as_tibble(out)
-}
-
-across_apply <- function(var, col, fn, ...) {
-  old_var <- context_poke("column", var)
-  on.exit(context_poke("column", old_var))
-  fn(col, ...)
 }
 
 #' @export

--- a/R/context.R
+++ b/R/context.R
@@ -107,8 +107,11 @@ context_poke <- function(name, value) {
   context_env[[name]] <- value
   old
 }
+context_peek_bare <- function(name) {
+  context_env[[name]]
+}
 context_peek <- function(name, fun, location = "dplyr verbs") {
-  context_env[[name]] %||%
+  context_peek_bare(name) %||%
     abort(glue("{fun} must only be used inside {location}"))
 }
 context_local <- function(name, value, frame = caller_env()) {

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -189,8 +189,8 @@ DataMask <- R6Class("DataMask",
       cols
     },
 
-    across_cache_get = function() {
-      private$across_cache
+    across_cache_get = function(key) {
+      private$across_cache[[key]]
     },
 
     across_cache_add = function(key, value) {

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -157,6 +157,24 @@ test_that("monitoring cache - across() internal cache key depends on all inputs"
   )
 })
 
+test_that("across() rejects non vectors", {
+  expect_error(
+    data.frame(x = 1) %>% summarise(across(everything(), ~sym("foo")))
+  )
+})
+
+test_that("across() uses tidy recycling rules", {
+  expect_equal(
+    data.frame(x = 1, y = 2) %>% summarise(across(everything(), ~rep(42, .))),
+    data.frame(x = rep(42, 2), y = rep(42, 2))
+  )
+
+  expect_error(
+    data.frame(x = 2, y = 3) %>% summarise(across(everything(), ~rep(42, .)))
+  )
+})
+
+
 # c_across ----------------------------------------------------------------
 
 test_that("selects and combines columns", {

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -147,6 +147,16 @@ test_that("monitoring cache - across() usage can depend on the group id", {
   )
 })
 
+test_that("monitoring cache - across() internal cache key depends on all inputs", {
+  df <- tibble(g = rep(1:2, each = 2), a = 1:4)
+  df <- group_by(df, g)
+
+  expect_identical(
+    mutate(df, tibble(x = across(is.numeric, mean)$a, y = across(is.numeric, max)$a)),
+    mutate(df, x = mean(a), y = max(a))
+  )
+})
+
 # c_across ----------------------------------------------------------------
 
 test_that("selects and combines columns", {


### PR DESCRIPTION
part of #4953 

This follows up @DavisVaughan work on caching things `across()` uses, and now also caches: 
- the function list
- the names of the outputs (calling `glue::glue()` repeatedly was expensive)

before: 

![image](https://user-images.githubusercontent.com/2625526/76679921-cb8a2a80-65e4-11ea-8a9e-f078f399c710.png)

with this: 

![image](https://user-images.githubusercontent.com/2625526/76679933-d9d84680-65e4-11ea-8979-a9c0947764be.png)

I believe more can be done without yet challenging evaluation: 

- `across_apply()` and particularly `local_column()` seem to be taking time: 

![image](https://user-images.githubusercontent.com/2625526/76679969-2c196780-65e5-11ea-8958-bbf2b8186183.png)

- `as_tibble()` too: 

![image](https://user-images.githubusercontent.com/2625526/76679982-40f5fb00-65e5-11ea-8849-3d554bc4b4d9.png)

I'd like to keep investigating in that direction because it benefits all uses of `across()` 

Then, perhaps we can preemptively recognize `across()` calls and handle it differently, e.g. we might not need to generate tibbles for chunks, ... but this starts to look more like hybrid evaluation, so I'd like to investigate how far we can go without doing this just yet. 
