### PR TITLE
Use `vec_is_list()` in `bind_cols()` and `bind_rows()`

### DIFF
--- a/R/bind.r
+++ b/R/bind.r
@@ -129,8 +129,7 @@ bind_rows <- function(..., .id = NULL) {
 bind_cols <- function(...) {
   dots <- list2(...)
 
-  is_flattenable <- function(x) is.list(x) && !is.data.frame(x)
-  dots <- squash_if(dots, is_flattenable)
+  dots <- squash_if(dots, vec_is_list)
   dots <- discard(dots, is.null)
 
   # Strip names off of data frame components so that vec_cbind() unpacks them

--- a/R/bind.r
+++ b/R/bind.r
@@ -81,7 +81,7 @@ bind_rows <- function(..., .id = NULL) {
   dots <- list2(...)
 
   # bind_rows() has weird legacy squashing behaviour
-  is_flattenable <- function(x) is.list(x) && !is_named(x) && !is.data.frame(x)
+  is_flattenable <- function(x) vec_is_list(x) && !is_named(x)
   if (length(dots) == 1 && is_bare_list(dots[[1]])) {
     dots <- dots[[1]]
   }

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -493,10 +493,14 @@ test_that("bind_cols() doesn't squash record types", {
   )
 })
 
-test_that("bind_rows handles typed lists (#3924)", {
+test_that("bind_rows() only flattens list subclasses with explicit inheritance (#3924)", {
   df <- data.frame(x = 1, y = 2)
-  lst <- structure(list(df, df, df), class = "special_lst")
-  expect_equal(bind_rows(lst), bind_rows(df,df,df))
+
+  lst1 <- structure(list(df, df, df), class = "special_lst")
+  expect_error(bind_rows(lst1), "must be a data frame or a named atomic vector")
+
+  lst2 <- structure(list(df, df, df), class = c("special_lst", "list"))
+  expect_equal(bind_rows(lst2), bind_rows(df,df,df))
 })
 
 test_that("bind_rows() handles named list", {

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -483,6 +483,16 @@ test_that("bind_cols() handles unnamed list with name repair (#3402)", {
   )
 })
 
+test_that("bind_cols() doesn't squash record types", {
+  df <- data.frame(x = 1)
+  posixlt <- as.POSIXlt(as.Date("1970-01-01"))
+
+  expect_identical(
+    bind_cols(df, y = posixlt),
+    new_data_frame(list(x = 1, y = posixlt))
+  )
+})
+
 test_that("bind_rows handles typed lists (#3924)", {
   df <- data.frame(x = 1, y = 2)
   lst <- structure(list(df, df, df), class = "special_lst")


### PR DESCRIPTION
Closes #4930

This looks to be different from #4931 

`vec_is_list()` is a new function in the CRAN version of vctrs for detecting a "list" in the vctrs sense. It returns TRUE if:

- x is a bare list with no class.

- x is a list explicitly inheriting from "list" or "vctrs_list_of".

- x is an S3 list that vec_is() returns TRUE for. For this to return TRUE, the class must implement a vec_proxy() method.

It requires a tweak to a test related to https://github.com/tidyverse/dplyr/issues/3924, but this was one of my own issues, so it is probably fine? It is technically a breaking change though.
