### PR TITLE
Add regression test for `bind_rows()` and named S3 objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -67,4 +67,4 @@ LazyData: yes
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.0
 Remotes:
-    r-lib/rlang#945
+    r-lib/rlang

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Imports:
     magrittr (>= 1.5),
     methods,
     R6,
-    rlang (>= 0.4.5),
+    rlang (>= 0.4.5.9000),
     tibble (>= 2.1.3),
     tidyselect (>= 1.0.0),
     utils,
@@ -66,3 +66,5 @@ Encoding: UTF-8
 LazyData: yes
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.0
+Remotes:
+    r-lib/rlang#945

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -494,6 +494,21 @@ test_that("bind_rows() handles named list", {
   expect_equivalent(bind_rows(!!!map(mtcars, mean)), summarise_all(mtcars, mean))
 })
 
+test_that("bind_rows() handles named S3 objects (#4931)", {
+  df <- tibble(x = "foo", y = "bar")
+  fct <- set_names(factor(c("a", "b")), c("x", "y"))
+
+  expect_identical(
+    bind_rows(df, fct),
+    tibble(x = c("foo", "a"), y = c("bar", "b"))
+  )
+
+  expect_identical(
+    bind_rows(fct, fct),
+    tibble(x = fct[c(1, 1)], y = fct[c(2, 2)])
+  )
+})
+
 test_that("bind_rows() correctly restores (#2457)", {
   df <- bind_rows(
     tibble(x = vctrs::list_of(1))


### PR DESCRIPTION
Closes #4931 

- Adds a test for `bind_rows()` with named factors

- We now have to rely on dev rlang again to get the fix to `!!!`