### PR TITLE
bind_cols(<...>) -> tibble

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: dplyr
 Title: A Grammar of Data Manipulation
-Version: 0.8.99.9000
+Version: 0.8.99.9001
 Authors@R: 
     c(person(given = "Hadley",
              family = "Wickham",

--- a/R/bind.r
+++ b/R/bind.r
@@ -137,7 +137,7 @@ bind_cols <- function(...) {
   names(dots)[is_data_frame] <- ""
 
   out <- vec_cbind(!!!dots)
-  if (!any(map_lgl(dots, function(.x) is.data.frame(vec_ptype(.x))))) {
+  if (!any(map_lgl(dots, is.data.frame))) {
     out <- as_tibble(out)
   }
   if (length(dots) && is_tibble(first <- dots[[1L]])) {

--- a/R/bind.r
+++ b/R/bind.r
@@ -137,6 +137,9 @@ bind_cols <- function(...) {
   names(dots)[is_data_frame] <- ""
 
   out <- vec_cbind(!!!dots)
+  if (!any(map_lgl(dots, function(.x) is.data.frame(vec_ptype(.x))))) {
+    out <- as_tibble(out)
+  }
   if (length(dots) && is_tibble(first <- dots[[1L]])) {
     out <- dplyr_reconstruct(out, first)
   }

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -21,7 +21,7 @@ test_that("cbind uses shallow copies", {
 })
 
 test_that("bind_cols handles lists (#1104)", {
-  exp <- data.frame(x = 1, y = "a", z = 2, stringsAsFactors = FALSE)
+  exp <- tibble(x = 1, y = "a", z = 2)
 
   l1 <- list(x = 1, y = "a")
   l2 <- list(z = 2)
@@ -31,12 +31,12 @@ test_that("bind_cols handles lists (#1104)", {
 })
 
 test_that("bind_cols handles empty argument list (#1963)", {
-  expect_equal(bind_cols(), data.frame())
+  expect_equal(bind_cols(), tibble())
 })
 
 test_that("bind_cols handles all-NULL values (#2303)", {
-  expect_identical(bind_cols(list(a = NULL, b = NULL)), data.frame())
-  expect_identical(bind_cols(NULL), data.frame())
+  expect_identical(bind_cols(list(a = NULL, b = NULL)), tibble())
+  expect_identical(bind_cols(NULL), tibble())
 })
 
 test_that("bind_cols repairs names", {
@@ -469,11 +469,11 @@ test_that("columns that are OBJECT but have NULL class are handled gracefully (#
 # Vectors ------------------------------------------------------------
 
 test_that("accepts named columns", {
-  expect_identical(bind_cols(a = 1:2, b = 3:4), data.frame(a = 1:2, b = 3:4))
+  expect_identical(bind_cols(a = 1:2, b = 3:4), tibble(a = 1:2, b = 3:4))
 })
 
 test_that("ignores NULL values", {
-  expect_identical(bind_cols(a = 1, NULL, b = 2, NULL), data.frame(a = 1, b = 2))
+  expect_identical(bind_cols(a = 1, NULL, b = 2, NULL), tibble(a = 1, b = 2))
 })
 
 test_that("bind_cols() handles unnamed list with name repair (#3402)", {


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)

bind_cols(data.frame(x = 1), y = 2)
#>   x y
#> 1 1 2
bind_cols(tibble(x = 1), y = 2)
#> # A tibble: 1 x 2
#>       x     y
#> * <dbl> <dbl>
#> 1     1     2
bind_cols(x = 1, y = 2)
#> # A tibble: 1 x 2
#>       x     y
#>   <dbl> <dbl>
#> 1     1     2
```

<sup>Created on 2020-03-18 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>