### PR TITLE
Check return type of predicate in tbl_if_vars

### DIFF
--- a/R/colwise.R
+++ b/R/colwise.R
@@ -193,10 +193,10 @@ tbl_if_vars <- function(.tbl, .p, .env, ..., .include_group_vars = FALSE) {
   if (is_logical(.p)) {
     if (length(.p) != length(tibble_vars)) {
       abort(c(
-        "`.p` is invalid",
-        x = "`.p` should have the same size as the number of variables in the tibble",
-        i = glue("`.p` is size {length(.p)}"),
-        i = glue("The tibble has {length(tibble_vars)} columns, {including} the grouping variables", including = if (.include_group_vars) "including" else "non including")
+        "`.p` is invalid.",
+        x = "`.p` should have the same size as the number of variables in the tibble.",
+        i = glue("`.p` is size {length(.p)}."),
+        i = glue("The tibble has {length(tibble_vars)} columns, {including} the grouping variables.", including = if (.include_group_vars) "including" else "non including")
       ))
     }
     return(syms(tibble_vars[.p]))
@@ -222,8 +222,17 @@ tbl_if_vars <- function(.tbl, .p, .env, ..., .include_group_vars = FALSE) {
   for (i in seq_len(n)) {
     column <- pull(.tbl, tibble_vars[[i]])
     cond <- eval_tidy(.p(column, ...))
-    if (!is.logical(cond) || length(cond) != 1) 
-        abort("Provided predicate function does not return a single logical")
+    if (!is.logical(cond) || length(cond) != 1) {
+      abort(c(
+        "`.p` is invalid.",
+        x = "`.p` should return a single logical.",
+        i = if(is.logical(cond)) {
+          glue("`.p` returns a size {length(cond)} <logical> for column `{tibble_vars[[i]]}`.")
+        } else {
+          glue("`.p` returns a <{vec_ptype_full(cond)}> for column `{tibble_vars[[i]]}`.")
+        }
+      ))
+    }
     selected[[i]] <- isTRUE(cond)
   }
 

--- a/R/colwise.R
+++ b/R/colwise.R
@@ -196,7 +196,7 @@ tbl_if_vars <- function(.tbl, .p, .env, ..., .include_group_vars = FALSE) {
         "`.p` is invalid",
         x = "`.p` should have the same size as the number of variables in the tibble",
         i = glue("`.p` is size {length(.p)}"),
-        i = glue("The tibble has {length(tibble_vars}) columns, {including} the grouping variables", including = if (.include_group_vars) "including" else "non including")
+        i = glue("The tibble has {length(tibble_vars)} columns, {including} the grouping variables", including = if (.include_group_vars) "including" else "non including")
       ))
     }
     return(syms(tibble_vars[.p]))
@@ -221,7 +221,10 @@ tbl_if_vars <- function(.tbl, .p, .env, ..., .include_group_vars = FALSE) {
 
   for (i in seq_len(n)) {
     column <- pull(.tbl, tibble_vars[[i]])
-    selected[[i]] <- isTRUE(eval_tidy(.p(column, ...)))
+    cond <- eval_tidy(.p(column, ...))
+    if (!is.logical(cond) || length(cond) != 1) 
+        abort("Provided predicate function did not return a single logical")
+    selected[[i]] <- isTRUE(cond)
   }
 
   tibble_vars[selected]

--- a/R/colwise.R
+++ b/R/colwise.R
@@ -223,7 +223,7 @@ tbl_if_vars <- function(.tbl, .p, .env, ..., .include_group_vars = FALSE) {
     column <- pull(.tbl, tibble_vars[[i]])
     cond <- eval_tidy(.p(column, ...))
     if (!is.logical(cond) || length(cond) != 1) 
-        abort("Provided predicate function did not return a single logical")
+        abort("Provided predicate function does not return a single logical")
     selected[[i]] <- isTRUE(cond)
   }
 

--- a/tests/testthat/test-colwise-select-errors.txt
+++ b/tests/testthat/test-colwise-select-errors.txt
@@ -22,3 +22,13 @@ colwise select()
 > df %>% select_all(list(tolower, toupper))
 Error: `.funs` must contain one renaming function, not 2
 
+> df %>% select_if(function(.x) 1)
+Error: `.p` is invalid.
+x `.p` should return a single logical.
+i `.p` returns a <double> for column `x`.
+
+> df %>% select_if(function(.x) c(TRUE, TRUE))
+Error: `.p` is invalid.
+x `.p` should return a single logical.
+i `.p` returns a size 2 <logical> for column `x`.
+

--- a/tests/testthat/test-colwise-select.R
+++ b/tests/testthat/test-colwise-select.R
@@ -184,5 +184,7 @@ test_that("colwise select() / rename() give meaningful errors", {
 
     "# colwise select() "
     df %>% select_all(list(tolower, toupper))
+    df %>% select_if(function(.x) 1)
+    df %>% select_if(function(.x) c(TRUE, TRUE))
   })
 })


### PR DESCRIPTION
When predicate function return type was wrong, error messages were somehow unclear about what went wrong:

`
select_if(iris, ~c(is.numeric(.x),is.numeric(.x)))
`

> more elements supplied than there are to replace

`select_if(iris, ~mean(.x))`

> Only strings can be converted to symbols

This short pull request adds the error message `abort("Provided predicate function did not return a single logical")` after checking that the result of the predicate function is a single logical value. 

Also fixed a typo in the first `abort` call of the function (swapped `(` and `}`).