### PR TITLE
grouped_df(drop=) defaults to use group_by_drop_default(data)

### DIFF
--- a/R/grouped-df.r
+++ b/R/grouped-df.r
@@ -15,7 +15,7 @@
 #'
 #' @import vctrs
 #' @export
-grouped_df <- function(data, vars, drop = FALSE) {
+grouped_df <- function(data, vars, drop = group_by_drop_default(data)) {
   if (!is.data.frame(data)) {
     abort("`data` must be a data frame")
   }

--- a/man/grouped_df.Rd
+++ b/man/grouped_df.Rd
@@ -6,7 +6,7 @@
 \alias{is_grouped_df}
 \title{A grouped data frame.}
 \usage{
-grouped_df(data, vars, drop = FALSE)
+grouped_df(data, vars, drop = group_by_drop_default(data))
 
 is.grouped_df(x)
 


### PR DESCRIPTION
I've checked and this does not seem to harm https://github.com/tidyverse/tidyr/pull/914