### PR TITLE
protect against tibble() .data masking in older versions of tibble::

### DIFF
--- a/R/distinct.R
+++ b/R/distinct.R
@@ -136,7 +136,8 @@ distinct.data.frame <- function(.data, ..., .keep_all = FALSE) {
 #' n_distinct(x)
 #' @export
 n_distinct <- function(..., na.rm = FALSE) {
-  data <- tibble(...)
+  # TODO: remove !!!list2() when tibble abandons `.data` masking
+  data <- tibble(!!!list2(...))
   if (isTRUE(na.rm)){
     data <- vec_slice(data, !reduce(map(data, vec_equal_na), `|`))
   }

--- a/tests/testthat/test-n_distinct.R
+++ b/tests/testthat/test-n_distinct.R
@@ -64,3 +64,7 @@ test_that("n_distinct handles expressions in na.rm (#3686)", {
   expect_equal(d %>% summarise(n = n_distinct(x, na.rm = TRUE || TRUE)) %>% pull(), 4)
 })
 
+test_that("n_distinct() respects .data (#5008)", {
+  data.frame(x = 42) %>%
+    summarise(n = n_distinct(.data$x))
+})


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)
data.frame(x = 42) %>%
  summarise(n = n_distinct(.data$x))
#>   n
#> 1 1
```

<sup>Created on 2020-03-20 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>