### PR TITLE
Don't `.` prefix `cols` in `c_across()`

### DIFF
--- a/R/across.R
+++ b/R/across.R
@@ -13,7 +13,7 @@
 #' semantics so you can easily select multiple variables. See
 #' `vignette("rowwise")` for more details.
 #'
-#' @param .cols <[`tidy-select`][dplyr_tidy_select]> Columns to transform.
+#' @param cols,.cols <[`tidy-select`][dplyr_tidy_select]> Columns to transform.
 #'   Because `across()` is used within functions like `summarise()` and
 #'   `mutate()`, you can't select or compute upon grouping variables.
 #' @param .fns Functions to apply to each of the selected columns.

--- a/R/across.R
+++ b/R/across.R
@@ -133,16 +133,16 @@ across <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
 
 #' @export
 #' @rdname across
-c_across <- function(.cols = everything()) {
+c_across <- function(cols = everything()) {
   key <- key_deparse(sys.call())
-  vars <- c_across_setup({{ .cols }}, key = key)
+  vars <- c_across_setup({{ cols }}, key = key)
 
   mask <- peek_mask()
 
-  .cols <- mask$current_cols(vars)
-  .cols <- unname(.cols)
+  cols <- mask$current_cols(vars)
+  cols <- unname(cols)
 
-  vec_c(!!!.cols)
+  vec_c(!!!cols)
 }
 
 # TODO: The usage of a cache in `across_setup()` and `c_across_setup()` is a stopgap solution, and

--- a/man/across.Rd
+++ b/man/across.Rd
@@ -10,10 +10,6 @@ across(.cols = everything(), .fns = NULL, ..., .names = NULL)
 c_across(cols = everything())
 }
 \arguments{
-\item{.cols}{<\code{\link[=dplyr_tidy_select]{tidy-select}}> Columns to transform.
-Because \code{across()} is used within functions like \code{summarise()} and
-\code{mutate()}, you can't select or compute upon grouping variables.}
-
 \item{.fns}{Functions to apply to each of the selected columns.
 Possible values are:
 \itemize{
@@ -34,6 +30,10 @@ columns. This can use \code{{col}} to stand for the selected column name, and
 \code{{fn}} to stand for the name of the function being applied. The default
 (\code{NULL}) is equivalent to \code{"{col}"} for the single function case and
 \code{"{col}_{fn}"} for the case where a list is used for \code{.fns}.}
+
+\item{cols, .cols}{<\code{\link[=dplyr_tidy_select]{tidy-select}}> Columns to transform.
+Because \code{across()} is used within functions like \code{summarise()} and
+\code{mutate()}, you can't select or compute upon grouping variables.}
 }
 \value{
 A tibble with one column for each column in \code{.cols} and each function in \code{.fns}.

--- a/man/across.Rd
+++ b/man/across.Rd
@@ -7,7 +7,7 @@
 \usage{
 across(.cols = everything(), .fns = NULL, ..., .names = NULL)
 
-c_across(.cols = everything())
+c_across(cols = everything())
 }
 \arguments{
 \item{.cols}{<\code{\link[=dplyr_tidy_select]{tidy-select}}> Columns to transform.


### PR DESCRIPTION
Reverts a small piece of #4979 that prefixed the `cols` argument of `c_across()` with a `.`. I don't think we need that