### PR TITLE
join_rows() giving meaningful error message

### DIFF
--- a/R/join-rows.R
+++ b/R/join-rows.R
@@ -6,8 +6,9 @@ join_rows <- function(x_key, y_key, type = c("inner", "left", "right", "full"), 
   tryCatch(
     matches <- vec_match(x_key, y_split$key, na_equal = na_equal),
     vctrs_error_incompatible_type = function(cnd) {
-      x_name <- sub("^needles[$]", "", cnd$x_arg)
-      y_name <- sub("^haystack[$]", "", cnd$y_arg)
+      rx <- "^[^$]+[$]"
+      x_name <- sub(rx, "", cnd$x_arg)
+      y_name <- sub(rx, "", cnd$y_arg)
 
       abort(c(
         glue("Can't join on `x${x_name}` x `y${y_name}` because of incompatible types. "),

--- a/R/join-rows.R
+++ b/R/join-rows.R
@@ -3,7 +3,20 @@ join_rows <- function(x_key, y_key, type = c("inner", "left", "right", "full"), 
 
   # Find matching rows in y for each row in x
   y_split <- vec_group_loc(y_key)
-  matches <- vec_match(x_key, y_split$key, na_equal = na_equal)
+  tryCatch(
+    matches <- vec_match(x_key, y_split$key, na_equal = na_equal),
+    vctrs_error_incompatible_type = function(cnd) {
+      x_name <- sub("^needles[$]", "", cnd$x_arg)
+      y_name <- sub("^haystack[$]", "", cnd$y_arg)
+
+      abort(c(
+        glue("Can't join on `x${x_name}` x `y${y_name}` because of incompatible types. "),
+        i = glue("`x${x_name}` is of type <{x_type}>>.", x_type = vec_ptype_full(cnd$x)),
+        i = glue("`y${y_name}` is of type <{y_type}>>.", y_type = vec_ptype_full(cnd$y))
+      ))
+    }
+  )
+
   y_loc <- y_split$loc[matches]
 
   if (type == "left" || type == "full") {

--- a/tests/testthat/test-join-rows.R
+++ b/tests/testthat/test-join-rows.R
@@ -29,3 +29,12 @@ test_that("full join contains all keys from both", {
   expect_equal(out$y, c(NA, 2L))
   expect_equal(out$y_extra, 1L)
 })
+
+test_that("join_rows() gives meaningful error message on incompatible types", {
+  verify_output(test_path("test-join-rows.txt"), {
+    join_rows(
+      data.frame(x = 1),
+      data.frame(x = factor("a"))
+    )
+  })
+})

--- a/tests/testthat/test-join-rows.txt
+++ b/tests/testthat/test-join-rows.txt
@@ -1,0 +1,5 @@
+> join_rows(data.frame(x = 1), data.frame(x = factor("a")))
+Error: Can't join on `x$x` x `y$x` because of incompatible types. 
+i `x$x` is of type <double>>.
+i `y$x` is of type <factor<127a2>>>.
+


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)

dplyr:::join_rows(
  data.frame(x = 1),
  data.frame(x = factor("a"))
)
#> Error: Can't join on `x$x` x `y$x` because of incompatible types. 
#> ℹ `x$x` is of type <double>>.
#> ℹ `y$x` is of type <factor<127a2>>>.

full_join(
  tibble(A=factor(1:3), B=LETTERS[1:3]),
  tibble(A=1:3, C=letters[1:3])
)
#> Joining, by = "A"
#> Error: Can't join on `x$A` x `y$A` because of incompatible types. 
#> ℹ `x$A` is of type <factor<d3bfc>>>.
#> ℹ `y$A` is of type <integer>>.
```

<sup>Created on 2020-03-23 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

Or, wondering if `vctrs::vec_match()` should expose arguments `x_arg` and `y_arg` like `vec_ptype2()` does 