### PR TITLE
Maintain grouping order in grouped_df methods

### DIFF
--- a/R/grouped-df.r
+++ b/R/grouped-df.r
@@ -210,7 +210,7 @@ as_tibble.grouped_df <- function(x, ...) {
   if (drop) {
     as_tibble(out)
   } else {
-    groups <- intersect(names(out), group_vars(x))
+    groups <- group_intersect(x, out)
     if ((missing(i) || nargs() == 2) && identical(groups, group_vars(x))) {
       new_grouped_df(out, group_data(x))
     } else {
@@ -223,7 +223,7 @@ as_tibble.grouped_df <- function(x, ...) {
 `$<-.grouped_df` <- function(x, name, ..., value) {
   out <- NextMethod()
   if (name %in% group_vars(x)) {
-    grouped_df(out, intersect(names(out), group_vars(x)), group_by_drop_default(x))
+    grouped_df(out, group_intersect(x, out), group_by_drop_default(x))
   } else {
     out
   }
@@ -232,13 +232,13 @@ as_tibble.grouped_df <- function(x, ...) {
 #' @export
 `[<-.grouped_df` <- function(x, i, j, ..., value) {
   out <- NextMethod()
-  grouped_df(out, intersect(names(out), group_vars(x)), group_by_drop_default(x))
+  grouped_df(out, group_intersect(x, out), group_by_drop_default(x))
 }
 
 #' @export
 `[[<-.grouped_df` <- function(x, ..., value) {
   out <- NextMethod()
-  grouped_df(out, intersect(names(out), group_vars(x)), group_by_drop_default(x))
+  grouped_df(out, group_intersect(x, out), group_by_drop_default(x))
 }
 
 #' @export
@@ -247,7 +247,7 @@ as_tibble.grouped_df <- function(x, ...) {
   names(data) <- value
 
   groups <- group_data(x)
-  group_loc <- match(intersect(names(x), names(groups)), names(x))
+  group_loc <- match(intersect(names(groups), names(x)), names(x))
   group_names <- c(value[group_loc], ".rows")
   if (!identical(group_names, names(groups))) {
     names(groups) <- c(value[group_loc], ".rows")
@@ -287,5 +287,9 @@ vec_split_id_order <- function(x) {
   split_id <- vec_group_loc(x)
   split_id$loc <- new_list_of(split_id$loc, ptype = integer())
   vec_slice(split_id, vec_order(split_id$key))
+}
+
+group_intersect <- function(x, new) {
+  intersect(group_vars(x), names(new))
 }
 

--- a/tests/testthat/test-grouped-df.r
+++ b/tests/testthat/test-grouped-df.r
@@ -85,6 +85,30 @@ test_that("names<- doesn't modify group data if not necessary", {
   expect_reference(group_data(gf1), group_data(gf2))
 })
 
+test_that("group order is maintained in grouped-df methods (#5040)", {
+  gdf <- group_by(mtcars, cyl, am, vs)
+
+  x <- gdf[0,]
+  expect_identical(group_vars(x), group_vars(gdf))
+
+  x <- gdf
+  x$am <- 1
+  expect_identical(group_vars(x), group_vars(gdf))
+
+  x <- gdf
+  x["am"] <- 1
+  expect_identical(group_vars(x), group_vars(gdf))
+
+  x <- gdf
+  x[["am"]] <- 1
+  expect_identical(group_vars(x), group_vars(gdf))
+
+  x <- gdf
+  names <- names(x)
+  names[9] <- "am2"
+  names(x) <- names
+  expect_identical(group_vars(x), group_vars(group_by(x, cyl, am2, vs)))
+})
 
 # compute_group ----------------------------------------------------------
 


### PR DESCRIPTION
Closes #5040

This PR maintains the grouping order in the grouped_df methods we have overwritten. We just needed to flip the order in an `intersect()` call, which I have extracted out into `group_intersect()`