### PR TITLE
use vec_sze() instead of length() in lead() and lag()

### DIFF
--- a/R/lead-lag.R
+++ b/R/lead-lag.R
@@ -60,7 +60,7 @@ lag <- function(x, n = 1L, default = NA, order_by = NULL, ...) {
   }
   if (n == 0) return(x)
 
-  xlen <- length(x)
+  xlen <- vec_size(x)
   n <- pmin(n, xlen)
 
   vec_c(
@@ -83,7 +83,7 @@ lead <- function(x, n = 1L, default = NA, order_by = NULL, ...) {
   }
   if (n == 0) return(x)
 
-  xlen <- length(x)
+  xlen <- vec_size(x)
   n <- pmin(n, xlen)
 
   vec_c(

--- a/tests/testthat/test-lead-lag.R
+++ b/tests/testthat/test-lead-lag.R
@@ -55,6 +55,15 @@ test_that("#937 is fixed", {
   )
 })
 
+test_that("lead() and lag() work for matrices (#5028)", {
+  m <- matrix(1:6, ncol = 2)
+  expect_equal(lag(m, 1), matrix(c(NA_integer_, 1L, 2L, NA_integer_, 4L, 5L), ncol = 2))
+  expect_equal(lag(m, 1, default = NA), matrix(c(NA_integer_, 1L, 2L, NA_integer_, 4L, 5L), ncol= 2))
+
+  expect_equal(lead(m, 1), matrix(c(2L, 3L, NA_integer_, 5L, 6L, NA_integer_), ncol = 2))
+  expect_equal(lead(m, 1, default = NA), matrix(c(2L, 3L, NA_integer_, 5L, 6L, NA_integer_), ncol = 2))
+})
+
 # Errors ------------------------------------------------------------------
 
 test_that("lead() / lag() give meaningful errors", {


### PR DESCRIPTION
close #5028

``` r
library(dplyr, warn.conflicts = FALSE)

m       <- matrix(1:120, ncol = 12)
lag(m, 1L)
#>       [,1] [,2] [,3] [,4] [,5] [,6] [,7] [,8] [,9] [,10] [,11] [,12]
#>  [1,]   NA   NA   NA   NA   NA   NA   NA   NA   NA    NA    NA    NA
#>  [2,]    1   11   21   31   41   51   61   71   81    91   101   111
#>  [3,]    2   12   22   32   42   52   62   72   82    92   102   112
#>  [4,]    3   13   23   33   43   53   63   73   83    93   103   113
#>  [5,]    4   14   24   34   44   54   64   74   84    94   104   114
#>  [6,]    5   15   25   35   45   55   65   75   85    95   105   115
#>  [7,]    6   16   26   36   46   56   66   76   86    96   106   116
#>  [8,]    7   17   27   37   47   57   67   77   87    97   107   117
#>  [9,]    8   18   28   38   48   58   68   78   88    98   108   118
#> [10,]    9   19   29   39   49   59   69   79   89    99   109   119
```

<sup>Created on 2020-03-26 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>