### PR TITLE
group_by() with mutate() semantics

### DIFF
--- a/R/group-by.r
+++ b/R/group-by.r
@@ -177,18 +177,20 @@ add_computed_columns <- function(.data, vars) {
   needs_mutate <- have_name(vars) | !is_symbol
 
   if (any(needs_mutate)) {
+    out <- .data
     col_names <- as.list(names(exprs_auto_name(vars)))
 
     out_cols <- list()
     # Process sequentially so we can keep the group names in order
     # TODO: re-write so works with dbplyr too
     for (i in which(needs_mutate)) {
-      cols <- mutate_cols(.data, !!!vars[i])
+      cols <- mutate_cols(out, !!!vars[i])
       out_cols[names(cols)] <- cols
       col_names[[i]] <- names(cols)
+
+      out <- dplyr_col_modify(out, cols)
     }
 
-    out <- dplyr_col_modify(.data, out_cols)
     col_names <- unique(unlist(col_names))
   } else {
     out <- .data

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -489,6 +489,15 @@ test_that("group_by() can combine usual spec and auto-splicing-mutate() step", {
   )
 })
 
+# mutate() semantics
+
+test_that("group_by() has mutate() semantics (#4984)", {
+  expect_equal(
+    tibble(a = 1, b = 2) %>% group_by(c = a * b, d = c + 1),
+    tibble(a = 1, b = 2) %>% mutate(c = a * b, d = c + 1) %>% group_by(c, d)
+  )
+})
+
 # Errors ------------------------------------------------------------------
 
 test_that("group_by() and ungroup() give meaningful error messages", {


### PR DESCRIPTION
close #4984

``` r
library(tidyverse)

tibble(a = 1, b = 2) %>%
  group_by(c = a * b, d = c + 1)
#> # A tibble: 1 x 4
#> # Groups:   c, d [1]
#>       a     b     c     d
#>   <dbl> <dbl> <dbl> <dbl>
#> 1     1     2     2     3
```

<sup>Created on 2020-03-27 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

Do we want to tailer the errors that occur during the `mutate()` step ? Perhaps in a different PR. 

``` r
library(tidyverse)

tibble(a = 1, b = 2) %>%
  group_by(c = a * b, d = e + 1)
#> Error: `mutate()` argument `d` errored.
#> ℹ `d` is `e + 1`.
#> x object 'e' not found
tibble(a = 1, b = 2) %>%
  distinct(c = a * b, d = e + 1)
#> Error: `mutate()` argument `d` errored.
#> ℹ `d` is `e + 1`.
#> x object 'e' not found
```

<sup>Created on 2020-03-27 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>