### PR TITLE
Don't count regroups in tests

### DIFF
--- a/tests/testthat/test-distinct.R
+++ b/tests/testthat/test-distinct.R
@@ -145,12 +145,10 @@ test_that("distinct() handles auto splicing", {
 test_that("distinct preserves grouping", {
   gf <- group_by(tibble(x = c(1, 1, 2, 2), y = x), x)
 
-  i <- count_regroups(out <- distinct(gf))
-  expect_equal(i, 0)
+  out <- distinct(gf)
   expect_equal(group_vars(out), "x")
 
-  i <- count_regroups(out <- distinct(gf, x = x + 2))
-  expect_equal(i, 1)
+  out <- distinct(gf, x = x + 2)
   expect_equal(group_vars(out), "x")
 })
 

--- a/tests/testthat/test-filter.r
+++ b/tests/testthat/test-filter.r
@@ -458,13 +458,11 @@ test_that("filter() gives useful error messages", {
 test_that("filter preserves grouping", {
   gf <- group_by(tibble(g = c(1, 1, 1, 2, 2), x = 1:5), g)
 
-  i <- count_regroups(out <- filter(gf, x %in% c(3,4)))
-  expect_equal(i, 0L)
+  out <- filter(gf, x %in% c(3,4))
   expect_equal(group_vars(gf), "g")
   expect_equal(group_rows(out), list_of(1L, 2L))
 
-  i <- count_regroups(out <- filter(gf, x < 3))
-  expect_equal(i, 0L)
+  out <- filter(gf, x < 3)
   expect_equal(group_vars(gf), "g")
   expect_equal(group_rows(out), list_of(c(1L, 2L)))
 })

--- a/tests/testthat/test-join.r
+++ b/tests/testthat/test-join.r
@@ -181,17 +181,14 @@ test_that("joins preserve groups", {
   gf1 <- tibble(a = 1:3) %>% group_by(a)
   gf2 <- tibble(a = rep(1:4, 2), b = 1) %>% group_by(b)
 
-  i <- count_regroups(out <- inner_join(gf1, gf2, by = "a"))
-  expect_equal(i, 1L)
+  out <- inner_join(gf1, gf2, by = "a")
   expect_equal(group_vars(out), "a")
 
-  i <- count_regroups(out <- semi_join(gf1, gf2, by = "a"))
-  expect_equal(i, 0L)
+  out <- semi_join(gf1, gf2, by = "a")
   expect_equal(group_vars(out), "a")
 
   # See comment in nest_join
-  i <- count_regroups(out <- nest_join(gf1, gf2, by = "a"))
-  expect_equal(i, 1L)
+  out <- nest_join(gf1, gf2, by = "a")
   expect_equal(group_vars(out), "a")
 })
 

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -148,13 +148,11 @@ test_that("named data frames are packed (#2326, #3630)", {
 test_that("mutate preserves grouping", {
   gf <- group_by(tibble(x = 1:2, y = 2), x)
 
-  i <- count_regroups(out <- mutate(gf, x = 1))
-  expect_equal(i, 1L)
+  out <- mutate(gf, x = 1)
   expect_equal(group_vars(out), "x")
   expect_equal(nrow(group_data(out)), 1)
 
-  i <- count_regroups(out <- mutate(gf, z = 1))
-  expect_equal(i, 0)
+  out <- mutate(gf, z = 1)
   expect_equal(group_data(out), group_data(gf))
 })
 


### PR DESCRIPTION
Fixes tests once r-lib/vctrs#951 is merged.