### PR TITLE
N distinct eval tidy

### DIFF
--- a/R/distinct.R
+++ b/R/distinct.R
@@ -120,6 +120,7 @@ distinct.data.frame <- function(.data, ..., .keep_all = FALSE) {
   out <- prep$data
   loc <- vec_unique_loc(as_tibble(out)[prep$vars])
 
+
   dplyr_row_slice(out[prep$keep], loc)
 }
 
@@ -136,8 +137,8 @@ distinct.data.frame <- function(.data, ..., .keep_all = FALSE) {
 #' n_distinct(x)
 #' @export
 n_distinct <- function(..., na.rm = FALSE) {
-  # TODO: remove !!!list2() when tibble abandons `.data` masking
-  data <- tibble(!!!list2(...))
+  columns <- map(enquos(..., .named = TRUE), eval_tidy)
+  data <- tibble(!!!columns)
   if (isTRUE(na.rm)){
     data <- vec_slice(data, !reduce(map(data, vec_equal_na), `|`))
   }

--- a/R/distinct.R
+++ b/R/distinct.R
@@ -138,7 +138,7 @@ distinct.data.frame <- function(.data, ..., .keep_all = FALSE) {
 #' @export
 n_distinct <- function(..., na.rm = FALSE) {
   columns <- map(enquos(..., .named = TRUE), eval_tidy)
-  data <- tibble(!!!columns)
+  data <- as_tibble(columns, .name_repair = "minimal")
   if (isTRUE(na.rm)){
     data <- vec_slice(data, !reduce(map(data, vec_equal_na), `|`))
   }

--- a/tests/testthat/test-n_distinct.R
+++ b/tests/testthat/test-n_distinct.R
@@ -52,8 +52,12 @@ test_that("n_distinct recycles length 1 vectors (#3685)", {
 })
 
 test_that("n_distinct() handles unnamed (#5069)", {
-  df <- data.frame(x = 1, y = 2)
-  expect_equal(n_distinct(df$x, df$y), 1L)
+  x <- iris$Sepal.Length
+  y <- iris$Sepal.Width
+  expect_equal(
+    n_distinct(iris$Sepal.Length, iris$Sepal.Width),
+    n_distinct(x, y)
+  )
 })
 
 test_that("n_distinct handles expressions in na.rm (#3686)", {

--- a/tests/testthat/test-n_distinct.R
+++ b/tests/testthat/test-n_distinct.R
@@ -51,6 +51,11 @@ test_that("n_distinct recycles length 1 vectors (#3685)", {
   expect_equal(res$n5, c(3,2))
 })
 
+test_that("n_distinct() handles unnamed (#5069)", {
+  df <- data.frame(x = 1, y = 2)
+  expect_equal(n_distinct(df$x, df$y), 1L)
+})
+
 test_that("n_distinct handles expressions in na.rm (#3686)", {
   d <- tibble(x = c(1:4,NA))
   yes <- TRUE


### PR DESCRIPTION
closes #5069

``` r
dplyr::n_distinct(iris$Sepal.Length, iris$Sepal.Width)
#> [1] 117
```

<sup>Created on 2020-03-30 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>