### PR TITLE
specific error for (lag|lead)(default=) when incompatible type.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,8 @@
 
 * The old data format for `grouped_df` is no longer supported. This may affect you if you have serialized grouped data frames to disk, e.g. with `saveRDS()` or when using knitr caching.
 
+* `lead()` and `lag()` are stricter about their inputs. 
+
 ## New features
 
 * The `cur_` functions (`cur_data()`, `cur_group()`, `cur_group_id()`, 

--- a/R/lead-lag.R
+++ b/R/lead-lag.R
@@ -42,6 +42,21 @@
 #' @name lead-lag
 NULL
 
+leadlag_default <- function(x, default) {
+  if (!identical(default, NA)) {
+    tryCatch(
+      vec_cast(default, x),
+      vctrs_error_incompatible_cast = function(cnd) {
+        abort(c(
+          glue("Incompatible type <{vec_ptype_full(default)}> for `default=`."),
+          i = glue("`x` is of type <{vec_ptype_full(x)}>.")
+        ))
+      }
+    )
+  }
+  default
+}
+
 #' @export
 #' @rdname lead-lag
 lag <- function(x, n = 1L, default = NA, order_by = NULL, ...) {
@@ -63,6 +78,7 @@ lag <- function(x, n = 1L, default = NA, order_by = NULL, ...) {
   xlen <- vec_size(x)
   n <- pmin(n, xlen)
 
+  default <- leadlag_default(x, default)
   vec_c(
     vec_rep(default, n),
     vec_slice(x, seq_len(xlen - n))
@@ -86,6 +102,7 @@ lead <- function(x, n = 1L, default = NA, order_by = NULL, ...) {
   xlen <- vec_size(x)
   n <- pmin(n, xlen)
 
+  default <- leadlag_default(x, default)
   vec_c(
     vec_slice(x, -seq_len(n)),
     vec_rep(default, n)

--- a/R/lead-lag.R
+++ b/R/lead-lag.R
@@ -44,12 +44,12 @@ NULL
 
 leadlag_default <- function(x, default) {
   if (!identical(default, NA)) {
-    tryCatch(
+    default <- tryCatch(
       vec_cast(default, x),
       vctrs_error_incompatible_cast = function(cnd) {
         abort(c(
-          glue("Incompatible type <{vec_ptype_full(default)}> for `default=`."),
-          i = glue("`x` is of type <{vec_ptype_full(x)}>.")
+          glue("Incompatible type for `default`."),
+          i = glue("<{vec_ptype_full(default)}> cannot be cast to type <{vec_ptype_full(x)}>.")
         ))
       }
     )

--- a/R/lead-lag.R
+++ b/R/lead-lag.R
@@ -42,21 +42,6 @@
 #' @name lead-lag
 NULL
 
-leadlag_default <- function(x, default) {
-  if (!identical(default, NA)) {
-    default <- tryCatch(
-      vec_cast(default, x),
-      vctrs_error_incompatible_cast = function(cnd) {
-        abort(c(
-          glue("Incompatible type for `default`."),
-          i = glue("<{vec_ptype_full(default)}> cannot be cast to type <{vec_ptype_full(x)}>.")
-        ))
-      }
-    )
-  }
-  default
-}
-
 #' @export
 #' @rdname lead-lag
 lag <- function(x, n = 1L, default = NA, order_by = NULL, ...) {
@@ -78,7 +63,7 @@ lag <- function(x, n = 1L, default = NA, order_by = NULL, ...) {
   xlen <- vec_size(x)
   n <- pmin(n, xlen)
 
-  default <- leadlag_default(x, default)
+  default <- vec_cast(default, x, x_arg = "default", to_arg = "x")
   vec_c(
     vec_rep(default, n),
     vec_slice(x, seq_len(xlen - n))
@@ -102,7 +87,7 @@ lead <- function(x, n = 1L, default = NA, order_by = NULL, ...) {
   xlen <- vec_size(x)
   n <- pmin(n, xlen)
 
-  default <- leadlag_default(x, default)
+  default <- vec_cast(default, x, x_arg = "default", to_arg = "x")
   vec_c(
     vec_slice(x, -seq_len(n)),
     vec_rep(default, n)

--- a/tests/testthat/test-lead-lag-errors.txt
+++ b/tests/testthat/test-lead-lag-errors.txt
@@ -26,6 +26,5 @@ incompatible default
 ====================
 
 > lag(c("1", "2", "3"), default = FALSE)
-Error: Incompatible type for `default`.
-i <logical> cannot be cast to type <character>.
+Error: Can't convert from `default` <logical> to `x` <character>.
 

--- a/tests/testthat/test-lead-lag-errors.txt
+++ b/tests/testthat/test-lead-lag-errors.txt
@@ -21,3 +21,11 @@ ts
 > lag(ts(1:10))
 Error: `x` must be a vector, not a ts object, do you want `stats::lag()`?
 
+
+incompatible default
+====================
+
+> lag(c("1", "2", "3"), default = FALSE)
+Error: Incompatible type for `default`.
+i <logical> cannot be cast to type <character>.
+

--- a/tests/testthat/test-lead-lag.R
+++ b/tests/testthat/test-lead-lag.R
@@ -76,5 +76,8 @@ test_that("lead() / lag() give meaningful errors", {
 
     "# ts"
     lag(ts(1:10))
+
+    "# incompatible default"
+    lag(c("1", "2", "3"), default = FALSE)
   })
 })


### PR DESCRIPTION
close #5073

``` r
library(dplyr, warn.conflicts = FALSE)

lag(c("1", "2", "3"), default = FALSE)
#> Error: Incompatible type for `default`.
#> ℹ <logical> cannot be cast to type <character>.
```

<sup>Created on 2020-03-31 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>