### PR TITLE
ignore data frames with 0 columns as results in summarise()

### DIFF
--- a/R/summarise.R
+++ b/R/summarise.R
@@ -178,12 +178,13 @@ summarise_cols <- function(.data, ...) {
       }
     }
 
-    recycle_info <- .Call(`dplyr_summarise_recycle_chunks`, chunks)
+    recycle_info <- .Call(`dplyr_summarise_recycle_chunks`, chunks, mask$get_rows())
     chunks <- recycle_info$chunks
     sizes <- recycle_info$sizes
 
     # materialize columns
     for (i in seq_along(dots)) {
+      if (is.null(chunks[[i]])) next
       result <- vec_c(!!!chunks[[i]])
 
       if ((is.null(dots_names) || dots_names[i] == "") && is.data.frame(result)) {

--- a/src/dplyr.h
+++ b/src/dplyr.h
@@ -65,7 +65,6 @@ SEXP dplyr_mask_eval_all(SEXP quo, SEXP env_private);
 SEXP dplyr_mask_eval_all_summarise(SEXP quo, SEXP env_private);
 SEXP dplyr_mask_eval_all_mutate(SEXP quo, SEXP env_private);
 SEXP dplyr_mask_eval_all_filter(SEXP quos, SEXP env_private, SEXP s_n, SEXP env_filter);
-SEXP dplyr_vec_sizes(SEXP chunks);
 SEXP dplyr_summarise_recycle_chunks(SEXP chunks);
 SEXP dplyr_group_indices(SEXP data, SEXP s_nr);
 SEXP dplyr_group_keys(SEXP group_data);

--- a/src/dplyr.h
+++ b/src/dplyr.h
@@ -65,7 +65,7 @@ SEXP dplyr_mask_eval_all(SEXP quo, SEXP env_private);
 SEXP dplyr_mask_eval_all_summarise(SEXP quo, SEXP env_private);
 SEXP dplyr_mask_eval_all_mutate(SEXP quo, SEXP env_private);
 SEXP dplyr_mask_eval_all_filter(SEXP quos, SEXP env_private, SEXP s_n, SEXP env_filter);
-SEXP dplyr_summarise_recycle_chunks(SEXP chunks);
+SEXP dplyr_summarise_recycle_chunks(SEXP chunks, SEXP rows);
 SEXP dplyr_group_indices(SEXP data, SEXP s_nr);
 SEXP dplyr_group_keys(SEXP group_data);
 

--- a/src/dplyr.h
+++ b/src/dplyr.h
@@ -65,7 +65,7 @@ SEXP dplyr_mask_eval_all(SEXP quo, SEXP env_private);
 SEXP dplyr_mask_eval_all_summarise(SEXP quo, SEXP env_private);
 SEXP dplyr_mask_eval_all_mutate(SEXP quo, SEXP env_private);
 SEXP dplyr_mask_eval_all_filter(SEXP quos, SEXP env_private, SEXP s_n, SEXP env_filter);
-SEXP dplyr_summarise_recycle_chunks(SEXP chunks, SEXP rows);
+SEXP dplyr_summarise_recycle_chunks(SEXP chunks, SEXP rows, SEXP ptypes);
 SEXP dplyr_group_indices(SEXP data, SEXP s_nr);
 SEXP dplyr_group_keys(SEXP group_data);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -87,7 +87,6 @@ static const R_CallMethodDef CallEntries[] = {
   {"dplyr_mask_eval_all_mutate", (DL_FUNC)& dplyr_mask_eval_all_mutate, 2},
   {"dplyr_mask_eval_all_filter", (DL_FUNC)& dplyr_mask_eval_all_filter, 4},
 
-  {"dplyr_vec_sizes", (DL_FUNC)& dplyr_vec_sizes, 1},
   {"dplyr_summarise_recycle_chunks", (DL_FUNC)& dplyr_summarise_recycle_chunks, 1},
 
   {"dplyr_group_indices", (DL_FUNC)& dplyr_group_indices, 2},

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -87,7 +87,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"dplyr_mask_eval_all_mutate", (DL_FUNC)& dplyr_mask_eval_all_mutate, 2},
   {"dplyr_mask_eval_all_filter", (DL_FUNC)& dplyr_mask_eval_all_filter, 4},
 
-  {"dplyr_summarise_recycle_chunks", (DL_FUNC)& dplyr_summarise_recycle_chunks, 1},
+  {"dplyr_summarise_recycle_chunks", (DL_FUNC)& dplyr_summarise_recycle_chunks, 2},
 
   {"dplyr_group_indices", (DL_FUNC)& dplyr_group_indices, 2},
   {"dplyr_group_keys", (DL_FUNC)& dplyr_group_keys, 1},

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -87,7 +87,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"dplyr_mask_eval_all_mutate", (DL_FUNC)& dplyr_mask_eval_all_mutate, 2},
   {"dplyr_mask_eval_all_filter", (DL_FUNC)& dplyr_mask_eval_all_filter, 4},
 
-  {"dplyr_summarise_recycle_chunks", (DL_FUNC)& dplyr_summarise_recycle_chunks, 2},
+  {"dplyr_summarise_recycle_chunks", (DL_FUNC)& dplyr_summarise_recycle_chunks, 3},
 
   {"dplyr_group_indices", (DL_FUNC)& dplyr_group_indices, 2},
   {"dplyr_group_keys", (DL_FUNC)& dplyr_group_keys, 1},

--- a/src/summarise.cpp
+++ b/src/summarise.cpp
@@ -22,19 +22,6 @@ SEXP dplyr_mask_eval_all_summarise(SEXP quo, SEXP env_private) {
   return chunks;
 }
 
-SEXP dplyr_vec_sizes(SEXP chunks) {
-  R_xlen_t n = XLENGTH(chunks);
-  SEXP res = PROTECT(Rf_allocVector(INTSXP, n));
-  int* p_res = INTEGER(res);
-
-  for (R_xlen_t i = 0; i < n; i++, ++p_res) {
-    *p_res = vctrs::short_vec_size(VECTOR_ELT(chunks, i));
-  }
-
-  UNPROTECT(1);
-  return res;
-}
-
 SEXP dplyr_summarise_recycle_chunks(SEXP chunks) {
   SEXP res = PROTECT(Rf_allocVector(VECSXP, 2));
   Rf_namesgets(res, dplyr::vectors::names_summarise_recycle_chunks);

--- a/src/summarise.cpp
+++ b/src/summarise.cpp
@@ -22,28 +22,57 @@ SEXP dplyr_mask_eval_all_summarise(SEXP quo, SEXP env_private) {
   return chunks;
 }
 
-SEXP dplyr_summarise_recycle_chunks(SEXP chunks) {
+SEXP dplyr_summarise_recycle_chunks(SEXP chunks, SEXP rows) {
+  // first we identify useless chunks, i.e. chunks that give
+  // data frame results of 0 columns,
+  // and replace those with NULL
+  R_len_t n_chunks = LENGTH(chunks);
+  R_len_t n_useful_chunks = 0;
+  for (R_len_t i = 0; i < n_chunks; i++) {
+    SEXP chunks_i = VECTOR_ELT(chunks, i);
+
+    bool keep = false;
+    R_xlen_t n_i = XLENGTH(chunks_i);
+    for (R_xlen_t j = 0; j < n_i; j++) {
+      SEXP chunks_i_j = VECTOR_ELT(chunks_i, j);
+      if (!Rf_inherits(chunks_i_j, "data.frame") || XLENGTH(chunks_i_j) > 0) {
+        keep = true;
+        n_useful_chunks++;
+        break;
+      }
+    }
+
+    if (!keep) {
+      SET_VECTOR_ELT(chunks, i, R_NilValue);
+    }
+  }
+
   SEXP res = PROTECT(Rf_allocVector(VECSXP, 2));
   Rf_namesgets(res, dplyr::vectors::names_summarise_recycle_chunks);
   SET_VECTOR_ELT(res, 0, chunks);
 
-  R_len_t n_chunks = LENGTH(chunks);
-  if (n_chunks == 0) {
+  // special case when there are no useful chunks
+  if (n_useful_chunks == 0) {
     SET_VECTOR_ELT(res, 1, Rf_ScalarInteger(1));
     UNPROTECT(1);
     return res;
   }
-  R_len_t n = LENGTH(VECTOR_ELT(chunks, 0));
+  R_len_t n = LENGTH(rows);
 
   bool all_one = true;
   int k = 1;
   SEXP sizes = PROTECT(Rf_allocVector(INTSXP, n));
   int* p_sizes = INTEGER(sizes);
   for (R_xlen_t i = 0; i < n; i++, ++p_sizes) {
-    R_len_t n_i = vctrs::short_vec_size(VECTOR_ELT(VECTOR_ELT(chunks, 0), i));
+    R_len_t n_i = 1;
 
-    for (R_len_t j = 1; j < n_chunks; j++) {
+    R_len_t j = 0;
+    for (; j < n_chunks; j++) {
+      // skip useless chunks before looking for chunk size
+      for (; j < n_chunks && VECTOR_ELT(chunks, j) == R_NilValue; j++);
+
       R_len_t n_i_j = vctrs::short_vec_size(VECTOR_ELT(VECTOR_ELT(chunks, j), i));
+
       if (n_i != n_i_j) {
         if (n_i == 1) {
           n_i = n_i_j;
@@ -65,6 +94,9 @@ SEXP dplyr_summarise_recycle_chunks(SEXP chunks) {
   } else {
     // perform recycling
     for (int j = 0; j < n_chunks; j++){
+      // skip useless chunks before recycling
+      for (; j < n_chunks && VECTOR_ELT(chunks, j) == R_NilValue; j++);
+
       SEXP chunks_j = VECTOR_ELT(chunks, j);
       int* p_sizes = INTEGER(sizes);
       for (int i = 0; i < n; i++, ++p_sizes) {

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -73,7 +73,7 @@ test_that("preserved class, but not attributes", {
   expect_equal(attr(out, "res"), NULL)
 })
 
-test_that("works with  unquoted values", {
+test_that("works with unquoted values", {
   df <- tibble(g = c(1, 1, 2, 2, 2), x = 1:5)
   expect_equal(summarise(df, out = !!1), tibble(out = 1))
   expect_equal(summarise(df, out = !!quo(1)), tibble(out = 1))
@@ -84,6 +84,14 @@ test_that("formulas are evaluated in the right environment (#3019)", {
   out <- mtcars %>% summarise(fn = list(rlang::as_function(~ list(~foo, environment()))))
   out <- out$fn[[1]]()
   expect_identical(environment(out[[1]]), out[[2]])
+})
+
+test_that("data frame results with 0 columns are ignored (#5084)", {
+  df1 <- tibble(x = 1:2)
+  expect_equal(df1 %>% group_by(x) %>% summarise(data.frame()), df1)
+
+  df2 <- tibble(x = 1:2, y = 3:4)
+  expect_equal(df2 %>% group_by(x) %>% summarise(data.frame()), df1)
 })
 
 # grouping ----------------------------------------------------------------

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -89,9 +89,13 @@ test_that("formulas are evaluated in the right environment (#3019)", {
 test_that("data frame results with 0 columns are ignored (#5084)", {
   df1 <- tibble(x = 1:2)
   expect_equal(df1 %>% group_by(x) %>% summarise(data.frame()), df1)
+  expect_equal(df1 %>% group_by(x) %>% summarise(data.frame(), y = 65), mutate(df1, y = 65))
+  expect_equal(df1 %>% group_by(x) %>% summarise(y = 65, data.frame()), mutate(df1, y = 65))
 
   df2 <- tibble(x = 1:2, y = 3:4)
   expect_equal(df2 %>% group_by(x) %>% summarise(data.frame()), df1)
+  expect_equal(df2 %>% group_by(x) %>% summarise(data.frame(), z = 98), mutate(df1, z = 98))
+  expect_equal(df2 %>% group_by(x) %>% summarise(z = 98, data.frame()), mutate(df1, z = 98))
 })
 
 # grouping ----------------------------------------------------------------


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)
df <- tibble(g1 = factor(letters[1:10]), g2 = factor(letters[1:10]))

df %>%
  group_by(g1, g2) %>% 
  summarise(across(is.factor, nlevels))
#> # A tibble: 10 x 2
#> # Groups:   g1 [10]
#>    g1    g2   
#>    <fct> <fct>
#>  1 a     a    
#>  2 b     b    
#>  3 c     c    
#>  4 d     d    
#>  5 e     e    
#>  6 f     f    
#>  7 g     g    
#>  8 h     h    
#>  9 i     i    
#> 10 j     j
```

<sup>Created on 2020-04-06 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

initial example in #5084: 

``` r
library(dplyr, warn.conflicts = FALSE)

# Test DF
df <- tibble(g1 = factor(letters[1:10]),
  g2 = factor(LETTERS[1:10]),
  a  = runif(10, 1, 10),
  b  = runif(10, 10, 20),
  c  = runif(10, 15, 30),
  d  = runif(10, 1, 50))

df %>%
  group_by(g1, g2) %>% 
  summarise(
    across(is.numeric, mean), 
    across(is.factor, nlevels),
    n = n(), 
  )
#> # A tibble: 10 x 7
#> # Groups:   g1 [10]
#>    g1    g2        a     b     c     d     n
#>    <fct> <fct> <dbl> <dbl> <dbl> <dbl> <int>
#>  1 a     A      2.83  16.7  19.8  2.83     1
#>  2 b     B      8.76  19.3  18.3 46.0      1
#>  3 c     C      8.23  15.4  29.9 19.4      1
#>  4 d     D      9.92  14.8  23.4 10.8      1
#>  5 e     E      3.56  19.4  28.3  4.74     1
#>  6 f     F      8.87  10.8  16.1  8.05     1
#>  7 g     G      8.21  14.5  28.9 33.9      1
#>  8 h     H      5.78  19.7  19.1 41.2      1
#>  9 i     I      4.44  12.8  24.0 28.8      1
#> 10 j     J      5.94  13.4  25.8 11.3      1
```

<sup>Created on 2020-04-06 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>