### PR TITLE
bind_rows(.id = NULL) does not set names.

### DIFF
--- a/R/bind.r
+++ b/R/bind.r
@@ -116,7 +116,9 @@ bind_rows <- function(..., .id = NULL) {
   }
 
   dots <- map(dots, function(.x) if (is.data.frame(.x)) .x else tibble(!!!.x))
-
+  if (is.null(.id)) {
+    names(dots) <- NULL
+  }
   out <- vec_rbind(!!!dots, .names_to = .id)
   if (length(dots) && is_tibble(first <- dots[[1L]])) {
     out <- dplyr_reconstruct(out, first)

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -164,6 +164,13 @@ test_that("bind_rows puts data frames in order received even if no columns (#217
   expect_equal(res$y, c(NA, "b"))
 })
 
+test_that("bind_rows(.id= NULL) does not set names (#5089)", {
+  expect_equal(
+    attr(bind_rows(list(a = tibble(x = 1:2))), "row.names"),
+    1:2
+  )
+})
+
 # Column coercion --------------------------------------------------------------
 
 test_that("bind_rows promotes integer to numeric", {


### PR DESCRIPTION
close #5087 I'll add a test if we decide to merge this

 ``` r
library(dplyr, warn.conflicts = FALSE, quietly = TRUE)
bind_rows(list(a = tibble(x = 1:2))) %>% row.names()
#> [1] "1" "2"
```

<sup>Created on 2020-04-06 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

<details>

<summary>Session info</summary>

``` r
devtools::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value                       
#>  version  R version 3.6.3 (2020-02-29)
#>  os       macOS Mojave 10.14.6        
#>  system   x86_64, darwin15.6.0        
#>  ui       X11                         
#>  language (EN)                        
#>  collate  en_US.UTF-8                 
#>  ctype    en_US.UTF-8                 
#>  tz       Europe/Paris                
#>  date     2020-04-06                  
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version     date       lib source                        
#>  assertthat    0.2.1       2019-03-21 [1] CRAN (R 3.6.0)                
#>  backports     1.1.5       2019-10-02 [1] CRAN (R 3.6.0)                
#>  callr         3.4.3       2020-03-28 [1] CRAN (R 3.6.2)                
#>  cli           2.0.2       2020-02-28 [1] CRAN (R 3.6.0)                
#>  crayon        1.3.4       2017-09-16 [1] CRAN (R 3.6.0)                
#>  desc          1.2.0       2018-05-01 [1] CRAN (R 3.6.0)                
#>  devtools      2.2.2       2020-02-17 [1] CRAN (R 3.6.0)                
#>  digest        0.6.25      2020-02-23 [1] CRAN (R 3.6.0)                
#>  dplyr       * 0.8.99.9002 2020-04-06 [1] local                         
#>  ellipsis      0.3.0       2019-09-20 [1] CRAN (R 3.6.0)                
#>  evaluate      0.14        2019-05-28 [1] CRAN (R 3.6.0)                
#>  fansi         0.4.1       2020-01-08 [1] CRAN (R 3.6.0)                
#>  fs            1.4.0       2020-03-31 [1] CRAN (R 3.6.2)                
#>  generics      0.0.2       2018-11-29 [1] CRAN (R 3.6.0)                
#>  glue          1.4.0       2020-04-03 [1] CRAN (R 3.6.3)                
#>  highr         0.8         2019-03-20 [1] CRAN (R 3.6.0)                
#>  htmltools     0.4.0       2019-10-04 [1] CRAN (R 3.6.0)                
#>  knitr         1.28        2020-02-06 [1] CRAN (R 3.6.0)                
#>  lifecycle     0.2.0       2020-03-06 [1] CRAN (R 3.6.0)                
#>  magrittr      1.5         2014-11-22 [1] CRAN (R 3.6.0)                
#>  memoise       1.1.0       2017-04-21 [1] CRAN (R 3.6.0)                
#>  pillar        1.4.3       2019-12-20 [1] CRAN (R 3.6.0)                
#>  pkgbuild      1.0.6       2019-10-09 [1] CRAN (R 3.6.0)                
#>  pkgconfig     2.0.3       2019-09-22 [1] CRAN (R 3.6.0)                
#>  pkgload       1.0.2       2018-10-29 [1] CRAN (R 3.6.0)                
#>  prettyunits   1.1.1       2020-01-24 [1] CRAN (R 3.6.0)                
#>  processx      3.4.2       2020-02-09 [1] CRAN (R 3.6.0)                
#>  ps            1.3.2       2020-02-13 [1] CRAN (R 3.6.0)                
#>  purrr         0.3.3.9000  2020-03-31 [1] local                         
#>  R6            2.4.1       2019-11-12 [1] CRAN (R 3.6.0)                
#>  Rcpp          1.0.4.6     2020-04-03 [1] Github (RcppCore/Rcpp@2da7d9c)
#>  remotes       2.1.1       2020-02-15 [1] CRAN (R 3.6.0)                
#>  rlang         0.4.5.9000  2020-04-01 [1] Github (r-lib/rlang@a90b04b)  
#>  rmarkdown     2.1         2020-01-20 [1] CRAN (R 3.6.0)                
#>  rprojroot     1.3-2       2018-01-03 [1] CRAN (R 3.6.0)                
#>  sessioninfo   1.1.1       2018-11-05 [1] CRAN (R 3.6.0)                
#>  stringi       1.4.6       2020-02-17 [1] CRAN (R 3.6.0)                
#>  stringr       1.4.0       2019-02-10 [1] CRAN (R 3.6.0)                
#>  testthat      2.3.2       2020-03-02 [1] CRAN (R 3.6.0)                
#>  tibble        3.0.0       2020-03-30 [1] CRAN (R 3.6.3)                
#>  tidyselect    1.0.0       2020-01-27 [1] CRAN (R 3.6.0)                
#>  usethis       1.5.1.9000  2020-03-24 [1] Github (r-lib/usethis@01dbd8f)
#>  vctrs         0.2.99.9010 2020-04-06 [1] local                         
#>  withr         2.1.2       2018-03-15 [1] CRAN (R 3.6.0)                
#>  xfun          0.12        2020-01-13 [1] CRAN (R 3.6.0)                
#>  yaml          2.2.1       2020-02-01 [1] CRAN (R 3.6.0)                
#> 
#> [1] /Users/romainfrancois/.R/library/3.6
#> [2] /Library/Frameworks/R.framework/Versions/3.6/Resources/library
```

</details>