### PR TITLE
make the promises throuh a function formals instead of env_bind_lazy()

### DIFF
--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -13,7 +13,6 @@ DataMask <- R6Class("DataMask",
 
       private$data <- data
       private$caller <- caller
-      private$bindings <- env(empty_env())
       private$keys <- group_keys(data)
       private$group_vars <- group_vars(data)
 
@@ -51,9 +50,9 @@ DataMask <- R6Class("DataMask",
           res
       }
 
-      promises <- map(seq_len(ncol(data)), function(.x) expr(promise_fn(!!.x)))
-
-      env_bind_lazy(private$bindings, !!!set_names(promises, names_bindings))
+      promises_args <- .Call(`dplyr_promises_args`, names_bindings, promise_fn)
+      fun <- new_function(promises_args, expr(environment()))
+      private$bindings <- fun()
 
       private$mask <- new_data_mask(private$bindings)
       private$mask$.data <- as_data_pronoun(private$mask)

--- a/src/datamask.cpp
+++ b/src/datamask.cpp
@@ -1,6 +1,6 @@
 #include "dplyr.h"
 
-SEXP dplyr_promises_args(SEXP names_bindings, SEXP promise_fn) {
+SEXP dplyr_init_promises_formals(SEXP names_bindings, SEXP promise_fn) {
   PROTECT_INDEX ipx;
   SEXP args = R_NilValue;
   PROTECT_WITH_INDEX(args, &ipx);

--- a/src/datamask.cpp
+++ b/src/datamask.cpp
@@ -4,12 +4,13 @@ SEXP dplyr_promises_args(SEXP names_bindings, SEXP promise_fn) {
   PROTECT_INDEX ipx;
   SEXP args = R_NilValue;
   PROTECT_WITH_INDEX(args, &ipx);
+  SEXP* p_names_bindings = STRING_PTR(names_bindings);
 
   for (R_len_t n = LENGTH(names_bindings); n > 0; n--) {
     SEXP i = PROTECT(Rf_ScalarInteger(n));
     SEXP call = PROTECT(Rf_lang2(promise_fn, i));
     REPROTECT(args = Rf_cons(call, args), ipx);
-    SET_TAG(args, Rf_installChar(STRING_ELT(names_bindings, n-1)));
+    SET_TAG(args, Rf_installChar(p_names_bindings[n-1]));
     UNPROTECT(2);
   }
   UNPROTECT(1);

--- a/src/datamask.cpp
+++ b/src/datamask.cpp
@@ -1,0 +1,17 @@
+#include "dplyr.h"
+
+SEXP dplyr_promises_args(SEXP names_bindings, SEXP promise_fn) {
+  PROTECT_INDEX ipx;
+  SEXP args = R_NilValue;
+  PROTECT_WITH_INDEX(args, &ipx);
+
+  for (R_len_t n = LENGTH(names_bindings); n > 0; n--) {
+    SEXP i = PROTECT(Rf_ScalarInteger(n));
+    SEXP call = PROTECT(Rf_lang2(promise_fn, i));
+    REPROTECT(args = Rf_cons(call, args), ipx);
+    SET_TAG(args, Rf_installChar(STRING_ELT(names_bindings, n-1)));
+    UNPROTECT(2);
+  }
+  UNPROTECT(1);
+  return args;
+}

--- a/src/dplyr.h
+++ b/src/dplyr.h
@@ -68,6 +68,7 @@ SEXP dplyr_mask_eval_all_filter(SEXP quos, SEXP env_private, SEXP s_n, SEXP env_
 SEXP dplyr_summarise_recycle_chunks(SEXP chunks, SEXP rows, SEXP ptypes);
 SEXP dplyr_group_indices(SEXP data, SEXP s_nr);
 SEXP dplyr_group_keys(SEXP group_data);
+SEXP dplyr_promises_args(SEXP names_bindings, SEXP promise_fn);
 
 #define DPLYR_MASK_INIT()                                                          \
 SEXP rows = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::rows));         \

--- a/src/dplyr.h
+++ b/src/dplyr.h
@@ -68,7 +68,7 @@ SEXP dplyr_mask_eval_all_filter(SEXP quos, SEXP env_private, SEXP s_n, SEXP env_
 SEXP dplyr_summarise_recycle_chunks(SEXP chunks, SEXP rows, SEXP ptypes);
 SEXP dplyr_group_indices(SEXP data, SEXP s_nr);
 SEXP dplyr_group_keys(SEXP group_data);
-SEXP dplyr_promises_args(SEXP names_bindings, SEXP promise_fn);
+SEXP dplyr_init_promises_formals(SEXP names_bindings, SEXP promise_fn);
 
 #define DPLYR_MASK_INIT()                                                          \
 SEXP rows = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::rows));         \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -92,6 +92,8 @@ static const R_CallMethodDef CallEntries[] = {
   {"dplyr_group_indices", (DL_FUNC)& dplyr_group_indices, 2},
   {"dplyr_group_keys", (DL_FUNC)& dplyr_group_keys, 1},
 
+  {"dplyr_promises_args", (DL_FUNC)& dplyr_promises_args, 2},
+
   {NULL, NULL, 0}
 };
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -92,7 +92,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"dplyr_group_indices", (DL_FUNC)& dplyr_group_indices, 2},
   {"dplyr_group_keys", (DL_FUNC)& dplyr_group_keys, 1},
 
-  {"dplyr_promises_args", (DL_FUNC)& dplyr_promises_args, 2},
+  {"dplyr_init_promises_formals", (DL_FUNC)& dplyr_init_promises_formals, 2},
 
   {NULL, NULL, 0}
 };

--- a/tests/testthat/test-arrange-errors.txt
+++ b/tests/testthat/test-arrange-errors.txt
@@ -3,8 +3,10 @@ duplicated column name
 ======================
 
 > tibble(x = 1, x = 1, .name_repair = "minimal") %>% arrange(x)
-Error: arrange() failed at implicit mutate() step. 
-x Can't bind data because some arguments have the same name
+# A tibble: 1 x 2
+      x     x
+  <dbl> <dbl>
+1     1     1
 
 
 error in mutate() step


### PR DESCRIPTION
This tries to limit the setup cost when dealing with data frames with many columns, in particular when creating the promises that are associated with each column. This uses formal arguments instead of `rlang::env_bind_lazy()`. 

For example with a 10000 columns data frame, i.e. this code: 

```r
library(dplyr, warn.conflicts = FALSE)
library(purrr)

idx <- 1:10000
df <- tibble(!!!set_names(map(idx, ~rnorm(1000)), paste0("x", idx)))

profvis::profvis(
  for(i in 1:100) summarise(df, mean(x1))
)
```

I'm getting: 

![image](https://user-images.githubusercontent.com/2625526/78694733-64b71300-78fd-11ea-8651-2ec0a17feaf9.png)

instead of this in master: 

![image](https://user-images.githubusercontent.com/2625526/78694800-7bf60080-78fd-11ea-9ab1-db2627833fde.png)

