### PR TITLE
lean more to evaluation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,8 @@ Imports:
     tibble (>= 2.1.3),
     tidyselect (>= 1.0.0),
     utils,
-    vctrs (>= 0.2.99.9010)
+    vctrs (>= 0.2.99.9010),
+    funs
 Suggests: 
     bench,
     broom,
@@ -69,4 +70,5 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.0
 Remotes:
     r-lib/rlang, 
-    r-lib/vctrs
+    r-lib/vctrs, 
+    r-lib/funs#50

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -139,16 +139,6 @@ summarise.rowwise_df <- function(.data, ...) {
   rowwise_df(out, group_vars(.data))
 }
 
-grouped_mean <- function(x, na.rm = FALSE) {
-  # TODO: rewrite in C++
-  if (na.rm) {
-    x <- map(x, function(.x) .x[!is.na(.x)])
-  }
-  res <- map(x, function(.x) mean.default(.x))
-
-  vec_c(!!!res)
-}
-
 hybrid_functions <- env(
   empty_env(),
   mean = function(x, ...) {
@@ -158,11 +148,11 @@ hybrid_functions <- env(
 
     stopifnot(is_symbol(call$x) && as_string(call$x) %in% vars)
     if (identical(names(call), c("", "x"))) {
-      grouped_mean(x, na.rm = TRUE)
+      funs::grouped_mean(x, na.rm = TRUE)
     } else if(identical(names(call), c("", "x", "na.rm"))) {
       na.rm <- call$na.rm
       stopifnot(is_scalar_logical(na.rm))
-      grouped_mean(x, na.rm = na.rm)
+      funs::grouped_mean(x, na.rm = na.rm)
     }
   },
   n = function() {


### PR DESCRIPTION
```r
data.frame(x = 1:10, y = 1:10) %>%
  summarise(z = mean(x))
```

The expression is `mean(x)`. 

This creates this function, with a special `hybrid_functions` as parent env: 

```r
fn <- function(x = mask$resolve("x"), y = mask$resolve("y")) mean(x)
```

which then eventually calls `hybrid_functions:::mean` : 

```r
mean = function(x, ...) {
    call <- match.call()
    mask <- peek_mask()
    vars <- mask$current_vars()

    stopifnot(is_symbol(call$x) && as_string(call$x) %in% vars)
    if (identical(names(call), c("", "x"))) {
      grouped_mean(x, na.rm = TRUE)
    } else if(identical(names(call), c("", "x", "na.rm"))) {
      na.rm <- call$na.rm
      stopifnot(is_scalar_logical(na.rm))
      grouped_mean(x, na.rm = na.rm)
    }
  }
```

that only ends up evaluating the `mask$resolve("x")` promise once actually calling `grouped_mean()`. 

`n` becomes: 

```r
n = function() {
    list_sizes(peek_mask()$get_rows())
  }
```

