### PR TITLE
dplyr_reconstruct() purges row names

### DIFF
--- a/R/generics.R
+++ b/R/generics.R
@@ -167,6 +167,9 @@ dplyr_reconstruct.data.frame <- function(data, template) {
   # `new_data_frame()` will add the `"data.frame"` class
   class <- setdiff(class(template), "data.frame")
   attr_new[["class"]] <- NULL
+  if (is.integer(attr_new[["row.names"]])) {
+    attr_new[["row.names"]] <- NULL
+  }
 
   size <- vec_size(data)
 

--- a/R/generics.R
+++ b/R/generics.R
@@ -167,9 +167,7 @@ dplyr_reconstruct.data.frame <- function(data, template) {
   # `new_data_frame()` will add the `"data.frame"` class
   class <- setdiff(class(template), "data.frame")
   attr_new[["class"]] <- NULL
-  if (is.integer(attr_new[["row.names"]])) {
-    attr_new[["row.names"]] <- NULL
-  }
+  attr_new[["row.names"]] <- .row_names_info(data, 0L)
 
   size <- vec_size(data)
 

--- a/tests/testthat/test-generics.R
+++ b/tests/testthat/test-generics.R
@@ -50,3 +50,35 @@ test_that("doesn't expand row names", {
 
   expect_equal(.row_names_info(out, 1), -10)
 })
+
+
+# dplyr_reconstruct -------------------------------------------------------
+
+test_that("classes are restored", {
+  expect_identical(
+    dplyr_reconstruct(tibble(), data.frame()),
+    data.frame()
+  )
+  expect_identical(
+    dplyr_reconstruct(tibble(), tibble()),
+    tibble()
+  )
+  expect_identical(
+    dplyr_reconstruct(tibble(), new_data_frame(class = "foo")),
+    new_data_frame(class = "foo")
+  )
+})
+
+test_that("attributes are kept", {
+  expect_identical(
+    dplyr_reconstruct(new_tibble(list(), nrow = 1, foo = 1), data.frame()),
+    new_data_frame(n = 1L, foo = 1)
+  )
+})
+
+test_that("row names", {
+  expect_identical(
+    .row_names_info(dplyr_reconstruct(vec_rbind(tibble(a = 1), tibble(a = 2)), tibble())),
+    .row_names_info(tibble(a = 0 + 1:2))
+  )
+})


### PR DESCRIPTION
Extracted from #5142. Otherwise row names may sneak in:

``` r
library(tidyverse)

bind_rows(tibble(a = 1), tibble(a = 2))
#> # A tibble: 2 x 1
#>       a
#> * <dbl>
#> 1     1
#> 2     2
```

<sup>Created on 2020-04-29 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

With this PR:

``` r
library(tidyverse)

bind_rows(tibble(a = 1), tibble(a = 2))
#> # A tibble: 2 x 1
#>       a
#>   <dbl>
#> 1     1
#> 2     2
```

<sup>Created on 2020-04-29 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

Should we unconditionally remove row names, given that `dplyr_reconstruct()` is implemented only for tibbles?