### PR TITLE
Simplify `dplyr_reconstruct()`

### DIFF
--- a/R/generics.R
+++ b/R/generics.R
@@ -158,19 +158,12 @@ dplyr_reconstruct <- function(data, template) {
 
 #' @export
 dplyr_reconstruct.data.frame <- function(data, template) {
-  attr_old <- attributes(template)
-  attr_new <- attributes(data)
+  attrs <- attributes(template)
 
-  to_copy <- setdiff(names(attr_old), c("class", "row.names", "names", ".drop"))
-  attr_new[to_copy] <- attr_old[to_copy]
+  attrs$names <- names(data)
+  attrs$row.names <- .row_names_info(data, type = 0L)
 
-  # `new_data_frame()` will add the `"data.frame"` class
-  class <- setdiff(class(template), "data.frame")
-  attr_new[["class"]] <- NULL
-
-  size <- vec_size(data)
-
-  data <- exec(new_data_frame, x = data, n = size, class = class, !!! attr_new)
+  attributes(data) <- attrs
 
   data
 }

--- a/tests/testthat/test-generics.R
+++ b/tests/testthat/test-generics.R
@@ -50,3 +50,38 @@ test_that("doesn't expand row names", {
 
   expect_equal(.row_names_info(out, 1), -10)
 })
+
+# dplyr_reconstruct -------------------------------------------------------
+
+test_that("classes are restored", {
+  expect_identical(
+    dplyr_reconstruct(tibble(), data.frame()),
+    data.frame()
+  )
+  expect_identical(
+    dplyr_reconstruct(tibble(), tibble()),
+    tibble()
+  )
+  expect_identical(
+    dplyr_reconstruct(tibble(), new_data_frame(class = "foo")),
+    new_data_frame(class = "foo")
+  )
+})
+
+test_that("attributes of `template` are kept", {
+  expect_identical(
+    dplyr_reconstruct(new_tibble(list(), nrow = 1), new_data_frame(foo = 1)),
+    new_data_frame(n = 1L, foo = 1)
+  )
+})
+
+test_that("row names", {
+  data <- vec_rbind(tibble(a = 1), tibble(a = 2))
+  template <- tibble()
+  expect <- tibble(a = c(1, 2))
+
+  expect_identical(
+    .row_names_info(dplyr_reconstruct(data, template), type = 0L),
+    .row_names_info(expect, type = 0L)
+  )
+})

--- a/tests/testthat/test-generics.R
+++ b/tests/testthat/test-generics.R
@@ -75,13 +75,18 @@ test_that("attributes of `template` are kept", {
   )
 })
 
-test_that("row names", {
+test_that("compact row names are retained", {
   data <- vec_rbind(tibble(a = 1), tibble(a = 2))
   template <- tibble()
+
+  x <- dplyr_reconstruct(data, template)
   expect <- tibble(a = c(1, 2))
 
+  expect_identical(x, expect)
+
+  # Explicitly ensure internal row name structure is identical
   expect_identical(
-    .row_names_info(dplyr_reconstruct(data, template), type = 0L),
+    .row_names_info(x, type = 0L),
     .row_names_info(expect, type = 0L)
   )
 })


### PR DESCRIPTION
Closes #5158 

This drastically simplifies `dplyr_reconstruct.data.frame()` by taking an approach similar to `dplyr_col_modify.data.frame()`, which just restores the attributes directly.

I've also pulled over the tests from #5158, but I think the attributes one might have been backwards. I think we care about keeping the attributes from `template`, not `data`.

The job of the data frame method of `dplyr_reconstruct()` is now very simple and well defined. It keeps all attributes of `template` except:

- `names` in case columns were modified
- `row.names` in case rows were modified

There was some code about the `.drop` attribute in the old `dplyr_reconstruct.data.frame()`, but I don't think it belonged there because we have a `grouped_df` method as well. It also wouldn't have worked right because the way to get to the drop attribute is through the group data of the data frame. It's not on the data frame directly.