### PR TITLE
Refactor `group_split()` to use `dplyr_row_slice()`

### DIFF
--- a/R/group_split.R
+++ b/R/group_split.R
@@ -112,15 +112,7 @@ group_split.grouped_df <- function(.tbl, ..., keep = TRUE) {
 group_split_impl <- function(data, grouped_data) {
   indices <- group_rows(grouped_data)
 
-  n <- length(indices)
-
-  out <- vector("list", n)
-
-  for (i in seq_len(n)) {
-    index <- indices[[i]]
-    out[[i]] <- dplyr_row_slice(data, index)
-  }
-
+  out <- map(indices, dplyr_row_slice, data = data)
   out <- new_list_of(out, ptype = vec_ptype(data))
 
   out

--- a/R/group_split.R
+++ b/R/group_split.R
@@ -72,11 +72,12 @@ group_split <- function(.tbl, ..., keep = TRUE) {
 
 #' @export
 group_split.data.frame <- function(.tbl, ..., keep = TRUE) {
-  if (dots_n(...)) {
-    group_split(group_by(.tbl, ...), keep = keep)
-  } else {
-    new_list_of(list(.tbl), ptype = .tbl[0L, ])
-  }
+  data <- .tbl
+  grouped_data <- group_by(.tbl, ...)
+
+  data <- group_split_col_slice(data, grouped_data, keep)
+
+  group_split_impl(data, grouped_data)
 }
 
 #' @export
@@ -87,10 +88,13 @@ group_split.rowwise_df <- function(.tbl, ..., keep = TRUE) {
   if (!missing(keep)) {
     warn("keep is ignored in group_split(<rowwise_df>)")
   }
-  new_list_of(
-    map(seq_len(nrow(.tbl)), vec_slice, x = .tbl),
-    ptype = vec_slice(.tbl, 0L)
-  )
+
+  grouped_data <- .tbl
+  data <- as_tibble(.tbl)
+
+  data <- group_split_col_slice(data, grouped_data, keep = TRUE)
+
+  group_split_impl(data, grouped_data)
 }
 
 #' @export
@@ -99,13 +103,42 @@ group_split.grouped_df <- function(.tbl, ..., keep = TRUE) {
     warn("... is ignored in group_split(<grouped_df>), please use group_by(..., .add = TRUE) %>% group_split()")
   }
 
-  data <- as_tibble(.tbl)
-  if (!isTRUE(keep)) {
-    data <- data[, setdiff(names(data), group_vars(.tbl))]
+  grouped_data <- .tbl
+  data <- as_tibble(grouped_data)
+
+  data <- group_split_col_slice(data, grouped_data, keep)
+
+  group_split_impl(data, grouped_data)
+}
+
+group_split_impl <- function(data, grouped_data) {
+  indices <- group_rows(grouped_data)
+
+  n <- length(indices)
+
+  out <- vector("list", n)
+
+  for (i in seq_len(n)) {
+    index <- indices[[i]]
+    out[[i]] <- dplyr_row_slice(data, index)
   }
 
-  new_list_of(
-    map(group_rows(.tbl), vec_slice, x = data),
-    ptype = vec_slice(data, 0L)
-  )
+  out <- new_list_of(out, ptype = vec_ptype(data))
+
+  out
+}
+
+group_split_col_slice <- function(data, grouped_data, keep) {
+  if (isTRUE(keep)) {
+    return(data)
+  }
+
+  remove <- group_vars(grouped_data)
+
+  cols <- names(data)
+  cols <- setdiff(cols, remove)
+
+  data <- data[cols]
+
+  data
 }

--- a/R/group_split.R
+++ b/R/group_split.R
@@ -75,7 +75,10 @@ group_split.data.frame <- function(.tbl, ..., keep = TRUE) {
   data <- .tbl
   grouped_data <- group_by(.tbl, ...)
 
-  data <- group_split_col_slice(data, grouped_data, keep)
+  if (!keep) {
+    cols <- group_vars(grouped_data)
+    data <- drop_cols(data, cols)
+  }
 
   group_split_impl(data, grouped_data)
 }
@@ -104,7 +107,10 @@ group_split.grouped_df <- function(.tbl, ..., keep = TRUE) {
   grouped_data <- .tbl
   data <- as_tibble(grouped_data)
 
-  data <- group_split_col_slice(data, grouped_data, keep)
+  if (!keep) {
+    cols <- group_vars(grouped_data)
+    data <- drop_cols(data, cols)
+  }
 
   group_split_impl(data, grouped_data)
 }
@@ -118,17 +124,8 @@ group_split_impl <- function(data, grouped_data) {
   out
 }
 
-group_split_col_slice <- function(data, grouped_data, keep) {
-  if (isTRUE(keep)) {
-    return(data)
-  }
-
-  remove <- group_vars(grouped_data)
-
-  cols <- names(data)
-  cols <- setdiff(cols, remove)
-
-  data <- data[cols]
-
-  data
+drop_cols <- function(data, cols) {
+  keep <- names(data)
+  keep <- setdiff(keep, cols)
+  data[keep]
 }

--- a/R/group_split.R
+++ b/R/group_split.R
@@ -92,8 +92,6 @@ group_split.rowwise_df <- function(.tbl, ..., keep = TRUE) {
   grouped_data <- .tbl
   data <- as_tibble(.tbl)
 
-  data <- group_split_col_slice(data, grouped_data, keep = TRUE)
-
   group_split_impl(data, grouped_data)
 }
 

--- a/tests/testthat/helper-s3.R
+++ b/tests/testthat/helper-s3.R
@@ -1,0 +1,3 @@
+local_methods <- function(..., .frame = caller_env()) {
+  local_bindings(..., .env = global_env(), .frame = .frame)
+}

--- a/tests/testthat/test-group_split.R
+++ b/tests/testthat/test-group_split.R
@@ -80,3 +80,25 @@ test_that("group_split() respects .drop", {
     group_split(f, .drop = TRUE)
   expect_identical(length(chunks), 1L)
 })
+
+test_that("group_split() on a bare data frame returns bare data frames", {
+  df <- data.frame(x = 1:2)
+  expect <- list_of(vec_slice(df, 1), vec_slice(df, 2))
+  expect_identical(group_split(df, x), expect)
+})
+
+test_that("group_split() on a grouped df returns a list of tibbles", {
+  df <- tibble(x = 1:2)
+  gdf <- group_by(df, x)
+  expect <- list_of(vec_slice(df, 1), vec_slice(df, 2))
+  expect_identical(group_split(gdf), expect)
+})
+
+test_that("group_split() on a rowwise df returns a list of tibbles", {
+  df <- tibble(x = 1:2)
+  rdf <- rowwise(df)
+  expect <- list_of(vec_slice(df, 1), vec_slice(df, 2))
+  expect_identical(group_split(rdf), expect)
+})
+
+

--- a/tests/testthat/test-group_split.R
+++ b/tests/testthat/test-group_split.R
@@ -3,28 +3,28 @@ context("group_split")
 test_that("group_split() keeps the grouping variables by default", {
   tbl <- tibble(x = 1:4, g = factor(rep(c("a", "b"), each = 2)))
   res <- group_split(tbl, g)
-  expect_equivalent(res, list(tbl[1:2,], tbl[3:4,]))
+  expect_identical(res, list_of(tbl[1:2,], tbl[3:4,]))
   expect_is(res, "vctrs_list_of")
-  expect_equal(attr(res, "ptype"), tibble(x = integer(), g = factor(levels = c("a", "b"))))
+  expect_identical(attr(res, "ptype"), tibble(x = integer(), g = factor(levels = c("a", "b"))))
 })
 
 test_that("group_split() can discard the grouping variables with keep = FALSE", {
   tbl <- tibble(x = 1:4, g = factor(rep(c("a", "b"), each = 2)))
   res <- group_split(tbl, g, keep = FALSE)
-  expect_equivalent(res, list(tbl[1:2, 1, drop = FALSE], tbl[3:4,1, drop = FALSE]))
+  expect_identical(res, list_of(tbl[1:2, 1, drop = FALSE], tbl[3:4,1, drop = FALSE]))
   expect_is(res, "vctrs_list_of")
-  expect_equal(attr(res, "ptype"), tibble(x = integer()))
+  expect_identical(attr(res, "ptype"), tibble(x = integer()))
 })
 
 test_that("group_split() respects empty groups", {
   tbl <- tibble(x = 1:4, g = factor(rep(c("a", "b"), each = 2), levels = c("a", "b", "c")))
   res <- group_split(tbl, g)
-  expect_equivalent(res, list(tbl[1:2,], tbl[3:4,]))
+  expect_identical(res, list_of(tbl[1:2,], tbl[3:4,]))
   expect_is(res, "vctrs_list_of")
-  expect_equal(attr(res, "ptype"), tibble(x = integer(), g = factor(levels = c("a", "b", "c"))))
+  expect_identical(attr(res, "ptype"), tibble(x = integer(), g = factor(levels = c("a", "b", "c"))))
 
   res <- group_split(tbl, g, .drop = FALSE)
-  expect_equivalent(res, list(tbl[1:2,], tbl[3:4,], tbl[integer(), ]))
+  expect_identical(res, list_of(tbl[1:2,], tbl[3:4,], tbl[integer(), ]))
 })
 
 test_that("group_split.grouped_df() warns about ...", {
@@ -36,7 +36,9 @@ test_that("group_split.rowwise_df() warns about ...", {
 })
 
 test_that("group_split.grouped_df() works", {
-  expect_equal(
+  iris <- as_tibble(iris)
+
+  expect_identical(
     iris %>% group_by(Species) %>% group_split(),
     iris %>% group_split(Species)
   )
@@ -46,20 +48,20 @@ test_that("group_split / bind_rows round trip", {
   setosa <- iris %>% filter(Species == "setosa") %>% as_tibble()
 
   chunks <- setosa %>% group_split(Species)
-  expect_equal(length(chunks), 1L)
-  expect_equal(bind_rows(chunks), setosa)
+  expect_identical(length(chunks), 1L)
+  expect_identical(bind_rows(chunks), setosa)
 
   chunks <- setosa %>% group_split(Species, .drop = FALSE)
-  expect_equal(length(chunks), 3L)
-  expect_equal(bind_rows(chunks), setosa)
+  expect_identical(length(chunks), 3L)
+  expect_identical(bind_rows(chunks), setosa)
 })
 
 test_that("group_split() works if no grouping column", {
-  expect_equivalent(group_split(iris), list(iris))
+  expect_identical(group_split(iris), list_of(iris))
 })
 
 test_that("group_split(keep=FALSE) does not try to remove virtual grouping columns (#4045)", {
-  iris3 <- iris[1:3,]
+  iris3 <- as_tibble(iris[1:3,])
   rows <- list(c(1L, 3L, 2L), c(3L, 2L, 3L))
   df <- new_grouped_df(
     iris3,
@@ -67,14 +69,14 @@ test_that("group_split(keep=FALSE) does not try to remove virtual grouping colum
   )
   res <- group_split(df, keep = FALSE)
 
-  expect_equivalent(
+  expect_identical(
     res,
-    list(iris3[rows[[1L]],], iris3[rows[[2L]],])
+    list_of(iris3[rows[[1L]],], iris3[rows[[2L]],])
     )
 })
 
 test_that("group_split() respects .drop", {
   chunks <- tibble(f = factor("b", levels = c("a", "b", "c"))) %>%
     group_split(f, .drop = TRUE)
-  expect_equal(length(chunks), 1L)
+  expect_identical(length(chunks), 1L)
 })

--- a/tests/testthat/test-group_split.R
+++ b/tests/testthat/test-group_split.R
@@ -101,4 +101,29 @@ test_that("group_split() on a rowwise df returns a list of tibbles", {
   expect_identical(group_split(rdf), expect)
 })
 
+test_that("group_split() internally uses dplyr_row_slice()", {
+  df <- new_tibble(list(x = c(1, 2, 2)), nrow = 3L, class = "foo_df")
+
+  local_methods(
+    dplyr_row_slice.foo_df = function(x, i, ...) {
+      signal("", class = "dplyr_row_slice_called")
+      NextMethod()
+    }
+  )
+
+  expect_condition(group_split(df), class = "dplyr_row_slice_called")
+})
+
+test_that("group_split(keep = FALSE) internally uses [", {
+  df <- new_tibble(list(x = c(1, 2)), nrow = 2L, class = "foo_df")
+
+  local_methods(
+    `[.foo_df` = function(x, i, ...) {
+      signal("", class = "[_called")
+      NextMethod()
+    }
+  )
+
+  expect_condition(group_split(df, x, keep = FALSE), class = "[_called")
+})
 


### PR DESCRIPTION
Closes #5165 

`group_split()` has been refactored to accomplish a few goals:

- It now uses `dplyr_row_slice()` to split with. Previously this was `vec_slice()`.

- There was a case where we used `[, i]` rather than 1D `[i]` when `keep = FALSE`. This has been fixed.

- group-splitting a rowwise data frame used to return a list-of rowwise data frames. I believe this is inconsistent, and it should just return a list of tibbles, like with grouped-dfs. The change has been made to make this more consistent.

- Methods for `data.frame`, `grouped_df`, and `rowwise_df` all now share the same implementation

@earowang, this makes `group_split(pedestrian, Sensor)` work since you have a `dplyr_row_slice()` method. You will still need a `group_split.grouped_ts()` method. It should just have to call `NextMethod()` to get the `group_split.grouped_df()` behavior, and then map over the resulting list of tibbles, coercing them to tbl_ts if applicable. I don't think we can do much better here. Adding that method should fix `nest_by()` automatically.