### PR TITLE
Simplify `group_split()` using `ungroup()`, not `as_tibble()`

### DIFF
--- a/tests/testthat/helper-s3.R
+++ b/tests/testthat/helper-s3.R
@@ -1,3 +1,22 @@
 local_methods <- function(..., .frame = caller_env()) {
   local_bindings(..., .env = global_env(), .frame = .frame)
 }
+
+local_foo_df <- function(frame = caller_env()) {
+  local_methods(.frame = frame,
+    group_by.foo_df = function(.data, ...) {
+      out <- NextMethod()
+      if (missing(...)) {
+        class(out) <- c("foo_df", class(out))
+      } else {
+        class(out) <- c("grouped_foo_df", class(out))
+      }
+      out
+    },
+    ungroup.grouped_foo_df = function(x, ...) {
+      out <- NextMethod()
+      class(out) <- c("foo_df", class(out))
+      out
+    }
+  )
+}

--- a/tests/testthat/test-group_map.R
+++ b/tests/testthat/test-group_map.R
@@ -28,7 +28,7 @@ test_that("group_map() can return arbitrary objects", {
 test_that("group_map() works on ungrouped data frames (#4067)", {
   expect_identical(
     group_map(mtcars, ~ head(.x, 2L)),
-    list(head(mtcars, 2L))
+    list(head(as_tibble(mtcars), 2L))
   )
 })
 


### PR DESCRIPTION
Follow up to #5167 

I have since realized that `group_split()` can be implemented in such a way that tsibble likely won't need to supply any methods for it.

The key was to switch a usage of `as_tibble()` for `ungroup()` in `group_split.grouped_df()`. Ungrouping is generic, so when a `grouped_ts` is ungrouped, it can correctly be dropped down to a `tbl_ts`. The previous usage of `as_tibble()` was incorrectly forcing this to be a bare tibble.

So now if tibble subclasses does both of these things, then `group_split()` works out of the box.
- Implement a `group_by.<tbl_subcls>()` method that returns a `<grouped_subcls>`
- Implement a `ungroup.<grouped_subcls>()` method that returns a `<tbl_subcls>`

tsibble does both of these.

---

This also unifies the code a bit more. We still can't make `group_split.data.frame()` go through `group_split.grouped_df()` though. If `gdf <- group_by(df, ...)` has empty dots, we get an ungrouped data frame back and by then immediately calling `group_split(gdf)` we would get stuck in an infinite loop.

---

Here is tsibble working out of the box. This is pinned to the commit before @earowang added her own `group_split.grouped_ts` method. @earowang you probably won't need that anymore after this, unless the behavior of `keep = FALSE` and `[.tbl_ts` is problematic.

<details>

```r
library(dplyr, warn.conflicts = FALSE)
library(tsibble)
# devtools::install_github("tidyverts/tsibble", ref = "41d9e910447d3f8313241396eb3ee554fcede9d0")

pedestrian %>%
  group_split(Sensor) %>%
  .[[1]] %>%
  head(2)
#> # A tsibble: 2 x 5 [1h] <Australia/Melbourne>
#> # Key:       Sensor [1]
#>   Sensor         Date_Time           Date        Time Count
#>   <chr>          <dttm>              <date>     <int> <int>
#> 1 Birrarung Marr 2015-01-01 00:00:00 2015-01-01     0  1630
#> 2 Birrarung Marr 2015-01-01 01:00:00 2015-01-01     1   826

# this happens because of tsibble's `[` method
# a custom `group_split` method would be required to fix it
pedestrian %>%
  group_split(Sensor, keep = FALSE) %>%
  .[[1]] %>%
  head(2)
#> # A tibble: 2 x 4
#>   Date_Time           Date        Time Count
#>   <dttm>              <date>     <int> <int>
#> 1 2015-01-01 00:00:00 2015-01-01     0  1630
#> 2 2015-01-01 01:00:00 2015-01-01     1   826

pedestrian %>%
  group_by(Sensor) %>%
  group_split() %>%
  .[[1]] %>%
  head(2)
#> # A tsibble: 2 x 5 [1h] <Australia/Melbourne>
#> # Key:       Sensor [1]
#>   Sensor         Date_Time           Date        Time Count
#>   <chr>          <dttm>              <date>     <int> <int>
#> 1 Birrarung Marr 2015-01-01 00:00:00 2015-01-01     0  1630
#> 2 Birrarung Marr 2015-01-01 01:00:00 2015-01-01     1   826

pedestrian %>%
  nest_by(Sensor, .keep = TRUE)
#> # A tibble: 4 x 2
#> # Rowwise:  Sensor
#>   Sensor                                      data
#>   <chr>                         <list<tbl_ts[,5]>>
#> 1 Birrarung Marr                      [14,566 × 5]
#> 2 Bourke Street Mall (North)          [16,414 × 5]
#> 3 QV Market-Elizabeth St (West)       [17,518 × 5]
#> 4 Southern Cross Station              [17,539 × 5]
```

</details>