### PR TITLE
lead(), lag(): cast default to common type rather than to type of x.

### DIFF
--- a/R/lead-lag.R
+++ b/R/lead-lag.R
@@ -63,7 +63,8 @@ lag <- function(x, n = 1L, default = NA, order_by = NULL, ...) {
   xlen <- vec_size(x)
   n <- pmin(n, xlen)
 
-  default <- vec_cast(default, x, x_arg = "default", to_arg = "x")
+  default <- vec_cast(default, vec_ptype2(x, default, x_arg = "default", y_arg = "x"))
+
   vec_c(
     vec_rep(default, n),
     vec_slice(x, seq_len(xlen - n))
@@ -87,7 +88,7 @@ lead <- function(x, n = 1L, default = NA, order_by = NULL, ...) {
   xlen <- vec_size(x)
   n <- pmin(n, xlen)
 
-  default <- vec_cast(default, x, x_arg = "default", to_arg = "x")
+  default <- vec_cast(default, vec_ptype2(x, default, x_arg = "default", y_arg = "x"))
   vec_c(
     vec_slice(x, -seq_len(n)),
     vec_rep(default, n)

--- a/R/lead-lag.R
+++ b/R/lead-lag.R
@@ -63,11 +63,11 @@ lag <- function(x, n = 1L, default = NA, order_by = NULL, ...) {
   xlen <- vec_size(x)
   n <- pmin(n, xlen)
 
-  default <- vec_cast(default, vec_ptype2(x, default, x_arg = "default", y_arg = "x"))
+  inputs <- vec_cast_common(default = default, x = x)
 
   vec_c(
-    vec_rep(default, n),
-    vec_slice(x, seq_len(xlen - n))
+    vec_rep(inputs$default, n),
+    vec_slice(inputs$x, seq_len(xlen - n))
   )
 }
 
@@ -88,9 +88,9 @@ lead <- function(x, n = 1L, default = NA, order_by = NULL, ...) {
   xlen <- vec_size(x)
   n <- pmin(n, xlen)
 
-  default <- vec_cast(default, vec_ptype2(x, default, x_arg = "default", y_arg = "x"))
+  inputs <- vec_cast_common(default = default, x = x)
   vec_c(
-    vec_slice(x, -seq_len(n)),
-    vec_rep(default, n)
+    vec_slice(inputs$x, -seq_len(n)),
+    vec_rep(inputs$default, n)
   )
 }

--- a/tests/testthat/test-lead-lag-errors.txt
+++ b/tests/testthat/test-lead-lag-errors.txt
@@ -26,5 +26,5 @@ incompatible default
 ====================
 
 > lag(c("1", "2", "3"), default = FALSE)
-Error: Can't combine `default` <character> and `x` <logical>.
+Error: Can't combine `default` <logical> and `x` <character>.
 

--- a/tests/testthat/test-lead-lag-errors.txt
+++ b/tests/testthat/test-lead-lag-errors.txt
@@ -26,5 +26,5 @@ incompatible default
 ====================
 
 > lag(c("1", "2", "3"), default = FALSE)
-Error: Can't convert `default` <logical> to `x` <character>.
+Error: Can't combine `default` <character> and `x` <logical>.
 


### PR DESCRIPTION
closes https://github.com/bergsmat/wrangle/pull/1

this does fix `nonmemica`

I'm not sure this should also `vec_cast(x)` ? 