### PR TITLE
across() and c_across() when used out of dplyr context

### DIFF
--- a/R/across.R
+++ b/R/across.R
@@ -158,7 +158,7 @@ c_across <- function(cols = everything()) {
 # to do any required "set up" work (like the `eval_select()` call) a single
 # time per top-level call, rather than once per group.
 across_setup <- function(cols, fns, names, key) {
-  mask <- peek_mask(fun = "across()")
+  mask <- peek_mask("across()")
 
   value <- mask$across_cache_get(key)
   if (!is.null(value)) {
@@ -220,7 +220,7 @@ across_setup <- function(cols, fns, names, key) {
 }
 
 c_across_setup <- function(cols, key) {
-  mask <- peek_mask(fun = "c_across()")
+  mask <- peek_mask("c_across()")
 
   value <- mask$across_cache_get(key)
   if (!is.null(value)) {

--- a/R/across.R
+++ b/R/across.R
@@ -158,7 +158,7 @@ c_across <- function(cols = everything()) {
 # to do any required "set up" work (like the `eval_select()` call) a single
 # time per top-level call, rather than once per group.
 across_setup <- function(cols, fns, names, key) {
-  mask <- peek_mask()
+  mask <- peek_mask(fun = "across()")
 
   value <- mask$across_cache_get(key)
   if (!is.null(value)) {
@@ -220,7 +220,7 @@ across_setup <- function(cols, fns, names, key) {
 }
 
 c_across_setup <- function(cols, key) {
-  mask <- peek_mask()
+  mask <- peek_mask(fun = "c_across()")
 
   value <- mask$across_cache_get(key)
   if (!is.null(value)) {

--- a/R/context.R
+++ b/R/context.R
@@ -112,7 +112,10 @@ context_peek_bare <- function(name) {
 }
 context_peek <- function(name, fun, location = "dplyr verbs") {
   context_peek_bare(name) %||%
-    abort(glue("{fun} must only be used inside {location}"))
+    abort(glue("{fun} must only be used inside {location}"),
+      class = "dplyr:::context_peek_error",
+      name = name, fun = fun, location = location
+    )
 }
 context_local <- function(name, value, frame = caller_env()) {
   old <- context_poke(name, value)

--- a/R/context.R
+++ b/R/context.R
@@ -112,10 +112,7 @@ context_peek_bare <- function(name) {
 }
 context_peek <- function(name, fun, location = "dplyr verbs") {
   context_peek_bare(name) %||%
-    abort(glue("{fun} must only be used inside {location}"),
-      class = "dplyr:::context_peek_error",
-      name = name, fun = fun, location = location
-    )
+    abort(glue("{fun} must only be used inside {location}"))
 }
 context_local <- function(name, value, frame = caller_env()) {
   old <- context_poke(name, value)

--- a/tests/testthat/test-across-errors.txt
+++ b/tests/testthat/test-across-errors.txt
@@ -3,3 +3,13 @@ Error: Problem with `summarise()` input `res`.
 x `.fns` must be NULL, a function, a formula, or a list of functions/formulas
 i Input `res` is `across(is.numeric, 42)`.
 
+
+outside context
+===============
+
+> across()
+Error: across() must only be used inside dplyr verbs
+
+> c_across()
+Error: c_across() must only be used inside dplyr verbs
+

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -111,6 +111,10 @@ test_that("across() gives meaningful messages", {
   verify_output(test_path("test-across-errors.txt"), {
     tibble(x = 1) %>%
       summarise(res = across(is.numeric, 42))
+
+    "# outside context"
+    across()
+    c_across()
   })
 })
 


### PR DESCRIPTION
closes #5180

``` r
library(dplyr, warn.conflicts = FALSE)
across()
#> Error: across() must only be used inside dplyr verbs
c_across()
#> Error: c_across() must only be used inside dplyr verbs
```

<sup>Created on 2020-05-05 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>