### PR TITLE
vec_c(.name_spec = zap())

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,7 @@ Imports:
     tibble (>= 2.1.3),
     tidyselect (>= 1.0.0),
     utils,
-    vctrs (>= 0.2.99.9010)
+    vctrs (>= 0.2.99.9011)
 Suggests: 
     bench,
     broom,

--- a/R/across.R
+++ b/R/across.R
@@ -137,19 +137,10 @@ c_across <- function(cols = everything()) {
   key <- key_deparse(sys.call())
   vars <- c_across_setup({{ cols }}, key = key)
 
-  mask <- peek_mask()
+  mask <- peek_mask("c_across()")
 
   cols <- mask$current_cols(vars)
-
-  # TODO: adapt after: https://github.com/r-lib/vctrs/issues/232
-  tryCatch(
-    vec_c(!!!unname(cols)),
-    error = function(e) {
-      # when combining fails, do it again with the names
-      # to get a more useful error message
-      vec_c(!!!cols)
-    }
-  )
+  vec_c(!!!cols, .name_spec = zap())
 }
 
 # TODO: The usage of a cache in `across_setup()` and `c_across_setup()` is a stopgap solution, and


### PR DESCRIPTION
simplified `c_across()` thanks to https://github.com/r-lib/vctrs/pull/1091