### PR TITLE
tally() not using .groups= 

### DIFF
--- a/R/count-tally.R
+++ b/R/count-tally.R
@@ -87,7 +87,7 @@ tally <- function(x, wt = NULL, sort = FALSE, name = NULL) {
   out <- local({
     old.options <- options(dplyr.summarise.inform = FALSE)
     on.exit(options(old.options))
-    ungroup(summarise(x, !!name := !!n))
+    summarise(x, !!name := !!n)
   })
 
   if (sort) {

--- a/R/count-tally.R
+++ b/R/count-tally.R
@@ -83,8 +83,12 @@ count <- function(x, ..., wt = NULL, sort = FALSE, name = NULL, .drop = group_by
 tally <- function(x, wt = NULL, sort = FALSE, name = NULL) {
   n <- tally_n(x, {{ wt }})
   name <- check_name(x, name)
-  out <- suppressMessages(ungroup(summarise(x, !!name := !!n)), class = "dplyr:::summarise_groups_information")
 
+  out <- local({
+    old.options <- options(dplyr.summarise.inform = FALSE)
+    on.exit(options(old.options))
+    ungroup(summarise(x, !!name := !!n))
+  })
 
   if (sort) {
     arrange(out, desc(!!sym(name)))

--- a/R/count-tally.R
+++ b/R/count-tally.R
@@ -83,7 +83,8 @@ count <- function(x, ..., wt = NULL, sort = FALSE, name = NULL, .drop = group_by
 tally <- function(x, wt = NULL, sort = FALSE, name = NULL) {
   n <- tally_n(x, {{ wt }})
   name <- check_name(x, name)
-  out <- summarise(x, !!name := !!n, .groups = "drop")
+  out <- suppressMessages(ungroup(summarise(x, !!name := !!n)), class = "dplyr:::summarise_groups_information")
+
 
   if (sort) {
     arrange(out, desc(!!sym(name)))

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -150,19 +150,19 @@ summarise.grouped_df <- function(.data, ..., .groups = NULL) {
       if (verbose) {
         inform(glue('`summarise()` regrouping by {new_groups} (override with `.groups` argument)',
           new_groups = glue_collapse(paste0("'", group_vars[-n], "'"), sep = ", ")
-        ), class = "dplyr:::summarise_groups_information")
+        ))
       }
       out <- grouped_df(out, group_vars[-n], group_by_drop_default(.data))
     } else {
       if (verbose) {
-        inform('`summarise()` ungrouping (override with `.groups` argument)', class = "dplyr:::summarise_groups_information")
+        inform('`summarise()` ungrouping (override with `.groups` argument)')
       }
     }
   } else if (identical(.groups, "keep")) {
     if (verbose) {
       inform(glue('`summarise()` regrouping by {new_groups} (override with `.groups` argument)',
         new_groups = glue_collapse(paste0("'", group_vars, "'"), sep = ", ")
-      ), class = "dplyr:::summarise_groups_information")
+      ))
     }
     out <- grouped_df(out, group_vars, group_by_drop_default(.data))
   } else if (identical(.groups, "rowwise")) {
@@ -186,7 +186,7 @@ summarise.rowwise_df <- function(.data, ..., .groups = NULL) {
   group_vars <- group_vars(.data)
   if (is.null(.groups) || identical(.groups, "rowwise") || identical(.groups, "keep")) {
     if (verbose) {
-      inform("summarise() regrouping by rows (override with `.groups` argument)", class = "dplyr:::summarise_groups_information")
+      inform("summarise() regrouping by rows (override with `.groups` argument)")
     }
     out <- rowwise_df(out, group_vars)
   } else if (!identical(.groups, "drop")) {

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -150,19 +150,19 @@ summarise.grouped_df <- function(.data, ..., .groups = NULL) {
       if (verbose) {
         inform(glue('`summarise()` regrouping by {new_groups} (override with `.groups` argument)',
           new_groups = glue_collapse(paste0("'", group_vars[-n], "'"), sep = ", ")
-        ))
+        ), class = "dplyr:::summarise_groups_information")
       }
       out <- grouped_df(out, group_vars[-n], group_by_drop_default(.data))
     } else {
       if (verbose) {
-        inform('`summarise()` ungrouping (override with `.groups` argument)')
+        inform('`summarise()` ungrouping (override with `.groups` argument)', class = "dplyr:::summarise_groups_information")
       }
     }
   } else if (identical(.groups, "keep")) {
     if (verbose) {
       inform(glue('`summarise()` regrouping by {new_groups} (override with `.groups` argument)',
         new_groups = glue_collapse(paste0("'", group_vars, "'"), sep = ", ")
-      ))
+      ), class = "dplyr:::summarise_groups_information")
     }
     out <- grouped_df(out, group_vars, group_by_drop_default(.data))
   } else if (identical(.groups, "rowwise")) {
@@ -186,7 +186,7 @@ summarise.rowwise_df <- function(.data, ..., .groups = NULL) {
   group_vars <- group_vars(.data)
   if (is.null(.groups) || identical(.groups, "rowwise") || identical(.groups, "keep")) {
     if (verbose) {
-      inform("summarise() regrouping by rows (override with `.groups` argument)")
+      inform("summarise() regrouping by rows (override with `.groups` argument)", class = "dplyr:::summarise_groups_information")
     }
     out <- rowwise_df(out, group_vars)
   } else if (!identical(.groups, "drop")) {

--- a/tests/testthat/test-bind-errors.txt
+++ b/tests/testthat/test-bind-errors.txt
@@ -56,8 +56,8 @@ incompatible size
 =================
 
 > bind_cols(a = 1:2, mtcars)
-Error: No common size for `a`, size 2, and `..2`, size 32.
+Error: Can't recycle `a` (size 2) to match `..2` (size 32).
 
 > bind_cols(mtcars, a = 1:3)
-Error: No common size for `..1`, size 32, and `a`, size 3.
+Error: Can't recycle `..1` (size 32) to match `a` (size 3).
 

--- a/tests/testthat/test-count-tally.r
+++ b/tests/testthat/test-count-tally.r
@@ -92,6 +92,15 @@ test_that("tally uses variable named n as default wt.", {
   expect_named(res, "nn")
 })
 
+test_that("tally() does .groups = 'drop_last' (#5199) ", {
+  res <- expect_message(
+    data.frame(x = 1, y = 2, z = 3) %>%
+      group_by(x, y) %>%
+      tally(wt = z),
+    NA)
+  expect_equal(group_vars(res), "x")
+})
+
 # add_tally ---------------------------------------------------------------
 
 test_that("can add tallies of a variable", {

--- a/tests/testthat/test-count-tally.r
+++ b/tests/testthat/test-count-tally.r
@@ -49,7 +49,6 @@ test_that("count() preserves with .drop", {
 })
 
 test_that("works with dbplyr", {
-  skip("until dbplyr knows about .groups=")
   db <- dbplyr::memdb_frame(x = c(1, 1, 1, 2, 2))
   df1 <- db %>% count(x) %>% as_tibble()
   expect_equal(df1, tibble(x = c(1, 2), n = c(3, 2)))


### PR DESCRIPTION
summarise() implementations might not know about `.groups=` yet. 

closes #5200

``` r
library(dplyr, warn.conflicts = FALSE)
con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
copy_to(con, mtcars)
DBI::dbListTables(con)
#> [1] "mtcars"       "sqlite_stat1" "sqlite_stat4"
con %>% 
  tbl("mtcars") %>% 
  count()
#> # Source:   lazy query [?? x 1]
#> # Database: sqlite 3.30.1 [:memory:]
#>       n
#>   <int>
#> 1    32
```

<sup>Created on 2020-05-07 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>