### PR TITLE
Ensure that `arrange()` always calls `dplyr_row_slice()`

### DIFF
--- a/R/arrange.R
+++ b/R/arrange.R
@@ -72,9 +72,6 @@ arrange <- function(.data, ..., .by_group = FALSE) {
 #' @export
 arrange.data.frame <- function(.data, ..., .by_group = FALSE) {
   dots <- enquos(...)
-  if (length(dots) == 0L) {
-    return(.data)
-  }
 
   if (.by_group) {
     dots <- c(quos(!!!groups(.data)), dots)
@@ -87,6 +84,10 @@ arrange.data.frame <- function(.data, ..., .by_group = FALSE) {
 # Helpers -----------------------------------------------------------------
 
 arrange_rows <- function(.data, dots) {
+  if (length(dots) == 0L) {
+    out <- seq_len(nrow(.data))
+    return(out)
+  }
 
   directions <- map_chr(dots, function(quosure) {
     if(quo_is_call(quosure, "desc")) "desc" else "asc"

--- a/tests/testthat/test-arrange.r
+++ b/tests/testthat/test-arrange.r
@@ -5,11 +5,11 @@ test_that("empty arrange() returns input", {
   df <- tibble(x = 1:10, y = 1:10)
   gf <- group_by(df, x)
 
-  expect_reference(arrange(df), df)
-  expect_reference(arrange(gf), gf)
+  expect_identical(arrange(df), df)
+  expect_identical(arrange(gf), gf)
 
-  expect_reference(arrange(df, !!!list()), df)
-  expect_reference(arrange(gf, !!!list()), gf)
+  expect_identical(arrange(df, !!!list()), df)
+  expect_identical(arrange(gf, !!!list()), gf)
 })
 
 test_that("can sort empty data frame", {
@@ -133,4 +133,20 @@ test_that("arrange() supports across() (#4679)", {
     df %>% arrange(across(y)),
     df %>% arrange(y)
   )
+})
+
+test_that("arrange() with empty dots still calls dplyr_row_slice()", {
+  tbl <- new_tibble(list(x = 1), nrow = 1L)
+  foo <- structure(tbl, class = c("foo_df", class(tbl)))
+
+  local_methods(
+    # `foo_df` always loses class when row slicing
+    dplyr_row_slice.foo_df = function(data, i, ...) {
+      out <- NextMethod()
+      new_tibble(out, nrow = nrow(out))
+    }
+  )
+
+  expect_s3_class(arrange(foo), class(tbl), exact = TRUE)
+  expect_s3_class(arrange(foo, x), class(tbl), exact = TRUE)
 })


### PR DESCRIPTION
I think that for consistency, `arrange.data.frame()` should always call `dplyr_row_slice()` even if there are no `...`.

I have a `dplyr_row_slice()` method that unconditionally removes the tibble subclass. If `arrange()` doesn't always call `dplyr_row_slice()`, then `arrange(<subtbl>)` vs `arrange(<subtbl>, col)` give inconsistently classed results

It is a sufficiently rare edge case that I don't think the performance cost of doing a row slice matters much here.