### PR TITLE
Bring back setOldClass() for ident

### DIFF
--- a/R/deprec-dbi.R
+++ b/R/deprec-dbi.R
@@ -1,3 +1,7 @@
+# Fix S4 dispatch in dbplyr
+setOldClass(c("sql", "character"))
+setOldClass(c("ident", "sql", "character"))
+
 #' Source for database backends
 #'
 #' @description


### PR DESCRIPTION
This solves the short-term problem. Omitting the calls for dplyr 1.0.0 means breakages for downstream packages that rely on this.

These calls definitely belong in dbplyr in the long run. It would be better to release a dbplyr update before dplyr 1.0.0.