### PR TITLE
stop_dplyr() gains a parent=

### DIFF
--- a/R/conditions.R
+++ b/R/conditions.R
@@ -34,7 +34,7 @@ or_1 <- function(x) {
 
 # Common ------------------------------------------------------------------
 
-stop_dplyr <- function(.index, dots, fn, problem, ..., .dot_data = FALSE, .show_group_details = TRUE) {
+stop_dplyr <- function(.index, dots, fn, problem, ..., .dot_data = FALSE, .show_group_details = TRUE, parent = NULL) {
   error_name <- arg_name(dots, .index)
   error_expression  <- if (.dot_data) {
     deparse(quo_get_expr(dots[[.index]]))
@@ -61,7 +61,8 @@ stop_dplyr <- function(.index, dots, fn, problem, ..., .dot_data = FALSE, .show_
     bullets,
     class = "dplyr_error",
     error_name = error_name, error_expression = error_expression,
-    index = .index, dots = dots, fn = fn
+    index = .index, dots = dots, fn = fn,
+    parent = parent
   )
 }
 

--- a/R/filter.R
+++ b/R/filter.R
@@ -123,9 +123,7 @@ filter_rows <- function(.data, ...) {
   tryCatch(
     mask$eval_all_filter(dots, env_filter),
     simpleError = function(e) {
-      stop_dplyr(env_filter$current_expression, dots, fn = "filter",
-        problem = conditionMessage(e)
-      )
+      stop_dplyr(env_filter$current_expression, dots, fn = "filter", problem = conditionMessage(e))
     }
   )
 }

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -329,7 +329,7 @@ mutate_cols <- function(.data, ...) {
     } else if(inherits(e, "dplyr:::error_mutate_incompatible_combine")) {
       stop_combine(e$parent, index = i, dots = dots, fn = "mutate")
     } else {
-      stop_dplyr(i, dots, fn = "mutate", problem = conditionMessage(e))
+      stop_dplyr(i, dots, fn = "mutate", problem = conditionMessage(e), parent = e)
     }
   })
 

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -270,8 +270,7 @@ summarise_cols <- function(.data, ...) {
       } else if (inherits(e, "dplyr:::summarise_incompatible_size")) {
         stop_summarise_incompatible_size(size = e$size, group = e$group, index = e$index, expected_size = e$expected_size, dots = dots)
       } else {
-        stop_dplyr(i, dots, fn = "summarise", problem = conditionMessage(e)
-        )
+        stop_dplyr(i, dots, fn = "summarise", problem = conditionMessage(e), parent = e)
       }
     })
 


### PR DESCRIPTION
 that can be used when rethrowing e.g. a vctrs error