### PR TITLE
rename() uses eval_rename(name_spec=)

### DIFF
--- a/R/rename.R
+++ b/R/rename.R
@@ -41,7 +41,12 @@ rename <- function(.data, ...) {
 
 #' @export
 rename.data.frame <- function(.data, ...) {
-  loc <- tidyselect::eval_rename(expr(c(...)), .data, name_spec = "{inner}")
+  loc <- tidyselect::eval_rename(expr(c(...)), .data, name_spec = function(outer, inner) {
+    abort(c(
+      glue("Problem with `rename()` input `{outer}`"),
+      x = glue("Input `{outer}` is a named vector")
+    ))
+  })
   # eval_rename() only returns changes
   names <- names(.data)
   names[loc] <- names(loc)

--- a/R/rename.R
+++ b/R/rename.R
@@ -41,7 +41,7 @@ rename <- function(.data, ...) {
 
 #' @export
 rename.data.frame <- function(.data, ...) {
-  loc <- tidyselect::eval_rename(expr(c(...)), .data)
+  loc <- tidyselect::eval_rename(expr(c(...)), .data, name_spec = "{inner}")
   # eval_rename() only returns changes
   names <- names(.data)
   names[loc] <- names(loc)

--- a/tests/testthat/test-rename-errors.txt
+++ b/tests/testthat/test-rename-errors.txt
@@ -1,0 +1,4 @@
+> rename(data.frame(old = 1), new = c(dud = "old"))
+Error: Problem with `rename()` input `new`
+x Input `new` is a named vector
+

--- a/tests/testthat/test-rename.R
+++ b/tests/testthat/test-rename.R
@@ -35,6 +35,16 @@ test_that("can rename with duplicate columns", {
   expect_named(df %>% rename(x2 = 2), c("x", "x2", "y"))
 })
 
+test_that("rename() aborts when outer and inner names are used (#5207)", {
+  expect_error(rename(data.frame(old = 1), new = c(dud = "old")))
+})
+
+test_that("rename() give meaningful errors", {
+  verify_output(test_path("test-rename-errors.txt"), {
+    rename(data.frame(old = 1), new = c(dud = "old"))
+  })
+})
+
 # rename_with -------------------------------------------------------------
 
 test_that("can select columns", {


### PR DESCRIPTION
closes #5207 

``` r
dplyr::rename(data.frame(old = 1), new = c(dud = "old"))
#>   dud
#> 1   1
```

<sup>Created on 2020-05-11 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

Or should this an error to use the form `new = c(...)` ?