### PR TITLE
across(<empty>) -> data frame with 0 columns and 1 row.

### DIFF
--- a/R/across.R
+++ b/R/across.R
@@ -82,6 +82,9 @@ across <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
   setup <- across_setup({{ .cols }}, fns = .fns, names = .names, key = key)
 
   vars <- setup$vars
+  if (length(vars) == 0L) {
+    return(new_tibble(list(), nrow = 1L))
+  }
   fns <- setup$fns
   names <- setup$names
 

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -177,6 +177,23 @@ test_that("across() uses tidy recycling rules", {
   )
 })
 
+test_that("across(<empty set>) returns a data frame with 1 row (#5204)", {
+  df <- tibble(x = 1:42)
+  expect_equal(
+    mutate(df, across(c(), as.factor)),
+    df
+  )
+  expect_equal(
+    mutate(df, y = across(c(), as.factor))$y,
+    tibble::new_tibble(list(), nrow = 42)
+  )
+  mutate(df, {
+    res <- across(c(), as.factor)
+    expect_equal(nrow(res), 1L)
+    res
+  })
+})
+
 
 # c_across ----------------------------------------------------------------
 


### PR DESCRIPTION
closes #5204

``` r
library(dplyr, warn.conflicts = FALSE)

as_tibble(iris) %>% 
  mutate(across(where(is.character), as.factor))
#> # A tibble: 150 x 5
#>    Sepal.Length Sepal.Width Petal.Length Petal.Width Species
#>           <dbl>       <dbl>        <dbl>       <dbl> <fct>  
#>  1          5.1         3.5          1.4         0.2 setosa 
#>  2          4.9         3            1.4         0.2 setosa 
#>  3          4.7         3.2          1.3         0.2 setosa 
#>  4          4.6         3.1          1.5         0.2 setosa 
#>  5          5           3.6          1.4         0.2 setosa 
#>  6          5.4         3.9          1.7         0.4 setosa 
#>  7          4.6         3.4          1.4         0.3 setosa 
#>  8          5           3.4          1.5         0.2 setosa 
#>  9          4.4         2.9          1.4         0.2 setosa 
#> 10          4.9         3.1          1.5         0.1 setosa 
#> # … with 140 more rows
```

<sup>Created on 2020-05-12 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>