### PR TITLE
round down proportions on slice_tail()

### DIFF
--- a/R/slice.R
+++ b/R/slice.R
@@ -149,7 +149,7 @@ slice_tail.data.frame <- function(.data, ..., n, prop) {
   size <- check_slice_size(n, prop)
   idx <- switch(size$type,
     n =    function(n) seq2(max(n - size$n + 1, 1), n),
-    prop = function(n) seq2(max(n - size$prop * n + 1, 1), n)
+    prop = function(n) seq2(max(ceiling(n - size$prop * n) + 1, 1), n)
   )
   slice(.data, idx(dplyr::n()))
 }

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -204,13 +204,13 @@ test_that("functions silently truncate results", {
 test_that("proportion computed correctly", {
   df <- data.frame(x = 1:10)
 
-  expect_equal(df %>% slice_head(prop = 0.1) %>% nrow(), 1)
-  expect_equal(df %>% slice_tail(prop = 0.1) %>% nrow(), 1)
-  expect_equal(df %>% slice_sample(prop = 0.1) %>% nrow(), 1)
-  expect_equal(df %>% slice_min(x, prop = 0.1) %>% nrow(), 1)
-  expect_equal(df %>% slice_max(x, prop = 0.1) %>% nrow(), 1)
-  expect_equal(df %>% slice_min(x, prop = 0.1, with_ties = FALSE) %>% nrow(), 1)
-  expect_equal(df %>% slice_max(x, prop = 0.1, with_ties = FALSE) %>% nrow(), 1)
+  expect_equal(df %>% slice_head(prop = 0.11) %>% nrow(), 1)
+  expect_equal(df %>% slice_tail(prop = 0.11) %>% nrow(), 1)
+  expect_equal(df %>% slice_sample(prop = 0.11) %>% nrow(), 1)
+  expect_equal(df %>% slice_min(x, prop = 0.11) %>% nrow(), 1)
+  expect_equal(df %>% slice_max(x, prop = 0.11) %>% nrow(), 1)
+  expect_equal(df %>% slice_min(x, prop = 0.11, with_ties = FALSE) %>% nrow(), 1)
+  expect_equal(df %>% slice_max(x, prop = 0.11, with_ties = FALSE) %>% nrow(), 1)
 })
 
 test_that("min and max return ties by default", {


### PR DESCRIPTION
closes #5233

``` r
library(dplyr, warn.conflicts = FALSE)

df <- data.frame(x = 1:10)

# this works
df %>% slice_head(prop = 0.11) 
#>   x
#> 1 1
df %>% slice_tail(prop = 0.10) 
#>    x
#> 1 10

# this doesn't
df %>% slice_tail(prop = runif(1))
#>    x
#> 1  6
#> 2  7
#> 3  8
#> 4  9
#> 5 10
df %>% slice_tail(prop = 0.11)
#>    x
#> 1 10
```

<sup>Created on 2020-05-12 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>