### PR TITLE
Refactor encoding test helpers and use withr::local_locale()

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -63,6 +63,11 @@ jobs:
           sysreqs=$(Rscript -e "cat(sysreqs::sysreq_commands('DESCRIPTION'))")
           sudo -s eval "$sysreqs"
 
+      - name: Install macOS dependencies
+        if: matrix.config.os == 'macOS-latest' && matrix.config.r == 'devel'
+        run: |
+          brew install mariadb-connector-c
+
       - name: Install dependencies
         run: |
           remotes::install_deps(dependencies = TRUE)

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -53,7 +53,9 @@ DataMask <- R6Class("DataMask",
 
       promises <- map(seq_len(ncol(data)), function(.x) expr(promise_fn(!!.x)))
 
-      env_bind_lazy(private$bindings, !!!set_names(promises, names_bindings))
+      suppressWarnings(
+        env_bind_lazy(private$bindings, !!!set_names(promises, names_bindings))
+      )
 
       private$mask <- new_data_mask(private$bindings)
       private$mask$.data <- as_data_pronoun(private$mask)

--- a/tests/testthat/test-colwise-mutate.R
+++ b/tests/testthat/test-colwise-mutate.R
@@ -134,48 +134,48 @@ test_that("summarise_at removes grouping variables (#3613)", {
 })
 
 test_that("group_by_(at,all) handle utf-8 names (#3829)", {
-  with_non_utf8_encoding({
-    name <- get_native_lang_string()
-    tbl <- tibble(a = 1) %>%
-      setNames(name)
+  local_non_utf8_encoding()
 
-    res <- group_by_all(tbl) %>% groups()
-    expect_equal(res[[1]], sym(name))
+  name <- get_native_lang_string()
+  tbl <- tibble(a = 1) %>%
+    setNames(name)
 
-    res <- group_by_at(tbl, name) %>% groups()
-    expect_equal(res[[1]], sym(name))
-  })
+  res <- group_by_all(tbl) %>% groups()
+  expect_equal(res[[1]], sym(name))
+
+  res <- group_by_at(tbl, name) %>% groups()
+  expect_equal(res[[1]], sym(name))
 })
 
 test_that("*_(all,at) handle utf-8 names (#2967)", {
-  with_non_utf8_encoding({
-    name <- get_native_lang_string()
-    tbl <- tibble(a = 1) %>%
-      setNames(name)
+  local_non_utf8_encoding()
 
-    res <- tbl %>%
-      mutate_all(list(as.character)) %>%
-      names()
-    expect_equal(res, name)
+  name <- get_native_lang_string()
+  tbl <- tibble(a = 1) %>%
+    setNames(name)
 
-    res <- tbl %>%
-      mutate_at(name, list(as.character)) %>%
-      names()
-    expect_equal(res, name)
+  res <- tbl %>%
+    mutate_all(list(as.character)) %>%
+    names()
+  expect_equal(res, name)
 
-    res <- tbl %>%
-      summarise_all(list(as.character)) %>%
-      names()
-    expect_equal(res, name)
+  res <- tbl %>%
+    mutate_at(name, list(as.character)) %>%
+    names()
+  expect_equal(res, name)
 
-    res <- tbl %>%
-      summarise_at(name, list(as.character)) %>%
-      names()
-    expect_equal(res, name)
+  res <- tbl %>%
+    summarise_all(list(as.character)) %>%
+    names()
+  expect_equal(res, name)
 
-    res <- select_at(tbl, name) %>% names()
-    expect_equal(res, name)
-  })
+  res <- tbl %>%
+    summarise_at(name, list(as.character)) %>%
+    names()
+  expect_equal(res, name)
+
+  res <- select_at(tbl, name) %>% names()
+  expect_equal(res, name)
 })
 
 test_that("summarise_at with multiple columns AND unnamed functions works (#4119)", {

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -210,28 +210,28 @@ test_that("ungroup.rowwise_df gives a tbl_df (#936)", {
 })
 
 test_that(paste0("group_by handles encodings for native strings (#1507)"), {
-  with_non_utf8_encoding({
-    special <- get_native_lang_string()
+  local_non_utf8_encoding()
 
-    df <- data.frame(x = 1:3, Eng = 2:4)
+  special <- get_native_lang_string()
 
-    for (names_converter in c(enc2native, enc2utf8)) {
-      for (dots_converter in c(enc2native, enc2utf8)) {
-        names(df) <- names_converter(c(special, "Eng"))
-        res <- group_by(df, !!!syms(dots_converter(special)))
-        expect_equal(names(res), names(df))
-        expect_equal(group_vars(res), special)
-      }
-    }
+  df <- data.frame(x = 1:3, Eng = 2:4)
 
-    for (names_converter in c(enc2native, enc2utf8)) {
+  for (names_converter in c(enc2native, enc2utf8)) {
+    for (dots_converter in c(enc2native, enc2utf8)) {
       names(df) <- names_converter(c(special, "Eng"))
-
-      res <- group_by(df, !!!special)
-      expect_equal(names(res), c(names(df), deparse(special)))
-      expect_equal(groups(res), list(as.name(enc2native(deparse(special)))))
+      res <- group_by(df, !!!syms(dots_converter(special)))
+      expect_equal(names(res), names(df))
+      expect_equal(group_vars(res), special)
     }
-  })
+  }
+
+  for (names_converter in c(enc2native, enc2utf8)) {
+    names(df) <- names_converter(c(special, "Eng"))
+
+    res <- group_by(df, !!!special)
+    expect_equal(names(res), c(names(df), deparse(special)))
+    expect_equal(groups(res), list(as.name(enc2native(deparse(special)))))
+  }
 })
 
 test_that("group_by handles raw columns (#1803)", {

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -236,13 +236,13 @@ test_that("mutate() to UTF-8 column names", {
 })
 
 test_that("Non-ascii column names in version 0.3 are not duplicated (#636)", {
-  with_non_utf8_encoding({
-    df <- tibble(a = "1", b = "2")
-    names(df) <- c("a", enc2native("\u4e2d"))
+  local_non_utf8_encoding()
 
-    res <- df %>% mutate_all(as.numeric)
-    expect_equal(names(res), as_utf8_character(names(df)))
-  })
+  df <- tibble(a = "1", b = "2")
+  names(df) <- c("a", enc2native("\u4e2d"))
+
+  res <- df %>% mutate_all(as.numeric)
+  expect_equal(names(res), as_utf8_character(names(df)))
 })
 
 test_that("mutate coerces results from one group with all NA values (#1463) ", {


### PR DESCRIPTION
Alternative to #5231. withr does have support for locale change, so I used that + some probing for a non-UTF-8 locale.