### PR TITLE
Document changed behaviour of 'right_join()'

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,8 @@
   Input must be a vector, not a `<data.frame/...>` object
   ```
 
+* `right_join()` no longer sorts the rows of the resulting tibble according to the order of the RHS `by` argument in tibble `y`.
+
 ## New features
 
 * The `cur_` functions (`cur_data()`, `cur_group()`, `cur_group_id()`, 

--- a/vignettes/two-table.Rmd
+++ b/vignettes/two-table.Rmd
@@ -88,7 +88,7 @@ There are four types of mutating join, which differ in their behaviour when a ma
 
 ```{r}
 df1 <- tibble(x = c(1, 2), y = 2:1)
-df2 <- tibble(x = c(1, 3), a = 10, b = "a")
+df2 <- tibble(x = c(3, 1), a = 10, b = "a")
 ```
 
   * `inner_join(x, y)` only includes observations that match in both `x` and `y`.
@@ -106,7 +106,7 @@ df2 <- tibble(x = c(1, 3), a = 10, b = "a")
     ```
   
   * `right_join(x, y)` includes all observations in `y`. It's equivalent to 
-    `left_join(y, x)`, but the columns will be ordered differently.
+    `left_join(y, x)`, but the columns and rows will be ordered differently.
   
     ```{r}
     df1 %>% right_join(df2)


### PR DESCRIPTION
Related to #4856

- add change in behaviour to NEWS.md
- small update to vignette "Two-table verbs"

I know some people who rely on `dplyr::right_join()` for sorting the LHS table according to the order of values in the RHS table, so maybe this could be helpful.