### PR TITLE
Use `where()` in remaining documentation

### DIFF
--- a/R/across.R
+++ b/R/across.R
@@ -45,7 +45,7 @@
 #'   summarise(across(starts_with("Sepal"), mean))
 #' iris %>%
 #'   as_tibble() %>%
-#'   mutate(across(is.factor, as.character))
+#'   mutate(across(where(is.factor), as.character))
 #'
 #' # A purrr-style formula
 #' iris %>%

--- a/R/colwise-distinct.R
+++ b/R/colwise-distinct.R
@@ -34,7 +34,7 @@
 #'
 #' distinct_if(df, is.numeric)
 #' # ->
-#' distinct(df, across(is.numeric))
+#' distinct(df, across(where(is.numeric)))
 #'
 #' # You can supply a function that will be applied before extracting the distinct values
 #' # The variables of the sorted tibble keep their original values.

--- a/R/colwise-filter.R
+++ b/R/colwise-filter.R
@@ -55,7 +55,7 @@
 #' filter_if(mtcars, ~ all(floor(.) == .), all_vars(. != 0))
 #' # ->
 #' is_int <- function(x) all(floor(x) == x)
-#' filter(mtcars, across(is_int, ~ .x != 0))
+#' filter(mtcars, across(where(is_int), ~ .x != 0))
 filter_all <- function(.tbl, .vars_predicate, .preserve = FALSE) {
   lifecycle::signal_superseded("1.0.0", "filter_all()", "across()")
   syms <- syms(tbl_vars(.tbl))

--- a/R/colwise-group-by.R
+++ b/R/colwise-group-by.R
@@ -30,7 +30,7 @@
 #' # Group by variables selected with a predicate:
 #' group_by_if(iris, is.factor)
 #' # ->
-#' iris %>% group_by(across(is.factor))
+#' iris %>% group_by(across(where(is.factor)))
 #'
 #' # Group by variables selected by name:
 #' group_by_at(mtcars, vars(vs, am))
@@ -46,7 +46,7 @@
 #'
 #' group_by_if(iris, is.factor, as.character)
 #' # ->
-#' iris %>% group_by(across(is.factor, as.character))
+#' iris %>% group_by(across(where(is.factor), as.character))
 group_by_all <- function(.tbl, .funs = list(), ..., .add = FALSE, .drop = group_by_drop_default(.tbl)) {
   lifecycle::signal_superseded("1.0.0", "group_by_all()", "across()")
   funs <- manip_all(.tbl, .funs, enquo(.funs), caller_env(), ..., .caller = "group_by_all")

--- a/R/colwise-mutate.R
+++ b/R/colwise-mutate.R
@@ -100,7 +100,7 @@
 #' starwars %>%
 #'   summarise_if(is.numeric, mean, na.rm = TRUE)
 #' starwars %>%
-#'   summarise(across(is.numeric, ~ mean(.x, na.rm = TRUE)))
+#'   summarise(across(where(is.numeric), ~ mean(.x, na.rm = TRUE)))
 #'
 #' by_species <- iris %>%
 #'   group_by(Species)
@@ -221,15 +221,15 @@ summarize_at <- summarise_at
 #' # returns TRUE or FALSE) to determine the relevant subset of
 #' # columns. Here we divide all the numeric columns by 100:
 #' starwars %>% mutate_if(is.numeric, scale2, na.rm = TRUE)
-#' starwars %>% mutate(across(is.numeric, ~ scale2(.x, na.rm = TRUE)))
+#' starwars %>% mutate(across(where(is.numeric), ~ scale2(.x, na.rm = TRUE)))
 #'
 #' # mutate_if() is particularly useful for transforming variables from
 #' # one type to another
 #' iris %>% mutate_if(is.factor, as.character)
 #' iris %>% mutate_if(is.double, as.integer)
 #' # ->
-#' iris %>% mutate(across(is.factor, as.character))
-#' iris %>% mutate(across(is.double, as.integer))
+#' iris %>% mutate(across(where(is.factor), as.character))
+#' iris %>% mutate(across(where(is.double), as.integer))
 #'
 #' # Multiple transformations ----------------------------------------
 #'
@@ -242,7 +242,7 @@ summarize_at <- summarise_at
 #' # ->
 #' iris %>%
 #'   as_tibble() %>%
-#'   mutate(across(is.numeric, list(scale = scale2, log = log)))
+#'   mutate(across(where(is.numeric), list(scale = scale2, log = log)))
 #'
 #' # When there's only one function in the list, it modifies existing
 #' # variables in place. Give it a name to instead create new variables:

--- a/R/colwise-select.R
+++ b/R/colwise-select.R
@@ -26,7 +26,7 @@
 #' is_whole <- function(x) all(floor(x) == x)
 #' mtcars %>% rename_if(is_whole, toupper)
 #' # ->
-#' mtcars %>% rename_with(toupper, is_whole)
+#' mtcars %>% rename_with(toupper, where(is_whole))
 #'
 #' mtcars %>% rename_at(vars(mpg:hp), toupper)
 #' # ->
@@ -41,7 +41,7 @@
 #' # Selection drops unselected variables:
 #' mtcars %>% select_if(is_whole, toupper)
 #' # ->
-#' mtcars %>% select(is_whole) %>% rename_with(toupper)
+#' mtcars %>% select(where(is_whole)) %>% rename_with(toupper)
 #'
 #' mtcars %>% select_at(vars(-contains("ar"), starts_with("c")), toupper)
 #' # ->

--- a/man/across.Rd
+++ b/man/across.Rd
@@ -60,7 +60,7 @@ iris \%>\%
   summarise(across(starts_with("Sepal"), mean))
 iris \%>\%
   as_tibble() \%>\%
-  mutate(across(is.factor, as.character))
+  mutate(across(where(is.factor), as.character))
 
 # A purrr-style formula
 iris \%>\%

--- a/man/distinct_all.Rd
+++ b/man/distinct_all.Rd
@@ -64,7 +64,7 @@ distinct(df, across(c(x, y)))
 
 distinct_if(df, is.numeric)
 # ->
-distinct(df, across(is.numeric))
+distinct(df, across(where(is.numeric)))
 
 # You can supply a function that will be applied before extracting the distinct values
 # The variables of the sorted tibble keep their original values.

--- a/man/filter_all.Rd
+++ b/man/filter_all.Rd
@@ -81,5 +81,5 @@ filter(mtcars, across(starts_with("d"), ~ (.x \%\% 2) == 0))
 filter_if(mtcars, ~ all(floor(.) == .), all_vars(. != 0))
 # ->
 is_int <- function(x) all(floor(x) == x)
-filter(mtcars, across(is_int, ~ .x != 0))
+filter(mtcars, across(where(is_int), ~ .x != 0))
 }

--- a/man/group_by_all.Rd
+++ b/man/group_by_all.Rd
@@ -81,7 +81,7 @@ mtcars \%>\% group_by(across())
 # Group by variables selected with a predicate:
 group_by_if(iris, is.factor)
 # ->
-iris \%>\% group_by(across(is.factor))
+iris \%>\% group_by(across(where(is.factor)))
 
 # Group by variables selected by name:
 group_by_at(mtcars, vars(vs, am))
@@ -97,5 +97,5 @@ d \%>\% group_by(across(everything(), as.factor))
 
 group_by_if(iris, is.factor, as.character)
 # ->
-iris \%>\% group_by(across(is.factor, as.character))
+iris \%>\% group_by(across(where(is.factor), as.character))
 }

--- a/man/mutate_all.Rd
+++ b/man/mutate_all.Rd
@@ -143,15 +143,15 @@ iris \%>\% mutate(across(matches("Sepal"), log))
 # returns TRUE or FALSE) to determine the relevant subset of
 # columns. Here we divide all the numeric columns by 100:
 starwars \%>\% mutate_if(is.numeric, scale2, na.rm = TRUE)
-starwars \%>\% mutate(across(is.numeric, ~ scale2(.x, na.rm = TRUE)))
+starwars \%>\% mutate(across(where(is.numeric), ~ scale2(.x, na.rm = TRUE)))
 
 # mutate_if() is particularly useful for transforming variables from
 # one type to another
 iris \%>\% mutate_if(is.factor, as.character)
 iris \%>\% mutate_if(is.double, as.integer)
 # ->
-iris \%>\% mutate(across(is.factor, as.character))
-iris \%>\% mutate(across(is.double, as.integer))
+iris \%>\% mutate(across(where(is.factor), as.character))
+iris \%>\% mutate(across(where(is.double), as.integer))
 
 # Multiple transformations ----------------------------------------
 
@@ -164,7 +164,7 @@ iris \%>\% mutate_if(is.numeric, list(scale = scale2, log = log))
 # ->
 iris \%>\%
   as_tibble() \%>\%
-  mutate(across(is.numeric, list(scale = scale2, log = log)))
+  mutate(across(where(is.numeric), list(scale = scale2, log = log)))
 
 # When there's only one function in the list, it modifies existing
 # variables in place. Give it a name to instead create new variables:

--- a/man/select_all.Rd
+++ b/man/select_all.Rd
@@ -62,7 +62,7 @@ mtcars \%>\% rename_with(toupper)
 is_whole <- function(x) all(floor(x) == x)
 mtcars \%>\% rename_if(is_whole, toupper)
 # ->
-mtcars \%>\% rename_with(toupper, is_whole)
+mtcars \%>\% rename_with(toupper, where(is_whole))
 
 mtcars \%>\% rename_at(vars(mpg:hp), toupper)
 # ->
@@ -77,7 +77,7 @@ mtcars \%>\% rename_with(toupper)
 # Selection drops unselected variables:
 mtcars \%>\% select_if(is_whole, toupper)
 # ->
-mtcars \%>\% select(is_whole) \%>\% rename_with(toupper)
+mtcars \%>\% select(where(is_whole)) \%>\% rename_with(toupper)
 
 mtcars \%>\% select_at(vars(-contains("ar"), starts_with("c")), toupper)
 # ->

--- a/man/summarise_all.Rd
+++ b/man/summarise_all.Rd
@@ -140,7 +140,7 @@ starwars \%>\%
 starwars \%>\%
   summarise_if(is.numeric, mean, na.rm = TRUE)
 starwars \%>\%
-  summarise(across(is.numeric, ~ mean(.x, na.rm = TRUE)))
+  summarise(across(where(is.numeric), ~ mean(.x, na.rm = TRUE)))
 
 by_species <- iris \%>\%
   group_by(Species)

--- a/vignettes/base.Rmd
+++ b/vignettes/base.Rmd
@@ -266,7 +266,7 @@ setNames(iris, toupper(names(iris)))
 iris %>% select(1:3)
 iris %>% select(Species, Sepal.Length)
 iris %>% select(starts_with("Petal"))
-iris %>% select(is.factor)
+iris %>% select(where(is.factor))
 ```
 
 Subsetting variables by position is straightforward in base R:

--- a/vignettes/colwise.Rmd
+++ b/vignettes/colwise.Rmd
@@ -58,7 +58,7 @@ Here are a couple of examples of `across()` in conjunction with its favourite ve
 
 ```{r}
 starwars %>% 
-  summarise(across(is.character, ~ length(unique(.x))))
+  summarise(across(where(is.character), ~ length(unique(.x))))
 
 starwars %>% 
   group_by(species) %>% 
@@ -68,7 +68,7 @@ starwars %>%
 starwars %>% 
   group_by(homeworld) %>% 
   filter(n() > 1) %>% 
-  summarise(across(is.numeric, ~ mean(.x, na.rm = TRUE)))
+  summarise(across(where(is.numeric), ~ mean(.x, na.rm = TRUE)))
 ```
 
 Because `across()` is usually used in combination with `summarise()` and `mutate()`, it doesn't select grouping variables in order to avoid accidentally modifying them:
@@ -77,7 +77,7 @@ Because `across()` is usually used in combination with `summarise()` and `mutate
 df <- data.frame(g = c(1, 1, 2), x = c(-1, 1, 3), y = c(-1, -4, -9))
 df %>% 
   group_by(g) %>% 
-  summarise(across(is.numeric, sum))
+  summarise(across(where(is.numeric), sum))
 ```
 
 ### Multiple functions
@@ -89,21 +89,21 @@ min_max <- list(
   min = ~min(.x, na.rm = TRUE), 
   max = ~max(.x, na.rm = TRUE)
 )
-starwars %>% summarise(across(is.numeric, min_max))
+starwars %>% summarise(across(where(is.numeric), min_max))
 ```
 
 Control how the names are created with the `.names` argument which takes a [glue](http://glue.tidyverse.org/) spec:
 
 ```{r}
-starwars %>% summarise(across(is.numeric, min_max, .names = "{fn}.{col}"))
+starwars %>% summarise(across(where(is.numeric), min_max, .names = "{fn}.{col}"))
 ```
 
 If you'd prefer all summaries with the same function to be grouped together, you'll have to expand the calls yourself:
 
 ```{r}
 starwars %>% summarise(
-  across(is.numeric, ~min(.x, na.rm = TRUE), .names = "min_{col}"),
-  across(is.numeric, ~max(.x, na.rm = TRUE), .names = "max_{col}")
+  across(where(is.numeric), ~min(.x, na.rm = TRUE), .names = "min_{col}"),
+  across(where(is.numeric), ~max(.x, na.rm = TRUE), .names = "max_{col}")
 )
 ```
 
@@ -129,21 +129,21 @@ Be careful when combining numeric summaries with `is.numeric`:
 df <- data.frame(x = c(1, 2, 3), y = c(1, 4, 9))
 
 df %>% 
-  summarise(n = n(), across(is.numeric, sd))
+  summarise(n = n(), across(where(is.numeric), sd))
 ```
 
 Here `n` becomes `NA` because `n` is numeric, so the `across()` computes its standard deviation, and the standard deviation of 3 (a constant) is `NA`. You probably want to compute `n()` last to avoid this problem:
 
 ```{r}
 df %>% 
-  summarise(across(is.numeric, sd), n = n())
+  summarise(across(where(is.numeric), sd), n = n())
 ```
 
 Alternatively, you could explicitly exclude `n` from the columns to operate on:
 
 ```{r}
 df %>% 
-  summarise(n = n(), across(is.numeric & !n, sd))
+  summarise(n = n(), across(where(is.numeric) & !n, sd))
 ```
 
 ### Other verbs
@@ -158,7 +158,7 @@ So far we've focussed on the use of `across()` with `summarise()`, but it works 
       (x - rng[1]) / (rng[2] - rng[1])
     }
     df <- tibble(x = 1:4, y = rnorm(4))
-    df %>% mutate(across(is.numeric, rescale01))
+    df %>% mutate(across(where(is.numeric), rescale01))
     ```
 
 *   Find all rows where no variable has missing values:
@@ -198,8 +198,8 @@ Why did we decide to move away from these functions in favour of `across()`?
     df %>%
       group_by(g1, g2) %>% 
       summarise(
-        across(is.numeric, mean), 
-        across(is.factor, nlevels),
+        across(where(is.numeric), mean), 
+        across(where(is.factor), nlevels),
         n = n(), 
       )
     ```
@@ -212,7 +212,7 @@ Why did we decide to move away from these functions in favour of `across()`?
 1.  `across()` unifies `_if` and `_at` semantics so that you can select by 
     position, name, and type, and you can now create compound selections that 
     were previously impossible. For example, you can now transform all numeric 
-    columns whose name begins with "x": `across(is.numeric & starts_with("x"))`.
+    columns whose name begins with "x": `across(where(is.numeric) & starts_with("x"))`.
 
 1.  `across()` doesn't need to use `vars()`. The `_at()` functions are the only
     place in dplyr where you have to manually quote variable names, which makes 
@@ -228,7 +228,7 @@ It's disappointing that we didn't discover `across()` earlier, and instead worke
 
 * We can use data frames to allow summary functions to return multiple columns.
 
-* We can use of absence of an outer name as a convention that you want to
+* We can use the absence of an outer name as a convention that you want to
   unpack a data frame column into individual columns.
 
 ### How do you convert existing code?
@@ -239,7 +239,7 @@ Fortunately, it's generally straightforward to translate your existing code to u
 
 *   Call `across()`. The first argument will be:
 
-    1. For `_if()`, the old second argument.
+    1. For `_if()`, the old second argument wrapped in `where()`.
     1. For `_at()`, the old second argument, with the call to `vars()` removed.
     1. For `_all()`, `everything()`.
 
@@ -250,7 +250,7 @@ For example:
 ```{r, results = FALSE}
 df %>% mutate_if(is.numeric, mean, na.rm = TRUE)
 # ->
-df %>% mutate(across(is.numeric, mean, na.rm = TRUE))
+df %>% mutate(across(where(is.numeric), mean, na.rm = TRUE))
 
 df %>% mutate_at(vars(c(x, starts_with("y"))), mean)
 # ->
@@ -277,11 +277,11 @@ There are a few exceptions to this rule:
     df <- tibble(x = c("a", "b"), y = c(1, 1), z = c(-1, 1))
     
     # Find all rows where EVERY numeric variable is greater than zero
-    df %>% filter(across(is.numeric, ~ .x > 0))
+    df %>% filter(across(where(is.numeric), ~ .x > 0))
     
     # Find all rows where ANY numeric variable is greater than zero
     rowAny <- function(x) rowSums(x) > 0
-    df %>% filter(rowAny(across(is.numeric, ~ .x > 0)))
+    df %>% filter(rowAny(across(where(is.numeric), ~ .x > 0)))
     ```
     
 *   When used in a `mutate()`, all transformations performed by an `across()` 

--- a/vignettes/programming.Rmd
+++ b/vignettes/programming.Rmd
@@ -160,7 +160,7 @@ As with data masking, tidy selection makes a common task easier at the cost of m
     }
     mtcars %>% 
       group_by(cyl) %>% 
-      summarise_mean(is.numeric)
+      summarise_mean(where(is.numeric))
     ```
 
 *   When you have an env-variable that is a character vector, you need to use

--- a/vignettes/rowwise.Rmd
+++ b/vignettes/rowwise.Rmd
@@ -104,7 +104,7 @@ Of course, if you have a lot of variables, it's going to be tedious to type in e
 
 ```{r}
 rf %>% mutate(total = sum(c_across(w:z)))
-rf %>% mutate(total = sum(c_across(is.numeric)))
+rf %>% mutate(total = sum(c_across(where(is.numeric))))
 ```
 
 You could combine this with column-wise operations (see `vignette("colwise")` for more details) to compute the proportion of the total for each column:
@@ -121,8 +121,8 @@ rf %>%
 The `rowwise()` approach will work for any summary function. But if you need greater speed, it's worth looking for a built-in row-wise variant of your summary function. These are more efficient because they operate on the data frame as whole; they don't split it into rows, compute the summary, and then join the results back together again.
 
 ```{r}
-df %>% mutate(total = rowSums(across(is.numeric)))
-df %>% mutate(mean = rowMeans(across(is.numeric)))
+df %>% mutate(total = rowSums(across(where(is.numeric))))
+df %>% mutate(mean = rowMeans(across(where(is.numeric))))
 ```
 
 **NB**: I use `df` (not `rf`) and `across()` (not `c_across()`) here because `rowMeans()` and `rowSums()` take a multi-row data frame as input.


### PR DESCRIPTION
Checked with a version of tidyselect where the warning is promoted to error.

Closes #5258.