### PR TITLE
swapi.co -> swapi.dev

### DIFF
--- a/R/data-starwars.R
+++ b/R/data-starwars.R
@@ -1,6 +1,6 @@
 #' Starwars characters
 #'
-#' This data comes from SWAPI, the Star Wars API, <http://swapi.co/>
+#' This data comes from SWAPI, the Star Wars API, <http://swapi.dev/>
 #'
 #' @format A tibble with 87 rows and 13 variables:
 #' \describe{

--- a/man/starwars.Rd
+++ b/man/starwars.Rd
@@ -25,7 +25,7 @@ A tibble with 87 rows and 13 variables:
 starwars
 }
 \description{
-This data comes from SWAPI, the Star Wars API, \url{http://swapi.co/}
+This data comes from SWAPI, the Star Wars API, \url{http://swapi.dev/}
 }
 \examples{
 starwars

--- a/vignettes/dplyr.Rmd
+++ b/vignettes/dplyr.Rmd
@@ -40,7 +40,7 @@ This document introduces you to dplyr's basic set of tools, and shows you how to
 
 ## Data: starwars
 
-To explore the basic data manipulation verbs of dplyr, we'll use the dataset `starwars`. This dataset contains `r nrow(starwars)` characters and comes from the [Star Wars API](http://swapi.co), and is documented in `?starwars`
+To explore the basic data manipulation verbs of dplyr, we'll use the dataset `starwars`. This dataset contains `r nrow(starwars)` characters and comes from the [Star Wars API](http://swapi.dev), and is documented in `?starwars`
 
 ```{r}
 dim(starwars)


### PR DESCRIPTION
This does not yet adress #3983 so the links in `data-raw/starwars.R` are still `.co` links. 

But this adresses this during `devtools::check(remote = TRUE, manual = TRUE)`

```
  Found the following (possibly) invalid URLs:
    URL: http://swapi.co (moved to https://swapi.co/)
      From: inst/doc/dplyr.html
      Status: 404
      Message: Not Found
    URL: http://swapi.co/ (moved to https://swapi.co/)
      From: man/starwars.Rd
      Status: 404
      Message: Not Found
```