### PR TITLE
Return data frame from `vec_data()`

### DIFF
--- a/R/generics.R
+++ b/R/generics.R
@@ -140,8 +140,8 @@ dplyr_col_modify.data.frame <- function(data, cols) {
   # Apply tidyverse recycling rules
   cols <- vec_recycle_common(!!!cols, .size = nrow(data))
 
-  out <- vec_data(data)
-  attr(out, "row.names") <- .row_names_info(data, 0L)
+  # Transform to list to avoid stripping inner names with `[[<-`
+  out <- as.list(dplyr_vec_data(data))
 
   nms <- as_utf8_character(names2(cols))
   names(out) <- as_utf8_character(names2(out))
@@ -150,6 +150,9 @@ dplyr_col_modify.data.frame <- function(data, cols) {
     nm <- nms[[i]]
     out[[nm]] <- cols[[i]]
   }
+
+  # Transform back to data frame before reconstruction
+  out <- new_data_frame(out, n = nrow(data))
 
   dplyr_reconstruct(out, data)
 }

--- a/R/grouped-df.r
+++ b/R/grouped-df.r
@@ -199,12 +199,12 @@ tbl_sum.grouped_df <- function(x) {
 #' @export
 as.data.frame.grouped_df <- function(x, row.names = NULL,
                                      optional = FALSE, ...) {
-  new_data_frame(vec_data(x), n = nrow(x))
+  new_data_frame(dplyr_vec_data(x), n = nrow(x))
 }
 
 #' @export
 as_tibble.grouped_df <- function(x, ...) {
-  new_tibble(vec_data(x), nrow = nrow(x))
+  new_tibble(dplyr_vec_data(x), nrow = nrow(x))
 }
 
 #' @importFrom tibble is_tibble

--- a/R/rowwise.r
+++ b/R/rowwise.r
@@ -94,7 +94,7 @@ new_rowwise_df <- function(data, group_data) {
 
   nrow <- nrow(data)
 
-  group_data <- new_tibble(vec_data(group_data), nrow = nrow) # strip attributes
+  group_data <- new_tibble(dplyr_vec_data(group_data), nrow = nrow) # strip attributes
   group_data$.rows <- new_list_of(as.list(seq_len(nrow)), ptype = integer())
   new_tibble(data, groups = group_data, nrow = nrow, class = "rowwise_df")
 }
@@ -112,7 +112,7 @@ tbl_sum.rowwise_df <- function(x) {
 
 #' @export
 as_tibble.rowwise_df <- function(x, ...) {
-  new_tibble(vec_data(x), nrow = nrow(x))
+  new_tibble(dplyr_vec_data(x), nrow = nrow(x))
 }
 
 #' @importFrom tibble is_tibble

--- a/R/utils.r
+++ b/R/utils.r
@@ -102,3 +102,15 @@ paste_line <- function(...) {
 abort_if_not <- function(...) {
   tryCatch(stopifnot(...), simpleError = function(e) abort(e))
 }
+
+# Until fixed upstream. `vec_data()` should not return lists from data
+# frames.
+dplyr_vec_data <- function(x) {
+  out <- vec_data(x)
+
+  if (is.data.frame(x)) {
+    new_data_frame(out, n = nrow(x))
+  } else {
+    out
+  }
+}

--- a/tests/testthat/helper-s3.R
+++ b/tests/testthat/helper-s3.R
@@ -20,3 +20,19 @@ local_foo_df <- function(frame = caller_env()) {
     }
   )
 }
+
+new_ctor <- function(base_class) {
+  function(x = list(), ..., class = NULL) {
+    if (inherits(x, "tbl_df")) {
+      tibble::new_tibble(x, class = c(class, base_class), nrow = nrow(x))
+    } else if (is.data.frame(x)) {
+      structure(x, class = c(class, base_class, "data.frame"), ...)
+    } else {
+      structure(x, class = c(class, base_class), ...)
+    }
+  }
+}
+
+foobar <- new_ctor("dplyr_foobar")
+foobaz <- new_ctor("dplyr_foobaz")
+quux <- new_ctor("dplyr_quux")

--- a/tests/testthat/test-generics.R
+++ b/tests/testthat/test-generics.R
@@ -51,6 +51,29 @@ test_that("doesn't expand row names", {
   expect_equal(.row_names_info(out, 1), -10)
 })
 
+test_that("reconstruct method gets a data frame", {
+  seen_df <- NULL
+
+  local_methods(
+    dplyr_reconstruct.dplyr_foobar = function(data, template) {
+      if (is.data.frame(data)) {
+        seen_df <<- TRUE
+      }
+      NextMethod()
+    }
+  )
+
+  df <- foobar(data.frame(x = 1))
+
+  seen_df <- FALSE
+  dplyr_col_modify(df, list(y = 2))
+  expect_true(seen_df)
+
+  seen_df <- FALSE
+  dplyr_row_slice(df, 1)
+  expect_true(seen_df)
+})
+
 # dplyr_reconstruct -------------------------------------------------------
 
 test_that("classes are restored", {


### PR DESCRIPTION
And ensure `dplyr_reconstruct()` methods are consistently passed a data frame.

I've checked all packages implementing `dplyr_reconstruct()` (fabletools, tsibble, rsample, and dials) and this doesn't cause any issue.