### PR TITLE
Strip attributes before reconstruction

### DIFF
--- a/R/generics.R
+++ b/R/generics.R
@@ -179,6 +179,13 @@ dplyr_col_modify.rowwise_df <- function(data, cols) {
 #' @export
 #' @rdname dplyr_extending
 dplyr_reconstruct <- function(data, template) {
+  # Strip attributes before dispatch to make it easier to implement
+  # methods and prevent unexpected leaking of irrelevant attributes.
+  data <- dplyr_new_data_frame(data)
+  return(dplyr_reconstruct_dispatch(data, template))
+  UseMethod("dplyr_reconstruct", template)
+}
+dplyr_reconstruct_dispatch <- function(data, template) {
   UseMethod("dplyr_reconstruct", template)
 }
 

--- a/R/utils.r
+++ b/R/utils.r
@@ -114,3 +114,20 @@ dplyr_vec_data <- function(x) {
     out
   }
 }
+
+# Until vctrs::new_data_frame() forwards row names automatically
+dplyr_new_data_frame <- function(x = data.frame(),
+                                 n = NULL,
+                                 ...,
+                                 row.names = NULL,
+                                 class = NULL) {
+  row.names <- row.names %||% .row_names_info(x, type = 0L)
+
+  new_data_frame(
+    x,
+    n = n,
+    ...,
+    row.names = row.names,
+    class = class
+  )
+}

--- a/tests/testthat/test-generics.R
+++ b/tests/testthat/test-generics.R
@@ -113,3 +113,21 @@ test_that("compact row names are retained", {
     .row_names_info(expect, type = 0L)
   )
 })
+
+test_that("dplyr_reconstruct() strips attributes before dispatch", {
+  local_methods(
+    dplyr_reconstruct.dplyr_foobar = function(data, template) {
+      out <<- data
+    }
+  )
+
+  df <- foobar(data.frame(x = 1), foo = "bar")
+  out <- NULL
+  dplyr_reconstruct(df, df)
+  expect_identical(out, data.frame(x = 1))
+
+  df <- foobar(data.frame(x = 1, row.names = "a"), foo = "bar")
+  out <- NULL
+  dplyr_reconstruct(df, df)
+  expect_identical(out, data.frame(x = 1, row.names = "a"))
+})


### PR DESCRIPTION
Makes it easier to implement methods and prevents unexpected leaking of irrelevant attributes.