### PR TITLE
Update indexing for dplyr_cummean (#5287)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: dplyr
 Title: A Grammar of Data Manipulation
-Version: 0.8.99.9003
+Version: 1.0.0
 Authors@R: 
     c(person(given = "Hadley",
              family = "Wickham",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# dplyr 1.0.0 (in development)
+# dplyr 1.0.0
 
 ## Breaking changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# dplyr 1.0.0.9000
+
+## Minor improvements and bug fixes
+
+* cummean() no longer has off-by-one indexing problem (#5287).
+
 # dplyr 1.0.0
 
 ## Breaking changes

--- a/src/funs.cpp
+++ b/src/funs.cpp
@@ -105,7 +105,7 @@ SEXP dplyr_cummean(SEXP x) {
   double* p_out = REAL(out);
   double* p_x = REAL(x);
 
-  double sum = *p_out++ = *p_x;
+  double sum = *p_out++ = *p_x++;
   for (R_xlen_t i = 1; i < n; i++, ++p_x, ++p_out) {
     sum += *p_x;
     *p_out = sum / (i + 1.0);

--- a/src/funs.cpp
+++ b/src/funs.cpp
@@ -105,8 +105,8 @@ SEXP dplyr_cummean(SEXP x) {
   double* p_out = REAL(out);
   double* p_x = REAL(x);
 
-  double sum = *p_out++ = *p_x++;
-  for (R_xlen_t i = 1; i < n; i++, ++p_x, ++p_out) {
+  double sum = 0.0;
+  for (R_xlen_t i = 0; i < n; i++, ++p_x, ++p_out) {
     sum += *p_x;
     *p_out = sum / (i + 1.0);
   }

--- a/tests/testthat/test-window.R
+++ b/tests/testthat/test-window.R
@@ -91,6 +91,8 @@ test_that("cummean is consistent with cumsum() and seq_along() (#5287)", {
   x <- 1:5
   expect_equal(cummean(x), c(1, 1.5, 2, 2.5, 3))
   expect_equal(cummean(x), cumsum(x) / seq_along(x))
+
+  expect_equal(cummean(numeric()), numeric())
 })
 
 test_that("order_by() returns correct value", {

--- a/tests/testthat/test-window.R
+++ b/tests/testthat/test-window.R
@@ -89,6 +89,7 @@ test_that("cummean is not confused by FP error (#1387)", {
 
 test_that("cummean is consistent with cumsum() and seq_along() (#5287)", {
   x <- 1:5
+  expect_equal(cummean(x), c(1, 1.5, 2, 2.5, 3))
   expect_equal(cummean(x), cumsum(x) / seq_along(x))
 })
 

--- a/tests/testthat/test-window.R
+++ b/tests/testthat/test-window.R
@@ -87,6 +87,11 @@ test_that("cummean is not confused by FP error (#1387)", {
   expect_true(all(cummean(a) == a))
 })
 
+test_that("cummean is consistent with cumsum() and seq_along() (#5287)", {
+  x <- 1:5
+  expect_equal(cummean(x), cumsum(x) / seq_along(x))
+})
+
 test_that("order_by() returns correct value", {
   expected <- int(15, 14, 12, 9, 5)
   expect_identical(order_by(5:1, cumsum(1:5)), expected)


### PR DESCRIPTION
Indexing off by one, causing first index to be repeated twice (and last index to be dropped). My intuition is we must keep *p_out and *p_x synced, so need to increment both on line 108. 

Example given:
x <- 1:5
Expected: 1.0 1.5 2.0 2.5 3.0
Actual:  1.000000 1.000000 1.333333 1.750000 2.200000
PR output: 1.0 1.5 2.0 2.5 3.0

Tested locally using Rcpp. Feedback welcome.