### PR TITLE
add context to warning in mutate()

### DIFF
--- a/R/conditions.R
+++ b/R/conditions.R
@@ -34,7 +34,7 @@ or_1 <- function(x) {
 
 # Common ------------------------------------------------------------------
 
-stop_dplyr <- function(.index, dots, fn, problem, ..., .dot_data = FALSE, .show_group_details = TRUE, parent = NULL, .abort = abort) {
+stop_dplyr <- function(.index, dots, fn, problem, ..., .dot_data = FALSE, .show_group_details = TRUE, parent = NULL, .signal = abort) {
   error_name <- arg_name(dots, .index)
   error_expression  <- if (.dot_data) {
     deparse(quo_get_expr(dots[[.index]]))
@@ -57,7 +57,7 @@ stop_dplyr <- function(.index, dots, fn, problem, ..., .dot_data = FALSE, .show_
     if(.show_group_details) cnd_bullet_cur_group_label(),
     .envir = envir
   )
-  .abort(
+  .signal(
     bullets,
     class = "dplyr_error",
     error_name = error_name, error_expression = error_expression,
@@ -67,7 +67,7 @@ stop_dplyr <- function(.index, dots, fn, problem, ..., .dot_data = FALSE, .show_
 }
 
 warn_dplyr <- function(...) {
-  stop_dplyr(..., .abort = warn)
+  stop_dplyr(..., .signal = warn)
 }
 
 combine_details <- function(x, arg) {

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -34,7 +34,7 @@ or_1 <- function(x) {
 
 # Common ------------------------------------------------------------------
 
-stop_dplyr <- function(.index, dots, fn, problem, ..., .dot_data = FALSE, .show_group_details = TRUE, parent = NULL) {
+stop_dplyr <- function(.index, dots, fn, problem, ..., .dot_data = FALSE, .show_group_details = TRUE, parent = NULL, .abort = abort) {
   error_name <- arg_name(dots, .index)
   error_expression  <- if (.dot_data) {
     deparse(quo_get_expr(dots[[.index]]))
@@ -57,13 +57,17 @@ stop_dplyr <- function(.index, dots, fn, problem, ..., .dot_data = FALSE, .show_
     if(.show_group_details) cnd_bullet_cur_group_label(),
     .envir = envir
   )
-  abort(
+  .abort(
     bullets,
     class = "dplyr_error",
     error_name = error_name, error_expression = error_expression,
     index = .index, dots = dots, fn = fn,
     parent = parent
   )
+}
+
+warn_dplyr <- function(...) {
+  stop_dplyr(..., .abort = warn)
 }
 
 combine_details <- function(x, arg) {

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -268,7 +268,7 @@ mutate_cols <- function(.data, ...) {
         }
       }
 
-      # evaluluate the chunks if needed
+      # evaluate the chunks if needed
       if (is.null(chunks)) {
         chunks <- mask$eval_all_mutate(dots[[i]])
       }
@@ -331,6 +331,9 @@ mutate_cols <- function(.data, ...) {
     } else {
       stop_dplyr(i, dots, fn = "mutate", problem = conditionMessage(e), parent = e)
     }
+  },
+  warning = function(w) {
+    warn_dplyr(i, dots, fn = "mutate", problem = conditionMessage(w), parent = w)
   })
 
   is_zap <- map_lgl(new_columns, inherits, "rlang_zap")


### PR DESCRIPTION
Handling warnings like errors, and adding some information about when the warning occurred gives: 

``` r
library(tidyverse)
foo_warn <- function(x, sym){
  if(any(x > 3)){
    warning(paste(sym, "has an implausible value"))
  }
  x
}
iris %>% 
  mutate(
    across(contains("Sepal"), ~foo_warn(.x, cur_column()))
  ) %>% 
  head()
#> Warning: Problem with `mutate()` input `..1`.
#> x Sepal.Length has an implausible value
#> ℹ Input `..1` is `across(contains("Sepal"), ~foo_warn(.x, cur_column()))`.
#>   Sepal.Length Sepal.Width Petal.Length Petal.Width Species
#> 1          5.1         3.5          1.4         0.2  setosa
#> 2          4.9         3.0          1.4         0.2  setosa
#> 3          4.7         3.2          1.3         0.2  setosa
#> 4          4.6         3.1          1.5         0.2  setosa
#> 5          5.0         3.6          1.4         0.2  setosa
#> 6          5.4         3.9          1.7         0.4  setosa
```

<sup>Created on 2020-06-09 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

I'll apply this to other functions if this is what you meant @hadley ?

