### PR TITLE
Support data frames in `coalesce()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,6 @@
 
 * `coalesce()` now supports data frames correctly (#5326).
 
-* `cummean()` no longer has off-by-one indexing problem (#5287).
 * `cummean()` no longer has off-by-one indexing problem (@cropgen, #5287).
 
 # dplyr 1.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,9 @@
 
 ## Minor improvements and bug fixes
 
-* cummean() no longer has off-by-one indexing problem (#5287).
+* `coalesce()` now supports data frames correctly (#5326).
+
+* `cummean()` no longer has off-by-one indexing problem (#5287).
 
 # dplyr 1.0.0
 

--- a/man/coalesce.Rd
+++ b/man/coalesce.Rd
@@ -9,7 +9,8 @@ coalesce(...)
 \arguments{
 \item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}> Vectors. Inputs should be
 recyclable (either be length 1 or same length as the longest vector) and
-coercible to a common type.}
+coercible to a common type. If data frames, they are coalesced column by
+column.}
 }
 \value{
 A vector the same length as the first \code{...} argument with

--- a/tests/testthat/test-coalesce.R
+++ b/tests/testthat/test-coalesce.R
@@ -26,3 +26,28 @@ test_that("coalesce() gives meaningful error messages", {
     coalesce(1:2, letters[1:2])
   })
 })
+
+test_that("coalesce() supports data frames (#5326)", {
+  out <- coalesce(
+    data.frame(x = c(NA, 1)),
+    data.frame(x = 1:2)
+  )
+  expect_identical(out, data.frame(x = c(1, 1)))
+
+  df1 <- data.frame(x = c(NA, 1, NA), y = c(2, NA, NA), z = c(1:2, NA))
+  df2 <- tibble::tibble(x = 1:3, y = c(3, 4, NA), z = c(NA, NA, NA))
+  df3 <- data.frame(x = NA, y = c(30, 40, 50), z = 101:103)
+  out <- coalesce(df1, df2, df3)
+  exp <- tibble(x = c(1, 1, 3), y = c(2, 4, 50), z = c(1L, 2L, 103L))
+  expect_identical(out, exp)
+
+  expect_error(
+    coalesce(
+      data.frame(x = c(NA, 1)),
+      data.frame(x = c("a", "b"))
+    ),
+    class = "vctrs_error_incompatible_type"
+  )
+
+  expect_error(coalesce(as.matrix(mtcars), as.matrix(mtcars)), "matrices")
+})


### PR DESCRIPTION
Closes #5326.

```r
df1 <- data.frame(x = c(NA, 1, NA), y = c(2, NA, NA), z = c(1:2, NA))
df2 <- tibble::tibble(x = 1:3, y = c(3, 4, NA), z = c(NA, NA, NA))
df3 <- data.frame(x = NA, y = c(30, 40, 50), z = 101:103)

df1
#>    x  y  z
#> 1 NA  2  1
#> 2  1 NA  2
#> 3 NA NA NA

df2
#> # A tibble: 3 x 3
#>       x     y z
#>   <int> <dbl> <lgl>
#> 1     1     3 NA
#> 2     2     4 NA
#> 3     3    NA NA

df3
#>    x  y   z
#> 1 NA 30 101
#> 2 NA 40 102
#> 3 NA 50 103

coalesce(df1, df2, df3)
#> # A tibble: 3 x 3
#>       x     y     z
#>   <dbl> <dbl> <int>
#> 1     1     2     1
#> 2     1     4     2
#> 3     3    50   103
```