### PR TITLE
Use `vec_proxy_order()` in place of `vec_proxy_compare(relax = TRUE)`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,7 @@ Imports:
     tibble (>= 2.1.3),
     tidyselect (>= 1.1.0),
     utils,
-    vctrs (>= 0.3.1.9000)
+    vctrs (>= 0.3.1)
 Suggests: 
     bench,
     broom,
@@ -67,5 +67,3 @@ Encoding: UTF-8
 LazyData: yes
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.0
-Remotes:
-    r-lib/vctrs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,7 @@ Imports:
     tibble (>= 2.1.3),
     tidyselect (>= 1.1.0),
     utils,
-    vctrs (>= 0.3.1)
+    vctrs (>= 0.3.1.9000)
 Suggests: 
     bench,
     broom,
@@ -67,3 +67,5 @@ Encoding: UTF-8
 LazyData: yes
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.0
+Remotes:
+    r-lib/vctrs

--- a/R/arrange.R
+++ b/R/arrange.R
@@ -125,7 +125,7 @@ arrange_rows <- function(.data, dots) {
   #
   # should really be map2(quosures, directions, ...)
   proxies <- map2(data, directions, function(column, direction) {
-    proxy <- vec_proxy_compare(column, relax = TRUE)
+    proxy <- vec_proxy_order(column)
     desc <- identical(direction, "desc")
     if (is.data.frame(proxy)) {
       proxy <- order(vec_order(proxy,

--- a/R/arrange.R
+++ b/R/arrange.R
@@ -119,13 +119,15 @@ arrange_rows <- function(.data, dots) {
     stop_arrange_transmute(cnd)
   })
 
+  use_proxy_order <- utils::packageVersion("vctrs") > "0.3.1"
+
   # we can't just use vec_compare_proxy(data) because we need to apply
   # direction for each column, so we get a list of proxies instead
   # and then mimic vctrs:::order_proxy
   #
   # should really be map2(quosures, directions, ...)
   proxies <- map2(data, directions, function(column, direction) {
-    proxy <- vec_proxy_order(column)
+    proxy <- dplyr_proxy_order(column, use_proxy_order)
     desc <- identical(direction, "desc")
     if (is.data.frame(proxy)) {
       proxy <- order(vec_order(proxy,
@@ -140,3 +142,16 @@ arrange_rows <- function(.data, dots) {
 
   exec("order", !!!unname(proxies), decreasing = FALSE, na.last = TRUE)
 }
+
+# FIXME: Temporary patch until vctrs 0.3.2 has been on CRAN for long enough
+# to reasonably expect that users have upgraded
+dplyr_proxy_order <- function(x, use_proxy_order) {
+  if (use_proxy_order) {
+    vec_proxy_order(x)
+  } else {
+    vec_proxy_compare(x, relax = TRUE)
+  }
+}
+# Hack to pass CRAN check with vctrs 0.3.1,
+# where `vec_proxy_order()` doesn't exist
+utils::globalVariables("vec_proxy_order")


### PR DESCRIPTION
Follow up to https://github.com/r-lib/vctrs/pull/1155 which removes the experimental `relax` argument in favor of `vec_proxy_order()`

We get errors without this since `ellipsis::check_dots_empty()` is run on the vctrs side, and having the `relax` arg is an issue. Using `vec_proxy_order()` is also now the way to order list-columns.

Note that this bumps dplyr to use dev vctrs