### PR TITLE
across(NULL) and across(character()) no-op

### DIFF
--- a/R/mutate.R
+++ b/R/mutate.R
@@ -227,7 +227,7 @@ mutate_cols <- function(.data, ...) {
     return(NULL)
   }
 
-  new_columns <- list()
+  new_columns <- set_names(list(), character())
 
   tryCatch({
     for (i in seq_along(dots)) {

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -476,6 +476,12 @@ test_that("group_by() can handle auto splicing in the mutate() step", {
     iris %>% group_by(across(starts_with("Sepal"), round))
   )
 
+  df <- tibble(x = c(1, 2), y = c(1, 2))
+  expect_identical(df %>% group_by(across(character())), df)
+  expect_identical(df %>% group_by(across(NULL)), df)
+
+  expect_identical(df %>% group_by(x) %>% group_by(across(character())), df)
+  expect_identical(df %>% group_by(x) %>% group_by(across(NULL)), df)
 })
 
 test_that("group_by() can combine usual spec and auto-splicing-mutate() step", {


### PR DESCRIPTION
closes #5316

``` r
library(dplyr, warn.conflicts = FALSE)

df <- data.frame(x = c(1, 2))

# already worked
df %>% summarise(across(NULL))
#> data frame with 0 columns and 1 row
df %>% mutate(across(NULL))
#>   x
#> 1 1
#> 2 2

# failed because an empty list has no names
df %>% group_by(across(NULL))
#> # A tibble: 2 x 1
#>       x
#>   <dbl>
#> 1     1
#> 2     2
names(list())
#> NULL
```

<sup>Created on 2020-06-29 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>