### PR TITLE
bind_cols() treating data frame with 0 columns as NULL, i.e. not contributing

### DIFF
--- a/R/bind.r
+++ b/R/bind.r
@@ -132,7 +132,7 @@ bind_cols <- function(...) {
   dots <- list2(...)
 
   dots <- squash_if(dots, vec_is_list)
-  dots <- discard(dots, is.null)
+  dots <- discard(dots, function(.) is.null(.) || (is.data.frame(.) && ncol(.) == 0))
 
   # Strip names off of data frame components so that vec_cbind() unpacks them
   is_data_frame <- map_lgl(dots, is.data.frame)

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -62,6 +62,10 @@ test_that("bind_cols unpacks tibbles", {
   )
 })
 
+test_that("bind_cols() treats data frames with 0 columns as NULL", {
+  df <- data.frame(x = 1:3)
+  expect_equal(bind_cols(df, data.frame()), df)
+})
 
 # rows --------------------------------------------------------------------
 


### PR DESCRIPTION
closes #5300. This is labelled as a documentation issu in #5300 but I don't think it hurts to ignore 0 columns data frames. 

``` r
library(dplyr, warn.conflicts = FALSE)

df <- data.frame(x = 1:3)
bind_cols(df, data.frame())
#>   x
#> 1 1
#> 2 2
#> 3 3
```

<sup>Created on 2020-06-29 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>