### PR TITLE
relocate() respecting ...

### DIFF
--- a/R/relocate.R
+++ b/R/relocate.R
@@ -59,13 +59,19 @@ relocate.data.frame <- function(.data, ..., .before = NULL, .after = NULL) {
     abort("Must supply only one of `.before` and `.after`.")
   } else if (has_before) {
     where <- min(unname(tidyselect::eval_select(.before, .data)))
-    to_move <- c(setdiff(to_move, where), where)
+    if (!where %in% to_move) {
+      to_move <- c(to_move, where)
+    }
   } else if (has_after) {
     where <- max(unname(tidyselect::eval_select(.after, .data)))
-    to_move <- c(where, setdiff(to_move, where))
+    if (!where %in% to_move) {
+      to_move <- c(where, to_move)
+    }
   } else {
     where <- 1L
-    to_move <- union(to_move, where)
+    if (!where %in% to_move) {
+      to_move <- union(to_move, where)
+    }
   }
 
   lhs <- setdiff(seq2(1, where - 1), to_move)

--- a/tests/testthat/test-relocate.R
+++ b/tests/testthat/test-relocate.R
@@ -39,9 +39,18 @@ test_that("before and after are defused with context", {
 })
 
 test_that("relocate() respects order specified by ... (#5328)", {
-  df <- tibble(a=1,x=1,b=1,z=1,y=1)
+  df <- tibble(a = 1, x = 1, b = 1, z = 1, y = 1)
 
-  expect_equal(names(relocate(df, x, y, z, .before=x)), c("a", "x", "y", "z", "b"))
-  expect_equal(names(relocate(df, x, y, z, .after = last_col())), c("a", "b", "x", "y", "z"))
-  expect_equal(names(relocate(df, x, a, z)), c("x", "a", "z", "b", "y"))
+  expect_equal(
+    names(relocate(df, x, y, z, .before = x)),
+    c("a", "x", "y", "z", "b")
+  )
+  expect_equal(
+    names(relocate(df, x, y, z, .after = last_col())),
+    c("a", "b", "x", "y", "z")
+  )
+  expect_equal(
+    names(relocate(df, x, a, z)),
+    c("x", "a", "z", "b", "y")
+  )
 })

--- a/tests/testthat/test-relocate.R
+++ b/tests/testthat/test-relocate.R
@@ -37,3 +37,11 @@ test_that("before and after are defused with context", {
     names(relocate(mtcars, 3, .after = 5))
   )
 })
+
+test_that("relocate() respects order specified by ... (#5328)", {
+  df <- tibble(a=1,x=1,b=1,z=1,y=1)
+
+  expect_equal(names(relocate(df, x, y, z, .before=x)), c("a", "x", "y", "z", "b"))
+  expect_equal(names(relocate(df, x, y, z, .after = last_col())), c("a", "b", "x", "y", "z"))
+  expect_equal(names(relocate(df, x, a, z)), c("x", "a", "z", "b", "y"))
+})


### PR DESCRIPTION
closes #5328

``` r
library(dplyr, warn.conflicts = FALSE)

df <- tibble(a=1,x=1,b=1,z=1,y=1)

relocate(df, x, y, z, .before=x)
#> # A tibble: 1 x 5
#>       a     x     y     z     b
#>   <dbl> <dbl> <dbl> <dbl> <dbl>
#> 1     1     1     1     1     1
relocate(df, x, y, z, .after = last_col())
#> # A tibble: 1 x 5
#>       a     b     x     y     z
#>   <dbl> <dbl> <dbl> <dbl> <dbl>
#> 1     1     1     1     1     1
relocate(df, x, a, z)
#> # A tibble: 1 x 5
#>       x     a     z     b     y
#>   <dbl> <dbl> <dbl> <dbl> <dbl>
#> 1     1     1     1     1     1
```

<sup>Created on 2020-07-01 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>