### PR TITLE
Prefer withCallingHandlers() when rethrowing

### DIFF
--- a/R/arrange.R
+++ b/R/arrange.R
@@ -113,7 +113,7 @@ arrange_rows <- function(.data, dots) {
   #
   #       revisit when we have something like mutate_one() to
   #       evaluate one quosure in the data mask
-  data <- tryCatch({
+  data <- withCallingHandlers({
     transmute(new_data_frame(.data), !!!quosures)
   }, error = function(cnd) {
     stop_arrange_transmute(cnd)

--- a/R/filter.R
+++ b/R/filter.R
@@ -120,7 +120,7 @@ filter_rows <- function(.data, ...) {
   mask <- DataMask$new(.data, caller_env())
 
   env_filter <- env()
-  tryCatch(
+  withCallingHandlers(
     mask$eval_all_filter(dots, env_filter),
     simpleError = function(e) {
       stop_dplyr(env_filter$current_expression, dots, fn = "filter", problem = conditionMessage(e))

--- a/R/join-rows.R
+++ b/R/join-rows.R
@@ -3,7 +3,7 @@ join_rows <- function(x_key, y_key, type = c("inner", "left", "right", "full"), 
 
   # Find matching rows in y for each row in x
   y_split <- vec_group_loc(y_key)
-  tryCatch(
+  withCallingHandlers(
     matches <- vec_match(x_key, y_split$key, na_equal = na_equal),
     vctrs_error_incompatible_type = function(cnd) {
       rx <- "^[^$]+[$]"

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -290,7 +290,7 @@ mutate_cols <- function(.data, ...) {
         if (length(rows) == 1) {
           result <- chunks[[1]]
         } else {
-          result <- tryCatch(
+          result <- withCallingHandlers(
             vec_unchop(chunks, rows),
             vctrs_error_incompatible_type = function(cnd) {
               abort(class = "dplyr:::error_mutate_incompatible_combine", parent = cnd)

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -216,7 +216,7 @@ summarise_cols <- function(.data, ...) {
   chunks <- vector("list", length(dots))
   types <- vector("list", length(dots))
 
-  tryCatch({
+  withCallingHandlers({
 
     # generate all chunks and monitor the sizes
     for (i in seq_along(dots)) {
@@ -230,7 +230,7 @@ summarise_cols <- function(.data, ...) {
 
       mask$across_cache_reset()
 
-      result_type <- types[[i]] <- tryCatch(
+      result_type <- types[[i]] <- withCallingHandlers(
         vec_ptype_common(!!!chunks[[i]]),
         vctrs_error_incompatible_type = function(cnd) {
           abort(class = "dplyr:::error_summarise_incompatible_combine", parent = cnd)


### PR DESCRIPTION
because it's faster than `tryCatch()` and reduces the depth of the call stack.