### PR TITLE
Allow column named .rows in group_by()

### DIFF
--- a/R/group_data.R
+++ b/R/group_data.R
@@ -82,7 +82,8 @@ group_keys.data.frame <- function(.tbl, ...) {
 #' @rdname group_data
 #' @export
 group_rows <- function(.data) {
-  group_data(.data)[[".rows"]]
+  groups <- group_data(.data)
+  groups[[length(groups)]]
 }
 
 #' @export
@@ -115,7 +116,12 @@ group_vars <- function(x) {
 }
 #' @export
 group_vars.data.frame <- function(x) {
-  setdiff(names(group_data(x)), ".rows")
+  names <- names(group_data(x))
+  if (names[[length(names)]] == ".rows") {
+    names[-length(names)]
+  } else {
+    names
+  }
 }
 
 #' @export

--- a/R/grouped-df.r
+++ b/R/grouped-df.r
@@ -47,7 +47,7 @@ compute_groups <- function(data, vars, drop = FALSE) {
 
   signal("", class = "dplyr_regroup")
 
-  groups <- tibble(!!!old_keys, ".rows" := old_rows)
+  groups <- tibble(!!!old_keys, ".rows" := old_rows, .name_repair = "minimal")
 
   if (!isTRUE(drop) && any(map_lgl(old_keys, is.factor))) {
     # Extra work is needed to auto expand empty groups
@@ -85,7 +85,7 @@ compute_groups <- function(data, vars, drop = FALSE) {
     })
     names(new_keys) <- vars
 
-    groups <- tibble(!!!new_keys, ".rows" := new_rows)
+    groups <- tibble(!!!new_keys, ".rows" := new_rows, .name_repair = "minimal")
   }
 
   structure(groups, .drop = drop)
@@ -277,16 +277,16 @@ cbind.grouped_df <- function(...) {
   bind_cols(...)
 }
 
+# Helpers -----------------------------------------------------------------
+
 group_data_trim <- function(group_data, preserve = FALSE) {
   if (preserve) {
     return(group_data)
   }
 
-  non_empty <- lengths(group_data$".rows") > 0
+  non_empty <- lengths(group_data[[length(group_data)]]) > 0
   group_data[non_empty, , drop = FALSE]
 }
-
-# Helpers -----------------------------------------------------------------
 
 expand_groups <- function(old_groups, positions, nr) {
   .Call(`dplyr_expand_groups`, old_groups, positions, nr)


### PR DESCRIPTION
A much simpler solution is to disallow it with a cleaner error message.

Closes #5382.