### PR TITLE
use rlang 0.4.7

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Imports:
     magrittr (>= 1.5),
     methods,
     R6,
-    rlang (>= 0.4.6),
+    rlang (>= 0.4.7),
     tibble (>= 2.1.3),
     tidyselect (>= 1.1.0),
     utils,


### PR DESCRIPTION
Should this also bump `tibble` dependency ?