### PR TITLE
Fix error message when data frame contains duplicated names

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Imports:
     magrittr (>= 1.5),
     methods,
     R6,
-    rlang (>= 0.4.6),
+    rlang (>= 0.4.7),
     tibble (>= 2.1.3),
     tidyselect (>= 1.1.0),
     utils,

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -38,6 +38,10 @@ DataMask <- R6Class("DataMask",
       private$used <- rep(FALSE, ncol(data))
 
       names_bindings <- chr_unserialise_unicode(names2(data))
+      if (anyDuplicated(names_bindings)) {
+        abort("Can't mutate a data frame with duplicate names.")
+      }
+
       private$resolved <- set_names(vector(mode = "list", length = ncol(data)), names_bindings)
 
       promise_fn <- function(index, chunks = resolve_chunks(index), name = names_bindings[index]) {

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -39,7 +39,7 @@ DataMask <- R6Class("DataMask",
 
       names_bindings <- chr_unserialise_unicode(names2(data))
       if (anyDuplicated(names_bindings)) {
-        abort("Can't mutate a data frame with duplicate names.")
+        abort("Can't transform a data frame with duplicate names.")
       }
 
       private$resolved <- set_names(vector(mode = "list", length = ncol(data)), names_bindings)

--- a/tests/testthat/test-arrange-errors.txt
+++ b/tests/testthat/test-arrange-errors.txt
@@ -4,7 +4,7 @@ duplicated column name
 
 > tibble(x = 1, x = 1, .name_repair = "minimal") %>% arrange(x)
 Error: arrange() failed at implicit mutate() step. 
-x Can't bind data because some arguments have the same name
+x Can't mutate a data frame with duplicate names.
 
 
 error in mutate() step

--- a/tests/testthat/test-arrange-errors.txt
+++ b/tests/testthat/test-arrange-errors.txt
@@ -4,7 +4,7 @@ duplicated column name
 
 > tibble(x = 1, x = 1, .name_repair = "minimal") %>% arrange(x)
 Error: arrange() failed at implicit mutate() step. 
-x Can't mutate a data frame with duplicate names.
+x Can't transform a data frame with duplicate names.
 
 
 error in mutate() step

--- a/tests/testthat/test-summarise-errors.txt
+++ b/tests/testthat/test-summarise-errors.txt
@@ -111,3 +111,10 @@ x Column `b` not found in `.data`
 i Input `c` is `.data$b`.
 i The error occurred in group 1: a = 1.
 
+
+Duplicate column names
+======================
+
+> tibble(x = 1, x = 1, .name_repair = "minimal") %>% summarise(x)
+Error: Can't transform a data frame with duplicate names.
+

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -260,5 +260,8 @@ test_that("summarise() gives meaningful errors", {
     "# .data pronoun"
     summarise(tibble(a = 1), c = .data$b)
     summarise(group_by(tibble(a = 1:3), a), c = .data$b)
+
+    "# Duplicate column names"
+    tibble(x = 1, x = 1, .name_repair = "minimal") %>% summarise(x)
   })
 })


### PR DESCRIPTION
Fixes the error message failure on CI. Binding functions in rlang no longer fail when there are duplicate bindings.

I took this opportunity to bump the rlang dep.