### PR TITLE
attempt to protect against late use of DataMask objects.

### DIFF
--- a/R/context.R
+++ b/R/context.R
@@ -142,7 +142,5 @@ peek_mask <- function(fun = "peek_mask()") {
   context_peek("mask", fun)
 }
 local_mask <- function(x, frame = caller_env()) {
-  expr <- expr(on.exit(mask$forget(), add = TRUE))
-  eval_bare(expr, frame)
   context_local("mask", x, frame = frame)
 }

--- a/R/context.R
+++ b/R/context.R
@@ -142,5 +142,7 @@ peek_mask <- function(fun = "peek_mask()") {
   context_peek("mask", fun)
 }
 local_mask <- function(x, frame = caller_env()) {
+  expr <- expr(on.exit(mask$forget(), add = TRUE))
+  eval_bare(expr, frame)
   context_local("mask", x, frame = frame)
 }

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -65,11 +65,15 @@ DataMask <- R6Class("DataMask",
       private$mask$.data <- as_data_pronoun(private$mask)
     },
 
-    forget = function() {
+    forget = function(fn) {
       names_bindings <- self$current_vars()
 
       osbolete_promise_fn <- function(name) {
-        abort(glue("Obsolete data mask, cannot resolve `{name}`"))
+        abort(c(
+          "Obsolete data mask.",
+          x = glue("Too late to resolve `{name}` after the end of `dplyr::{fn}()`."),
+          i = glue("Did you save an object that uses `{name}` lazily in a column in the `dplyr::{fn}()` expression ?")
+        ))
       }
 
       promises <- map(names_bindings, function(.x) expr(osbolete_promise_fn(!!.x)))

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -45,8 +45,14 @@ DataMask <- R6Class("DataMask",
       private$resolved <- set_names(vector(mode = "list", length = ncol(data)), names_bindings)
 
       promise_fn <- function(index, chunks = resolve_chunks(index), name = names_bindings[index]) {
+          current_group <- self$get_current_group()
+
+          if (is.na(current_group)) {
+            abort("Attempt to use data mask too late")
+          }
+
           # resolve the chunks and hold the slice for current group
-          res <- .subset2(chunks, self$get_current_group())
+          res <- .subset2(chunks, current_group)
 
           # track - not safe to directly use `index`
           self$set(name, chunks)

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -73,9 +73,10 @@ DataMask <- R6Class("DataMask",
       }
 
       promises <- map(names_bindings, function(.x) expr(osbolete_promise_fn(!!.x)))
-      suppressWarnings(
+      suppressWarnings({
+        rm(list = names_bindings, envir = private$bindings)
         env_bind_lazy(private$bindings, !!!set_names(promises, names_bindings))
-      )
+      })
     },
 
     add = function(name, chunks) {

--- a/R/filter.R
+++ b/R/filter.R
@@ -118,6 +118,7 @@ filter.data.frame <- function(.data, ..., .preserve = FALSE) {
 filter_rows <- function(.data, ...) {
   dots <- check_filter(enquos(...))
   mask <- DataMask$new(.data, caller_env())
+  on.exit(mask$forget(), add = TRUE)
 
   env_filter <- env()
   withCallingHandlers(

--- a/R/filter.R
+++ b/R/filter.R
@@ -118,7 +118,7 @@ filter.data.frame <- function(.data, ..., .preserve = FALSE) {
 filter_rows <- function(.data, ...) {
   dots <- check_filter(enquos(...))
   mask <- DataMask$new(.data, caller_env())
-  on.exit(mask$forget(), add = TRUE)
+  on.exit(mask$forget("filter"), add = TRUE)
 
   env_filter <- env()
   withCallingHandlers(

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -218,7 +218,7 @@ transmute.data.frame <- function(.data, ...) {
 
 mutate_cols <- function(.data, ...) {
   mask <- DataMask$new(.data, caller_env())
-  on.exit(mask$forget(), add = TRUE)
+  on.exit(mask$forget("mutate"), add = TRUE)
   rows <- mask$get_rows()
 
   dots <- enquos(...)

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -218,6 +218,7 @@ transmute.data.frame <- function(.data, ...) {
 
 mutate_cols <- function(.data, ...) {
   mask <- DataMask$new(.data, caller_env())
+  on.exit(mask$forget(), add = TRUE)
   rows <- mask$get_rows()
 
   dots <- enquos(...)

--- a/R/slice.R
+++ b/R/slice.R
@@ -249,6 +249,7 @@ slice_rows <- function(.data, ...) {
   }
 
   mask <- DataMask$new(.data, caller_env())
+  on.exit(mask$forget(), add = TRUE)
   rows <- mask$get_rows()
 
   quo <- quo(c(!!!dots))

--- a/R/slice.R
+++ b/R/slice.R
@@ -249,7 +249,7 @@ slice_rows <- function(.data, ...) {
   }
 
   mask <- DataMask$new(.data, caller_env())
-  on.exit(mask$forget(), add = TRUE)
+  on.exit(mask$forget("slice"), add = TRUE)
   rows <- mask$get_rows()
 
   quo <- quo(c(!!!dots))

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -205,6 +205,7 @@ summarise.rowwise_df <- function(.data, ..., .groups = NULL) {
 
 summarise_cols <- function(.data, ...) {
   mask <- DataMask$new(.data, caller_env())
+  on.exit(mask$forget(), add = TRUE)
 
   dots <- enquos(...)
   dots_names <- names(dots)

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -205,7 +205,7 @@ summarise.rowwise_df <- function(.data, ..., .groups = NULL) {
 
 summarise_cols <- function(.data, ...) {
   mask <- DataMask$new(.data, caller_env())
-  on.exit(mask$forget(), add = TRUE)
+  on.exit(mask$forget("summarise"), add = TRUE)
 
   dots <- enquos(...)
   dots_names <- names(dots)

--- a/src/dplyr.h
+++ b/src/dplyr.h
@@ -72,7 +72,9 @@ SEXP current_group = PROTECT(Rf_ScalarInteger(NA_INTEGER));                     
 Rf_defineVar(dplyr::symbols::current_group, current_group, env_private);           \
 int* p_current_group = INTEGER(current_group)
 
-#define DPLYR_MASK_FINALISE() UNPROTECT(5);
+#define DPLYR_MASK_FINALISE()                             \
+  *p_current_group = NA_INTEGER;                          \
+  UNPROTECT(5);
 
 #define DPLYR_MASK_SET_GROUP(INDEX)                                                   \
 *p_current_group = INDEX + 1;                                                         \

--- a/src/dplyr.h
+++ b/src/dplyr.h
@@ -72,9 +72,9 @@ SEXP current_group = PROTECT(Rf_ScalarInteger(NA_INTEGER));                     
 Rf_defineVar(dplyr::symbols::current_group, current_group, env_private);           \
 int* p_current_group = INTEGER(current_group)
 
-#define DPLYR_MASK_FINALISE()                             \
-  *p_current_group = NA_INTEGER;                          \
-  UNPROTECT(5);
+#define DPLYR_MASK_FINALISE()                                  \
+                                                               \
+UNPROTECT(5);
 
 #define DPLYR_MASK_SET_GROUP(INDEX)                                                   \
 *p_current_group = INDEX + 1;                                                         \

--- a/tests/testthat/test-mutate-errors.txt
+++ b/tests/testthat/test-mutate-errors.txt
@@ -119,3 +119,14 @@ x Column `b` not found in `.data`
 i Input `c` is `.data$b`.
 i The error occurred in group 1: a = 1.
 
+
+obsolete data mask
+==================
+
+> lazy <- (function(x) list(enquo(x)))
+> res <- tbl %>% rowwise() %>% mutate(z = lazy(x), .keep = "unused")
+> eval_tidy(res$z[[1]])
+Error: Obsolete data mask.
+x Too late to resolve `x` after the end of `dplyr::mutate()`.
+i Did you save an object that uses `x` lazily in a column in the `dplyr::mutate()` expression ?
+

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -368,6 +368,21 @@ test_that("mutate() preserves the call stack on error (#5308)", {
   expect_true(some(stack, is_call, "foobar"))
 })
 
+test_that("dplyr data mask can become obsolete", {
+  lazy <- function(x) {
+    list(enquo(x))
+  }
+  df <- tibble(
+    x = 1:2
+  )
+
+  res <- df %>%
+    rowwise() %>%
+    mutate(y = lazy(x), .keep = "unused")
+  expect_equal(names(res), c("x", "y"))
+  expect_error(eval_tidy(res$y[[1]]))
+})
+
 # Error messages ----------------------------------------------------------
 
 test_that("mutate() give meaningful errors", {
@@ -427,5 +442,12 @@ test_that("mutate() give meaningful errors", {
     tibble(a = 1:3) %>%
       group_by(a) %>%
       mutate(c = .data$b)
+
+    "# obsolete data mask"
+    lazy <- function(x) list(enquo(x))
+    res <- tbl %>%
+      rowwise() %>%
+      mutate(z = lazy(x), .keep = "unused")
+    eval_tidy(res$z[[1]])
   })
 })


### PR DESCRIPTION
Related to #5388

``` r
library(dplyr, warn.conflicts = FALSE)
library(ggplot2)

plot_this <- function(.data, x, y, label) {
  ggplot() +
    geom_point(data = .data, aes(mpg, hp)) +
    geom_point(aes(x = {{ x }}, y = {{ y }}), color = "red", size = 4) +
    geom_text(aes(x = {{ x }}, y = {{ y }}, label = {{ label }}), color = "white", fontface = "bold")
}

df <- tibble(
  data = list(mtcars),
  x = c(16, 18, 19),
  y = c(80, 90, 100)
) %>% 
  tibble::rowid_to_column()
df
#> # A tibble: 3 x 4
#>   rowid data                    x     y
#>   <int> <list>              <dbl> <dbl>
#> 1     1 <df[,11] [32 × 11]>    16    80
#> 2     2 <df[,11] [32 × 11]>    18    90
#> 3     3 <df[,11] [32 × 11]>    19   100
plots <- df %>% 
  rowwise() %>% 
  mutate(
    plot = plot_this(data, x, y, rowid) %>% list(), 
    .keep = "unused"
  ) %>% 
  pull()
plots[[1L]]
#> Error: Attempt to use data mask too late
#> Backtrace:
#>      █
#>   1. ├─base::tryCatch(...)
#>   2. │ └─base:::tryCatchList(expr, classes, parentenv, handlers)
#>   3. │   ├─base:::tryCatchOne(...)
#>   4. │   │ └─base:::doTryCatch(return(expr), name, parentenv, handler)
#>   5. │   └─base:::tryCatchList(expr, names[-nh], parentenv, handlers[-nh])
#>   6. │     └─base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
#>   7. │       └─base:::doTryCatch(return(expr), name, parentenv, handler)
#>   8. ├─base::withCallingHandlers(...)
#>   9. ├─base::saveRDS(...)
#>  10. ├─base::do.call(...)
#>  11. ├─(function (what, args, quote = FALSE, envir = parent.frame()) ...
#>  12. ├─(function (input, opts) ...
#>  13. │ └─rmarkdown::render(input, quiet = TRUE, envir = globalenv(), encoding = "UTF-8")
#>  14. │   └─knitr::knit(knit_input, knit_output, envir = envir, quiet = quiet)
#>  15. │     └─knitr:::process_file(text, output)
#>  16. │       ├─base::withCallingHandlers(...)
#>  17. │       ├─knitr:::process_group(group)
#>  18. │       └─knitr:::process_group.block(group)
#>  19. │         └─knitr:::call_block(x)
#>  20. │           └─knitr:::block_exec(params)
#>  21. │             ├─knitr:::in_dir(...)
#>  22. │             └─knitr:::evaluate(...)
#>  23. │               └─evaluate::evaluate(...)
#>  24. │                 └─evaluate:::evaluate_call(...)
#>  25. │                   ├─evaluate:::handle(...)
#>  26. │                   │ └─base::try(f, silent = TRUE)
#>  27. │                   │   └─base::tryCatch(...)
#>  28. │                   │     └─base:::tryCatchList(expr, classes, parentenv, handlers)
#>  29. │                   │       └─base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
#>  30. │                   │         └─base:::doTryCatch(return(expr), name, parentenv, handler)
#>  31. │                   ├─base::withCallingHandlers(...)
#>  32. │                   ├─base::withVisible(value_fun(ev$value, ev$visible))
#>  33. │                   └─knitr:::value_fun(ev$value, ev$visible)
#>  34. │                     └─knitr:::fun(x, options = options)
#>  35. │                       ├─base::withVisible(knit_print(x, ...))
#>  36. │                       ├─knitr::knit_print(x, ...)
#>  37. │                       └─knitr:::knit_print.default(x, ...)
#>  38. │                         └─evaluate:::normal_print(x)
#>  39. │                           ├─base::print(x)
#>  40. │                           └─ggplot2:::print.ggplot(x)
#>  41. │                             ├─ggplot2::ggplot_build(x)
#>  42. │                             └─ggplot2:::ggplot_build.ggplot(x)
#>  43. │                               └─ggplot2:::by_layer(function(l, d) l$compute_aesthetics(d, plot))
#>  44. │                                 └─ggplot2:::f(l = layers[[i]], d = data[[i]])
#>  45. │                                   └─l$compute_aesthetics(d, plot)
#>  46. │                                     └─ggplot2:::f(..., self = self)
#>  47. │                                       └─base::lapply(aesthetics, eval_tidy, data = data, env = env)
#>  48. │                                         └─rlang:::FUN(X[[i]], ...)
#>  49. └─dplyr:::promise_fn(3L)
```

<sup>Created on 2020-07-13 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>