### PR TITLE
Improve detection of modern order proxy

### DIFF
--- a/R/arrange.R
+++ b/R/arrange.R
@@ -140,3 +140,19 @@ arrange_rows <- function(.data, dots) {
 
   exec("order", !!!unname(proxies), decreasing = FALSE, na.last = TRUE)
 }
+
+# FIXME: Temporary util until the API change from
+# https://github.com/r-lib/vctrs/pull/1155 is on CRAN and we can
+# depend on it
+delayedAssign(
+  "dplyr_proxy_order",
+  if (env_has(ns_env("vctrs"), "vec_proxy_order")) {
+    vec_proxy_order
+  } else {
+    function(x, ...) vec_proxy_compare(x, ..., relax = TRUE)
+  }
+)
+
+# Hack to pass CRAN check with older vctrs versions where
+# `vec_proxy_order()` doesn't exist
+utils::globalVariables("vec_proxy_order")

--- a/R/arrange.R
+++ b/R/arrange.R
@@ -119,15 +119,13 @@ arrange_rows <- function(.data, dots) {
     stop_arrange_transmute(cnd)
   })
 
-  use_proxy_order <- utils::packageVersion("vctrs") > "0.3.1"
-
   # we can't just use vec_compare_proxy(data) because we need to apply
   # direction for each column, so we get a list of proxies instead
   # and then mimic vctrs:::order_proxy
   #
   # should really be map2(quosures, directions, ...)
   proxies <- map2(data, directions, function(column, direction) {
-    proxy <- dplyr_proxy_order(column, use_proxy_order)
+    proxy <- dplyr_proxy_order(column)
     desc <- identical(direction, "desc")
     if (is.data.frame(proxy)) {
       proxy <- order(vec_order(proxy,
@@ -142,16 +140,3 @@ arrange_rows <- function(.data, dots) {
 
   exec("order", !!!unname(proxies), decreasing = FALSE, na.last = TRUE)
 }
-
-# FIXME: Temporary patch until vctrs 0.3.2 has been on CRAN for long enough
-# to reasonably expect that users have upgraded
-dplyr_proxy_order <- function(x, use_proxy_order) {
-  if (use_proxy_order) {
-    vec_proxy_order(x)
-  } else {
-    vec_proxy_compare(x, relax = TRUE)
-  }
-}
-# Hack to pass CRAN check with vctrs 0.3.1,
-# where `vec_proxy_order()` doesn't exist
-utils::globalVariables("vec_proxy_order")

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -1,3 +1,13 @@
+
+# FIXME: Temporary util until the API change from
+# https://github.com/r-lib/vctrs/pull/1155 has been on CRAN for long
+# enough to reasonably expect that users have upgraded
+dplyr_proxy_order <- function(x) NULL
+
+# Hack to pass CRAN check with vctrs 0.3.1,
+# where `vec_proxy_order()` doesn't exist
+utils::globalVariables("vec_proxy_order")
+
 .onLoad <- function(libname, pkgname) {
   op <- options()
   op.dplyr <- list(
@@ -6,8 +16,16 @@
   toset <- !(names(op.dplyr) %in% names(op))
   if (any(toset)) options(op.dplyr[toset])
 
-  ns <- ns_env("dplyr")
-  .Call(dplyr_init_library, ns_env())
+  if ("relax" %in% names(formals(vec_proxy_compare))) {
+    dplyr_proxy_order <<- function(x, ..., relax = TRUE) {
+      vec_proxy_compare(x, ..., relax = relax)
+    }
+  } else {
+    dplyr_proxy_order <<- vec_proxy_order
+  }
+
+  .Call(dplyr_init_library, ns_env("dplyr"))
+
   invisible()
 }
 

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -4,8 +4,8 @@
 # enough to reasonably expect that users have upgraded
 dplyr_proxy_order <- function(x) NULL
 
-# Hack to pass CRAN check with vctrs 0.3.1,
-# where `vec_proxy_order()` doesn't exist
+# Hack to pass CRAN check with older vctrs versions where
+# `vec_proxy_order()` doesn't exist
 utils::globalVariables("vec_proxy_order")
 
 .onLoad <- function(libname, pkgname) {

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -1,13 +1,4 @@
 
-# FIXME: Temporary util until the API change from
-# https://github.com/r-lib/vctrs/pull/1155 has been on CRAN for long
-# enough to reasonably expect that users have upgraded
-dplyr_proxy_order <- function(x) NULL
-
-# Hack to pass CRAN check with older vctrs versions where
-# `vec_proxy_order()` doesn't exist
-utils::globalVariables("vec_proxy_order")
-
 .onLoad <- function(libname, pkgname) {
   op <- options()
   op.dplyr <- list(
@@ -15,14 +6,6 @@ utils::globalVariables("vec_proxy_order")
   )
   toset <- !(names(op.dplyr) %in% names(op))
   if (any(toset)) options(op.dplyr[toset])
-
-  if ("relax" %in% names(formals(vec_proxy_compare))) {
-    dplyr_proxy_order <<- function(x, ..., relax = TRUE) {
-      vec_proxy_compare(x, ..., relax = relax)
-    }
-  } else {
-    dplyr_proxy_order <<- vec_proxy_order
-  }
 
   .Call(dplyr_init_library, ns_env("dplyr"))
 


### PR DESCRIPTION
In the end the next version of vctrs will not include the order proxy. So we detect it from the formal signature of `vec_proxy_compare()` instead of the vctrs version. Edit: Now detecting presence of `vec_proxy_order()` in the vctrs namespace.