### PR TITLE
Update ntile documentation link

### DIFF
--- a/R/rank.R
+++ b/R/rank.R
@@ -55,7 +55,7 @@ row_number <- function(x) {
 }
 
 # Definition from
-# http://blogs.msdn.com/b/craigfr/archive/2008/03/31/ranking-functions-rank-dense-rank-and-ntile.aspx
+# https://techcommunity.microsoft.com/t5/sql-server/ranking-functions-rank-dense-rank-and-ntile/ba-p/383384
 #' @param n number of groups to split up into.
 #' @export
 #' @rdname ranking


### PR DESCRIPTION
In the `ntile()` docs, the definition link gives a 404 error since Microsoft migrated the blog. Seem to have found it though&mdash;same author, title, and date posted.
