### PR TITLE
avoid look past std::vector, as identified by cran valgrind

### DIFF
--- a/src/group_by.cpp
+++ b/src/group_by.cpp
@@ -178,7 +178,9 @@ public:
       for (R_xlen_t j = start; j < end;) {
         R_xlen_t current = vec_pos[j];
         R_xlen_t start_idx = j;
-        while (j < end && vec_pos[++j] == current);
+
+        j++;
+        while (j < end && vec_pos[j++] == current) ;
         expanders.push_back(expander(data_, positions_, depth_ + 1, current, start_idx, j));
       }
     }

--- a/src/group_by.cpp
+++ b/src/group_by.cpp
@@ -179,8 +179,8 @@ public:
         R_xlen_t current = vec_pos[j];
         R_xlen_t start_idx = j;
 
-        j++;
-        while (j < end && vec_pos[j++] == current) ;
+        ++j;
+        for (; j < end && vec_pos[j] == current; ++j);
         expanders.push_back(expander(data_, positions_, depth_ + 1, current, start_idx, j));
       }
     }


### PR DESCRIPTION
Dealing with: https://www.stats.ox.ac.uk/pub/bdr/memtests/valgrind/dplyr/tests/testthat.Rout

rhub::check_with_valgrind(): https://builder.r-hub.io/status/dplyr_1.0.1.tar.gz-0eeefce6aa944aeeb5cc6b6d5af15b32