### PR TITLE
Improve `n_distinct()` performance

### DIFF
--- a/R/distinct.R
+++ b/R/distinct.R
@@ -138,9 +138,11 @@ distinct.data.frame <- function(.data, ..., .keep_all = FALSE) {
 #' n_distinct(x)
 #' @export
 n_distinct <- function(..., na.rm = FALSE) {
-  size <- vec_size_common(...)
+  args <- list2(...)
 
-  data <- vec_recycle_common(..., .size = size)
+  size <- vec_size_common(!!!args)
+
+  data <- vec_recycle_common(!!!args, .size = size)
 
   # Remove after r-lib/vctrs#1198
   data <- set_names(data, seq_along(data))

--- a/R/distinct.R
+++ b/R/distinct.R
@@ -138,10 +138,18 @@ distinct.data.frame <- function(.data, ..., .keep_all = FALSE) {
 #' n_distinct(x)
 #' @export
 n_distinct <- function(..., na.rm = FALSE) {
-  columns <- map(enquos(..., .named = TRUE), eval_tidy)
-  data <- as_tibble(columns, .name_repair = "minimal")
+  size <- vec_size_common(...)
+
+  data <- vec_recycle_common(..., .size = size)
+
+  # Remove after r-lib/vctrs#1198
+  data <- set_names(data, seq_along(data))
+
+  data <- new_data_frame(data, n = size)
+
   if (isTRUE(na.rm)){
     data <- vec_slice(data, !reduce(map(data, vec_equal_na), `|`))
   }
+
   vec_unique_count(data)
 }

--- a/R/distinct.R
+++ b/R/distinct.R
@@ -144,7 +144,6 @@ n_distinct <- function(..., na.rm = FALSE) {
 
   data <- vec_recycle_common(!!!args, .size = size)
 
-  # Remove after r-lib/vctrs#1198
   nms <- vec_rep("", length(data))
   data <- set_names(data, nms)
 

--- a/R/distinct.R
+++ b/R/distinct.R
@@ -145,7 +145,8 @@ n_distinct <- function(..., na.rm = FALSE) {
   data <- vec_recycle_common(!!!args, .size = size)
 
   # Remove after r-lib/vctrs#1198
-  data <- set_names(data, seq_along(data))
+  nms <- vec_rep("", length(data))
+  data <- set_names(data, nms)
 
   data <- new_data_frame(data, n = size)
 

--- a/tests/testthat/test-n_distinct.R
+++ b/tests/testthat/test-n_distinct.R
@@ -79,3 +79,16 @@ test_that("n_distinct() respects .data (#5008)", {
     data.frame(n = 1L)
   )
 })
+
+test_that("n_distinct() works with `{{ }}` (#5461)", {
+  wrapper <- function(data, col) {
+    summarise(data, result = n_distinct({{ col }}, na.rm = TRUE))
+  }
+
+  df <- data.frame(x = c(1, 1, 3, NA))
+
+  expect_identical(
+    wrapper(df, x),
+    data.frame(result = 2L)
+  )
+})


### PR DESCRIPTION
Closes #5428 

The `map()` and `as_tibble()` calls in `n_distinct()` are fairly slow when called repeatedly (added in https://github.com/tidyverse/dplyr/pull/5072).

This PR refactors `n_distinct()` to avoid tibble and `map()` and instead only use vctrs. I imagine this will be further improved with hybrid eval, but this should help significantly for now. I don't think it should change any behavior of `n_distinct()`.

Below is an adjusted example from #5428. It reduces the number of rows from 50,000,000 down to a more reasonable 500,000. The example there was a bit extreme to run on 50 million rows, but I imagine that it should at least work now.

``` r
library(tidyverse)

set.seed(123)
table_size <- 500000

dates <- seq(as.Date('2020/07/01'), as.Date('2020/07/18'), by = "day")

table_tbl <- tibble(
  column_1 = sample.int(n = 100, size = table_size, replace = T),
  date = sample(x = dates, size = table_size, replace = TRUE),
  column_3 = sample.int(n = 100, size = table_size, replace = T),
  column_4 = sample.int(n = 100, size = table_size, replace = T),
  column_5 = sample.int(n = 100, size = table_size, replace = T),
  column_6 = sample.int(n = 100, size = table_size, replace = T),
  column_7 = sample.int(n = 100, size = table_size, replace = T)
)

tbl <- group_by(table_tbl, column_1, date, column_3, column_4, column_5)
```

```r
# before
bench::mark(
  expr = summarise(tbl, ndist = n_distinct(column_6, column_7), .groups = "drop_last")
)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 expr          1.76m    1.76m   0.00947     130MB     4.87

# after
bench::mark(
  expr = summarise(tbl, ndist = n_distinct(column_6, column_7), .groups = "drop_last")
)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 expr          8.74s    8.74s     0.114     130MB     4.69
```

<sup>Created on 2020-07-21 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>