### PR TITLE
Improve group_by()'s example to show empty group

### DIFF
--- a/R/group-by.r
+++ b/R/group-by.r
@@ -72,13 +72,13 @@
 #'   group_vars()
 #'
 #'
-#' # when factors are involved, groups can be empty
+#' # when factors are involved and .drop = FALSE, groups can be empty
 #' tbl <- tibble(
 #'   x = 1:10,
 #'   y = factor(rep(c("a", "c"), each  = 5), levels = c("a", "b", "c"))
 #' )
 #' tbl %>%
-#'   group_by(y) %>%
+#'   group_by(y, .drop = FALSE) %>%
 #'   group_rows()
 #'
 group_by <- function(.data, ..., .add = FALSE, .drop = group_by_drop_default(.data)) {

--- a/man/group_by.Rd
+++ b/man/group_by.Rd
@@ -94,13 +94,13 @@ by_cyl \%>\%
   group_vars()
 
 
-# when factors are involved, groups can be empty
+# when factors are involved and .drop = FALSE, groups can be empty
 tbl <- tibble(
   x = 1:10,
   y = factor(rep(c("a", "c"), each  = 5), levels = c("a", "b", "c"))
 )
 tbl \%>\%
-  group_by(y) \%>\%
+  group_by(y, .drop = FALSE) \%>\%
   group_rows()
 
 }


### PR DESCRIPTION
Current example on `group_by()`'s help page doesn't actually show usage of the empty group. I guess `.drop = FALSE` is intended here.

``` r
library(dplyr, warn.conflicts = FALSE)

tbl <- tibble(
  x = 1:10,
  y = factor(rep(c("a", "c"), each  = 5), levels = c("a", "b", "c"))
)

tbl %>%
  group_by(y) %>%
  group_rows()
#> <list_of<integer>[2]>
#> [[1]]
#> [1] 1 2 3 4 5
#> 
#> [[2]]
#> [1]  6  7  8  9 10
```

<sup>Created on 2020-07-24 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
