### PR TITLE
allow local variables in across(.names=)

### DIFF
--- a/R/across.R
+++ b/R/across.R
@@ -79,7 +79,7 @@
 #' @export
 across <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
   key <- key_deparse(sys.call())
-  setup <- across_setup({{ .cols }}, fns = .fns, names = .names, key = key)
+  setup <- across_setup({{ .cols }}, fns = .fns, names = .names, key = key, .caller_env = caller_env())
 
   vars <- setup$vars
   if (length(vars) == 0L) {
@@ -153,7 +153,7 @@ c_across <- function(cols = everything()) {
 # next version of hybrid evaluation, which should offer a way for any function
 # to do any required "set up" work (like the `eval_select()` call) a single
 # time per top-level call, rather than once per group.
-across_setup <- function(cols, fns, names, key, .caller_env = caller_env(n = 2)) {
+across_setup <- function(cols, fns, names, key, .caller_env) {
   mask <- peek_mask("across()")
   value <- mask$across_cache_get(key)
   if (!is.null(value)) {

--- a/R/across.R
+++ b/R/across.R
@@ -153,9 +153,8 @@ c_across <- function(cols = everything()) {
 # next version of hybrid evaluation, which should offer a way for any function
 # to do any required "set up" work (like the `eval_select()` call) a single
 # time per top-level call, rather than once per group.
-across_setup <- function(cols, fns, names, key) {
+across_setup <- function(cols, fns, names, key, .caller_env = caller_env(n = 2)) {
   mask <- peek_mask("across()")
-
   value <- mask$across_cache_get(key)
   if (!is.null(value)) {
     return(value)
@@ -169,7 +168,7 @@ across_setup <- function(cols, fns, names, key) {
 
   if (is.null(fns)) {
     if (!is.null(names)) {
-      names <- vec_as_names(glue(names, col = vars, fn = "1"), repair = "check_unique")
+      names <- vec_as_names(glue(names, .envir = env(.caller_env, col = vars, fn = "1")), repair = "check_unique")
     }
 
     value <- list(vars = vars, fns = fns, names = names)
@@ -207,8 +206,7 @@ across_setup <- function(cols, fns, names, key) {
   }
 
   names <- vec_as_names(glue(names,
-    col = rep(vars, each = length(fns)),
-    fn  = rep(names_fns, length(vars))
+    .envir = env(.caller_env, col = rep(vars, each = length(fns)), fn = rep(names_fns, length(vars)))
   ), repair = "check_unique")
 
   value <- list(vars = vars, fns = fns, names = names)

--- a/man/across.Rd
+++ b/man/across.Rd
@@ -26,10 +26,10 @@ to access the current column and grouping keys respectively.}
 \item{...}{Additional arguments for the function calls in \code{.fns}.}
 
 \item{.names}{A glue specification that describes how to name the output
-columns. This can use \code{{col}} to stand for the selected column name, and
-\code{{fn}} to stand for the name of the function being applied. The default
-(\code{NULL}) is equivalent to \code{"{col}"} for the single function case and
-\code{"{col}_{fn}"} for the case where a list is used for \code{.fns}.}
+columns. This can use \code{{.col}} to stand for the selected column name, and
+\code{{.fn}} to stand for the name of the function being applied. The default
+(\code{NULL}) is equivalent to \code{"{.col}"} for the single function case and
+\code{"{.col}_{.fn}"} for the case where a list is used for \code{.fns}.}
 
 \item{cols, .cols}{<\code{\link[=dplyr_tidy_select]{tidy-select}}> Columns to transform.
 Because \code{across()} is used within functions like \code{summarise()} and
@@ -75,13 +75,13 @@ iris \%>\%
 # Use the .names argument to control the output names
 iris \%>\%
   group_by(Species) \%>\%
-  summarise(across(starts_with("Sepal"), mean, .names = "mean_{col}"))
+  summarise(across(starts_with("Sepal"), mean, .names = "mean_{.col}"))
 iris \%>\%
   group_by(Species) \%>\%
-  summarise(across(starts_with("Sepal"), list(mean = mean, sd = sd), .names = "{col}.{fn}"))
+  summarise(across(starts_with("Sepal"), list(mean = mean, sd = sd), .names = "{.col}.{.fn}"))
 iris \%>\%
   group_by(Species) \%>\%
-  summarise(across(starts_with("Sepal"), list(mean, sd), .names = "{col}.fn{fn}"))
+  summarise(across(starts_with("Sepal"), list(mean, sd), .names = "{.col}.fn{.fn}"))
 
 # c_across() ---------------------------------------------------------------
 df <- tibble(id = 1:4, w = runif(4), x = runif(4), y = runif(4), z = runif(4))

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -194,6 +194,15 @@ test_that("across(<empty set>) returns a data frame with 1 row (#5204)", {
   })
 })
 
+test_that("across(.names=) can use local variables in addition to {col} and {fn}", {
+  res <- local({
+    prefix <- "MEAN"
+    data.frame(x = 42) %>%
+      summarise(across(everything(), mean, .names = "{prefix}_{col}"))
+  })
+  expect_identical(res, data.frame(MEAN_x = 42))
+})
+
 
 # c_across ----------------------------------------------------------------
 

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -22,7 +22,7 @@ test_that("across() correctly names output columns", {
     c("x", "y", "z", "s")
   )
   expect_named(
-    summarise(gf, across(.names = "id_{col}")),
+    summarise(gf, across(.names = "id_{.col}")),
     c("x", "id_y", "id_z", "id_s")
   )
   expect_named(
@@ -30,7 +30,7 @@ test_that("across() correctly names output columns", {
     c("x", "y", "z")
   )
   expect_named(
-    summarise(gf, across(where(is.numeric), mean, .names = "mean_{col}")),
+    summarise(gf, across(where(is.numeric), mean, .names = "mean_{.col}")),
     c("x", "mean_y", "mean_z")
   )
   expect_named(
@@ -50,7 +50,7 @@ test_that("across() correctly names output columns", {
     c("x", "y_1", "y_2", "z_1", "z_2")
   )
   expect_named(
-    summarise(gf, across(where(is.numeric), list(mean = mean, sum = sum), .names = "{fn}_{col}")),
+    summarise(gf, across(where(is.numeric), list(mean = mean, sum = sum), .names = "{.fn}_{.col}")),
     c("x", "mean_y", "sum_y", "mean_z", "sum_z")
   )
 })
@@ -198,7 +198,7 @@ test_that("across(.names=) can use local variables in addition to {col} and {fn}
   res <- local({
     prefix <- "MEAN"
     data.frame(x = 42) %>%
-      summarise(across(everything(), mean, .names = "{prefix}_{col}"))
+      summarise(across(everything(), mean, .names = "{prefix}_{.col}"))
   })
   expect_identical(res, data.frame(MEAN_x = 42))
 })

--- a/vignettes/colwise.Rmd
+++ b/vignettes/colwise.Rmd
@@ -95,15 +95,15 @@ starwars %>% summarise(across(where(is.numeric), min_max))
 Control how the names are created with the `.names` argument which takes a [glue](http://glue.tidyverse.org/) spec:
 
 ```{r}
-starwars %>% summarise(across(where(is.numeric), min_max, .names = "{fn}.{col}"))
+starwars %>% summarise(across(where(is.numeric), min_max, .names = "{.fn}.{.col}"))
 ```
 
 If you'd prefer all summaries with the same function to be grouped together, you'll have to expand the calls yourself:
 
 ```{r}
 starwars %>% summarise(
-  across(where(is.numeric), ~min(.x, na.rm = TRUE), .names = "min_{col}"),
-  across(where(is.numeric), ~max(.x, na.rm = TRUE), .names = "max_{col}")
+  across(where(is.numeric), ~min(.x, na.rm = TRUE), .names = "min_{.col}"),
+  across(where(is.numeric), ~max(.x, na.rm = TRUE), .names = "max_{.col}")
 )
 ```
 

--- a/vignettes/programming.Rmd
+++ b/vignettes/programming.Rmd
@@ -324,7 +324,7 @@ Use the `.names` argument to `across()` to control the names of the output.
 my_summarise <- function(data, group_var, summarise_var) {
   data %>%
     group_by(across({{ group_var }})) %>% 
-    summarise(across({{ summarise_var }}, mean, .names = "mean_{col}"))
+    summarise(across({{ summarise_var }}, mean, .names = "mean_{.col}"))
 }
 ```
 


### PR DESCRIPTION
https://stackoverflow.com/questions/63151985/how-to-glue-a-function-argument-to-names-in-dplyrs-across-function

``` r
library(palmerpenguins)
library(dplyr, warn.conflicts = FALSE)

mean_by <- function(data, by, var, prefix = "avg") {
  data %>% 
    group_by({{ by }}) %>% 
    summarise(across({{ var }}, mean, .names = "{prefix}_{col}"))
}

penguins %>% 
  mean_by(species, starts_with("bill"))
#> `summarise()` ungrouping output (override with `.groups` argument)
#> # A tibble: 3 x 3
#>   species   avg_bill_length_mm avg_bill_depth_mm
#>   <fct>                  <dbl>             <dbl>
#> 1 Adelie                  NA                NA  
#> 2 Chinstrap               48.8              18.4
#> 3 Gentoo                  NA                NA
```

<sup>Created on 2020-07-31 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>
