### PR TITLE
Update inner_join description

### DIFF
--- a/R/join.r
+++ b/R/join.r
@@ -4,7 +4,7 @@
 #' The mutating joins add columns from `y` to `x`, matching rows based on the
 #' keys:
 #'
-#' * `inner_join()`: includes all rows in `x` and `y`.
+#' * `inner_join()`: includes all rows in `x` and `y` that match.
 #' * `left_join()`: includes all rows in `x`.
 #' * `right_join()`: includes all rows in `y`.
 #' * `full_join()`: includes all rows in `x` or `y`.


### PR DESCRIPTION
The description for `inner_join` and `full_join` are the same - indicating that all rows from x and y are joined. This is not the case with an `inner_join`. I have updated the description to highlight the fact that an `inner_join` only joins all rows from x and y **where there is a match in the key**.