### PR TITLE
Wrap the arguments of verbs that should be evaluated at once with tibble()

### DIFF
--- a/R/summarise.R
+++ b/R/summarise.R
@@ -112,6 +112,12 @@
 #'   group_by(cyl) %>%
 #'   summarise(disp = mean(disp), sd = sd(disp))
 #'
+#' # To avoid this, you can wrap these two arguments with tibble() so that they
+#' # are evaluated at once, instead of sequentially.
+#' mtcars %>%
+#'   group_by(cyl) %>%
+#'   summarise(tibble(disp = mean(disp), sd = sd(disp)))
+#'
 #' # Refer to column names stored as strings with the `.data` pronoun:
 #' var <- "mass"
 #' summarise(starwars, avg = mean(.data[[var]], na.rm = TRUE))

--- a/man/summarise.Rd
+++ b/man/summarise.Rd
@@ -138,6 +138,12 @@ mtcars \%>\%
   group_by(cyl) \%>\%
   summarise(disp = mean(disp), sd = sd(disp))
 
+# To avoid this, you can wrap these two arguments with tibble() so that they
+# are evaluated at once, instead of sequentially.
+mtcars \%>\%
+  group_by(cyl) \%>\%
+  summarise(tibble(disp = mean(disp), sd = sd(disp)))
+
 # Refer to column names stored as strings with the `.data` pronoun:
 var <- "mass"
 summarise(starwars, avg = mean(.data[[var]], na.rm = TRUE))

--- a/vignettes/colwise.Rmd
+++ b/vignettes/colwise.Rmd
@@ -98,12 +98,14 @@ Control how the names are created with the `.names` argument which takes a [glue
 starwars %>% summarise(across(where(is.numeric), min_max, .names = "{.fn}.{.col}"))
 ```
 
-If you'd prefer all summaries with the same function to be grouped together, you'll have to expand the calls yourself:
+If you'd prefer all summaries with the same function to be grouped together, you'll have to expand the calls yourself (note that we wrap two `across()`s with `tibble()` because otherwise the first `across()`'s result get accidentally `across()`ed and `max_min_` columns would be created):
 
 ```{r}
 starwars %>% summarise(
-  across(where(is.numeric), ~min(.x, na.rm = TRUE), .names = "min_{.col}"),
-  across(where(is.numeric), ~max(.x, na.rm = TRUE), .names = "max_{.col}")
+  tibble(
+    across(where(is.numeric), ~min(.x, na.rm = TRUE), .names = "min_{.col}"),
+    across(where(is.numeric), ~max(.x, na.rm = TRUE), .names = "max_{.col}")
+  )
 )
 ```
 


### PR DESCRIPTION
Fix #5433