### PR TITLE
Configure git username and email on GitHub Actions CI

### DIFF
--- a/.github/workflows/continuous-benchmarks.yaml
+++ b/.github/workflows/continuous-benchmarks.yaml
@@ -28,7 +28,10 @@ jobs:
         run: Rscript -e 'bench::cb_fetch()'
 
       - name: Run benchmarks
-        run: Rscript -e 'bench::cb_run()'
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
+          Rscript -e 'bench::cb_run()'
 
       - name: Show benchmarks
         run: git notes --ref benchmarks show

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -41,5 +41,7 @@ jobs:
         run: R CMD INSTALL .
 
       - name: Deploy package
-        run: pkgdown::deploy_to_branch(new_process = FALSE)
-        shell: Rscript {0}
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
+          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'


### PR DESCRIPTION
GitHub action requires us to set username and email explicitly (c.f. https://github.com/r-lib/actions/issues/135). Otherwise it fails with the errors like this:

```
Run Rscript -e 'bench::cb_run()'
  Rscript -e 'bench::cb_run()'
  shell: /bin/bash -e {0}
  env:
    R_LIBS_USER: /Users/runner/work/_temp/Library
    TZ: UTC
    NOT_CRAN: true

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'runner@Mac-1596551650870.(none)')
##[error]Error: git notes failed with exit code 128.
```