### PR TITLE
improve nth() error message about n=

### DIFF
--- a/R/compat-purrr.R
+++ b/R/compat-purrr.R
@@ -1,4 +1,4 @@
-# nocov start - compat-purrr (last updated: rlang 0.3.0.9000)
+# nocov start - compat-purrr (last updated: rlang 0.3.2.9000)
 
 # This file serves as a reference for compatibility functions for
 # purrr. They are not drop-in replacements but allow a similar style
@@ -28,6 +28,11 @@ map_chr <- function(.x, .f, ...) {
 }
 map_cpl <- function(.x, .f, ...) {
   map_mold(.x, .f, complex(1), ...)
+}
+
+walk <- function(.x, .f, ...) {
+  map(.x, .f, ...)
+  invisible(.x)
 }
 
 pluck <- function(.x, .f) {
@@ -72,15 +77,12 @@ map2_chr <- function(.x, .y, .f, ...) {
 map2_cpl <- function(.x, .y, .f, ...) {
   as.vector(map2(.x, .y, .f, ...), "complex")
 }
-walk2 <- function(.x, .y, .f, ...) {
-  map2(.x, .y, .f, ...)
-  invisible(.x)
-}
+
 args_recycle <- function(args) {
-  lengths <- lengths(args)
+  lengths <- map_int(args, length)
   n <- max(lengths)
 
-  abort_if_not(all(lengths == 1L | lengths == n))
+  stopifnot(all(lengths == 1L | lengths == n))
   to_recycle <- lengths == 1L
   args[to_recycle] <- map(args[to_recycle], function(x) rep.int(x, n))
 
@@ -97,7 +99,7 @@ pmap <- function(.l, .f, ...) {
 
 probe <- function(.x, .p, ...) {
   if (is_logical(.p)) {
-    abort_if_not(length(.p) == length(.x))
+    stopifnot(length(.p) == length(.x))
     .p
   } else {
     map_lgl(.x, .p, ...)

--- a/R/deprec-src-local.r
+++ b/R/deprec-src-local.r
@@ -21,7 +21,7 @@ src_local <- function(tbl, pkg = NULL, env = NULL) {
     env <- getNamespaceInfo(pkg, "lazydata")
     name <- paste0("<package: ", pkg, ">")
   } else {
-    abort_if_not(is.environment(env))
+    stopifnot(is.environment(env))
     name <- utils::capture.output(print(env))
   }
 

--- a/R/deprec-tibble.R
+++ b/R/deprec-tibble.R
@@ -41,7 +41,7 @@ as.tbl.data.frame <- function(x, ...) {
 add_rownames <- function(df, var = "rowname") {
   lifecycle::deprecate_warn("1.0.0", "add_rownames()", "tibble::rownames_to_column()")
 
-  abort_if_not(is.data.frame(df))
+  stopifnot(is.data.frame(df))
 
   rn <- as_tibble(setNames(list(rownames(df)), var))
   rownames(df) <- NULL

--- a/R/distinct.R
+++ b/R/distinct.R
@@ -70,7 +70,7 @@ distinct <- function(.data, ..., .keep_all = FALSE) {
 #' @rdname group_by_prepare
 #' @export
 distinct_prepare <- function(.data, vars, group_vars = character(), .keep_all = FALSE) {
-  abort_if_not(is_quosures(vars), is.character(group_vars))
+  stopifnot(is_quosures(vars), is.character(group_vars))
 
   # If no input, keep all variables
   if (length(vars) == 0) {

--- a/R/funs-predicates.R
+++ b/R/funs-predicates.R
@@ -31,7 +31,7 @@ any_exprs <- function(..., .vectorised = TRUE) {
 ##   environment][rlang::base_env] unless you supply a
 ##   [quosure][rlang::quo].
 quo_reduce <- function(..., .op) {
-  abort_if_not(is_symbol(.op) || is_function(.op))
+  stopifnot(is_symbol(.op) || is_function(.op))
 
   dots <- enquos(...)
   if (length(dots) == 0) {

--- a/R/nth-value.R
+++ b/R/nth-value.R
@@ -40,7 +40,9 @@
 #' # These functions always return a single value
 #' first(integer())
 nth <- function(x, n, order_by = NULL, default = default_missing(x)) {
-  abort_if_not(length(n) == 1, is.numeric(n))
+  if (length(n) != 1 || !is.numeric(n)) {
+    abort("`nth()` argument `n=` should be a single integer")
+  }
   n <- trunc(n)
 
   if (n == 0 || n > length(x) || n < -length(x)) {

--- a/R/nth-value.R
+++ b/R/nth-value.R
@@ -41,7 +41,7 @@
 #' first(integer())
 nth <- function(x, n, order_by = NULL, default = default_missing(x)) {
   if (length(n) != 1 || !is.numeric(n)) {
-    abort("`nth()` argument `n=` should be a single integer.")
+    abort("`n` must be a single integer.")
   }
   n <- trunc(n)
 

--- a/R/nth-value.R
+++ b/R/nth-value.R
@@ -41,7 +41,7 @@
 #' first(integer())
 nth <- function(x, n, order_by = NULL, default = default_missing(x)) {
   if (length(n) != 1 || !is.numeric(n)) {
-    abort("`nth()` argument `n=` should be a single integer")
+    abort("`nth()` argument `n=` should be a single integer.")
   }
   n <- trunc(n)
 

--- a/R/utils.r
+++ b/R/utils.r
@@ -99,10 +99,6 @@ paste_line <- function(...) {
   paste(chr(...), collapse = "\n")
 }
 
-abort_if_not <- function(...) {
-  tryCatch(stopifnot(...), simpleError = function(e) abort(e))
-}
-
 # Until fixed upstream. `vec_data()` should not return lists from data
 # frames.
 dplyr_vec_data <- function(x) {

--- a/tests/testthat/test-nth-value.R
+++ b/tests/testthat/test-nth-value.R
@@ -38,3 +38,9 @@ test_that("firsts uses default value for 0 length augmented vectors", {
   expect_equal(first(dt[0]), dt[NA])
   expect_equal(first(tm[0]), tm[NA])
 })
+
+test_that("nth() gives meaningful error message (#5466)", {
+  verify_output(test_path("test-nth-value.txt"), {
+    nth(1:10, "x")
+  })
+})

--- a/tests/testthat/test-nth-value.txt
+++ b/tests/testthat/test-nth-value.txt
@@ -1,3 +1,3 @@
 > nth(1:10, "x")
-Error: `nth()` argument `n=` should be a single integer.
+Error: `n` must be a single integer.
 

--- a/tests/testthat/test-nth-value.txt
+++ b/tests/testthat/test-nth-value.txt
@@ -1,0 +1,3 @@
+> nth(1:10, "x")
+Error: `nth()` argument `n=` should be a single integer
+

--- a/tests/testthat/test-nth-value.txt
+++ b/tests/testthat/test-nth-value.txt
@@ -1,3 +1,3 @@
 > nth(1:10, "x")
-Error: `nth()` argument `n=` should be a single integer
+Error: `nth()` argument `n=` should be a single integer.
 


### PR DESCRIPTION
``` r
dplyr::nth(1:10, "x")
#> Error: `nth()` argument `n=` should be a single integer
#> Backtrace:
#>     █
#>  1. └─dplyr::nth(1:10, "x")
```

<sup>Created on 2020-08-10 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>