### PR TITLE
+ mask$(set/get)_current_quosure_env()

### DIFF
--- a/R/across.R
+++ b/R/across.R
@@ -79,7 +79,8 @@
 #' @export
 across <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
   key <- key_deparse(sys.call())
-  setup <- across_setup({{ .cols }}, fns = .fns, names = .names, key = key, .caller_env = caller_env())
+  .cols <- enquo(.cols)
+  setup <- across_setup(.cols, fns = .fns, names = .names, key = key, .caller_env = caller_env())
 
   vars <- setup$vars
   if (length(vars) == 0L) {
@@ -169,10 +170,9 @@ across_setup <- function(cols, fns, names, key, .caller_env) {
     return(value)
   }
 
-  cols <- enquo(cols)
   across_cols <- mask$across_cols()
 
-  vars <- tidyselect::eval_select(expr(!!cols), across_cols)
+  vars <- tidyselect::eval_select(quo_get_expr(cols), data = across_cols, env = mask$get_current_quosure_env())
   vars <- names(vars)
 
   if (is.null(fns)) {

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -249,6 +249,14 @@ DataMask <- R6Class("DataMask",
 
     across_cache_reset = function() {
       private$across_cache <- list()
+    },
+
+    set_current_quosure_env = function(env) {
+      private$current_quosure_env <- env
+    },
+
+    get_current_quosure_env = function() {
+      private$current_quosure_env
     }
 
   ),
@@ -266,6 +274,7 @@ DataMask <- R6Class("DataMask",
     bindings = NULL,
     current_group = 0L,
     caller = NULL,
-    across_cache = list()
+    across_cache = list(),
+    current_quosure_env = NULL
   )
 )

--- a/R/filter.R
+++ b/R/filter.R
@@ -117,9 +117,14 @@ filter.data.frame <- function(.data, ..., .preserve = FALSE) {
 
 filter_rows <- function(.data, ...) {
   dots <- check_filter(enquos(...))
+  if (!length(dots)) {
+    return(seq_len(nrow(.data)))
+  }
+
   mask <- DataMask$new(.data, caller_env())
   on.exit(mask$forget("filter"), add = TRUE)
 
+  mask$set_current_quosure_env(quo_get_env(dots[[1L]]))
   env_filter <- env()
   withCallingHandlers(
     mask$eval_all_filter(dots, env_filter),

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -232,6 +232,7 @@ mutate_cols <- function(.data, ...) {
 
   withCallingHandlers({
     for (i in seq_along(dots)) {
+      mask$set_current_quosure_env(quo_get_env(dots[[i]]))
       not_named <- (is.null(dots_names) || dots_names[i] == "")
 
       # a list in which each element is the result of

--- a/R/slice.R
+++ b/R/slice.R
@@ -257,6 +257,7 @@ slice_rows <- function(.data, ...) {
   rows <- mask$get_rows()
 
   quo <- quo(c(!!!dots))
+  mask$set_current_quosure_env(quo_get_env(quo))
   chunks <- mask$eval_all(quo)
 
   slice_indices <- new_list(length(rows))

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -222,6 +222,7 @@ summarise_cols <- function(.data, ...) {
     # generate all chunks and monitor the sizes
     for (i in seq_along(dots)) {
       quo <- dots[[i]]
+      mask$set_current_quosure_env(quo_get_env(dots[[i]]))
 
       # a list in which each element is the result of
       # evaluating the quosure in the "sliced data mask"

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -203,6 +203,13 @@ test_that("across(.names=) can use local variables in addition to {col} and {fn}
   expect_identical(res, data.frame(MEAN_x = 42))
 })
 
+test_that("across() uses environment from the current quosure (#5460)", {
+  df <- data.frame(x = 1, y = 2.4)
+  y <- "x"
+  expect_equal(df %>% summarise(across(all_of(y), mean)), data.frame(x = 1))
+  expect_equal(df %>% mutate(across(all_of(y), mean)), df)
+  expect_equal(df %>% filter(across(all_of(y), ~ .x < 2)), df)
+})
 
 # c_across ----------------------------------------------------------------
 


### PR DESCRIPTION
closes #5460

I'm not sure about this, it is about `tidyselect::eval_select()` using "the right" environment. 

``` r
library(dplyr, warn.conflicts = FALSE)
df <- data.frame(x = 1, y = 2.4)
y <- "x"
df %>% 
  summarise(across(all_of(y), mean))
#>   x
#> 1 1
```

<sup>Created on 2020-08-10 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>