### PR TITLE
allow n() in select(where()) and select_if()

### DIFF
--- a/R/colwise-select.R
+++ b/R/colwise-select.R
@@ -73,6 +73,8 @@ select_if <- function(.tbl, .predicate, .funs = list(), ...) {
   if (!is_logical(.predicate)) {
     .predicate <- as_fun_list(.predicate, caller_env(), .caller = "select_if", .caller_arg = ".predicate")
   }
+  # faking a mask to get n() to work
+  local_mask(list(current_rows = function() seq_len(nrow(.tbl))))
   vars <- tbl_if_vars(.tbl, .predicate, caller_env(), .include_group_vars = TRUE)
   syms <- vars_select_syms(vars, funs, .tbl)
   select(.tbl, !!!syms)

--- a/R/select.R
+++ b/R/select.R
@@ -122,6 +122,9 @@ select.list <- function(.data, ...) {
 
 #' @export
 select.data.frame <- function(.data, ...) {
+  # faking a mask to get n() to work
+  local_mask(list(current_rows = function() seq_len(nrow(.data))))
+
   loc <- tidyselect::eval_select(expr(c(...)), .data)
   loc <- ensure_group_vars(loc, .data, notify = TRUE)
 


### PR DESCRIPTION
closes #5453

This is a bit of a stretch I'd say, but otherwise I believe we would have to come up with a better error message: 

```r
mtcars %>% select_if( ~(sum(.x) > n()) )
# Error: `n()` must only be used inside dplyr verbs.
```
