### PR TITLE
Use rlang to manipulate environment bindings without warnings

### DIFF
--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -56,10 +56,7 @@ DataMask <- R6Class("DataMask",
       }
 
       promises <- map(seq_len(ncol(data)), function(.x) expr(promise_fn(!!.x)))
-
-      suppressWarnings(
-        env_bind_lazy(private$bindings, !!!set_names(promises, names_bindings))
-      )
+      env_bind_lazy(private$bindings, !!!set_names(promises, names_bindings))
 
       private$mask <- new_data_mask(private$bindings)
       private$mask$.data <- as_data_pronoun(private$mask)
@@ -77,10 +74,8 @@ DataMask <- R6Class("DataMask",
       }
 
       promises <- map(names_bindings, function(.x) expr(osbolete_promise_fn(!!.x)))
-      suppressWarnings({
-        rm(list = names_bindings, envir = private$bindings)
-        env_bind_lazy(private$bindings, !!!set_names(promises, names_bindings))
-      })
+      env_unbind(private$bindings, names_bindings)
+      env_bind_lazy(private$bindings, !!!set_names(promises, names_bindings))
     },
 
     add = function(name, chunks) {
@@ -119,7 +114,7 @@ DataMask <- R6Class("DataMask",
 
     remove = function(name) {
       self$set(name, NULL)
-      rm(list = name, envir = private$bindings)
+      env_unbind(private$bindings, name)
     },
 
     resolve = function(name) {

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -279,9 +279,7 @@ mutate_cols <- function(.data, ...) {
       if (is.null(chunks)) {
         if (!is.null(dots_names) && dots_names[i] != "") {
           new_columns[[dots_names[i]]] <- zap()
-
-          # we might get a warning if dots_names[i] does not exist
-          suppressWarnings(mask$remove(dots_names[i]))
+          mask$remove(dots_names[i])
         }
         next
       }


### PR DESCRIPTION
With the last version of rlang (on which we now depend), the locale warnings on Windows should be fixed.

Also `env_unbind()` doesn't warn when the binding doesn't exist, unlike `rm()`.