### PR TITLE
Fix data masking of tidyselect env-expressions in `across()` 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dplyr (development version)
 
+* Fixed `across()` issue where data frame columns would mask objects referred to
+  from `all_of()` (#5460).
+
 * `bind_cols()` gains a `.name_repair` argument, passed to `vctrs::vec_cbind()` (#5451)
 
 # dplyr 1.0.1

--- a/R/across.R
+++ b/R/across.R
@@ -172,7 +172,7 @@ across_setup <- function(cols, fns, names, key, .caller_env) {
   # `across()` is evaluated in a data mask so we need to remove the
   # mask layer from the quosure environment (#5460)
   cols <- enquo(cols)
-  cols <- quo_set_env(cols, data_mask_top(quo_get_env(cols)))
+  cols <- quo_set_env(cols, data_mask_top(quo_get_env(cols), recursive = TRUE))
 
   vars <- tidyselect::eval_select(cols, data = mask$across_cols())
   vars <- names(vars)

--- a/R/across.R
+++ b/R/across.R
@@ -172,7 +172,7 @@ across_setup <- function(cols, fns, names, key, .caller_env) {
   # `across()` is evaluated in a data mask so we need to remove the
   # mask layer from the quosure environment (#5460)
   cols <- enquo(cols)
-  cols <- quo_set_env(cols, data_mask_top(quo_get_env(cols), recursive = TRUE))
+  cols <- quo_set_env(cols, data_mask_top(quo_get_env(cols), recursive = TRUE, inherit = TRUE))
 
   vars <- tidyselect::eval_select(cols, data = mask$across_cols())
   vars <- names(vars)
@@ -230,9 +230,9 @@ across_setup <- function(cols, fns, names, key, .caller_env) {
 }
 
 # FIXME: This pattern should be encapsulated by rlang
-data_mask_top <- function(env, recursive = FALSE) {
-  while (env_has(env, ".__tidyeval_data_mask__.")) {
-    env <- env_parent(env$.top_env)
+data_mask_top <- function(env, recursive = FALSE, inherit = FALSE) {
+  while (env_has(env, ".__tidyeval_data_mask__.", inherit = inherit)) {
+    env <- env_parent(env_get(env, ".top_env", inherit = inherit))
     if (!recursive) {
       return(env)
     }

--- a/R/across.R
+++ b/R/across.R
@@ -169,10 +169,12 @@ across_setup <- function(cols, fns, names, key, .caller_env) {
     return(value)
   }
 
+  # `across()` is evaluated in a data mask so we need to remove the
+  # mask layer from the quosure environment (#5460)
   cols <- enquo(cols)
-  across_cols <- mask$across_cols()
+  cols <- quo_set_env(cols, data_mask_top(quo_get_env(cols)))
 
-  vars <- tidyselect::eval_select(expr(!!cols), across_cols)
+  vars <- tidyselect::eval_select(cols, data = mask$across_cols())
   vars <- names(vars)
 
   if (is.null(fns)) {
@@ -225,6 +227,18 @@ across_setup <- function(cols, fns, names, key, .caller_env) {
   mask$across_cache_add(key, value)
 
   value
+}
+
+# FIXME: This pattern should be encapsulated by rlang
+data_mask_top <- function(env, recursive = FALSE) {
+  while (env_has(env, ".__tidyeval_data_mask__.")) {
+    env <- env_parent(env$.top_env)
+    if (!recursive) {
+      return(env)
+    }
+  }
+
+  env
 }
 
 c_across_setup <- function(cols, key) {

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -215,6 +215,19 @@ test_that("across() uses environment from the current quosure (#5460)", {
   # Recursive case
   out <- df %>% summarise(summarise(across(), across(all_of(y), mean)))
   expect_equal(out, data.frame(x = 1))
+
+  # Inherited case
+  out <- df %>% summarise(local(across(all_of(y), mean)))
+  expect_equal(out, data.frame(x = 1))
+
+  # Recursive + inherited case
+  out <- df %>%
+    summarise(
+      local(
+        summarise(across(), across(all_of(y), mean))
+      )
+    )
+  expect_equal(out, data.frame(x = 1))
 })
 
 

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -204,11 +204,17 @@ test_that("across(.names=) can use local variables in addition to {col} and {fn}
 })
 
 test_that("across() uses environment from the current quosure (#5460)", {
+  # If the data frame `y` is selected, causes a subscript conversion
+  # error since it is fractional
   df <- data.frame(x = 1, y = 2.4)
   y <- "x"
   expect_equal(df %>% summarise(across(all_of(y), mean)), data.frame(x = 1))
   expect_equal(df %>% mutate(across(all_of(y), mean)), df)
   expect_equal(df %>% filter(across(all_of(y), ~ .x < 2)), df)
+
+  # Recursive case
+  out <- df %>% summarise(summarise(across(), across(all_of(y), mean)))
+  expect_equal(out, data.frame(x = 1))
 })
 
 

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -203,6 +203,14 @@ test_that("across(.names=) can use local variables in addition to {col} and {fn}
   expect_identical(res, data.frame(MEAN_x = 42))
 })
 
+test_that("across() uses environment from the current quosure (#5460)", {
+  df <- data.frame(x = 1, y = 2.4)
+  y <- "x"
+  expect_equal(df %>% summarise(across(all_of(y), mean)), data.frame(x = 1))
+  expect_equal(df %>% mutate(across(all_of(y), mean)), df)
+  expect_equal(df %>% filter(across(all_of(y), ~ .x < 2)), df)
+})
+
 
 # c_across ----------------------------------------------------------------
 


### PR DESCRIPTION
Follow-up to #5469
Closes #5460
