### PR TITLE
Correct glue spec in colwise vignette for .names in across()

### DIFF
--- a/vignettes/colwise.Rmd
+++ b/vignettes/colwise.Rmd
@@ -95,15 +95,15 @@ starwars %>% summarise(across(where(is.numeric), min_max))
 Control how the names are created with the `.names` argument which takes a [glue](https://glue.tidyverse.org/) spec:
 
 ```{r}
-starwars %>% summarise(across(where(is.numeric), min_max, .names = "{.fn}.{.col}"))
+starwars %>% summarise(across(where(is.numeric), min_max, .names = "{fn}.{col}"))
 ```
 
 If you'd prefer all summaries with the same function to be grouped together, you'll have to expand the calls yourself:
 
 ```{r}
 starwars %>% summarise(
-  across(where(is.numeric), ~min(.x, na.rm = TRUE), .names = "min_{.col}"),
-  across(where(is.numeric), ~max(.x, na.rm = TRUE), .names = "max_{.col}")
+  across(where(is.numeric), ~min(.x, na.rm = TRUE), .names = "min_{col}"),
+  across(where(is.numeric), ~max(.x, na.rm = TRUE), .names = "max_{col}")
 )
 ```
 


### PR DESCRIPTION
Vignette examples for .names in across() generate glue error - 'glue cannot interpolate functions into strings'. Aligned to definition in help docs ?across()