### PR TITLE
Avoid where(is.numeric) in colwise vignette when using across twice

### DIFF
--- a/R/across.R
+++ b/R/across.R
@@ -58,6 +58,8 @@
 #' iris %>%
 #'   group_by(Species) %>%
 #'   summarise(across(starts_with("Sepal"), list(mean = mean, sd = sd), .names = "{.col}.{.fn}"))
+#'
+#' # When the list is not named, .fn is replaced by the function's position
 #' iris %>%
 #'   group_by(Species) %>%
 #'   summarise(across(starts_with("Sepal"), list(mean, sd), .names = "{.col}.fn{.fn}"))

--- a/man/across.Rd
+++ b/man/across.Rd
@@ -70,6 +70,8 @@ iris \%>\%
 iris \%>\%
   group_by(Species) \%>\%
   summarise(across(starts_with("Sepal"), list(mean = mean, sd = sd), .names = "{.col}.{.fn}"))
+
+# When the list is not named, .fn is replaced by the function's position
 iris \%>\%
   group_by(Species) \%>\%
   summarise(across(starts_with("Sepal"), list(mean, sd), .names = "{.col}.fn{.fn}"))

--- a/vignettes/colwise.Rmd
+++ b/vignettes/colwise.Rmd
@@ -89,26 +89,49 @@ min_max <- list(
   min = ~min(.x, na.rm = TRUE), 
   max = ~max(.x, na.rm = TRUE)
 )
-starwars %>% summarise(across(c(height, mass), min_max))
+starwars %>% summarise(across(where(is.numeric), min_max))
+starwars %>% summarise(across(c(height, mass, birth_year), min_max))
 ```
 
 Control how the names are created with the `.names` argument which takes a [glue](https://glue.tidyverse.org/) spec:
 
 ```{r}
-starwars %>% summarise(across(c(height, mass), min_max, .names = "{.fn}.{.col}"))
+starwars %>% summarise(across(where(is.numeric), min_max, .names = "{.fn}.{.col}"))
+starwars %>% summarise(across(c(height, mass, birth_year), min_max, .names = "{.fn}.{.col}"))
 ```
 
 If you'd prefer all summaries with the same function to be grouped together, you'll have to expand the calls yourself:
 
 ```{r}
 starwars %>% summarise(
-  across(c(height, mass), ~min(.x, na.rm = TRUE), .names = "min_{.col}"),
-  across(c(height, mass), ~max(.x, na.rm = TRUE), .names = "max_{.col}")
+  across(c(height, mass, birth_year), ~min(.x, na.rm = TRUE), .names = "min_{.col}"),
+  across(c(height, mass, birth_year), ~max(.x, na.rm = TRUE), .names = "max_{.col}")
 )
 ```
 
 (One day this might become an argument to `across()` but we're not yet sure how it would work.)
 
+We cannot however use `where(is.numeric)` in that last case because the second `across()` 
+would pick up the variables that were newly created ("min_height", "min_mass" and "min_birth_year"). 
+
+We can work around this by combining both calls to `across()` into a single expression: 
+
+```{r}
+starwars %>% summarise(
+  tibble(
+    across(where(is.numeric), ~min(.x, na.rm = TRUE), .names = "min_{.col}"),
+    across(where(is.numeric), ~max(.x, na.rm = TRUE), .names = "max_{.col}")  
+  )
+)
+```
+
+Alternatively we could reorganize results with `relocate()`:
+
+```{r}
+starwars %>% 
+  summarise(across(where(is.numeric), min_max, .names = "{.fn}.{.col}")) %>% 
+  relocate(starts_with("min"))
+```
 
 ### Current column
 
@@ -123,7 +146,7 @@ df %>% mutate(across(all_of(names(mult)), ~ .x * mult[[cur_column()]]))
 
 ### Gotchas
 
-Be careful when combining numeric summaries with `is.numeric`:
+Be careful when combining numeric summaries with `where(is.numeric)`:
 
 ```{r}
 df <- data.frame(x = c(1, 2, 3), y = c(1, 4, 9))
@@ -145,6 +168,9 @@ Alternatively, you could explicitly exclude `n` from the columns to operate on:
 df %>% 
   summarise(n = n(), across(where(is.numeric) & !n, sd))
 ```
+
+
+
 
 ### Other verbs
 

--- a/vignettes/colwise.Rmd
+++ b/vignettes/colwise.Rmd
@@ -89,21 +89,21 @@ min_max <- list(
   min = ~min(.x, na.rm = TRUE), 
   max = ~max(.x, na.rm = TRUE)
 )
-starwars %>% summarise(across(where(is.numeric), min_max))
+starwars %>% summarise(across(c(height, mass), min_max))
 ```
 
 Control how the names are created with the `.names` argument which takes a [glue](https://glue.tidyverse.org/) spec:
 
 ```{r}
-starwars %>% summarise(across(where(is.numeric), min_max, .names = "{.fn}.{.col}"))
+starwars %>% summarise(across(c(height, mass), min_max, .names = "{.fn}.{.col}"))
 ```
 
 If you'd prefer all summaries with the same function to be grouped together, you'll have to expand the calls yourself:
 
 ```{r}
 starwars %>% summarise(
-  across(where(is.numeric), ~min(.x, na.rm = TRUE), .names = "min_{.col}"),
-  across(where(is.numeric), ~max(.x, na.rm = TRUE), .names = "max_{.col}")
+  across(c(height, mass), ~min(.x, na.rm = TRUE), .names = "min_{.col}"),
+  across(c(height, mass), ~max(.x, na.rm = TRUE), .names = "max_{.col}")
 )
 ```
 

--- a/vignettes/colwise.Rmd
+++ b/vignettes/colwise.Rmd
@@ -114,7 +114,7 @@ starwars %>% summarise(
 We cannot however use `where(is.numeric)` in that last case because the second `across()` 
 would pick up the variables that were newly created ("min_height", "min_mass" and "min_birth_year"). 
 
-We can work around this by combining both calls to `across()` into a single expression: 
+We can work around this by combining both calls to `across()` into a single expression that returns a tibble:
 
 ```{r}
 starwars %>% summarise(
@@ -169,12 +169,20 @@ df %>%
   summarise(n = n(), across(where(is.numeric) & !n, sd))
 ```
 
+Another approach is to combine both the call to `n()` and `across()` in a single
+expression that returns a tibble: 
 
+```{r}
+df %>% 
+  summarise(
+    tibble(n = n(), across(where(is.numeric), sd))
+  )
+```
 
 
 ### Other verbs
 
-So far we've focussed on the use of `across()` with `summarise()`, but it works with any other dplyr verb that uses data masking:
+So far we've focused on the use of `across()` with `summarise()`, but it works with any other dplyr verb that uses data masking:
 
 *   Rescale all numeric variables to range 0-1:
 


### PR DESCRIPTION
alternatively, this could illustrate the problem and offer alternatives as discussed in #5433 but it might be confusing in the vignette ?