### PR TITLE
check that n= or prop= can be forced.

### DIFF
--- a/R/slice.R
+++ b/R/slice.R
@@ -130,7 +130,7 @@ slice_head <- function(.data, ..., n, prop) {
 #' @export
 slice_head.data.frame <- function(.data, ..., n, prop) {
   ellipsis::check_dots_empty()
-  size <- check_slice_size(n, prop)
+  size <- check_slice_size(n, prop, "slice_head")
   idx <- switch(size$type,
     n =    function(n) seq2(1, min(size$n, n)),
     prop = function(n) seq2(1, min(size$prop * n, n))
@@ -148,7 +148,7 @@ slice_tail <- function(.data, ..., n, prop) {
 #' @export
 slice_tail.data.frame <- function(.data, ..., n, prop) {
   ellipsis::check_dots_empty()
-  size <- check_slice_size(n, prop)
+  size <- check_slice_size(n, prop, "slice_tail")
   idx <- switch(size$type,
     n =    function(n) seq2(max(n - size$n + 1, 1), n),
     prop = function(n) seq2(max(ceiling(n - size$prop * n) + 1, 1), n)
@@ -173,7 +173,7 @@ slice_min.data.frame <- function(.data, order_by, ..., n, prop, with_ties = TRUE
   }
 
   ellipsis::check_dots_empty()
-  size <- check_slice_size(n, prop)
+  size <- check_slice_size(n, prop, "slice_min")
   if (with_ties) {
     idx <- switch(size$type,
       n =    function(x, n) head(order(x), smaller_ranks(x, size$n)),
@@ -200,7 +200,7 @@ slice_max.data.frame <- function(.data, order_by, ..., n, prop, with_ties = TRUE
     abort("argument `order_by` is missing, with no default.")
   }
   ellipsis::check_dots_empty()
-  size <- check_slice_size(n, prop)
+  size <- check_slice_size(n, prop, "slice_max")
   if (with_ties) {
     idx <- switch(size$type,
       n =    function(x, n) head(
@@ -233,7 +233,7 @@ slice_sample <- function(.data, ..., n, prop, weight_by = NULL, replace = FALSE)
 
 #' @export
 slice_sample.data.frame <- function(.data, ..., n, prop, weight_by = NULL, replace = FALSE) {
-  size <- check_slice_size(n, prop)
+  size <- check_slice_size(n, prop, "slice_sample")
   ellipsis::check_dots_empty()
   idx <- switch(size$type,
     n =    function(x, n) sample_int(n, size$n, replace = replace, wt = x),
@@ -289,10 +289,20 @@ slice_rows <- function(.data, ...) {
   vec_c(!!!slice_indices, .ptype = integer())
 }
 
-check_slice_size <- function(n, prop) {
+check_constant <- function(x, name, fn) {
+  withCallingHandlers(force(x), error = function(e) {
+    abort(c(
+      glue("`{name}` must be constant across groups in `{fn}()`."),
+      x = conditionMessage(e)
+    ), parent = e)
+  })
+}
+
+check_slice_size <- function(n, prop, .slice_fn = "check_slice_size") {
   if (missing(n) && missing(prop)) {
     list(type = "n", n = 1L)
   } else if (!missing(n) && missing(prop)) {
+    n <- check_constant(n, "n", .slice_fn)
     if (!is.numeric(n) || length(n) != 1) {
       abort("`n` must be a single number.")
     }
@@ -302,6 +312,7 @@ check_slice_size <- function(n, prop) {
 
     list(type = "n", n = n)
   } else if (!missing(prop) && missing(n)) {
+    prop <- check_constant(prop, "prop", .slice_fn)
     if (!is.numeric(prop) || length(prop) != 1) {
       abort("`prop` must be a single number")
     }

--- a/R/slice.R
+++ b/R/slice.R
@@ -292,7 +292,7 @@ slice_rows <- function(.data, ...) {
 check_constant <- function(x, name, fn) {
   withCallingHandlers(force(x), error = function(e) {
     abort(c(
-      glue("`{name}` must be constant across groups in `{fn}()`."),
+      glue("`{name}` must be a constant in `{fn}()`."),
       x = conditionMessage(e)
     ), parent = e)
   })

--- a/tests/testthat/test-slice-errors.txt
+++ b/tests/testthat/test-slice-errors.txt
@@ -38,10 +38,10 @@ Error: `n` must be a non-missing positive number.
 Error: `prop` must be a non-missing positive number.
 
 > check_slice_size(n = n())
-Error: `n` must be constant across groups in `check_slice_size()`.
+Error: `n` must be a constant in `check_slice_size()`.
 x `n()` must only be used inside dplyr verbs.
 
 > check_slice_size(prop = n())
-Error: `prop` must be constant across groups in `check_slice_size()`.
+Error: `prop` must be a constant in `check_slice_size()`.
 x `n()` must only be used inside dplyr verbs.
 

--- a/tests/testthat/test-slice-errors.txt
+++ b/tests/testthat/test-slice-errors.txt
@@ -37,3 +37,11 @@ Error: `n` must be a non-missing positive number.
 > check_slice_size(prop = -1)
 Error: `prop` must be a non-missing positive number.
 
+> check_slice_size(n = n())
+Error: `n` must be constant across groups in `check_slice_size()`.
+x `n()` must only be used inside dplyr verbs.
+
+> check_slice_size(prop = n())
+Error: `prop` must be constant across groups in `check_slice_size()`.
+x `n()` must only be used inside dplyr verbs.
+

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -253,7 +253,7 @@ test_that("slice_*() checks for empty ...", {
   expect_error(slice_tail(df, 5))
   expect_error(slice_min(df, x, 5))
   expect_error(slice_max(df, x, 5))
-  expect_error(slice_saple(df, 5))
+  expect_error(slice_sample(df, 5))
 })
 
 test_that("slice_*() checks for constant n= and prop=", {

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -256,6 +256,24 @@ test_that("slice_*() checks for empty ...", {
   expect_error(slice_saple(df, 5))
 })
 
+test_that("slice_*() checks for constant n= and prop=", {
+  df <- data.frame(x = 1:10)
+  expect_error(slice_head(df, n = n()), "constant")
+  expect_error(slice_head(df, prop = n()), "constant")
+
+  expect_error(slice_tail(df, n = n()), "constant")
+  expect_error(slice_tail(df, prop = n()), "constant")
+
+  expect_error(slice_min(df, x, n = n()), "constant")
+  expect_error(slice_min(df, x, prop = n()), "constant")
+
+  expect_error(slice_max(df, x, n = n()), "constant")
+  expect_error(slice_max(df, x, prop = n()), "constant")
+
+  expect_error(slice_sample(df, n = n()), "constant")
+  expect_error(slice_sample(df, prop = n()), "constant")
+})
+
 # Errors ------------------------------------------------------------------
 
 test_that("rename errors with invalid grouped data frame (#640)", {
@@ -276,5 +294,7 @@ test_that("rename errors with invalid grouped data frame (#640)", {
     check_slice_size(prop = "a")
     check_slice_size(n = -1)
     check_slice_size(prop = -1)
+    check_slice_size(n = n())
+    check_slice_size(prop = n())
   })
 })


### PR DESCRIPTION
related to #5478

Trying to be more informative in the error message: 

``` r
library(dplyr, warn.conflicts = FALSE)

df <- data.frame(col1 = c('a', 'b', 'b', 'c'), col2 = 1:4)
df %>% 
  group_by(col1) %>% 
  slice_sample(n = max(n() * 0.5, 1))
#> Error: `n` must be constant across groups in `slice_sample()`.
#> x `n()` must only be used inside dplyr verbs.
#> Backtrace:
#>      █
#>   1. └─df %>% group_by(col1) %>% slice_sample(n = max(n() * 0.5, 1))
#>   2.   ├─base::withVisible(eval(quote(`_fseq`(`_lhs`)), env, env))
#>   3.   └─base::eval(quote(`_fseq`(`_lhs`)), env, env)
#>   4.     └─base::eval(quote(`_fseq`(`_lhs`)), env, env)
#>   5.       └─`_fseq`(`_lhs`)
#>   6.         └─magrittr::freduce(value, `_function_list`)
#>   7.           ├─base::withVisible(function_list[[k]](value))
#>   8.           └─function_list[[k]](value)
#>   9.             ├─dplyr::slice_sample(., n = max(n() * 0.5, 1))
#>  10.             ├─dplyr:::slice_sample.data.frame(., n = max(n() * 0.5, 1)) /Users/romainfrancois/git/tidyverse/dplyr/R/slice.R:231:2
#>  11.             │ └─dplyr:::check_slice_size(n, prop, "slice_sample") /Users/romainfrancois/git/tidyverse/dplyr/R/slice.R:236:2
#>  12.             │   └─dplyr:::check_constant(n, "n", .slice_fn) /Users/romainfrancois/git/tidyverse/dplyr/R/slice.R:305:4
#>  13.             │     ├─base::withCallingHandlers(...) /Users/romainfrancois/git/tidyverse/dplyr/R/slice.R:293:2
#>  14.             │     └─base::force(x) /Users/romainfrancois/git/tidyverse/dplyr/R/slice.R:293:2
#>  15.             └─dplyr::n() /Users/romainfrancois/git/tidyverse/dplyr/R/slice.R:236:2
#>  16.               └─dplyr:::peek_mask("n()") /Users/romainfrancois/git/tidyverse/dplyr/R/context.R:53:2
#>  17.                 └─dplyr:::context_peek("mask", fun) /Users/romainfrancois/git/tidyverse/dplyr/R/context.R:143:2
#>  18.                   └─context_peek_bare(name) %||% abort(glue("`{fun}` must only be used inside {location}.")) /Users/romainfrancois/git/tidyverse/dplyr/R/context.R:126:2
#> Backtrace:
#>      █
#>   1. └─df %>% group_by(col1) %>% slice_sample(n = max(n() * 0.5, 1))
#>   2.   ├─base::withVisible(eval(quote(`_fseq`(`_lhs`)), env, env))
#>   3.   └─base::eval(quote(`_fseq`(`_lhs`)), env, env)
#>   4.     └─base::eval(quote(`_fseq`(`_lhs`)), env, env)
#>   5.       └─`_fseq`(`_lhs`)
#>   6.         └─magrittr::freduce(value, `_function_list`)
#>   7.           ├─base::withVisible(function_list[[k]](value))
#>   8.           └─function_list[[k]](value)
#>   9.             ├─dplyr::slice_sample(., n = max(n() * 0.5, 1))
#>  10.             ├─dplyr:::slice_sample.data.frame(., n = max(n() * 0.5, 1)) /Users/romainfrancois/git/tidyverse/dplyr/R/slice.R:231:2
#>  11.             │ └─dplyr:::check_slice_size(n, prop, "slice_sample") /Users/romainfrancois/git/tidyverse/dplyr/R/slice.R:236:2
#>  12.             │   └─dplyr:::check_constant(n, "n", .slice_fn) /Users/romainfrancois/git/tidyverse/dplyr/R/slice.R:305:4
#>  13.             │     ├─base::withCallingHandlers(...) /Users/romainfrancois/git/tidyverse/dplyr/R/slice.R:293:2
#>  14.             │     └─base::force(x) /Users/romainfrancois/git/tidyverse/dplyr/R/slice.R:293:2
#>  15.             └─dplyr::n() /Users/romainfrancois/git/tidyverse/dplyr/R/slice.R:236:2
#>  16.               └─dplyr:::peek_mask("n()") /Users/romainfrancois/git/tidyverse/dplyr/R/context.R:53:2
#>  17.                 └─dplyr:::context_peek("mask", fun) /Users/romainfrancois/git/tidyverse/dplyr/R/context.R:143:2
#>  18.                   ├─context_peek_bare(name) %||% abort(glue("`{fun}` must only be used inside {location}.")) /Users/romainfrancois/git/tidyverse/dplyr/R/context.R:126:2
#>  19.                   └─rlang::abort(glue("`{fun}` must only be used inside {location}.")) /Users/romainfrancois/git/tidyverse/dplyr/R/context.R:126:2
#>  20.                     └─rlang:::signal_abort(cnd)
#>  21.                       └─base::stop(fallback)
#> <parent: error/rlang_error>
#> Backtrace:
#> █
```

<sup>Created on 2020-08-31 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>