### PR TITLE
using rep_len() instead of rep() 

### DIFF
--- a/R/generics.R
+++ b/R/generics.R
@@ -107,7 +107,7 @@ dplyr_row_slice.grouped_df <- function(data, i, ..., preserve = FALSE) {
   new_id <- vec_slice(group_indices(data), i)
   new_grps <- vec_group_loc(new_id)
 
-  rows <- rep(list_of(integer()), length.out = nrow(groups))
+  rows <- rep_len(list_of(integer()), length.out = nrow(groups))
   rows[new_grps$key] <- new_grps$loc
   groups$.rows <- rows
   if (!preserve && isTRUE(attr(groups, ".drop"))) {


### PR DESCRIPTION
to avoid interference of possible `rep.list()` function defined in some third-^party package.

closes #5506