### PR TITLE
`across()` handles data frames with 0 columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Fixed `across()` issue where data frame columns would could not be referred to
   with `all_of()` in the nested case (`mutate()` within `mutate()`) (#5498).
+  
+* `across()` handles data frames with 0 columns (#5523). 
 
 # dplyr 1.0.2
 

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -211,7 +211,8 @@ DataMask <- R6Class("DataMask",
 
       cols <- vec_c(cols_unused, cols_used)
 
-      # workaround until https://github.com/r-lib/vctrs/issues/1263
+      # workaround until vctrs 0.3.5 is on CRAN
+      # (https://github.com/r-lib/vctrs/issues/1263)
       if (length(cols) == 0) {
         names(cols) <- character()
       }

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -211,6 +211,11 @@ DataMask <- R6Class("DataMask",
 
       cols <- vec_c(cols_unused, cols_used)
 
+      # workaround until https://github.com/r-lib/vctrs/issues/1263
+      if (length(cols) == 0) {
+        names(cols) <- character()
+      }
+
       # Match original ordering
       cols <- cols[across_vars]
 

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -248,6 +248,12 @@ test_that("across() sees columns in the recursive case (#5498)", {
   expect_identical(out, exp)
 })
 
+test_that("across() works with empty data frames (#5523)", {
+   expect_equal(
+     mutate(tibble(), across()),
+     tibble()
+   )
+})
 
 # c_across ----------------------------------------------------------------
 


### PR DESCRIPTION
closes #5523

``` r
library(dplyr)

tibble(hello = 1:5) %>% mutate(across(NULL, ~ .x + 1))
#> # A tibble: 5 x 1
#>   hello
#>   <int>
#> 1     1
#> 2     2
#> 3     3
#> 4     4
#> 5     5
tibble(.rows = 5) %>% mutate(across(NULL, ~ .x + 1))
#> # A tibble: 5 x 0
```

<sup>Created on 2020-09-17 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>