### PR TITLE
promises for chops, active bindings for slices

### DIFF
--- a/R/context.R
+++ b/R/context.R
@@ -78,7 +78,7 @@ cur_group <- function() {
 #' @rdname context
 #' @export
 cur_group_id <- function() {
-  peek_mask("cur_group_id()")$get_current_group()
+  peek_mask("cur_group_id()")$get_current_group()[]
 }
 
 #' @rdname context

--- a/R/filter.R
+++ b/R/filter.R
@@ -118,6 +118,7 @@ filter.data.frame <- function(.data, ..., .preserve = FALSE) {
 filter_rows <- function(.data, ...) {
   dots <- check_filter(enquos(...))
   mask <- DataMask$new(.data, caller_env())
+  on.exit(mask$forget("filter"), add = TRUE)
 
   env_filter <- env()
   withCallingHandlers(

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -218,6 +218,8 @@ transmute.data.frame <- function(.data, ...) {
 
 mutate_cols <- function(.data, ...) {
   mask <- DataMask$new(.data, caller_env())
+  on.exit(mask$forget("mutate"), add = TRUE)
+
   rows <- mask$get_rows()
 
   dots <- enquos(...)

--- a/R/slice.R
+++ b/R/slice.R
@@ -253,6 +253,8 @@ slice_rows <- function(.data, ...) {
   }
 
   mask <- DataMask$new(.data, caller_env())
+  on.exit(mask$forget("slice"), add = TRUE)
+
   rows <- mask$get_rows()
 
   quo <- quo(c(!!!dots))

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -210,6 +210,7 @@ summarise.rowwise_df <- function(.data, ..., .groups = NULL) {
 
 summarise_cols <- function(.data, ...) {
   mask <- DataMask$new(.data, caller_env())
+  on.exit(mask$forget("summarise"), add = TRUE)
 
   dots <- enquos(...)
   dots_names <- names(dots)

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -137,7 +137,7 @@ SEXP dplyr_mask_eval_all_filter(SEXP quos, SEXP env_private, SEXP s_n, SEXP env_
     SEXP rows_i = VECTOR_ELT(rows, i);
     R_xlen_t n_i = XLENGTH(rows_i);
 
-    SEXP result_i = PROTECT(eval_filter_one(quos, VECTOR_ELT(masks, i), caller, n_i, env_filter));
+    SEXP result_i = PROTECT(eval_filter_one(quos, mask, caller, n_i, env_filter));
 
     int* p_rows_i = INTEGER(rows_i);
     int* p_result_i = LOGICAL(result_i);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -40,7 +40,7 @@ SEXP get_names_summarise_recycle_chunks(){
 SEXP symbols::ptype = Rf_install("ptype");
 SEXP symbols::levels = Rf_install("levels");
 SEXP symbols::groups = Rf_install("groups");
-SEXP symbols::current_group = Rf_install("current_group");
+SEXP symbols::dot_current_group = Rf_install(".current_group");
 SEXP symbols::current_expression = Rf_install("current_expression");
 SEXP symbols::rows = Rf_install("rows");
 SEXP symbols::caller = Rf_install("caller");
@@ -49,7 +49,7 @@ SEXP symbols::dot_drop = Rf_install(".drop");
 SEXP symbols::abort_glue = Rf_install("abort_glue");
 SEXP symbols::dot_indices = Rf_install(".indices");
 SEXP symbols::chops = Rf_install("chops");
-SEXP symbols::masks = Rf_install("masks");
+SEXP symbols::mask = Rf_install("mask");
 SEXP symbols::rm = Rf_install("rm");
 SEXP symbols::envir = Rf_install("envir");
 SEXP symbols::vec_is_list = Rf_install("vec_is_list");
@@ -65,6 +65,7 @@ SEXP vectors::names_summarise_recycle_chunks = get_names_summarise_recycle_chunk
 SEXP functions::vec_chop = NULL;
 SEXP functions::dot_subset2 = NULL;
 SEXP functions::list = NULL;
+SEXP functions::function = NULL;
 
 } // dplyr
 
@@ -75,6 +76,8 @@ SEXP dplyr_init_library(SEXP ns_dplyr, SEXP ns_vctrs, SEXP ns_rlang) {
   dplyr::functions::vec_chop = Rf_findVarInFrame(ns_vctrs, Rf_install("vec_chop"));
   dplyr::functions::dot_subset2 = Rf_findVarInFrame(R_BaseEnv, Rf_install(".subset2"));
   dplyr::functions::list = Rf_findVarInFrame(R_BaseEnv, Rf_install("list"));
+  dplyr::functions::function = Rf_eval(Rf_install("function"), R_BaseEnv);
+
   return R_NilValue;
 }
 

--- a/src/mask.cpp
+++ b/src/mask.cpp
@@ -59,11 +59,8 @@ SEXP dplyr_mask_add(SEXP env_private, SEXP s_name, SEXP chunks) {
   SEXP chops = Rf_findVarInFrame(env_private, dplyr::symbols::chops);
   Rf_defineVar(sym_name, chunks, chops);
 
-  SEXP masks = Rf_findVarInFrame(env_private, dplyr::symbols::masks);
-  R_xlen_t n_groups = XLENGTH(masks);
-  for (R_xlen_t i = 0; i < n_groups; i++) {
-    Rf_defineVar(sym_name, VECTOR_ELT(chunks, i), ENCLOS(VECTOR_ELT(masks, i)));
-  }
+  SEXP mask = Rf_findVarInFrame(env_private, dplyr::symbols::mask);
+  add_mask_binding(sym_name, ENCLOS(mask), chops);
 
   return R_NilValue;
 }
@@ -93,12 +90,8 @@ SEXP dplyr_mask_remove(SEXP env_private, SEXP s_name) {
     SET_TAG(CDDR(rm_call), dplyr::symbols::envir);
     Rf_eval(rm_call, R_BaseEnv);
 
-    SEXP masks = Rf_findVarInFrame(env_private, dplyr::symbols::masks);
-    R_xlen_t n = XLENGTH(masks);
-    for (R_xlen_t i = 0; i < n; i++) {
-      SETCAR(CDDR(rm_call), ENCLOS(VECTOR_ELT(masks, i)));
-      Rf_eval(rm_call, R_BaseEnv);
-    }
+    SETCAR(CDDR(rm_call), ENCLOS(Rf_findVarInFrame(env_private, dplyr::symbols::mask)));
+    Rf_eval(rm_call, R_BaseEnv);
 
     UNPROTECT(1);
   }

--- a/tests/testthat/test-mutate-errors.txt
+++ b/tests/testthat/test-mutate-errors.txt
@@ -126,7 +126,9 @@ obsolete data mask
 > lazy <- (function(x) list(enquo(x)))
 > res <- tbl %>% rowwise() %>% mutate(z = lazy(x), .keep = "unused")
 > eval_tidy(res$z[[1]])
-[1] 1
+Error: Obsolete data mask.
+x Too late to resolve `x` after the end of `dplyr::mutate()`.
+i Did you save an object that uses `x` lazily in a column in the `dplyr::mutate()` expression ?
 
 
 Error that contains {


### PR DESCRIPTION
This builds on top of #5520 but instead of creating one rlang data mask per group with promises, this has only one data mask, but holding active bindings. 

The active binding still uses the lazy chops which still live in an environment full of promises. 

For example with `data.frame(x = 1:2, y = 3:4) %>% group_by(x)` we create: 

 - the lazy chops: an environment with promises of chops for `x` and `y`. The parent of this env has the `.current_group` variable that needs to be changed as the evaluation moves from one group to the other. 
 - the rlang data mask, with bindings like `function() .subset2(x, .current_group)`. The binding function's enclosure is the lazy chops env

``` r
library(dplyr)
set.seed(123)

group_size <- 5L
n_groups <- 1e5
size <- n_groups * group_size

g <- rep(seq_len(n_groups), each = group_size)
x <- rnorm(size)

df <- tibble(x = x, g = g)

gdf <- group_by(df, g)
```

This PR: 

```r
bench::mark(
  sum = summarise(gdf, x = sum(x), .groups = "drop_last")
)[1:8]
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 sum           141ms    166ms      5.75    7.41MB     15.8
```

#5520 (with promises and one mask per group): 

``` r
bench::mark(
  sum = summarise(gdf, x = sum(x), .groups = "drop_last")
)[1:8]
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 sum           1.59s    1.59s     0.628     137MB     3.77
```

master: 

``` r
bench::mark(
  sum = summarise(gdf, x = sum(x), .groups = "drop_last")
)[1:8]
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 sum           116ms    128ms      7.81    7.49MB     9.77
```

<sup>Created on 2020-10-27 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>

Performance feels similar to master on the "many groups" case. Presumably using an active binding (instead of the adhoc system we had to update the mask based on what has been used/resolved) is slightly more expensive. 
