### PR TITLE
add examples to show more ways of selecting columns in across() documentation

### DIFF
--- a/R/across.R
+++ b/R/across.R
@@ -43,10 +43,10 @@
 #'   mutate(across(c(1, 2), round))
 #' iris %>%
 #'   as_tibble() %>%
-#'   mutate(across(c(1:Sepal.Width), round))
+#'   mutate(across(1:Sepal.Width, round))
 #' iris %>%
 #'   as_tibble() %>%
-#'   mutate(across(c(where(is.double), -c(Petal.Length, Petal.Width)), round))
+#'   mutate(across(where(is.double) & !c(Petal.Length, Petal.Width), round))
 #'
 #' # A purrr-style formula
 #' iris %>%

--- a/R/across.R
+++ b/R/across.R
@@ -35,6 +35,7 @@
 #' @examples
 #' # across() -----------------------------------------------------------------
 #' # Different ways to select the same set of columns
+#' # See <https://tidyselect.r-lib.org/articles/syntax.html> for details
 #' iris %>%
 #'   as_tibble() %>%
 #'   mutate(across(c(Sepal.Length, Sepal.Width), round))

--- a/R/across.R
+++ b/R/across.R
@@ -34,12 +34,19 @@
 #' A tibble with one column for each column in `.cols` and each function in `.fns`.
 #' @examples
 #' # across() -----------------------------------------------------------------
-#' iris %>%
-#'   group_by(Species) %>%
-#'   summarise(across(starts_with("Sepal"), mean))
+#' # Different ways to select the same set of columns
 #' iris %>%
 #'   as_tibble() %>%
-#'   mutate(across(where(is.factor), as.character))
+#'   mutate(across(c(Sepal.Length, Sepal.Width), round))
+#' iris %>%
+#'   as_tibble() %>%
+#'   mutate(across(c(1, 2), round))
+#' iris %>%
+#'   as_tibble() %>%
+#'   mutate(across(c(1:Sepal.Width), round))
+#' iris %>%
+#'   as_tibble() %>%
+#'   mutate(across(c(where(is.double), -c(Petal.Length, Petal.Width)), round))
 #'
 #' # A purrr-style formula
 #' iris %>%

--- a/man/across.Rd
+++ b/man/across.Rd
@@ -46,12 +46,20 @@ more details.
 }
 \examples{
 # across() -----------------------------------------------------------------
-iris \%>\%
-  group_by(Species) \%>\%
-  summarise(across(starts_with("Sepal"), mean))
+# Different ways to select the same set of columns
+# See <https://tidyselect.r-lib.org/articles/syntax.html> for details
 iris \%>\%
   as_tibble() \%>\%
-  mutate(across(where(is.factor), as.character))
+  mutate(across(c(Sepal.Length, Sepal.Width), round))
+iris \%>\%
+  as_tibble() \%>\%
+  mutate(across(c(1, 2), round))
+iris \%>\%
+  as_tibble() \%>\%
+  mutate(across(1:Sepal.Width, round))
+iris \%>\%
+  as_tibble() \%>\%
+  mutate(across(where(is.double) & !c(Petal.Length, Petal.Width), round))
 
 # A purrr-style formula
 iris \%>\%


### PR DESCRIPTION
Addresses #5517 .

A few notes:

- I didn't change the examples which demonstrates how to use the `.fns` and `.names` arguments because I think these examples would be easier to understand if the selected columns (`starts_with("Sepal")`) remain the same.
- Some examples (especially the one with `across(c(1:Sepal.Width)`) may seem weird, but I think they can inspire users to try related selecting strategies.

This is my first attempt to make a pull request, so please let me know if it needs further refinements :).