### PR TITLE
allow duplicate rows in x to be updated

### DIFF
--- a/R/rows.R
+++ b/R/rows.R
@@ -119,11 +119,8 @@ rows_update.data.frame <- function(x, y, by = NULL, ..., copy = FALSE, in_place 
     abort("Attempting to update missing rows.")
   }
   idx <- vctrs::vec_match(x[key], y[key])
-  pos <- seq_len(vec_size(x))
-
-  keep <- !is.na(idx)
-  pos <- pos[keep]
-  idx <- idx[keep]
+  pos <- which(!is.na(idx))
+  idx <- idx[pos]
 
   x[pos, names(y)] <- vec_slice(y, idx)
   x

--- a/R/rows.R
+++ b/R/rows.R
@@ -85,8 +85,11 @@ rows_insert.data.frame <- function(x, y, by = NULL, ..., copy = FALSE, in_place 
   y <- auto_copy(x, y, copy = copy)
   rows_df_in_place(in_place)
 
-  rows_check_key_df(x, key, df_name = "x")
-  rows_check_key_df(y, key, df_name = "y")
+  rows_check_key_names_df(x, key, df_name = "x")
+  rows_check_key_unique_df(x, key, df_name = "x")
+
+  rows_check_key_names_df(y, key, df_name = "y")
+  rows_check_key_unique_df(y, key, df_name = "y")
 
   idx <- vctrs::vec_match(y[key], x[key])
   bad <- which(!is.na(idx))
@@ -112,8 +115,9 @@ rows_update.data.frame <- function(x, y, by = NULL, ..., copy = FALSE, in_place 
   y <- auto_copy(x, y, copy = copy)
   rows_df_in_place(in_place)
 
-  rows_check_key_df(x, key, df_name = "x", .check_unique = FALSE)
-  rows_check_key_df(y, key, df_name = "y")
+  rows_check_key_names_df(x, key, df_name = "x")
+  rows_check_key_names_df(y, key, df_name = "y")
+  rows_check_key_unique_df(y, key, df_name = "y")
 
   if (!all(vec_in(y[key], x[key]))){
     abort("Attempting to update missing rows.")
@@ -141,8 +145,12 @@ rows_patch.data.frame <- function(x, y, by = NULL, ..., copy = FALSE, in_place =
   y <- auto_copy(x, y, copy = copy)
   rows_df_in_place(in_place)
 
-  rows_check_key_df(x, key, df_name = "x")
-  rows_check_key_df(y, key, df_name = "y")
+  rows_check_key_names_df(x, key, df_name = "x")
+  rows_check_key_unique_df(x, key, df_name = "x")
+
+  rows_check_key_names_df(y, key, df_name = "y")
+  rows_check_key_unique_df(y, key, df_name = "y")
+
   idx <- vctrs::vec_match(y[key], x[key])
 
   bad <- which(is.na(idx))
@@ -171,8 +179,12 @@ rows_upsert.data.frame <- function(x, y, by = NULL, ..., copy = FALSE, in_place 
   y <- auto_copy(x, y, copy = copy)
   rows_df_in_place(in_place)
 
-  rows_check_key_df(x, key, df_name = "x")
-  rows_check_key_df(y, key, df_name = "y")
+  rows_check_key_names_df(x, key, df_name = "x")
+  rows_check_key_unique_df(x, key, df_name = "x")
+
+  rows_check_key_names_df(y, key, df_name = "y")
+  rows_check_key_unique_df(y, key, df_name = "y")
+
   idx <- vctrs::vec_match(y[key], x[key])
   new <- is.na(idx)
   idx_existing <- idx[!new]
@@ -197,8 +209,11 @@ rows_delete.data.frame <- function(x, y, by = NULL, ..., copy = FALSE, in_place 
   y <- auto_copy(x, y, copy = copy)
   rows_df_in_place(in_place)
 
-  rows_check_key_df(x, key, df_name = "x")
-  rows_check_key_df(y, key, df_name = "y")
+  rows_check_key_names_df(x, key, df_name = "x")
+  rows_check_key_unique_df(x, key, df_name = "x")
+
+  rows_check_key_names_df(y, key, df_name = "y")
+  rows_check_key_unique_df(y, key, df_name = "y")
 
   extra_cols <- setdiff(names(y), key)
   if (has_length(extra_cols)) {
@@ -243,12 +258,15 @@ rows_check_key <- function(by, x, y) {
   by
 }
 
-rows_check_key_df <- function(df, by, df_name, .check_unique = TRUE) {
+rows_check_key_names_df <- function(df, by, df_name) {
   y_miss <- setdiff(by, colnames(df))
   if (length(y_miss) > 0) {
     abort(glue("All `by` columns must exist in `{df_name}`."))
   }
-  if (.check_unique && vctrs::vec_duplicate_any(df[by])) {
+}
+
+rows_check_key_unique_df <- function(df, by, df_name) {
+  if (vctrs::vec_duplicate_any(df[by])) {
     abort(glue("`{df_name}` key values are not unique."))
   }
 }

--- a/R/rows.R
+++ b/R/rows.R
@@ -81,6 +81,7 @@ rows_insert <- function(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
 #' @export
 rows_insert.data.frame <- function(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
   key <- rows_check_key(by, x, y)
+  rows_check_subset(x, y)
   y <- auto_copy(x, y, copy = copy)
   rows_df_in_place(in_place)
 
@@ -108,6 +109,7 @@ rows_update <- function(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
 #' @export
 rows_update.data.frame <- function(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
   key <- rows_check_key(by, x, y)
+  rows_check_subset(x, y)
   y <- auto_copy(x, y, copy = copy)
   rows_df_in_place(in_place)
 
@@ -136,6 +138,7 @@ rows_patch <- function(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
 #' @export
 rows_patch.data.frame <- function(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
   key <- rows_check_key(by, x, y)
+  rows_check_subset(x, y)
   y <- auto_copy(x, y, copy = copy)
   rows_df_in_place(in_place)
 
@@ -164,6 +167,7 @@ rows_upsert <- function(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
 #' @export
 rows_upsert.data.frame <- function(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
   key <- rows_check_key(by, x, y)
+  rows_check_subset(x, y)
   y <- auto_copy(x, y, copy = copy)
   rows_df_in_place(in_place)
 
@@ -201,6 +205,8 @@ rows_delete <- function(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
 #' @export
 rows_delete.data.frame <- function(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
   key <- rows_check_key(by, x, y)
+  rows_check_subset(x, y)
+
   y <- auto_copy(x, y, copy = copy)
   rows_df_in_place(in_place)
 
@@ -238,12 +244,14 @@ rows_check_key <- function(by, x, y) {
     abort("`by` must be unnamed.")
   }
 
+  by
+}
+
+rows_check_subset <- function(x, y) {
   bad <- setdiff(colnames(y), colnames(x))
   if (has_length(bad)) {
     abort("All columns in `y` must exist in `x`.")
   }
-
-  by
 }
 
 rows_check_key_names_df <- function(df, by, df_name) {

--- a/tests/testthat/test-rows.R
+++ b/tests/testthat/test-rows.R
@@ -20,16 +20,28 @@ test_that("rows_update()", {
     tibble(a = 1:3, b = c("a", "z", "z"), c = data$c)
   )
 
-  expect_error(
-    rows_update(data, tibble(a = 2:3, b = "z"), by = c("a", "b")),
-    "update missing"
-  )
-
   expect_silent(
     expect_identical(
       rows_update(data, tibble(b = "z", a = 2:3), by = "a"),
       tibble(a = 1:3, b = c("a", "z", "z"), c = data$c)
     )
+  )
+
+  expect_error(
+    rows_update(data, tibble(d = 1)),
+    "must exist"
+  )
+  expect_error(
+    rows_update(data, tibble(a = c(1, 1))),
+    "not unique"
+  )
+  expect_error(
+    rows_update(data, tibble(a = 1), by = "b"),
+    "must exist"
+  )
+  expect_error(
+    rows_update(data, tibble(a = 1), by = c(b = "a")),
+    "must be unnamed"
   )
 })
 
@@ -41,16 +53,28 @@ test_that("rows_patch()", {
     tibble(a = 1:3, b = c("a", "b", "z"), c = data$c)
   )
 
-  expect_error(
-    rows_patch(data, tibble(a = 2:3, b = "z"), by = c("a", "b")),
-    "patch missing"
-  )
-
   expect_silent(
     expect_identical(
       rows_patch(data, tibble(b = "z", a = 2:3), by = "a"),
       tibble(a = 1:3, b = c("a", "b", "z"), c = data$c)
     )
+  )
+
+  expect_error(
+    rows_patch(data, tibble(d = 1)),
+    "must exist"
+  )
+  expect_error(
+    rows_patch(data, tibble(a = c(1, 1))),
+    "not unique"
+  )
+  expect_error(
+    rows_patch(data, tibble(a = 1), by = "b"),
+    "must exist"
+  )
+  expect_error(
+    rows_patch(data, tibble(a = 1), by = c(b = "a")),
+    "must be unnamed"
   )
 })
 
@@ -60,6 +84,23 @@ test_that("rows_upsert()", {
   expect_identical(
     rows_upsert(data, tibble(a = 2:4, b = "z")),
     tibble(a = 1:4, b = c("a", "z", "z", "z"), c = c(data$c, NA))
+  )
+
+  expect_error(
+    rows_upsert(data, tibble(d = 1)),
+    "must exist"
+  )
+  expect_error(
+    rows_upsert(data, tibble(a = c(1, 1))),
+    "not unique"
+  )
+  expect_error(
+    rows_upsert(data, tibble(a = 1), by = "b"),
+    "must exist"
+  )
+  expect_error(
+    rows_upsert(data, tibble(a = 1), by = c(b = "a")),
+    "must be unnamed"
   )
 })
 
@@ -71,19 +112,14 @@ test_that("rows_delete()", {
     data[1, ]
   )
 
-  expect_error(
-    rows_delete(data, tibble(a = 2:4)),
-    "delete missing"
-  )
-
   expect_identical(
     rows_delete(data, tibble(a = 2:3, b = "b")),
     data[1, ]
   )
 
-  expect_error(
-    rows_delete(data, tibble(a = 2:3, b = "b"), by = c("a", "b")),
-    "delete missing"
+  expect_message(
+    rows_delete(data, tibble(a = 2:3, b = "b")),
+    "Ignoring extra columns"
   )
 })
 
@@ -97,12 +133,10 @@ verify_output("test-rows.txt", {
 
   "# Update"
   rows_update(data, tibble(a = 2:3, b = "z"))
-  rows_update(data, tibble(a = 2:3, b = "z"), by = c("a", "b"))
   rows_update(data, tibble(b = "z", a = 2:3), by = "a")
 
   "# Variants: patch and upsert"
   rows_patch(data, tibble(a = 2:3, b = "z"))
-  rows_patch(data, tibble(a = 2:3, b = "z"), by = c("a", "b"))
   rows_upsert(data, tibble(a = 2:4, b = "z"))
 
   "# Delete and truncate"
@@ -112,9 +146,7 @@ verify_output("test-rows.txt", {
   rows_delete(data, tibble(a = 2:3, b = "b"), by = c("a", "b"))
 
   "# Errors"
-  rows_insert(data[c(1, 1), ], tibble(a = 3))
   rows_insert(data, tibble(a = c(4, 4)))
-
   rows_insert(data, tibble(d = 4))
   rows_insert(data, tibble(a = 4, b = "z"), by = "e")
 })

--- a/tests/testthat/test-rows.txt
+++ b/tests/testthat/test-rows.txt
@@ -41,9 +41,6 @@ Message: Matching, by = "a"
 2     2 z       1.5
 3     3 z       2.5
 
-> rows_update(data, tibble(a = 2:3, b = "z"), by = c("a", "b"))
-Error: Attempting to update missing rows.
-
 > rows_update(data, tibble(b = "z", a = 2:3), by = "a")
 # A tibble: 3 x 3
       a b         c
@@ -65,9 +62,6 @@ Message: Matching, by = "a"
 1     1 a       0.5
 2     2 b       1.5
 3     3 z       2.5
-
-> rows_patch(data, tibble(a = 2:3, b = "z"), by = c("a", "b"))
-Error: Attempting to patch missing rows.
 
 > rows_upsert(data, tibble(a = 2:4, b = "z"))
 Message: Matching, by = "a"
@@ -95,7 +89,10 @@ Message: Matching, by = "a"
 > rows_delete(data, tibble(a = 2:4))
 Message: Matching, by = "a"
 
-Error: Attempting to delete missing rows.
+# A tibble: 1 x 3
+      a b         c
+  <int> <chr> <dbl>
+1     1 a       0.5
 
 > rows_delete(data, tibble(a = 2:3, b = "b"))
 Message: Matching, by = "a"
@@ -108,16 +105,15 @@ Message: Ignoring extra columns: b
 1     1 a       0.5
 
 > rows_delete(data, tibble(a = 2:3, b = "b"), by = c("a", "b"))
-Error: Attempting to delete missing rows.
+# A tibble: 2 x 3
+      a b         c
+  <int> <chr> <dbl>
+1     1 a       0.5
+2     3 <NA>    2.5
 
 
 Errors
 ======
-
-> rows_insert(data[c(1, 1), ], tibble(a = 3))
-Message: Matching, by = "a"
-
-Error: `x` key values are not unique.
 
 > rows_insert(data, tibble(a = c(4, 4)))
 Message: Matching, by = "a"


### PR DESCRIPTION
I need to review the other functions, and understand better what they all do, but I think this is legit for #5553

``` r
library(dplyr)

df1 <- tibble(x = c(1, 1, 2), y = c(2, 3, 5))
df2 <- tibble(x = 1, y = 4)
rows_update(df1, df2, by = "x")
#> # A tibble: 3 x 2
#>       x     y
#>   <dbl> <dbl>
#> 1     1     4
#> 2     1     4
#> 3     2     5
```

<sup>Created on 2020-11-04 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>