### PR TITLE
improve distinct() and grouo_by() error messages when adding computed…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * `relocate()` can rename columns it relocates (#5569).
 
+* `distinct()` and `group_by()` have better error messages when the mutate step fails (#5060).
+
 * Clarify that `between()` is not vectorised (#5493).
 
 * Fixed `across()` issue where data frame columns would could not be referred to

--- a/R/distinct.R
+++ b/R/distinct.R
@@ -82,7 +82,7 @@ distinct_prepare <- function(.data, vars, group_vars = character(), .keep_all = 
   }
 
   # If any calls, use mutate to add new columns, then distinct on those
-  computed_columns <- add_computed_columns(.data, vars)
+  computed_columns <- add_computed_columns(.data, vars, "distinct")
   .data <- computed_columns$data
   distinct_vars <- computed_columns$added_names
 

--- a/tests/testthat/test-distinct-errors.txt
+++ b/tests/testthat/test-distinct-errors.txt
@@ -11,3 +11,9 @@ x `bb` not found in `.data`.
 Error: `distinct()` must use existing variables.
 x `aa` not found in `.data`.
 
+> df %>% distinct(y = a + 1)
+Error: Problem adding computed columns in `distinct()`.
+x Problem with `mutate()` input `y`.
+x object 'a' not found
+i Input `y` is `a + 1`.
+

--- a/tests/testthat/test-distinct.R
+++ b/tests/testthat/test-distinct.R
@@ -164,5 +164,7 @@ test_that("distinct gives a warning when selecting an unknown column (#3140)", {
     df %>% distinct(aa, x)
     df %>% distinct(aa, bb)
     df %>% distinct(.data$aa)
+
+    df %>% distinct(y = a + 1)
   })
 })

--- a/tests/testthat/test-group-by-errors.txt
+++ b/tests/testthat/test-group-by-errors.txt
@@ -16,3 +16,9 @@ Did you misspecify an argument?
 Error: Can't subset columns that don't exist.
 x Column `z` doesn't exist.
 
+> df %>% group_by(z = a + 1)
+Error: Problem adding computed columns in `group_by()`.
+x Problem with `mutate()` input `z`.
+x object 'a' not found
+i Input `z` is `a + 1`.
+

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -523,6 +523,8 @@ test_that("group_by() and ungroup() give meaningful error messages", {
 
     df %>% ungroup(x)
     df %>% group_by(x, y) %>% ungroup(z)
+
+    df %>% group_by(z = a + 1)
   })
 })
 


### PR DESCRIPTION
… columns fails.

closes #5060

``` r
library(tidyverse)
#> Warning: package 'tibble' was built under R version 4.0.2
#> Warning: package 'tidyr' was built under R version 4.0.2

tibble(a = 1, b = 2) %>%
  group_by(c = a * b, d = e + 1)
#> Error: Problem adding computed columns in `group_by()`.
#> x Problem with `mutate()` input `d`.
#> x object 'e' not found
#> ℹ Input `d` is `e + 1`.

tibble(a = 1, b = 2) %>%
  distinct(c = a * b, d = e + 1)
#> Error: Problem adding computed columns in `distinct()`.
#> x Problem with `mutate()` input `d`.
#> x object 'e' not found
#> ℹ Input `d` is `e + 1`.
```

<sup>Created on 2020-11-06 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>