### PR TITLE
fix link for 0.8.4 release

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -138,8 +138,6 @@ news:
   releases:
   - text: "Version 1.0.0"
     href: https://www.tidyverse.org/blog/2020/06/dplyr-1-0-0/
-  - text: "Version 0.8.4"
-    href: https://dplyr.tidyverse.org/news/index.html#dplyr-0-8-4-2020-01-30-2020-01-31
   - text: "Version 0.8.3"
     href: https://www.tidyverse.org/articles/2019/07/dplyr-0-8-3/
   - text: "Version 0.8.2"

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -139,7 +139,7 @@ news:
   - text: "Version 1.0.0"
     href: https://www.tidyverse.org/blog/2020/06/dplyr-1-0-0/
   - text: "Version 0.8.4"
-    href: https://www.tidyverse.org/articles/2019/10/dplyr-0-8-4/
+    href: https://dplyr.tidyverse.org/news/index.html#dplyr-0-8-4-2020-01-30-2020-01-31
   - text: "Version 0.8.3"
     href: https://www.tidyverse.org/articles/2019/07/dplyr-0-8-3/
   - text: "Version 0.8.2"


### PR DESCRIPTION
or perhaps we can remove it altogether, there's nothing to see there