### PR TITLE
special case cur_group_label() when data has 0 rows.

### DIFF
--- a/R/context.R
+++ b/R/context.R
@@ -96,9 +96,9 @@ group_labels_details <- function(keys) {
 cur_group_label <- function() {
   mask <- peek_mask("cur_group_label()")
   data <- mask$full_data()
-  if (is_grouped_df(data)) {
-    paste0("group ", cur_group_id(), ": ", group_labels_details(cur_group()))
-  } else if (inherits(data, "rowwise_df")) {
+  if(is_grouped_df(data) && nrow(data) > 0) {
+    glue("group {id}: {label}", id = cur_group_id(), label = group_labels_details(cur_group()))
+  } else if (inherits(data, "rowwise_df") && nrow(data) > 0) {
     paste0("row ", cur_group_id())
   } else {
     ""

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -383,6 +383,9 @@ mutate_cols <- function(.data, ...) {
       i = cnd_bullet_input_info(),
       i = cnd_bullet_cur_group_label()
     ))
+
+    # cancel `w`
+    invokeRestart("muffleWarning")
   })
 
   is_zap <- map_lgl(new_columns, inherits, "rlang_zap")

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -403,6 +403,21 @@ test_that("dplyr data mask can become obsolete", {
   expect_error(eval_tidy(res$y[[1]]))
 })
 
+test_that("mutate() deals with 0 groups (#5534)", {
+  df <- data.frame(x = numeric()) %>%
+    group_by(x)
+
+  expect_equal(
+    mutate(df, y = x + 1),
+    data.frame(x = numeric(), y = numeric()) %>% group_by(x)
+  )
+
+  expect_warning(
+    mutate(df, y = max(x)),
+    "Inf"
+  )
+})
+
 # Error messages ----------------------------------------------------------
 
 test_that("mutate() give meaningful errors", {


### PR DESCRIPTION
closes #5534

``` r
library(dplyr, warn.conflicts = FALSE)

data.frame(x = numeric()) %>%
  group_by(x) %>%
  mutate(y = max(x))
#> Warning: Problem with `mutate()` input `y`.
#> ℹ no non-missing arguments to max; returning -Inf
#> ℹ Input `y` is `max(x)`.
#> Warning in max(x): no non-missing arguments to max; returning -Inf
#> # A tibble: 0 x 2
#> # Groups:   x [0]
#> # … with 2 variables: x <dbl>, y <dbl>
```

<sup>Created on 2020-11-09 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>

@lionel- is there a way to only keep one of these warnings: 

``` r
withCallingHandlers(warning("a"), warning = function(w) warning("b"))
#> Warning in (function (w) : b
#> Warning in withCallingHandlers(warning("a"), warning = function(w)
#> warning("b")): a
```

<sup>Created on 2020-11-09 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>

