### PR TITLE
compute groups on ungrouped data.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr (development version)
 
+* `group_by()` uses the ungrouped data for the implicit mutate step (#5598).
+
 * Clarify that `between()` is not vectorised (#5493).
 
 * Fixed `across()` issue where data frame columns would could not be referred to

--- a/R/group-by.r
+++ b/R/group-by.r
@@ -150,7 +150,7 @@ group_by_prepare <- function(.data, ..., .add = FALSE, .dots = deprecated(), add
   new_groups <- new_groups[!map_lgl(new_groups, quo_is_missing)]
 
   # If any calls, use mutate to add new columns, then group by those
-  computed_columns <- add_computed_columns(.data, new_groups)
+  computed_columns <- add_computed_columns(ungroup(.data), new_groups)
   out <- computed_columns$data
   group_names <- computed_columns$added_names
 

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -505,6 +505,14 @@ test_that("group_by() has mutate() semantics (#4984)", {
   )
 })
 
+test_that("implicit mutate() operates on ungrouped data (#5598)", {
+  vars <- tibble(x = c(1,2), y = c(3,4), z = c(5,6)) %>%
+    dplyr::group_by(y) %>%
+    dplyr::group_by(across(any_of(c('y','z')))) %>%
+    dplyr::group_vars()
+  expect_equal(vars, c("y", "z"))
+})
+
 # Errors ------------------------------------------------------------------
 
 test_that("group_by() and ungroup() give meaningful error messages", {


### PR DESCRIPTION
related to #5473

``` r
library(dplyr, warn.conflicts = FALSE)

df <- tibble(x = c(1,2), y = c(3,4), z = c(5,6))

df %>% 
  dplyr::group_by(y) %>%
  dplyr::group_by(across(any_of(c('y','z')))) %>%
  dplyr::group_vars() 
#> [1] "y" "z"

df %>% 
  dplyr::group_by(y) %>%
  dplyr::group_by(y, z) %>%
  dplyr::group_vars() 
#> [1] "y" "z"
```

<sup>Created on 2020-11-09 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>

On master, only the second one incorporates `y`. Is there any reason why the implicit `mutate()` step uses the grouped data instead of the ungrouped data, as suggested by this PR ? 

``` r
library(dplyr, warn.conflicts = FALSE)

df <- tibble(x = c(1,2), y = c(3,4), z = c(5,6))

df %>% 
  dplyr::group_by(y) %>%
  dplyr::group_by(across(any_of(c('y','z')))) %>%
  dplyr::group_vars() 
#> [1] "z"

df %>% 
  dplyr::group_by(y) %>%
  dplyr::group_by(y, z) %>%
  dplyr::group_vars() 
#> [1] "y" "z"
```

<sup>Created on 2020-11-09 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>

I'll add some tests if this is sound. 

