### PR TITLE
remove warning from installChar()

### DIFF
--- a/src/chop.cpp
+++ b/src/chop.cpp
@@ -1,5 +1,17 @@
 #include "dplyr.h"
 
+namespace dplyr {
+SEXP as_symbol(SEXP str) {
+  const char* str_native = Rf_translateChar(str);
+
+  if (str_native == CHAR(str)) {
+    return Rf_installChar(str);
+  } else {
+    return Rf_install(str_native);
+  }
+}
+}
+
 SEXP new_environment(int size, SEXP parent)  {
   SEXP call = PROTECT(Rf_lang4(dplyr::symbols::new_env, Rf_ScalarLogical(TRUE), parent, Rf_ScalarInteger(size)));
   SEXP res = Rf_eval(call, R_BaseEnv);
@@ -24,7 +36,7 @@ void dplyr_lazy_vec_chop_grouped(SEXP chops_env, SEXP rows, SEXP data, bool roww
     }
     SET_PRVALUE(prom, R_UnboundValue);
 
-    Rf_defineVar(Rf_installChar(p_names[i]), prom, chops_env);
+    Rf_defineVar(dplyr::as_symbol(p_names[i]), prom, chops_env);
     UNPROTECT(1);
   }
 
@@ -43,7 +55,8 @@ void dplyr_lazy_vec_chop_ungrouped(SEXP chops_env, SEXP data) {
     SET_PRCODE(prom, Rf_lang2(dplyr::functions::list, p_data[i]));
     SET_PRVALUE(prom, R_UnboundValue);
 
-    Rf_defineVar(Rf_installChar(p_names[i]), prom, chops_env);
+    SEXP symb = dplyr::as_symbol(p_names[i]);
+    Rf_defineVar(symb, prom, chops_env);
     UNPROTECT(1);
   }
 
@@ -88,7 +101,7 @@ SEXP dplyr_data_masks_setup(SEXP env_chops, SEXP data, SEXP rows) {
   R_xlen_t mask_size = XLENGTH(data) + 20;
   SEXP env_bindings = PROTECT(new_environment(mask_size, R_EmptyEnv));
   for (R_xlen_t i = 0; i < n_columns; i++) {
-    SEXP name = Rf_installChar(p_names[i]);
+    SEXP name = dplyr::as_symbol(p_names[i]);
     add_mask_binding(name, env_bindings, env_chops);
   }
   SEXP mask = PROTECT(rlang::new_data_mask(env_bindings, R_NilValue));
@@ -107,7 +120,7 @@ SEXP env_resolved(SEXP env, SEXP names) {
   const SEXP* p_names = STRING_PTR_RO(names);
 
   for(R_xlen_t i = 0; i < n; i++) {
-    SEXP prom = Rf_findVarInFrame(env, Rf_installChar(p_names[i]));
+    SEXP prom = Rf_findVarInFrame(env, dplyr::as_symbol(p_names[i]));
     p_res[i] = PRVALUE(prom) != R_UnboundValue;
   }
 

--- a/src/chop.cpp
+++ b/src/chop.cpp
@@ -1,6 +1,8 @@
 #include "dplyr.h"
 
 namespace dplyr {
+
+// TODO: replace it with using the callable r_str_as_symbol() from rlang when available.
 SEXP as_symbol(SEXP str) {
   const char* str_native = Rf_translateChar(str);
 

--- a/src/dplyr.h
+++ b/src/dplyr.h
@@ -27,6 +27,8 @@
 
 namespace dplyr {
 
+SEXP as_symbol(SEXP str);
+
 struct envs {
   static SEXP ns_dplyr;
   static SEXP ns_vctrs;

--- a/src/mask.cpp
+++ b/src/mask.cpp
@@ -55,7 +55,7 @@ SEXP dplyr_mask_add(SEXP env_private, SEXP s_name, SEXP chunks) {
     UNPROTECT(1);
   }
 
-  SEXP sym_name = Rf_installChar(name);
+  SEXP sym_name = dplyr::as_symbol(name);
   SEXP chops = Rf_findVarInFrame(env_private, dplyr::symbols::chops);
   Rf_defineVar(sym_name, chunks, chops);
 
@@ -100,7 +100,7 @@ SEXP dplyr_mask_remove(SEXP env_private, SEXP s_name) {
     Rf_defineVar(dplyr::symbols::all_vars, new_all_vars, env_private);
 
     SEXP chops = Rf_findVarInFrame(env_private, dplyr::symbols::chops);
-    SEXP sym_name = Rf_installChar(name);
+    SEXP sym_name = dplyr::as_symbol(name);
     rm(sym_name, chops);
     rm(sym_name, ENCLOS(Rf_findVarInFrame(env_private, dplyr::symbols::mask)));
 


### PR DESCRIPTION
This is copied from https://github.com/r-lib/rlang/blob/898449d00b51ac32839715be0bdd8c5330f56aca/src/lib/vec-chr.h#L92 

@lionel- is there a way to use something like `r_str_as_symbol` directly from rlang ?