### PR TITLE
Add ... to signature of db_list_tables

### DIFF
--- a/R/dbplyr.R
+++ b/R/dbplyr.R
@@ -40,6 +40,7 @@
 #'  backend to throw an error if a table exists when it shouldn't.
 #' @name backend_dbplyr
 #' @param con A database connection.
+#' @param ... Arguments passed to other methods.
 #' @keywords internal
 NULL
 
@@ -53,7 +54,7 @@ sql_translate_env <- function(con) UseMethod("sql_translate_env")
 
 #' @name backend_dbplyr
 #' @export
-db_list_tables <- function(con) UseMethod("db_list_tables")
+db_list_tables <- function(con, ...) UseMethod("db_list_tables")
 
 #' @name backend_dbplyr
 #' @export

--- a/man/backend_dbplyr.Rd
+++ b/man/backend_dbplyr.Rd
@@ -34,7 +34,7 @@ db_desc(x)
 
 sql_translate_env(con)
 
-db_list_tables(con)
+db_list_tables(con, ...)
 
 db_has_table(con, table)
 
@@ -95,6 +95,8 @@ sql_escape_ident(con, x)
 }
 \arguments{
 \item{con}{A database connection.}
+
+\item{...}{Arguments passed to other methods.}
 
 \item{table}{A string, the table name.}
 


### PR DESCRIPTION
We have an extension which needs further arguments. <strike>I'll file another PR so as not to break `dbplyr` shortly.</strike>

Actually I see that as of https://github.com/tidyverse/dbplyr/pull/499, `dbplyr` no longer uses this generic. Will it be deprecated here as well?