### PR TITLE
rethrow shiny errors as is, instead of promoting them like other errors.

### DIFF
--- a/R/arrange.R
+++ b/R/arrange.R
@@ -116,6 +116,7 @@ arrange_rows <- function(.data, dots) {
   data <- withCallingHandlers({
     transmute(new_data_frame(.data), !!!quosures)
   }, error = function(cnd) {
+    shiny_error_bypass(cnd)
     if (inherits(cnd, "dplyr:::mutate_error")) {
       error_name <- cnd$error_name
       index <- sub("^.*_", "", error_name)

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -88,3 +88,8 @@ abort_glue <- function(message, .envir = parent.frame(), class = NULL) {
   }
 }
 
+shiny_error_bypass <- function(e) {
+  if (inherits(e, "shiny.silent.error")) {
+    stop(e)
+  }
+}

--- a/R/filter.R
+++ b/R/filter.R
@@ -124,6 +124,7 @@ filter_rows <- function(.data, ...) {
   withCallingHandlers(
     mask$eval_all_filter(dots, env_filter),
     error = function(e) {
+      shiny_error_bypass(e)
       local_call_step(dots = dots, .index = env_filter$current_expression, .fn = "filter")
 
       abort(c(

--- a/R/group-by.r
+++ b/R/group-by.r
@@ -183,6 +183,7 @@ add_computed_columns <- function(.data, vars, .fn = "group_by") {
       cols <- withCallingHandlers(
         mutate_cols(.data, !!!vars),
         error = function(e) {
+          shiny_error_bypass(e)
           abort(c(
             glue("Problem adding computed columns in `{.fn}()`."),
             x = e$message

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -325,6 +325,8 @@ mutate_cols <- function(.data, ...) {
 
   },
   error = function(e) {
+    shiny_error_bypass(e)
+
     local_call_step(dots = dots, .index = i, .fn = "mutate", .dot_data = inherits(e, "rlang_error_data_pronoun_not_found"))
     call_step_envir <- peek_call_step()
     error_name <- call_step_envir$error_name

--- a/R/slice.R
+++ b/R/slice.R
@@ -292,6 +292,7 @@ slice_rows <- function(.data, ...) {
 
 check_constant <- function(x, name, fn) {
   withCallingHandlers(force(x), error = function(e) {
+    shiny_error_bypass(e)
     abort(c(
       glue("`{name}` must be a constant in `{fn}()`."),
       x = conditionMessage(e)

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -270,6 +270,7 @@ summarise_cols <- function(.data, ...) {
 
   },
   error = function(e) {
+    shiny_error_bypass(e)
     local_call_step(dots = dots, .index = i, .fn = "summarise",
       .dot_data = inherits(e, "rlang_error_data_pronoun_not_found")
     )

--- a/tests/testthat/test-shiny.R
+++ b/tests/testthat/test-shiny.R
@@ -1,0 +1,18 @@
+expect_propagate <- function(verb) {
+  tryCatch(
+    verb(data.frame(), rlang::abort("abcdef", class = "shiny.silent.error")),
+    error = function(e) {
+      expect_s3_class(e, "shiny.silent.error")
+      expect_equal(conditionMessage(e), "abcdef")
+    }
+  )
+}
+
+test_that("verbs propagate shiny issues (#5552)", {
+  expect_propagate(filter)
+  expect_propagate(slice)
+  expect_propagate(group_by)
+  expect_propagate(mutate)
+  expect_propagate(summarise)
+  expect_propagate(arrange)
+})


### PR DESCRIPTION
closes #5552

Because we catch and improve errors in all `dplyr` verbs, some `shiny` errors don't interrupt the flow the way they are expected to. 

Not sure this is the only error we should consider. cc @wch

Alternatively, we could re-add the `shiny.silent.error` class to the error we create. 

More generally, should we do something to preserve the class and/or other parts of the errors we rebrand ?