### PR TITLE
Bump required vctrs version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,7 @@ Imports:
     tibble (>= 2.1.3),
     tidyselect (>= 1.1.0),
     utils,
-    vctrs (>= 0.3.3)
+    vctrs (>= 0.3.5)
 Suggests: 
     bench,
     broom,


### PR DESCRIPTION
Closes #5568 

Since this issue is now fixed in the CRAN version of vctrs (0.3.5) https://github.com/r-lib/vctrs/issues/1291