### PR TITLE
Bump required R version to 3.3 (#5532)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ URL: https://dplyr.tidyverse.org,
     https://github.com/tidyverse/dplyr
 BugReports: https://github.com/tidyverse/dplyr/issues
 Depends: 
-    R (>= 3.2.0)
+    R (>= 3.3.0)
 Imports: 
     ellipsis,
     generics,


### PR DESCRIPTION
The `import(except=)` namespace directive that is being used was added in R 3.3.