### PR TITLE
down cast before vec_order()

### DIFF
--- a/R/grouped-df.r
+++ b/R/grouped-df.r
@@ -294,7 +294,10 @@ expand_groups <- function(old_groups, positions, nr) {
 vec_split_id_order <- function(x) {
   split_id <- vec_group_loc(x)
   split_id$loc <- new_list_of(split_id$loc, ptype = integer())
-  vec_slice(split_id, vec_order(split_id$key))
+
+  # TODO: remove as.data.frame() once this is resolved
+  #       https://github.com/r-lib/vctrs/issues/1298
+  vec_slice(split_id, vec_order(as.data.frame(split_id$key)))
 }
 
 group_intersect <- function(x, new) {


### PR DESCRIPTION
closes #5622

workaround for dplyr until https://github.com/r-lib/vctrs/issues/1298