### PR TITLE
Grammar typos in between function error fixed

### DIFF
--- a/R/funs.R
+++ b/R/funs.R
@@ -5,7 +5,7 @@
 #' appropriate SQL for remote tables.
 #'
 #' @param x A numeric vector of values
-#' @param left,right Boundary values (must be scalars).
+#' @param left, right Boundary values (must be scalars).
 #' @export
 #' @examples
 #' between(1:12, 7, 9)
@@ -24,7 +24,7 @@ between <- function(x, left, right) {
     abort("`left` must be length 1")
   }
   if (length(right) != 1) {
-    abort("`right` must length 1")
+    abort("`right` must be length 1")
   }
 
   if (!is.double(x)) {

--- a/R/funs.R
+++ b/R/funs.R
@@ -5,7 +5,7 @@
 #' appropriate SQL for remote tables.
 #'
 #' @param x A numeric vector of values
-#' @param left, right Boundary values (must be scalars).
+#' @param left,right Boundary values (must be scalars).
 #' @export
 #' @examples
 #' between(1:12, 7, 9)


### PR DESCRIPTION
This request fixes some minor documentation in the updated `between` function.

1. Added the word "be" to error message when right argument is not a scalar so it is now "`right` must be length 1" instead of "`right` must length 1"
2. Added a space after comma in documentation.

Related to #5501 