### PR TITLE
only call PRVALUE if prom is indeed a PROMSXP

### DIFF
--- a/src/chop.cpp
+++ b/src/chop.cpp
@@ -111,7 +111,8 @@ SEXP env_resolved(SEXP env, SEXP names) {
   for(R_xlen_t i = 0; i < n; i++) {
     SEXP name = PROTECT(rlang::str_as_symbol(p_names[i]));
     SEXP prom = PROTECT(Rf_findVarInFrame(env, name));
-    p_res[i] = PRVALUE(prom) != R_UnboundValue;
+    SEXP val = TYPEOF(prom) == PROMSXP ? PRVALUE(prom) : prom;
+    p_res[i] = val != R_UnboundValue;
     UNPROTECT(2);
   }
 


### PR DESCRIPTION
Since `Rf_findVarInFrame()` might return a promise, and it might not.

(At least in an R-devel build with `--enable-strict-barrier`, it seems like this may not necessarily be a `PROMSXP`.)