### PR TITLE
cast to common type results of mutate() and summarise().

### DIFF
--- a/R/mutate.R
+++ b/R/mutate.R
@@ -295,7 +295,7 @@ mutate_cols <- function(.data, ...) {
           result <- chunks[[1]]
         } else {
           result <- withCallingHandlers(
-            vec_unchop(chunks, rows),
+            vec_unchop(chunks <- vec_cast_common(!!!chunks), rows),
             vctrs_error_incompatible_type = function(cnd) {
               abort(class = "dplyr:::error_mutate_incompatible_combine", parent = cnd)
             }

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -242,6 +242,8 @@ summarise_cols <- function(.data, ...) {
         }
       )
 
+      chunks[[i]] <- vec_cast_common(!!!chunks[[i]], .to = result_type)
+
       if ((is.null(dots_names) || dots_names[i] == "") && is.data.frame(result_type)) {
         # remember each result separately
         map2(seq_along(result_type), names(result_type), function(j, nm) {

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -441,6 +441,15 @@ test_that("functions are not skipped in data pronoun (#5608)", {
   expect_equal(two, 2)
 })
 
+test_that("mutate() casts data frame results to common type (#5646)", {
+  df <- data.frame(x = 1:2, g = 1:2) %>% group_by(g)
+
+  res <- df %>%
+    mutate(if (g == 1) data.frame(y = 1) else data.frame(y = 1, z = 2))
+  expect_equal(res$z, c(NA, 2))
+})
+
+
 # Error messages ----------------------------------------------------------
 
 test_that("mutate() give meaningful errors", {

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -202,6 +202,14 @@ test_that("summarise(.groups=)", {
   expect_equal(rf %>% summarise(.groups = "keep") %>% group_vars(), c("x", "y"))
 })
 
+test_that("summarise() casts data frame results to common type (#5646)", {
+  df <- data.frame(x = 1:2, g = 1:2) %>% group_by(g)
+
+  res <- df %>%
+    summarise(if (g == 1) data.frame(y = 1) else data.frame(y = 1, z = 2), .groups = "drop")
+  expect_equal(res$z, c(NA, 2))
+})
+
 # errors -------------------------------------------------------------------
 
 test_that("summarise() preserves the call stack on error (#5308)", {


### PR DESCRIPTION
closes #5646

on the original example: 

``` r
library(dplyr, warn.conflicts = FALSE)

my_vals <- function(x) {
  name_x <- rlang::expr_deparse(rlang::enexpr(x))
  out <- lapply(unique(x), function (i) {
    out_i <- tibble(i)
    names(out_i) <- paste(name_x, i, sep = ": ")
    out_i
  })
  vctrs::vec_cbind(!!!out)
}

mtcars %>%
  group_by(cyl) %>%
  summarise(
    my_vals(am),
    my_vals(vs)
  )
#> `summarise()` has ungrouped output. You can override using the `.groups` argument.
#> # A tibble: 3 x 5
#>     cyl `am: 1` `am: 0` `vs: 1` `vs: 0`
#> * <dbl>   <dbl>   <dbl>   <dbl>   <dbl>
#> 1     4       1       0       1       0
#> 2     6       1       0       1       0
#> 3     8       1       0      NA       0
```

<sup>Created on 2020-12-15 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>