### PR TITLE
Preserve ordered factors with `group_by(.drop = FALSE)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr (development version)
 
+* `group_by(.drop = FALSE)` preserves ordered factors (@brianrice2, #5545).
+
 * `count()` and `tally()` are now generic. 
 
 * Removed default fallbacks to lazyeval methods; this will yield better error messages when 

--- a/R/grouped-df.r
+++ b/R/grouped-df.r
@@ -76,8 +76,12 @@ compute_groups <- function(data, vars, drop = FALSE) {
 
     # Make the new keys from the old keys and the new_indices
     new_keys <- pmap(list(old_keys, new_indices, uniques), function(key, index, unique) {
-      if(is.factor(key)) {
-        new_factor(index, levels = levels(key))
+      if (is.factor(key)) {
+        if (is.ordered(key)) {
+          new_ordered(index, levels = levels(key))
+        } else {
+          new_factor(index, levels = levels(key))
+        }
       } else {
         vec_slice(unique, index)
       }

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -387,6 +387,15 @@ test_that("grouped data frames remember their .drop = FALSE (#4337)", {
   expect_false(group_by_drop_default(res2))
 })
 
+test_that("group_by(.drop = FALSE) preserve ordered factors (#5455)", {
+  df <- tibble(x = ordered("x"))
+  drop <- df %>% group_by(x) %>% group_data()
+  nodrop <- df %>% group_by(x, .drop = FALSE) %>% group_data()
+
+  expect_equal(is.ordered(drop$x), is.ordered(nodrop$x))
+  expect_true(is.ordered(nodrop$x))
+})
+
 test_that("summarise maintains the .drop attribute (#4061)", {
   df <- tibble(
     f1 = factor("a", levels = c("a", "b", "c")),


### PR DESCRIPTION
Passing `.drop = FALSE` to `group_by()` causes ordered factors to become unordered. I added a simple check in `compute_groups()` to check if a factor is ordered, and if so, create an ordered factor in its place instead of an unordered one.

Includes tests which currently fail. Lmk if you have any questions/feedback 👌

Fixes #5455 