### PR TITLE
remove the message about going from 1 to 0 groups

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr (development version)
 
+* `summarise()` no longer informs when the result is ungrouped (#5633).
+
 * `group_by(.drop = FALSE)` preserves ordered factors (@brianrice2, #5545).
 
 * `count()` and `tally()` are now generic. 

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -156,10 +156,6 @@ summarise.grouped_df <- function(.data, ..., .groups = NULL) {
         summarise_inform("has grouped output by {new_groups}")
       }
       out <- grouped_df(out, group_vars[-n], group_by_drop_default(.data))
-    } else {
-      if (verbose) {
-        summarise_inform("has ungrouped output")
-      }
     }
   } else if (identical(.groups, "keep")) {
     if (verbose) {

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -54,9 +54,9 @@
 #'   * If all the results have 1 row, you get "drop_last".
 #'   * If the number of rows varies, you get "keep".
 #'
-#'   In addition, a message informs you of that choice, unless the
-#'   option "dplyr.summarise.inform" is set to `FALSE`, or when `summarise()`
-#'   is called from a function in a package.
+#'   In addition, a message informs you of that choice, unless the result is ungrouped,
+#'   the option "dplyr.summarise.inform" is set to `FALSE`,
+#'   or when `summarise()` is called from a function in a package.
 #'
 #' @family single table verbs
 #' @return

--- a/man/summarise.Rd
+++ b/man/summarise.Rd
@@ -40,9 +40,9 @@ based on the number of rows of the results:
 \item If the number of rows varies, you get "keep".
 }
 
-In addition, a message informs you of that choice, unless the
-option "dplyr.summarise.inform" is set to \code{FALSE}, or when \code{summarise()}
-is called from a function in a package.}
+In addition, a message informs you of that choice, unless the result is ungrouped,
+the option "dplyr.summarise.inform" is set to \code{FALSE},
+or when \code{summarise()} is called from a function in a package.}
 }
 \value{
 An object \emph{usually} of the same type as \code{.data}.

--- a/tests/testthat/test-summarise-errors.txt
+++ b/tests/testthat/test-summarise-errors.txt
@@ -5,9 +5,6 @@ Messages about .groups=
 > ignored <- tibble(x = 1, y = 2) %>% group_by(x, y) %>% summarise()
 Message: `summarise()` has grouped output by 'x'. You can override using the `.groups` argument.
 
-> ignored <- tibble(x = 1, y = 2) %>% group_by(x) %>% summarise()
-Message: `summarise()` has ungrouped output. You can override using the `.groups` argument.
-
 > ignored <- tibble(x = 1, y = 2) %>% group_by(x, y) %>% summarise(z = c(2, 2))
 Message: `summarise()` has grouped output by 'x', 'y'. You can override using the `.groups` argument.
 

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -230,7 +230,6 @@ test_that("summarise() gives meaningful errors", {
   verify_output(env = env(global_env()), test_path("test-summarise-errors.txt"), {
     "# Messages about .groups="
     ignored <- tibble(x = 1, y = 2) %>% group_by(x, y) %>% summarise()
-    ignored <- tibble(x = 1, y = 2) %>% group_by(x) %>% summarise()
     ignored <- tibble(x = 1, y = 2) %>% group_by(x, y) %>% summarise(z = c(2,2))
     ignored <- tibble(x = 1, y = 2) %>% rowwise(x, y) %>% summarise()
     ignored <- tibble(x = 1, y = 2) %>% rowwise() %>% summarise()


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)

# these are kept
.... <- tibble(x = 1, y = 2) %>% group_by(x, y) %>% summarise()
#> `summarise()` has grouped output by 'x'. You can override using the `.groups` argument.
.... <- tibble(x = 1, y = 2) %>% group_by(x, y) %>% summarise(z = c(2,2))
#> `summarise()` has grouped output by 'x', 'y'. You can override using the `.groups` argument.
.... <- tibble(x = 1, y = 2) %>% group_by(x) %>% summarise(z = c(2, 2))
#> `summarise()` has grouped output by 'x'. You can override using the `.groups` argument.

# but not 
.... <- tibble(x = 1, y = 2) %>% group_by(x) %>% summarise()
```

<sup>Created on 2020-12-18 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>

Should the messages that we keep include more insight about why this is what is chosen ?