### PR TITLE
Don't instrument muffled warnings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 # dplyr (development version)
 
 # dplyr 1.0.3
+* Fixed a performance regression in `mutate()` when warnings occur once per
+  group (#5675). We no longer instrument warnings with debugging information
+  when `mutate()` is called within `suppressWarnings()`.
 
 * `summarise()` no longer informs when the result is ungrouped (#5633).
 

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -1,0 +1,16 @@
+on_load <- function(expr, env = topenv(parent.frame())) {
+  expr <- substitute(expr)
+  callback <- function() eval_bare(expr, env)
+  env$.__rlang_hook__. <- c(env$.__rlang_hook__., list(callback))
+}
+
+run_on_load <- function(env = topenv(caller_env())) {
+  hook <- env$.__rlang_hook__.
+  env_unbind(env, ".__rlang_hook__.")
+
+  for (callback in hook) {
+    callback()
+  }
+
+  env$.__rlang_hook__. <- NULL
+}

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -423,7 +423,7 @@ check_muffled_warning <- function(cnd) {
   # `tryCatch(warning = )`, the original warning `cnd` will be caught
   # instead of the instrumented warning.
   on.exit(
-    if (early_exit) {
+    if (can_return_from_exit && early_exit) {
       return(FALSE)
     }
   )
@@ -439,3 +439,7 @@ check_muffled_warning <- function(cnd) {
   early_exit <- FALSE
   muffled
 }
+
+on_load(
+  can_return_from_exit <- getRversion() >= "3.5.0"
+)

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -388,7 +388,7 @@ mutate_cols <- function(.data, ...) {
     # the warning. This avoids doing the expensive work below for a
     # silenced warning (#5675).
     if (check_muffled_warning(w)) {
-      return()
+      maybe_restart("muffleWarning")
     }
 
     local_call_step(dots = dots, .index = i, .fn = "mutate")
@@ -400,8 +400,8 @@ mutate_cols <- function(.data, ...) {
       i = cnd_bullet_cur_group_label()
     ))
 
-    # cancel `w`
-    invokeRestart("muffleWarning")
+    # Cancel `w`
+    maybe_restart("muffleWarning")
   })
 
   is_zap <- map_lgl(new_columns, inherits, "rlang_zap")

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -384,6 +384,10 @@ mutate_cols <- function(.data, ...) {
 
   },
   warning = function(w) {
+    # Allow upstack calling handler to muffle the warning. This avoids
+    # doing the expensive work below for a silenced warning (#5675).
+    signalCondition(w)
+
     local_call_step(dots = dots, .index = i, .fn = "mutate")
 
     warn(c(

--- a/R/utils.r
+++ b/R/utils.r
@@ -127,3 +127,9 @@ dplyr_new_data_frame <- function(x = data.frame(),
     class = class
   )
 }
+
+maybe_restart <- function(restart) {
+  if (!is_null(findRestart(restart))) {
+    invokeRestart(restart)
+  }
+}

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -14,6 +14,8 @@
     s3_register("dplyr::tally", "tbl_sql")
   }
 
+  run_on_load()
+
   invisible()
 }
 

--- a/tests/testthat/helper-dplyr.R
+++ b/tests/testthat/helper-dplyr.R
@@ -1,3 +1,6 @@
 expect_no_error <- function(object, ...) {
-  expect_error(object, NA, ...)
+  expect_error({{ object }}, NA, ...)
+}
+expect_no_warning <- function(object, ...) {
+  expect_warning({{ object }}, NA, ...)
 }

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -457,7 +457,14 @@ test_that("can suppress or catch warnings from the outside (#5675)", {
 
   f <- function() warn("foo", "dplyr:::foo")
   x <- tryCatch(warning = identity, mutate(mtcars, f()))
-  expect_match(conditionMessage(x), "foo")
+  msg <- conditionMessage(x)
+  expect_match(msg, "foo")
+
+  # Check that caught warnings are instrumented. Requires
+  # <https://github.com/wch/r-source/commit/688eaebf>.
+  if (getRversion() >= "3.5.0") {
+    expect_match(msg, "Problem with")
+  }
 })
 
 

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -462,7 +462,7 @@ test_that("can suppress or catch warnings from the outside (#5675)", {
 
   # Check that caught warnings are instrumented. Requires
   # <https://github.com/wch/r-source/commit/688eaebf>.
-  if (getRversion() >= "3.5.0") {
+  if (can_return_from_exit) {
     expect_match(msg, "Problem with")
   }
 })

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -449,6 +449,17 @@ test_that("mutate() casts data frame results to common type (#5646)", {
   expect_equal(res$z, c(NA, 2))
 })
 
+test_that("can suppress or catch warnings from the outside (#5675)", {
+  # Check that basic warning handling still works
+  expect_no_warning(
+    suppressWarnings(mutate(tibble(), warning("foo")))
+  )
+
+  f <- function() warn("foo", "dplyr:::foo")
+  x <- tryCatch(warning = identity, mutate(mtcars, f()))
+  expect_match(conditionMessage(x), "foo")
+})
+
 
 # Error messages ----------------------------------------------------------
 


### PR DESCRIPTION
Closes #5675

```r
foo <- function() {
  warning("foo")
  NA
}
df <-
  tibble(x = rep(1:1000, 2)) %>%
  group_by(x)

bench::workout({
  mutate(df, foo())
  suppressWarnings(mutate(df, foo()))
  mutate(df, suppressWarnings(foo()))
})

#> # 1.0.0
#>   exprs                                process     real
#>   <bch:expr>                          <bch:tm> <bch:tm>
#> 1 mutate(df, foo())                      191ms    208ms
#> 2 suppressWarnings(mutate(df, foo()))    208ms    213ms
#> 3 mutate(df, suppressWarnings(foo()))    220ms    225ms

#> # dev version
#>   exprs                                process     real
#>   <bch:expr>                          <bch:tm> <bch:tm>
#> 1 mutate(df, foo())                      3.02s    3.13s
#> 2 suppressWarnings(mutate(df, foo()))    3.25s    3.39s
#> 3 mutate(df, suppressWarnings(foo())) 272.19ms 282.59ms

#> # patch
#>   exprs                                process     real
#>   <bch:expr>                          <bch:tm> <bch:tm>
#> 1 mutate(df, foo())                      2.82s     2.9s
#> 2 suppressWarnings(mutate(df, foo())) 331.18ms  342.6ms
#> 3 mutate(df, suppressWarnings(foo())) 212.85ms  218.7ms
```