### PR TITLE
Fix typo in arrange() documentation

### DIFF
--- a/R/arrange.R
+++ b/R/arrange.R
@@ -38,7 +38,7 @@
 #' @param .data A data frame, data frame extension (e.g. a tibble), or a
 #'   lazy data frame (e.g. from dbplyr or dtplyr). See *Methods*, below, for
 #'   more details.
-#' @param ... <[`data-masking`][dplyr_data_masking]> Variables, or functions or
+#' @param ... <[`data-masking`][dplyr_data_masking]> Variables, or functions of
 #'   variables. Use [desc()] to sort a variable in descending order.
 #' @family single table verbs
 #' @examples

--- a/man/arrange.Rd
+++ b/man/arrange.Rd
@@ -14,7 +14,7 @@ arrange(.data, ..., .by_group = FALSE)
 lazy data frame (e.g. from dbplyr or dtplyr). See \emph{Methods}, below, for
 more details.}
 
-\item{...}{<\code{\link[=dplyr_data_masking]{data-masking}}> Variables, or functions or
+\item{...}{<\code{\link[=dplyr_data_masking]{data-masking}}> Variables, or functions of
 variables. Use \code{\link[=desc]{desc()}} to sort a variable in descending order.}
 
 \item{.by_group}{If \code{TRUE}, will sort first by grouping variable. Applies to

--- a/man/select.Rd
+++ b/man/select.Rd
@@ -160,13 +160,14 @@ The \code{:} operator selects a range of consecutive variables:\if{html}{\out{<d
 
 The \code{!} operator negates a selection:\if{html}{\out{<div class="r">}}\preformatted{starwars \%>\% select(!(name:mass))
 #> # A tibble: 87 x 11
-#>   hair_color skin_color  eye_color birth_year sex   gender    homeworld species films     vehicles  starships
-#>   <chr>      <chr>       <chr>          <dbl> <chr> <chr>     <chr>     <chr>   <list>    <list>    <list>   
-#> 1 blond      fair        blue            19   male  masculine Tatooine  Human   <chr [5]> <chr [2]> <chr [2]>
-#> 2 <NA>       gold        yellow         112   none  masculine Tatooine  Droid   <chr [6]> <chr [0]> <chr [0]>
-#> 3 <NA>       white, blue red             33   none  masculine Naboo     Droid   <chr [7]> <chr [0]> <chr [0]>
-#> 4 none       white       yellow          41.9 male  masculine Tatooine  Human   <chr [4]> <chr [0]> <chr [1]>
-#> # ... with 83 more rows
+#>   hair_color skin_color eye_color birth_year sex   gender homeworld species
+#>   <chr>      <chr>      <chr>          <dbl> <chr> <chr>  <chr>     <chr>  
+#> 1 blond      fair       blue            19   male  mascu~ Tatooine  Human  
+#> 2 <NA>       gold       yellow         112   none  mascu~ Tatooine  Droid  
+#> 3 <NA>       white, bl~ red             33   none  mascu~ Naboo     Droid  
+#> 4 none       white      yellow          41.9 male  mascu~ Tatooine  Human  
+#> # ... with 83 more rows, and 3 more variables: films <list>, vehicles <list>,
+#> #   starships <list>
 
 iris \%>\% select(!c(Sepal.Length, Petal.Length))
 #> # A tibble: 150 x 3


### PR DESCRIPTION
Unless I'm reading it wrong, the text in the arguments section:

> `<data-masking>` Variables, or functions or variables. Use desc() to sort a variable in descending order.

Should read:

> `<data-masking>` Variables, or functions of variables. Use desc() to sort a variable in descending order.