### PR TITLE
summarise() silently ignore NULL results.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * New functions `if_any()` and `if_all()` to use inside `filter()` (#4770).
 
+* `summarise()` silently ignores NULL results (#5708).
+
 # dplyr 1.0.3
 
 * Fixed a performance regression in `mutate()` when warnings occur once per

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -310,6 +310,7 @@ summarise_cols <- function(.data, ...) {
         i = glue("An earlier column had size {expected_size}.", expected_size = e$expected_size)
       )
     } else if (inherits(e, "dplyr:::summarise_mixed_null")) {
+      show_group_details <- FALSE
       bullets <- c(
         x = glue("`{error_name}` must return compatible vectors across groups."),
         i = "Cannot combine NULL and non NULL results."
@@ -320,11 +321,12 @@ summarise_cols <- function(.data, ...) {
       )
     }
 
-    bullets <- c(cnd_bullet_header(), bullets, i = cnd_bullet_input_info())
-    if (!show_group_details) {
-      bullets <- c(bullets, i = cnd_bullet_cur_group_label())
-    }
-
+    bullets <- c(
+      cnd_bullet_header(),
+      bullets,
+      i = cnd_bullet_input_info(),
+      i = if (show_group_details) cnd_bullet_cur_group_label()
+    )
     abort(bullets, class = "dplyr_error")
 
   })

--- a/tests/testthat/test-summarise-errors.txt
+++ b/tests/testthat/test-summarise-errors.txt
@@ -28,6 +28,7 @@ i Input `a` is `rlang::env(a = 1)`.
 Error: Problem with `summarise()` input `a`.
 x Input `a` must be a vector, not an environment.
 i Input `a` is `rlang::env(a = 1)`.
+i The error occurred in group 1: x = 1, y = 1.
 
 > tibble(x = 1, y = c(1, 2, 2), z = runif(3)) %>% rowwise() %>% summarise(a = lm(
 +   y ~ x))
@@ -35,6 +36,7 @@ Error: Problem with `summarise()` input `a`.
 x Input `a` must be a vector, not a `lm` object.
 i Did you mean: `a = list(lm(y ~ x))` ?
 i Input `a` is `lm(y ~ x)`.
+i The error occurred in row 1.
 
 
 mixed types
@@ -46,13 +48,11 @@ x Input `a` must return compatible vectors across groups
 i Result type for group 1 (id = 1): <double>.
 i Result type for group 2 (id = 2): <character>.
 i Input `a` is `a[[1]]`.
-i The error occurred in group 2: id = 2.
 
 > tibble(id = 1:2, a = list(1, "2")) %>% rowwise() %>% summarise(a = a[[1]])
 Error: Problem with `summarise()` input `a`.
 x Input `a` must return compatible vectors across groups
 i Input `a` is `a[[1]]`.
-i The error occurred in row 2.
 
 
 incompatible size
@@ -69,12 +69,14 @@ Error: Problem with `summarise()` input `y`.
 x Input `y` must be size 3 or 1, not 2.
 i An earlier column had size 3.
 i Input `y` is `1:2`.
+i The error occurred in group 1: z = 1.
 
 > tibble(z = c(1, 3)) %>% group_by(z) %>% summarise(x = seq_len(z), y = 1:2)
 Error: Problem with `summarise()` input `y`.
 x Input `y` must be size 3 or 1, not 2.
 i An earlier column had size 3.
 i Input `y` is `1:2`.
+i The error occurred in group 2: z = 3.
 
 
 NULL and no NULL
@@ -99,6 +101,7 @@ i Input `a` is `mean(not_there)`.
 Error: Problem with `summarise()` input `a`.
 x object 'not_there' not found
 i Input `a` is `mean(not_there)`.
+i The error occurred in group 1: cyl = 4.
 
 
 .data pronoun
@@ -113,6 +116,7 @@ i Input `c` is `.data$b`.
 Error: Problem with `summarise()` input `c`.
 x Column `b` not found in `.data`
 i Input `c` is `.data$b`.
+i The error occurred in group 1: a = 1.
 
 
 Duplicate column names
@@ -135,4 +139,5 @@ i Input `..1` is `stop("{")`.
 Error: Problem with `summarise()` input `a`.
 x !
 i Input `a` is `stop("!")`.
+i The error occurred in group 1: b = "{value:1, unit:a}".
 

--- a/tests/testthat/test-summarise-errors.txt
+++ b/tests/testthat/test-summarise-errors.txt
@@ -28,7 +28,6 @@ i Input `a` is `rlang::env(a = 1)`.
 Error: Problem with `summarise()` input `a`.
 x Input `a` must be a vector, not an environment.
 i Input `a` is `rlang::env(a = 1)`.
-i The error occurred in group 1: x = 1, y = 1.
 
 > tibble(x = 1, y = c(1, 2, 2), z = runif(3)) %>% rowwise() %>% summarise(a = lm(
 +   y ~ x))
@@ -36,7 +35,6 @@ Error: Problem with `summarise()` input `a`.
 x Input `a` must be a vector, not a `lm` object.
 i Did you mean: `a = list(lm(y ~ x))` ?
 i Input `a` is `lm(y ~ x)`.
-i The error occurred in row 1.
 
 
 mixed types
@@ -48,11 +46,13 @@ x Input `a` must return compatible vectors across groups
 i Result type for group 1 (id = 1): <double>.
 i Result type for group 2 (id = 2): <character>.
 i Input `a` is `a[[1]]`.
+i The error occurred in group 2: id = 2.
 
 > tibble(id = 1:2, a = list(1, "2")) %>% rowwise() %>% summarise(a = a[[1]])
 Error: Problem with `summarise()` input `a`.
 x Input `a` must return compatible vectors across groups
 i Input `a` is `a[[1]]`.
+i The error occurred in row 2.
 
 
 incompatible size
@@ -69,14 +69,22 @@ Error: Problem with `summarise()` input `y`.
 x Input `y` must be size 3 or 1, not 2.
 i An earlier column had size 3.
 i Input `y` is `1:2`.
-i The error occurred in group 1: z = 1.
 
 > tibble(z = c(1, 3)) %>% group_by(z) %>% summarise(x = seq_len(z), y = 1:2)
 Error: Problem with `summarise()` input `y`.
 x Input `y` must be size 3 or 1, not 2.
 i An earlier column had size 3.
 i Input `y` is `1:2`.
-i The error occurred in group 2: z = 3.
+
+
+NULL and no NULL
+================
+
+> data.frame(x = 1:2, g = 1:2) %>% group_by(g) %>% summarise(x = if (g == 1) 42)
+Error: Problem with `summarise()` input `x`.
+x `x` must return compatible vectors across groups.
+i Cannot combine NULL and non NULL results.
+i Input `x` is `if (g == 1) 42`.
 
 
 Missing variable
@@ -91,7 +99,6 @@ i Input `a` is `mean(not_there)`.
 Error: Problem with `summarise()` input `a`.
 x object 'not_there' not found
 i Input `a` is `mean(not_there)`.
-i The error occurred in group 1: cyl = 4.
 
 
 .data pronoun
@@ -106,7 +113,6 @@ i Input `c` is `.data$b`.
 Error: Problem with `summarise()` input `c`.
 x Column `b` not found in `.data`
 i Input `c` is `.data$b`.
-i The error occurred in group 1: a = 1.
 
 
 Duplicate column names
@@ -129,5 +135,4 @@ i Input `..1` is `stop("{")`.
 Error: Problem with `summarise()` input `a`.
 x !
 i Input `a` is `stop("!")`.
-i The error occurred in group 1: b = "{value:1, unit:a}".
 

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -210,6 +210,13 @@ test_that("summarise() casts data frame results to common type (#5646)", {
   expect_equal(res$z, c(NA, 2))
 })
 
+test_that("summarise() silently skips when all results are NULL (#5708)", {
+  df <- data.frame(x = 1:2, g = 1:2) %>% group_by(g)
+
+  expect_equal(summarise(df, x = NULL), summarise(df))
+  expect_error(summarise(df, x = if(g == 1) 42))
+})
+
 # errors -------------------------------------------------------------------
 
 test_that("summarise() preserves the call stack on error (#5308)", {
@@ -261,6 +268,9 @@ test_that("summarise() gives meaningful errors", {
     tibble(z = c(1, 3)) %>%
       group_by(z) %>%
       summarise(x = seq_len(z), y = 1:2)
+
+    "# NULL and no NULL"
+    data.frame(x = 1:2, g = 1:2) %>% group_by(g) %>% summarise(x = if(g == 1) 42)
 
     "# Missing variable"
     summarise(mtcars, a = mean(not_there))


### PR DESCRIPTION
closes #5708

silently ignoring when *all the results* are NULL, and otherwise shout: 

``` r
library(dplyr, warn.conflicts = FALSE)

df <- data.frame(x = 1:2, g = 1:2) %>% group_by(g)

# silently ignored
summarise(df, x = NULL)
#> # A tibble: 2 x 1
#>       g
#> * <int>
#> 1     1
#> 2     2

# mix of NULL and non NULL -> error
summarise(df, x = if(g == 1) 42)
#> Error: Problem with `summarise()` input `x`.
#> x `x` must return compatible vectors across groups.
#> ℹ Cannot combine NULL and non NULL results.
#> ℹ Input `x` is `if (g == 1) 42`.
```

<sup>Created on 2021-01-27 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>