### PR TITLE
tweak formula when in top_across()

### DIFF
--- a/R/across.R
+++ b/R/across.R
@@ -268,7 +268,7 @@ across_setup_impl <- function(cols, fns, names, .caller_env, mask = peek_mask("a
 
   fns <- map(fns, function(fn) {
     if (is_formula(fn) && is_top_across) {
-      f_rhs(fn) <- call2(eval_tidy, expr(expr(!!f_rhs(fn))), data = mask$get_rlang_mask())
+      f_rhs(fn) <- call2(eval_tidy, expr(rlang::expr(!!f_rhs(fn))), data = mask$get_rlang_mask())
     }
     fn <- as_function(fn)
     fn

--- a/R/across.R
+++ b/R/across.R
@@ -266,9 +266,13 @@ across_setup_impl <- function(cols, fns, names, .caller_env, mask = peek_mask("a
     ))
   }
 
+  expr_protect <- function(x) {
+    call2(quote, x)
+  }
+
   fns <- map(fns, function(fn) {
     if (is_formula(fn) && is_top_across) {
-      f_rhs(fn) <- call2(eval_tidy, expr(rlang::expr(!!f_rhs(fn))), data = mask$get_rlang_mask())
+      f_rhs(fn) <- call2(quote(rlang::eval_tidy), expr_protect(f_rhs(fn)), data = mask$get_rlang_mask())
     }
     fn <- as_function(fn)
     fn

--- a/R/across.R
+++ b/R/across.R
@@ -267,10 +267,11 @@ across_setup_impl <- function(cols, fns, names, .caller_env, mask = peek_mask("a
   }
 
   fns <- map(fns, function(fn) {
-    if (is_formula(fn)) {
-      f_env(fn) <- mask$get_env_bindings()
+    if (is_formula(fn) && is_top_across) {
+      f_rhs(fn) <- call2(eval_tidy, expr(expr(!!f_rhs(fn))), data = mask$get_rlang_mask())
     }
-    as_function(fn)
+    fn <- as_function(fn)
+    fn
   })
 
   # make sure fns has names, use number to replace unnamed

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -188,6 +188,10 @@ DataMask <- R6Class("DataMask",
 
     get_env_bindings = function() {
       parent.env(private$mask)
+    },
+
+    get_rlang_mask = function() {
+      private$mask
     }
 
   ),


### PR DESCRIPTION
closes #5717

initial reprex from #5717: 

``` r
library(dplyr, warn.conflicts = FALSE)

data.frame(x = 1, y = 2, z = 3) %>% 
  summarise(
    across(c(x, y), ~ . / z)
  )
#>           x         y
#> 1 0.3333333 0.6666667

data.frame(x = 1, y = 2, z = 3) %>% 
  summarise(
    across(c(x, y), ~ . / .data[["z"]])
  )
#>           x         y
#> 1 0.3333333 0.6666667
```

<sup>Created on 2021-01-29 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

This also fix the issue with `mde`: 

``` r
library(mde)
#> Welcome to mde. This is mde version 0.2.2.9000.
#>  Please file issues and feedback at https://www.github.com/Nelson-Gon/mde/issues
#> Turn this message off using 'suppressPackageStartupMessages(library(mde))'
#>  Happy Exploration :)
library(dplyr, warn.conflicts = FALSE)

some_data <- data.frame(ID=c("A1","A2","A3", "A4"), 
                        A=c(5,NA,0,8), B=c(10,0,0,1),
                        C=c(1,NA,NA,25))

recode_na_if(some_data,grouping_col="ID", target_groups=c("A2","A3"), replacement= 0)
#> # A tibble: 4 x 4
#>   ID        A     B     C
#>   <chr> <dbl> <dbl> <dbl>
#> 1 A1        5    10     1
#> 2 A2        0     0     0
#> 3 A3        0     0     0
#> 4 A4        8     1    25
```

<sup>Created on 2021-01-29 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
