### PR TITLE
Update typo in across.R

### DIFF
--- a/R/across.R
+++ b/R/across.R
@@ -6,7 +6,7 @@
 #' functions like [summarise()] and [mutate()]. See `vignette("colwise")` for
 #'  more details.
 #'
-#' `if_any()` and `if_all()` are used with [select()] semantics to apply the same
+#' `if_any()` and `if_all()` apply the same
 #' predicate function to a selection of columns and combine the
 #' results into a single logical vector.
 #'

--- a/R/across.R
+++ b/R/across.R
@@ -6,7 +6,7 @@
 #' functions like [summarise()] and [mutate()]. See `vignette("colwise")` for
 #'  more details.
 #'
-#' `if_any()` and `if_all()` are used with to apply the same
+#' `if_any()` and `if_all()` are used with [select()] semantics to apply the same
 #' predicate function to a selection of columns and combine the
 #' results into a single logical vector.
 #'

--- a/man/across.Rd
+++ b/man/across.Rd
@@ -49,7 +49,7 @@ columns, allowing you to use \code{\link[=select]{select()}} semantics inside in
 functions like \code{\link[=summarise]{summarise()}} and \code{\link[=mutate]{mutate()}}. See \code{vignette("colwise")} for
 more details.
 
-\code{if_any()} and \code{if_all()} are used with to apply the same
+\code{if_any()} and \code{if_all()} apply the same
 predicate function to a selection of columns and combine the
 results into a single logical vector.
 


### PR DESCRIPTION
description for if_any() and if_all() was missing a word ("...are used with ____ to apply the same...") , I assumed the missing word was select() semantics...

I used select() semantics because that is the phrasing used in the description for across().