### PR TITLE
Fix pkgdown build

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -18,7 +18,6 @@ reference:
 - title: One table verbs
   contents:
   - arrange
-  - condense
   - count
   - distinct
   - filter
@@ -34,6 +33,7 @@ reference:
   contents:
   - bind
   - intersect
+  - setops
   - left_join
   - nest_join
   - semi_join
@@ -47,6 +47,7 @@ reference:
 - title: Vector functions
   contents:
   - across
+  - c_across
   - between
   - case_when
   - coalesce


### PR DESCRIPTION
I found the pkgdown site is still at 1.0.2: https://dplyr.tidyverse.org/

This seems because there's some missing topics and a defunct topic.

```
-- Building function reference -------------------------------------------------
Error in check_missing_topics(rows, pkg) : 
  Topics missing from index: c_acrosssetops
Calls: <Anonymous> ... stopifnot -> data_reference_index -> check_missing_topics
In addition: Warning message:
In '_pkgdown.yml', topic must be a known topic name or alias
✖ Not 'condense' 
```
https://github.com/tidyverse/dplyr/runs/1816406217#step:9:44