### PR TITLE
use attr<-() instead of structure() as it somehow messes up row.names 

### DIFF
--- a/R/grouped-df.r
+++ b/R/grouped-df.r
@@ -91,7 +91,8 @@ compute_groups <- function(data, vars, drop = FALSE) {
     groups <- tibble(!!!new_keys, ".rows" := new_rows)
   }
 
-  structure(groups, .drop = drop)
+  attr(groups, ".drop") <- drop
+  groups
 }
 
 count_regroups <- function(code) {

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -522,6 +522,11 @@ test_that("implicit mutate() operates on ungrouped data (#5598)", {
   expect_equal(vars, c("y", "z"))
 })
 
+test_that("grouped_df() does not break row.names (#5745)", {
+  groups <- compute_groups(data.frame(x = 1:10), "x")
+  expect_equal(.row_names_info(groups, type = 0), c(NA, -10L))
+})
+
 # Errors ------------------------------------------------------------------
 
 test_that("group_by() and ungroup() give meaningful error messages", {


### PR DESCRIPTION
closes #5745

initial example: 

``` r
library(dplyr, warn.conflicts = FALSE)
library(tibble)

# Medians for each species
iris_med <- iris %>% 
  group_by(Species) %>% 
  summarize(across(where(is.double), median))

iris_med %>% column_to_rownames("Species")
#>            Sepal.Length Sepal.Width Petal.Length Petal.Width
#> setosa              5.0         3.4         1.50         0.2
#> versicolor          5.9         2.8         4.35         1.3
#> virginica           6.5         3.0         5.55         2.0
```

<sup>Created on 2021-02-11 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>