### PR TITLE
work around sample.int()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dplyr (development version)
 
+* Fixed edge case of `slice_sample()` when `weight_by=` is used and there 
+  0 rows (#5729). 
+
 # dplyr 1.0.4
 
 * Improved performance for `across()`. This makes `summarise(across())` and 

--- a/R/slice.R
+++ b/R/slice.R
@@ -239,7 +239,6 @@ slice_sample.data.frame <- function(.data, ..., n, prop, weight_by = NULL, repla
     n =    function(x, n) sample_int(n, size$n, replace = replace, wt = x),
     prop = function(x, n) sample_int(n, size$prop * n, replace = replace, wt = x),
   )
-
   slice(.data, idx({{ weight_by }}, dplyr::n()))
 }
 
@@ -327,10 +326,13 @@ check_slice_size <- function(n, prop, .slice_fn = "check_slice_size") {
 }
 
 sample_int <- function(n, size, replace = FALSE, wt = NULL) {
-  if (replace) {
-    sample.int(n, size, prob = wt, replace = TRUE)
+  if (!replace) {
+    size <- min(size, n)
+  }
+  if (size == 0L) {
+    integer(0)
   } else {
-    sample.int(n, min(size, n), prob = wt)
+    sample.int(n, size, prob = wt, replace = replace)
   }
 }
 

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -274,6 +274,12 @@ test_that("slice_*() checks for constant n= and prop=", {
   expect_error(slice_sample(df, prop = n()), "constant")
 })
 
+test_that("slice_sample() does not error on zero rows (#5729)", {
+  df <- tibble(dummy = character(), weight = numeric(0))
+  res <- expect_error(slice_sample(df, prop=0.5, weight_by = weight), NA)
+  expect_equal(nrow(res), 0L)
+})
+
 # Errors ------------------------------------------------------------------
 
 test_that("rename errors with invalid grouped data frame (#640)", {


### PR DESCRIPTION
closes #5729

The original code gives: 

``` r
library(dplyr, warn.conflicts = FALSE)

tibble(dummy = character(), weight = numeric(0)) %>% 
  slice_sample(prop=0.5, weight_by = weight)
#> # A tibble: 0 x 2
#> # … with 2 variables: dummy <chr>, weight <dbl>
```

<sup>Created on 2021-02-11 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

There might be a better way to address this 🤷, this feels like a `sample.int()` shortcoming:

``` r
sample.int(0, 0, prob = numeric(0))
#> Error in sample.int(0, 0, prob = numeric(0)): too few positive probabilities
```

<sup>Created on 2021-02-11 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>