### PR TITLE
eval_tidy() the top_across() call with the right mask and caller env

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Fixed edge case of `slice_sample()` when `weight_by=` is used and there 
   0 rows (#5729). 
+  
+* `across()` can again use columns in functions defined inline (#5734). 
 
 # dplyr 1.0.4
 

--- a/R/across.R
+++ b/R/across.R
@@ -233,11 +233,10 @@ across_setup_impl <- function(cols, fns, names, .caller_env, mask = peek_mask("a
     #        across_setup() is only ever called on the first group anyway
     #        but perhaps it is time to review how across_cols() work
     mask$set_current_group(1L)
-  } else {
-    # The real `across()` is evaluated in a data mask so we need to remove the
-    # mask layer from the quosure environment (#5460)
-    cols <- quo_set_env(cols, data_mask_top(quo_get_env(cols), recursive = FALSE, inherit = TRUE))
   }
+  # `across()` is evaluated in a data mask so we need to remove the
+  # mask layer from the quosure environment (#5460)
+  cols <- quo_set_env(cols, data_mask_top(quo_get_env(cols), recursive = FALSE, inherit = TRUE))
 
   vars <- tidyselect::eval_select(cols, data = mask$across_cols())
   vars <- names(vars)
@@ -270,17 +269,7 @@ across_setup_impl <- function(cols, fns, names, .caller_env, mask = peek_mask("a
     call2(quote, x)
   }
 
-  fns <- map(fns, function(fn) {
-    if (is_formula(fn) && .top_level) {
-      f_rhs(fn) <- call2(
-        quote(rlang::eval_tidy),
-        expr_protect(f_rhs(fn)),
-        data = mask$get_rlang_mask()
-      )
-    }
-    fn <- as_function(fn)
-    fn
-  })
+  fns <- map(fns, as_function)
 
   # make sure fns has names, use number to replace unnamed
   if (is.null(names(fns))) {
@@ -429,7 +418,8 @@ expand_quosure <- function(quo) {
     # call top_across() instead of across()
     quo_env <- quo_get_env(quo)
     quo <- new_quosure(node_poke_car(quo_get_expr(quo), top_across), quo_env)
-    expressions <- eval_tidy(quo)
+    mask <- peek_mask()
+    expressions <- eval_tidy(quo, mask$get_rlang_mask(), mask$get_caller_env())
     names_expressions <- names(expressions)
 
     # process the results of top_across()

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -192,6 +192,10 @@ DataMask <- R6Class("DataMask",
 
     get_rlang_mask = function() {
       private$mask
+    },
+
+    get_caller_env = function() {
+      private$caller
     }
 
   ),

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -279,6 +279,14 @@ test_that("lambdas in across() can use columns in follow up expressions (#5717)"
   )
 })
 
+test_that("functions defined inline can use columns (#5734)", {
+  df <- data.frame(x = 1, y = 2)
+  expect_equal(
+    df %>% mutate(across('x', function(.x) .x / y)) %>% pull(x),
+    0.5
+  )
+})
+
 test_that("if_any() and if_all() enforce logical", {
   # TODO: use snapshot tests
   d <- data.frame(x = 10, y = 10)


### PR DESCRIPTION
closes #5734

``` r
library(dplyr, warn.conflicts = FALSE)

df <- data.frame(x = 1, y = 2)
df %>% 
  mutate(across('x', function(.x) {
    return(.x/y)
  }))
#>     x y
#> 1 0.5 2
```

OTOH, this does not work: 

```r
f <- function(.x) .x / y
df %>% mutate(across('x', f))
#> Error: Problem with `mutate()` input `..1`.
#> x object 'y' not found
#> ℹ Input `..1` is `(function (.cols = everything(), .fns = NULL, ..., .names = NULL) ...`.
```

<sup>Created on 2021-02-12 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>