### PR TITLE
internal error dealing with .current_group

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
 
 * Using testthat 3rd edition. 
 
+* Fixed bug introduced in `across()` in previous version (#5765).
+
 # dplyr 1.0.4
 
 * Improved performance for `across()`. This makes `summarise(across())` and 

--- a/R/across.R
+++ b/R/across.R
@@ -213,7 +213,7 @@ across_setup <- function(cols, fns, names, key, .caller_env) {
   mask <- peek_mask("across()")
   value <- mask$across_cache_get(key)
   if (is.null(value)) {
-    value <- across_setup_impl({{cols}},
+    value <- across_setup_impl({{ cols }},
       fns = fns, names = names, .caller_env = .caller_env, mask = mask,
       .top_level = FALSE
     )
@@ -263,10 +263,6 @@ across_setup_impl <- function(cols, fns, names, .caller_env, mask = peek_mask("a
     abort(c("Problem with `across()` input `.fns`.",
       i = "Input `.fns` must be NULL, a function, a formula, or a list of functions/formulas."
     ))
-  }
-
-  expr_protect <- function(x) {
-    call2(quote, x)
   }
 
   fns <- map(fns, as_function)

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -103,7 +103,7 @@ DataMask <- R6Class("DataMask",
     },
 
     set_current_group = function(group) {
-      parent.env(private$chops)$.current_group <- group
+      parent.env(private$chops)$.current_group[] <- group
     },
 
     full_data = function() {


### PR DESCRIPTION
closes #5733

It's the kind of problem that is not easily reproducible in a test, but the original code from #5733 now gives: 

``` r
library(tidyverse)
library(palmerpenguins)

# code A
penguins %>%
  group_by(species, island) %>%
  summarise(
    prob = c(.25, .75),
    across(
      c(bill_length_mm, bill_depth_mm, flipper_length_mm),
      ~ quantile(., prob, na.rm = TRUE)
    )
  )
#> `summarise()` has grouped output by 'species', 'island'. You can override using the `.groups` argument.
#> # A tibble: 10 x 6
#> # Groups:   species, island [5]
#>    species   island     prob bill_length_mm bill_depth_mm flipper_length_mm
#>    <fct>     <fct>     <dbl>          <dbl>         <dbl>             <dbl>
#>  1 Adelie    Biscoe     0.25           37.7          17.6              185.
#>  2 Adelie    Biscoe     0.75           40.7          19.0              193 
#>  3 Adelie    Dream      0.25           36.8          17.5              185 
#>  4 Adelie    Dream      0.75           40.4          18.8              193 
#>  5 Adelie    Torgersen  0.25           36.7          17.4              187 
#>  6 Adelie    Torgersen  0.75           41.1          19.2              195 
#>  7 Chinstrap Dream      0.25           46.3          17.5              191 
#>  8 Chinstrap Dream      0.75           51.1          19.4              201 
#>  9 Gentoo    Biscoe     0.25           45.3          14.2              212 
#> 10 Gentoo    Biscoe     0.75           49.6          15.7              221

# code B
penguins %>%
  group_by(species) %>%
  summarise(
    n = n(),
    across(starts_with("bill_"), mean, na.rm = TRUE),
    Area = mean(bill_length_mm * bill_depth_mm, na.rm = TRUE),
    across(ends_with("_g"), mean, na.rm = TRUE),
  )
#> # A tibble: 3 x 6
#>   species       n bill_length_mm bill_depth_mm  Area body_mass_g
#>   <fct>     <int>          <dbl>         <dbl> <dbl>       <dbl>
#> 1 Adelie      152           38.8          18.3  712.       3701.
#> 2 Chinstrap    68           48.8          18.4  900.       3733.
#> 3 Gentoo      124           47.5          15.0  712.       5076.
```

<sup>Created on 2021-02-15 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup> 