### PR TITLE
keep attributes when adding computed columns, ungroup() is too strong

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@
 
 * Fixed bug introduced in `across()` in previous version (#5765).
 
+* `group_by()` keeps attributes unrelated to the grouping (#5760).
+
 # dplyr 1.0.4
 
 * Improved performance for `across()`. This makes `summarise(across())` and 

--- a/R/group-by.r
+++ b/R/group-by.r
@@ -149,7 +149,15 @@ group_by_prepare <- function(.data, ..., .add = FALSE, .dots = deprecated(), add
   }
 
   # If any calls, use mutate to add new columns, then group by those
-  computed_columns <- add_computed_columns(ungroup(.data), new_groups, "group_by")
+  ungrouped <- ungroup(.data)
+  atts <- attributes(.data)
+  atts <- append(
+    attributes(ungrouped),
+    atts[setdiff(names(atts), c("names", "row.names", "groups", "class"))]
+  )
+  attributes(ungrouped) <- atts
+
+  computed_columns <- add_computed_columns(ungrouped, new_groups, "group_by")
   out <- computed_columns$data
   group_names <- computed_columns$added_names
 

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -529,6 +529,17 @@ test_that("grouped_df() does not break row.names (#5745)", {
   expect_equal(.row_names_info(groups, type = 0), c(NA, -10L))
 })
 
+test_that("group_by() keeps attributes unrelated to the grouping (#5760)", {
+  d <- data.frame(x = 453, y = 642)
+  attr(d, "foo") <- "bar"
+
+  d2 <- group_by(d, x)
+  expect_equal(attr(d2, "foo"), "bar")
+
+  d3 <- group_by(d2, y, .add = TRUE)
+  expect_equal(attr(d2, "foo"), "bar")
+})
+
 # Errors ------------------------------------------------------------------
 
 test_that("group_by() and ungroup() give meaningful error messages", {


### PR DESCRIPTION
closes #5760

``` r
library(dplyr, warn.conflicts = FALSE)

m <- mtcars
attr(m, "foo") <- "a"
m <- dplyr::group_by(m, vs)
attr(m, "foo")
#> [1] "a"
m <- dplyr::group_by(m, cyl, .add = TRUE)
attr(m, "foo")
#> [1] "a"
```

<sup>Created on 2021-02-16 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

`ungroup()` wipes all attributes, but `dplyr_reconstruct()` would restore `@groups` which we don't want. Not sure this can be abstracted away ?

