### PR TITLE
across() not operating sequentially

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 
 * Using testthat 3rd edition. 
 
-* Fixed bug introduced in `across()` in previous version (#5765).
+* Fixed bugs introduced in `across()` in previous version (#5765).
 
 * `group_by()` keeps attributes unrelated to the grouping (#5760).
 

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -236,10 +236,11 @@ mutate_cols <- function(.data, ...) {
     for (i in seq_along(dots)) {
       mask$across_cache_reset()
 
+      # get results from all the quosures that are expanded from ..i
+      # then ingest them after
       quosures <- expand_quosure(dots[[i]])
-
-      # first populate `quosures_results`
       quosures_results <- vector(mode = "list", length = length(quosures))
+
       for (k in seq_along(quosures)) {
         quo <- quosures[[k]]
         quo_data <- attr(quo, "dplyr:::data")
@@ -305,7 +306,7 @@ mutate_cols <- function(.data, ...) {
         quosures_results[[k]] <- list(result = result, chunks = chunks)
       }
 
-      # then use `quosures_results` to update the mask and new columns
+
       for (k in seq_along(quosures)) {
         quo <- quosures[[k]]
         quo_data <- attr(quo, "dplyr:::data")

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -238,6 +238,8 @@ mutate_cols <- function(.data, ...) {
 
       quosures <- expand_quosure(dots[[i]])
 
+      # first populate `quosures_results`
+      quosures_results <- vector(mode = "list", length = length(quosures))
       for (k in seq_along(quosures)) {
         quo <- quosures[[k]]
         quo_data <- attr(quo, "dplyr:::data")
@@ -283,11 +285,6 @@ mutate_cols <- function(.data, ...) {
         }
 
         if (is.null(chunks)) {
-          if (quo_data$is_named) {
-            name <- quo_data$name_given
-            new_columns[[name]] <- zap()
-            mask$remove(name)
-          }
           next
         }
 
@@ -304,6 +301,27 @@ mutate_cols <- function(.data, ...) {
             )
           }
         }
+
+        quosures_results[[k]] <- list(result = result, chunks = chunks)
+      }
+
+      # then use `quosures_results` to update the mask and new columns
+      for (k in seq_along(quosures)) {
+        quo <- quosures[[k]]
+        quo_data <- attr(quo, "dplyr:::data")
+
+        quo_result <- quosures_results[[k]]
+        if (is.null(quo_result)) {
+          if (quo_data$is_named) {
+            name <- quo_data$name_given
+            new_columns[[name]] <- zap()
+            mask$remove(name)
+          }
+          next
+        }
+
+        result <- quo_result$result
+        chunks <- quo_result$chunks
 
         if (!quo_data$is_named && is.data.frame(result)) {
           new_columns[names(result)] <- result

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -225,6 +225,7 @@ summarise_cols <- function(.data, ...) {
       mask$across_cache_reset()
 
       quosures <- expand_quosure(dots[[i]])
+      quosures_results <- vector(mode = "list", length = length(quosures))
 
       # with the previous part above, for each element of ... we can
       # have either one or several quosures, each of them handled here:
@@ -245,6 +246,20 @@ summarise_cols <- function(.data, ...) {
           }
         )
         chunks_k <- vec_cast_common(!!!chunks_k, .to = types_k)
+
+        quosures_results[[k]] <- list(chunks = chunks_k, types = types_k)
+      }
+
+      for (k in seq_along(quosures)) {
+        quo <- quosures[[k]]
+        quo_data <- attr(quo, "dplyr:::data")
+
+        quo_result <- quosures_results[[k]]
+        if (is.null(quo_result)) {
+          next
+        }
+        types_k <- quo_result$types
+        chunks_k <- quo_result$chunks
 
         if (!quo_data$is_named && is.data.frame(types_k)) {
           chunks_extracted <- .Call(dplyr_extract_chunks, chunks_k, types_k)

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -254,27 +254,87 @@ test_that("across() works with empty data frames (#5523)", {
    )
 })
 
-test_that("lambdas in across() can use columns", {
+test_that("lambdas in mutate() + across() can use columns", {
   df <- tibble(x = 2, y = 4, z = 8)
   expect_identical(
-    df %>% mutate_all(~ .x / y),
+    df %>% mutate(data.frame(x = x / y, y = y / y, z = z / y)),
     df %>% mutate(across(everything(), ~ .x / y))
   )
   expect_identical(
-    df %>% mutate_all(~ .x / y),
+    df %>% mutate(data.frame(x = x / y, y = y / y, z = z / y)),
+    df %>% mutate(+across(everything(), ~ .x / y))
+  )
+
+  expect_identical(
+    df %>% mutate(data.frame(x = x / y, y = y / y, z = z / y)),
     df %>% mutate(across(everything(), ~ .x / .data$y))
+  )
+  expect_identical(
+    df %>% mutate(data.frame(x = x / y, y = y / y, z = z / y)),
+    df %>% mutate(+across(everything(), ~ .x / .data$y))
   )
 })
 
-test_that("lambdas in across() can use columns in follow up expressions (#5717)", {
+test_that("lambdas in summarise() + across() can use columns", {
   df <- tibble(x = 2, y = 4, z = 8)
   expect_identical(
-    df %>% mutate(a = 2, x = x / y, y = y / y, z = z / y),
+    df %>% summarise(data.frame(x = x / y, y = y / y, z = z / y)),
+    df %>% summarise(across(everything(), ~ .x / y))
+  )
+  expect_identical(
+    df %>% summarise(data.frame(x = x / y, y = y / y, z = z / y)),
+    df %>% summarise(+across(everything(), ~ .x / y))
+  )
+
+  expect_identical(
+    df %>% summarise(data.frame(x = x / y, y = y / y, z = z / y)),
+    df %>% summarise(across(everything(), ~ .x / .data$y))
+  )
+  expect_identical(
+    df %>% summarise(data.frame(x = x / y, y = y / y, z = z / y)),
+    df %>% summarise(+across(everything(), ~ .x / .data$y))
+  )
+})
+
+test_that("lambdas in mutate() + across() can use columns in follow up expressions (#5717)", {
+  df <- tibble(x = 2, y = 4, z = 8)
+  expect_identical(
+    df %>% mutate(a = 2, data.frame(x = x / y, y = y / y, z = z / y)),
     df %>% mutate(a = 2, across(c(x, y, z), ~ .x / y))
   )
   expect_identical(
-    df %>% mutate(a = 2, x = x / y, y = y / y, z = z / y),
+    df %>% mutate(a = 2, data.frame(x = x / y, y = y / y, z = z / y)),
+    df %>% mutate(a = 2, +across(c(x, y, z), ~ .x / y))
+  )
+
+  expect_identical(
+    df %>% mutate(a = 2, data.frame(x = x / y, y = y / y, z = z / y)),
     df %>% mutate(a = 2, across(c(x, y, z), ~ .x / .data$y))
+  )
+  expect_identical(
+    df %>% mutate(a = 2, data.frame(x = x / y, y = y / y, z = z / y)),
+    df %>% mutate(a = 2, +across(c(x, y, z), ~ .x / .data$y))
+  )
+})
+
+test_that("lambdas in summarise() + across() can use columns in follow up expressions (#5717)", {
+  df <- tibble(x = 2, y = 4, z = 8)
+  expect_identical(
+    df %>% summarise(a = 2, data.frame(x = x / y, y = y / y, z = z / y)),
+    df %>% summarise(a = 2, across(c(x, y, z), ~ .x / y))
+  )
+  expect_identical(
+    df %>% summarise(a = 2, data.frame(x = x / y, y = y / y, z = z / y)),
+    df %>% summarise(a = 2, +across(c(x, y, z), ~ .x / y))
+  )
+
+  expect_identical(
+    df %>% summarise(a = 2, data.frame(x = x / y, y = y / y, z = z / y)),
+    df %>% summarise(a = 2, across(c(x, y, z), ~ .x / .data$y))
+  )
+  expect_identical(
+    df %>% summarise(a = 2, data.frame(x = x / y, y = y / y, z = z / y)),
+    df %>% summarise(a = 2, +across(c(x, y, z), ~ .x / .data$y))
   )
 })
 


### PR DESCRIPTION
I added some tests too, code from #5770: 

``` r
library(palmerpenguins); library(tidyverse)
(tbl1 <- penguins %>%
    group_by(species, island, sex) %>%
    summarize(n = n()) %>%
    pivot_wider(names_from = sex, values_from = n))
#> `summarise()` has grouped output by 'species', 'island'. You can override using the `.groups` argument.
#> # A tibble: 5 x 5
#> # Groups:   species, island [5]
#>   species   island    female  male  `NA`
#>   <fct>     <fct>      <int> <int> <int>
#> 1 Adelie    Biscoe        22    22    NA
#> 2 Adelie    Dream         27    28     1
#> 3 Adelie    Torgersen     24    23     5
#> 4 Chinstrap Dream         34    34    NA
#> 5 Gentoo    Biscoe        58    61     5
(tbl2 <- tbl1 %>%
    ungroup() %>%
    rowwise(species, island) %>%
    mutate(across(everything(), ~ . / sum(c_across(everything()), na.rm = T))))
#> # A tibble: 5 x 5
#> # Rowwise:  species, island
#>   species   island    female  male    `NA`
#>   <fct>     <fct>      <dbl> <dbl>   <dbl>
#> 1 Adelie    Biscoe     0.5   0.5   NA     
#> 2 Adelie    Dream      0.482 0.5    0.0179
#> 3 Adelie    Torgersen  0.462 0.442  0.0962
#> 4 Chinstrap Dream      0.5   0.5   NA     
#> 5 Gentoo    Biscoe     0.468 0.492  0.0403
(tbl3 <- tbl1 %>%
    ungroup() %>%
    rowwise(species, island) %>%
    mutate(across(female:male, ~ . / sum(c_across(female:male), na.rm = T))))
#> # A tibble: 5 x 5
#> # Rowwise:  species, island
#>   species   island    female  male  `NA`
#>   <fct>     <fct>      <dbl> <dbl> <int>
#> 1 Adelie    Biscoe     0.5   0.5      NA
#> 2 Adelie    Dream      0.491 0.509     1
#> 3 Adelie    Torgersen  0.511 0.489     5
#> 4 Chinstrap Dream      0.5   0.5      NA
#> 5 Gentoo    Biscoe     0.487 0.513     5
```

<sup>Created on 2021-02-18 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

