### PR TITLE
Remove name argument from compute() generic

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@
 
 * The `.cols=` argument of `if_any()` and `if_all()` defaults to `everything()`. 
 
+* Removed the `name` argument from the `compute()` generic (@ianmcook, #5783).
+
 # dplyr 1.0.4
 
 * Improved performance for `across()`. This makes `summarise(across())` and 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dplyr (development version)
+
+* Removed the `name` argument from the `compute()` generic (@ianmcook, #5783).
+
 # dplyr 1.0.5
 
 * Fixed edge case of `slice_sample()` when `weight_by=` is used and there 
@@ -12,8 +16,6 @@
 * `group_by()` keeps attributes unrelated to the grouping (#5760).
 
 * The `.cols=` argument of `if_any()` and `if_all()` defaults to `everything()`. 
-
-* Removed the `name` argument from the `compute()` generic (@ianmcook, #5783).
 
 # dplyr 1.0.4
 

--- a/R/compute-collect.r
+++ b/R/compute-collect.r
@@ -22,7 +22,7 @@
 #' @param x A data frame, data frame extension (e.g. a tibble), or a lazy
 #'   data frame (e.g. from dbplyr or dtplyr). See *Methods*, below, for more
 #'   details.
-#' @param ... Other arguments passed on to methods
+#' @param ... Arguments passed on to methods
 #' @seealso [copy_to()], the opposite of `collect()`: it takes a local data
 #'   frame and uploads it to the remote source.
 #' @export

--- a/R/compute-collect.r
+++ b/R/compute-collect.r
@@ -22,7 +22,6 @@
 #' @param x A data frame, data frame extension (e.g. a tibble), or a lazy
 #'   data frame (e.g. from dbplyr or dtplyr). See *Methods*, below, for more
 #'   details.
-#' @param name Name of temporary table on database.
 #' @param ... Other arguments passed on to methods
 #' @seealso [copy_to()], the opposite of `collect()`: it takes a local data
 #'   frame and uploads it to the remote source.
@@ -45,7 +44,7 @@
 #'   # Creates a fresh query based on the generated SQL
 #'   collapse(remote)
 #' }
-compute <- function(x, name = random_table_name(), ...) {
+compute <- function(x, ...) {
   UseMethod("compute")
 }
 #' @export

--- a/man/compute.Rd
+++ b/man/compute.Rd
@@ -6,7 +6,7 @@
 \alias{collapse}
 \title{Force computation of a database query}
 \usage{
-compute(x, name = random_table_name(), ...)
+compute(x, ...)
 
 collect(x, ...)
 
@@ -16,8 +16,6 @@ collapse(x, ...)
 \item{x}{A data frame, data frame extension (e.g. a tibble), or a lazy
 data frame (e.g. from dbplyr or dtplyr). See \emph{Methods}, below, for more
 details.}
-
-\item{name}{Name of temporary table on database.}
 
 \item{...}{Other arguments passed on to methods}
 }

--- a/man/compute.Rd
+++ b/man/compute.Rd
@@ -17,7 +17,7 @@ collapse(x, ...)
 data frame (e.g. from dbplyr or dtplyr). See \emph{Methods}, below, for more
 details.}
 
-\item{...}{Other arguments passed on to methods}
+\item{...}{Arguments passed on to methods}
 }
 \description{
 \code{compute()} stores results in a remote temporary table.


### PR DESCRIPTION
The `name` argument of the `compute()` generic is a vestige from the old days before dbplyr was broken out as a separate package. It would be best to remove it if doing so will not break any reverse dependencies.

Some dplyr backend packages need a method to force evaluation of lazy operations _without_ assigning an external name to the materialized result where it's stored in the backend system. An example of this is the arrow R package.

It _seems_ like this change should not break anything, because dplyr SQL backend packages should all use `dbplyr::compute.tbl_sql()` (which redefines the `name` argument) or else define their own `compute()` methods.