### PR TITLE
typo: replace mean with sd

### DIFF
--- a/vignettes/programming.Rmd
+++ b/vignettes/programming.Rmd
@@ -254,7 +254,7 @@ If you want the user to provide multiple expressions, embrace each of them:
 ```{r}
 my_summarise3 <- function(data, mean_var, sd_var) {
   data %>% 
-    summarise(mean = mean({{ mean_var }}), sd = mean({{ sd_var }}))
+    summarise(mean = mean({{ mean_var }}), sd = sd({{ sd_var }}))
 }
 ```
 
@@ -272,7 +272,7 @@ my_summarise5 <- function(data, mean_var, sd_var) {
   data %>% 
     summarise(
       "mean_{{mean_var}}" := mean({{ mean_var }}), 
-      "sd_{{sd_var}}" := mean({{ sd_var }})
+      "sd_{{sd_var}}" := sd({{ sd_var }})
     )
 }
 ```


### PR DESCRIPTION
I found a  minor typo in the dplyr-programming vignette, where `mean` is used instead of `sd`.

So I changed the two occurences and hereby open my first pull-request.

If I did anything wrong, please let me know.

Otherwise, I hope this is the right way to contribute to improving the tidyverse-documentation.

Thanks,
Sebastian