### PR TITLE
across() gains .call= so that we can control which call governs the caching

### DIFF
--- a/R/across.R
+++ b/R/across.R
@@ -33,6 +33,8 @@
 #'   `{.fn}` to stand for the name of the function being applied. The default
 #'   (`NULL`) is equivalent to `"{.col}"` for the single function case and
 #'   `"{.col}_{.fn}"` for the case where a list is used for `.fns`.
+#' @param .call Call used by the caching mechanism. This is only useful when `across()`
+#'   is called from another function, and should mostly just be ignored.
 #'
 #' @returns
 #' `across()` returns a tibble with one column for each column in `.cols` and each function in `.fns`.
@@ -86,8 +88,8 @@
 #'
 #' @export
 #' @seealso [c_across()] for a function that returns a vector
-across <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
-  key <- key_deparse(sys.call())
+across <- function(.cols = everything(), .fns = NULL, ..., .names = NULL, .call = sys.call()) {
+  key <- key_deparse(.call)
   setup <- across_setup({{ .cols }}, fns = .fns, names = .names, key = key, .caller_env = caller_env())
 
   vars <- setup$vars
@@ -147,8 +149,8 @@ across <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
 
 #' @rdname across
 #' @export
-if_any <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
-  df <- across({{ .cols }}, .fns = .fns, ..., .names = .names)
+if_any <- function(.cols = everything(), .fns = NULL, ..., .names = NULL, .call = sys.call()) {
+  df <- across({{ .cols }}, .fns = .fns, ..., .names = .names, .call = .call)
   n <- nrow(df)
   df <- vec_cast_common(!!!df, .to = logical())
   .Call(dplyr_reduce_lgl_or, df, n)
@@ -156,8 +158,8 @@ if_any <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
 
 #' @rdname across
 #' @export
-if_all <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
-  df <- across({{ .cols }}, .fns = .fns, ..., .names = .names)
+if_all <- function(.cols = everything(), .fns = NULL, ..., .names = NULL, .call = sys.call()) {
+  df <- across({{ .cols }}, .fns = .fns, ..., .names = .names, .call = .call)
   n <- nrow(df)
   df <- vec_cast_common(!!!df, .to = logical())
   .Call(dplyr_reduce_lgl_and, df, n)

--- a/man/across.Rd
+++ b/man/across.Rd
@@ -6,11 +6,29 @@
 \alias{if_all}
 \title{Apply a function (or functions) across multiple columns}
 \usage{
-across(.cols = everything(), .fns = NULL, ..., .names = NULL)
+across(
+  .cols = everything(),
+  .fns = NULL,
+  ...,
+  .names = NULL,
+  .call = sys.call()
+)
 
-if_any(.cols = everything(), .fns = NULL, ..., .names = NULL)
+if_any(
+  .cols = everything(),
+  .fns = NULL,
+  ...,
+  .names = NULL,
+  .call = sys.call()
+)
 
-if_all(.cols = everything(), .fns = NULL, ..., .names = NULL)
+if_all(
+  .cols = everything(),
+  .fns = NULL,
+  ...,
+  .names = NULL,
+  .call = sys.call()
+)
 }
 \arguments{
 \item{.fns}{Functions to apply to each of the selected columns.
@@ -33,6 +51,9 @@ columns. This can use \code{{.col}} to stand for the selected column name, and
 \code{{.fn}} to stand for the name of the function being applied. The default
 (\code{NULL}) is equivalent to \code{"{.col}"} for the single function case and
 \code{"{.col}_{.fn}"} for the case where a list is used for \code{.fns}.}
+
+\item{.call}{Call used by the caching mechanism. This is only useful when \code{across()}
+is called from another function, and should mostly just be ignored.}
 
 \item{cols, .cols}{<\code{\link[=dplyr_tidy_select]{tidy-select}}> Columns to transform.
 Because \code{across()} is used within functions like \code{summarise()} and

--- a/man/select.Rd
+++ b/man/select.Rd
@@ -160,13 +160,14 @@ The \code{:} operator selects a range of consecutive variables:\if{html}{\out{<d
 
 The \code{!} operator negates a selection:\if{html}{\out{<div class="r">}}\preformatted{starwars \%>\% select(!(name:mass))
 #> # A tibble: 87 x 11
-#>   hair_color skin_color  eye_color birth_year sex   gender    homeworld species films     vehicles  starships
-#>   <chr>      <chr>       <chr>          <dbl> <chr> <chr>     <chr>     <chr>   <list>    <list>    <list>   
-#> 1 blond      fair        blue            19   male  masculine Tatooine  Human   <chr [5]> <chr [2]> <chr [2]>
-#> 2 <NA>       gold        yellow         112   none  masculine Tatooine  Droid   <chr [6]> <chr [0]> <chr [0]>
-#> 3 <NA>       white, blue red             33   none  masculine Naboo     Droid   <chr [7]> <chr [0]> <chr [0]>
-#> 4 none       white       yellow          41.9 male  masculine Tatooine  Human   <chr [4]> <chr [0]> <chr [1]>
-#> # ... with 83 more rows
+#>   hair_color skin_color eye_color birth_year sex   gender homeworld species
+#>   <chr>      <chr>      <chr>          <dbl> <chr> <chr>  <chr>     <chr>  
+#> 1 blond      fair       blue            19   male  mascu~ Tatooine  Human  
+#> 2 <NA>       gold       yellow         112   none  mascu~ Tatooine  Droid  
+#> 3 <NA>       white, bl~ red             33   none  mascu~ Naboo     Droid  
+#> 4 none       white      yellow          41.9 male  mascu~ Tatooine  Human  
+#> # ... with 83 more rows, and 3 more variables: films <list>, vehicles <list>,
+#> #   starships <list>
 
 iris \%>\% select(!c(Sepal.Length, Petal.Length))
 #> # A tibble: 150 x 3

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -367,6 +367,16 @@ test_that("if_any() and if_all() can be used in mutate() (#5709)", {
   expect_equal(res$all, c(FALSE, FALSE, FALSE, TRUE))
 })
 
+test_that("across() caching not confused when used from if_any() and if_all() (#5782)", {
+  res <- data.frame(x = 1:3) %>%
+    mutate(
+      any = if_any(x, ~ . >= 2) + if_any(x, ~ . >= 3),
+      all = if_all(x, ~ . >= 2) + if_all(x, ~ . >= 3)
+    )
+  expect_equal(res$any, c(0, 1, 2))
+  expect_equal(res$all, c(0, 1, 2))
+})
+
 test_that("if_any() and if_all() respect filter()-like NA handling", {
   df <- expand.grid(
     x = c(TRUE, FALSE, NA), y = c(TRUE, FALSE, NA)


### PR DESCRIPTION
closes #5782

``` r
library(dplyr, warn.conflicts = FALSE)

df <- data.frame(
  x = 1:3
)
df %>% mutate(
  y1 = case_when(
    if_any(everything(), ~ . >= 3) ~ "big",
    if_any(everything(), ~ . >= 2) ~ "medium",
    TRUE ~ "small"
  ),
  y2 =  case_when(
    x >= 3 ~ "big",
    x >= 2 ~ "medium",
    TRUE ~ "small"
  )
)
#>   x     y1     y2
#> 1 1  small  small
#> 2 2 medium medium
#> 3 3    big    big
```

<sup>Created on 2021-03-04 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>