### PR TITLE
set R_CHECK_CONSTANTS=5 to trigger new cran test

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,6 +41,7 @@ jobs:
       _R_CHECK_FORCE_SUGGESTS_: false
       RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_CHECK_CONSTANTS: 5
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
```
These checks should be really easy to reproduce with any installation of
R-devel, just run checks using

env R_COMPILE_PKGS=1 R_JIT_STRATEGY=4 R_CHECK_CONSTANTS=5

(and most likely just R_CHECK_CONSTANTS=5)
```

So that I don't have to install R-devel locally