### PR TITLE
Update R-CMD-check.yaml

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,6 +41,7 @@ jobs:
       _R_CHECK_FORCE_SUGGESTS_: false
       RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_CHECK_CONSTANTS: 5
 
     steps:
       - uses: actions/checkout@v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: dplyr
 Title: A Grammar of Data Manipulation
-Version: 1.0.4
+Version: 1.0.4.8000
 Authors@R: 
     c(person(given = "Hadley",
              family = "Wickham",


### PR DESCRIPTION
Trying to see if setting `R_CHECK_CONSTANTS: 5` makes 1.0.4 fail the constant checks
