### PR TITLE
transmute() forbids .keep, .after, .before

### DIFF
--- a/R/mutate.R
+++ b/R/mutate.R
@@ -215,20 +215,24 @@ transmute <- function(.data, ...) {
 
 #' @export
 transmute.data.frame <- function(.data, ...) {
-  dots <- enquos(...)
-  if (".keep" %in% names(dots)) {
-    abort("`transmute()` does not support the `.keep` argument")
-  }
-  if (".before" %in% names(dots)) {
-    abort("`transmute()` does not support the `.before` argument")
-  }
-  if (".after" %in% names(dots)) {
-    abort("`transmute()` does not support the `.after` argument")
-  }
+  dots <- check_transmute_args(...)
   mutate(.data, !!!dots, .keep = "none")
 }
 
 # Helpers -----------------------------------------------------------------
+
+check_transmute_args <- function(..., .keep, .before, .after) {
+  if (!missing(.keep)) {
+    abort("`transmute()` does not support the `.keep` argument")
+  }
+  if (!missing(.before)) {
+    abort("`transmute()` does not support the `.before` argument")
+  }
+  if (!missing(.after)) {
+    abort("`transmute()` does not support the `.after` argument")
+  }
+  enquos(...)
+}
 
 mutate_cols <- function(.data, ...) {
   mask <- DataMask$new(.data, caller_env())

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -214,8 +214,18 @@ transmute <- function(.data, ...) {
 }
 
 #' @export
-transmute.data.frame <- function(.data, ..., .keep = "none") {
-  mutate(.data, ..., .keep = .keep)
+transmute.data.frame <- function(.data, ...) {
+  dots <- enquos(...)
+  if (".keep" %in% names(dots)) {
+    abort("`transmute()` does not support the `.keep` argument")
+  }
+  if (".before" %in% names(dots)) {
+    abort("`transmute()` does not support the `.before` argument")
+  }
+  if (".after" %in% names(dots)) {
+    abort("`transmute()` does not support the `.after` argument")
+  }
+  mutate(.data, !!!dots, .keep = "none")
 }
 
 # Helpers -----------------------------------------------------------------

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -214,8 +214,8 @@ transmute <- function(.data, ...) {
 }
 
 #' @export
-transmute.data.frame <- function(.data, ...) {
-  mutate(.data, ..., .keep = "none")
+transmute.data.frame <- function(.data, ..., .keep = "none") {
+  mutate(.data, ..., .keep = .keep)
 }
 
 # Helpers -----------------------------------------------------------------

--- a/tests/testthat/_snaps/transmute.md
+++ b/tests/testthat/_snaps/transmute.md
@@ -4,16 +4,10 @@
       transmute(mtcars, cyl2 = cyl, .keep = "all")
     Error <rlang_error>
       `transmute()` does not support the `.keep` argument
-
----
-
     Code
       transmute(mtcars, cyl2 = cyl, .before = disp)
     Error <rlang_error>
       `transmute()` does not support the `.before` argument
-
----
-
     Code
       transmute(mtcars, cyl2 = cyl, .after = disp)
     Error <rlang_error>

--- a/tests/testthat/_snaps/transmute.md
+++ b/tests/testthat/_snaps/transmute.md
@@ -1,0 +1,21 @@
+# transmute() error messages
+
+    Code
+      transmute(mtcars, cyl2 = cyl, .keep = "all")
+    Error <rlang_error>
+      `transmute()` does not support the `.keep` argument
+
+---
+
+    Code
+      transmute(mtcars, cyl2 = cyl, .before = disp)
+    Error <rlang_error>
+      `transmute()` does not support the `.before` argument
+
+---
+
+    Code
+      transmute(mtcars, cyl2 = cyl, .after = disp)
+    Error <rlang_error>
+      `transmute()` does not support the `.after` argument
+

--- a/tests/testthat/test-transmute.R
+++ b/tests/testthat/test-transmute.R
@@ -65,15 +65,10 @@ test_that("transmute() can handle auto splicing", {
   )
 })
 
-test_that("transmute() forbids mutate() special arguments (#5799)", {
-  expect_error(transmute(mtcars, cyl2 = cyl, .keep = 'all'))
-  expect_error(transmute(mtcars, cyl2 = cyl, .before = disp))
-  expect_error(transmute(mtcars, cyl2 = cyl, .after = disp))
-})
-
 test_that("transmute() error messages", {
-  expect_snapshot(error = TRUE, transmute(mtcars, cyl2 = cyl, .keep = 'all'))
-  expect_snapshot(error = TRUE, transmute(mtcars, cyl2 = cyl, .before = disp))
-  expect_snapshot(error = TRUE, transmute(mtcars, cyl2 = cyl, .after = disp))
+  expect_snapshot(error = TRUE, {
+    transmute(mtcars, cyl2 = cyl, .keep = 'all')
+    transmute(mtcars, cyl2 = cyl, .before = disp)
+    transmute(mtcars, cyl2 = cyl, .after = disp)
+  })
 })
-

--- a/tests/testthat/test-transmute.R
+++ b/tests/testthat/test-transmute.R
@@ -64,3 +64,16 @@ test_that("transmute() can handle auto splicing", {
     iris %>% select(Sepal.Length, Sepal.Width)
   )
 })
+
+test_that("transmute() forbids mutate() special arguments (#5799)", {
+  expect_error(transmute(mtcars, cyl2 = cyl, .keep = 'all'))
+  expect_error(transmute(mtcars, cyl2 = cyl, .before = disp))
+  expect_error(transmute(mtcars, cyl2 = cyl, .after = disp))
+})
+
+test_that("transmute() error messages", {
+  expect_snapshot(error = TRUE, transmute(mtcars, cyl2 = cyl, .keep = 'all'))
+  expect_snapshot(error = TRUE, transmute(mtcars, cyl2 = cyl, .before = disp))
+  expect_snapshot(error = TRUE, transmute(mtcars, cyl2 = cyl, .after = disp))
+})
+


### PR DESCRIPTION
closes #5796

I'm not sure this is the right way, perhaps we should instead just (with a warning maybe) cancel `.keep`, `.after` and `.before` 