### PR TITLE
c_across(.names =)

### DIFF
--- a/R/across.R
+++ b/R/across.R
@@ -175,6 +175,9 @@ if_all <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
 #' * It uses [vctrs::vec_c()] in order to give safer outputs.
 #'
 #' @inheritParams across
+#' @param .names A glue specification that describes how to name the output
+#'   vector. This can use `{.col}` to stand for the selected column name.
+#'   The default (`NULL`) gives an unnamed output.
 #' @seealso [across()] for a function that returns a tibble.
 #' @export
 #' @examples

--- a/R/across.R
+++ b/R/across.R
@@ -185,14 +185,19 @@ if_all <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
 #'     sum = sum(c_across(w:z)),
 #'     sd = sd(c_across(w:z))
 #'  )
-c_across <- function(cols = everything()) {
+c_across <- function(cols = everything(), .names = NULL) {
   key <- key_deparse(sys.call())
   vars <- c_across_setup({{ cols }}, key = key)
 
   mask <- peek_mask("c_across()")
 
   cols <- mask$current_cols(vars)
-  vec_c(!!!cols, .name_spec = zap())
+  out <- vec_c(!!!cols, .name_spec = zap())
+  if (!is.null(.names)) {
+    glue_mask <- across_glue_mask(caller_env(), .fn = NULL, .col = vars)
+    names(out) <- vec_as_names(glue(.names, .envir = glue_mask), repair = "check_unique")
+  }
+  out
 }
 
 across_glue_mask <- function(.col, .fn, .caller_env) {

--- a/man/c_across.Rd
+++ b/man/c_across.Rd
@@ -4,12 +4,16 @@
 \alias{c_across}
 \title{Combine values from multiple columns}
 \usage{
-c_across(cols = everything())
+c_across(cols = everything(), .names = NULL)
 }
 \arguments{
 \item{cols}{<\code{\link[=dplyr_tidy_select]{tidy-select}}> Columns to transform.
 Because \code{across()} is used within functions like \code{summarise()} and
 \code{mutate()}, you can't select or compute upon grouping variables.}
+
+\item{.names}{A glue specification that describes how to name the output
+vector. This can use \code{{.col}} to stand for the selected column name.
+The default (\code{NULL}) gives an unnamed output.}
 }
 \description{
 \code{c_across()} is designed to work with \code{\link[=rowwise]{rowwise()}} to make it easy to

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -388,3 +388,9 @@ test_that("selects and combines columns", {
   out <- df %>% summarise(z = list(c_across(x:y)))
   expect_equal(out$z, list(1:4))
 })
+
+test_that("c_across(.names=)", {
+  df <- data.frame(x = 1, y = 2)
+  out <- df %>% rowwise() %>% summarise(z = list(c_across(x:y, .names = "prefix_{.col}")))
+  expect_equal(out$z, list(c(prefix_x = 1, prefix_y = 2)))
+})


### PR DESCRIPTION
closes #5771

🤔 unfortunately this does not do well when the data is not rowwised, which I didn't realize was possible with `c_across()`. 

``` r
library(dplyr, warn.conflicts = FALSE)

data.frame(x = 1:2, y = 3:4) %>% 
  summarise(z = list(c_across(x:y, .names = "{.col}"))) %>% 
  pull(z)
#> [[1]]
#>    x    y <NA> <NA> 
#>    1    2    3    4
```

<sup>Created on 2021-03-05 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>