### PR TITLE
use vctrs:::vec_order_locs() in group_by() and vctrs:::vec_order_radix() in arrange()

### DIFF
--- a/R/arrange.R
+++ b/R/arrange.R
@@ -131,24 +131,5 @@ arrange_rows <- function(.data, dots) {
 
   })
 
-  # we can't just use vec_compare_proxy(data) because we need to apply
-  # direction for each column, so we get a list of proxies instead
-  # and then mimic vctrs:::order_proxy
-  #
-  # should really be map2(quosures, directions, ...)
-  proxies <- map2(data, directions, function(column, direction) {
-    proxy <- vec_proxy_order(column)
-    desc <- identical(direction, "desc")
-    if (is.data.frame(proxy)) {
-      proxy <- order(vec_order(proxy,
-        direction = direction,
-        na_value = if(desc) "smallest" else "largest"
-      ))
-    } else if(desc) {
-      proxy <- desc(proxy)
-    }
-    proxy
-  })
-
-  exec("order", !!!unname(proxies), decreasing = FALSE, na.last = TRUE)
+  vctrs:::vec_order_radix(data, direction = directions)
 }

--- a/R/grouped-df.r
+++ b/R/grouped-df.r
@@ -297,10 +297,9 @@ expand_groups <- function(old_groups, positions, nr) {
 }
 
 vec_split_id_order <- function(x) {
-  split_id <- vec_group_loc(x)
-  split_id$loc <- new_list_of(split_id$loc, ptype = integer())
-
-  vec_slice(split_id, vec_order(split_id$key))
+  split_id <- vctrs:::vec_order_locs(x)
+  split_id$loc <- new_list_of(split_id$loc, integer())
+  split_id
 }
 
 group_intersect <- function(x, new) {


### PR DESCRIPTION
closes #4406

``` r
set.seed(42)
library(dplyr)
library(tibble)
x <- runif(1e7)
grp <- sample(1e6, 1e7, replace=TRUE)
tib <- tibble(grp, x)

bench::mark(
  tib %>% group_by(grp), 
)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 x 6
#>   expression                 min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>            <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 tib %>% group_by(grp)    627ms    627ms      1.60     228MB     4.79
```

vs on master: 

``` r
set.seed(42)
library(dplyr)
library(tibble)
x <- runif(1e7)
grp <- sample(1e6, 1e7, replace=TRUE)
tib <- tibble(grp, x)

bench::mark(
  not_ordered = tib %>% group_by(grp), 
  ordered = {
    o <- order(grp)
    tibo <- tibble(grp=grp[o], x=x[o])
    b <- tibo %>% group_by(grp)
  }, 
  check = FALSE
)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 x 6
#>   expression       min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>  <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 not_ordered    2.64s    2.64s     0.379     248MB     1.14
#> 2 ordered        1.33s    1.33s     0.752     400MB     1.50
```

<sup>Created on 2021-03-10 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>