### PR TITLE
Supply proper caller environments to dplyr masks

### DIFF
--- a/R/distinct.R
+++ b/R/distinct.R
@@ -69,7 +69,11 @@ distinct <- function(.data, ..., .keep_all = FALSE) {
 #' vars (character vector) comes out.
 #' @rdname group_by_prepare
 #' @export
-distinct_prepare <- function(.data, vars, group_vars = character(), .keep_all = FALSE) {
+distinct_prepare <- function(.data,
+                             vars,
+                             group_vars = character(),
+                             .keep_all = FALSE,
+                             caller_env = caller_env(2)) {
   stopifnot(is_quosures(vars), is.character(group_vars))
 
   # If no input, keep all variables
@@ -82,7 +86,12 @@ distinct_prepare <- function(.data, vars, group_vars = character(), .keep_all = 
   }
 
   # If any calls, use mutate to add new columns, then distinct on those
-  computed_columns <- add_computed_columns(.data, vars, "distinct")
+  computed_columns <- add_computed_columns(
+    .data,
+    vars,
+    "distinct",
+    caller_env = caller_env
+  )
   .data <- computed_columns$data
   distinct_vars <- computed_columns$added_names
 
@@ -111,10 +120,12 @@ distinct_prepare <- function(.data, vars, group_vars = character(), .keep_all = 
 
 #' @export
 distinct.data.frame <- function(.data, ..., .keep_all = FALSE) {
-  prep <- distinct_prepare(.data,
+  prep <- distinct_prepare(
+    .data,
     vars = enquos(...),
     group_vars = group_vars(.data),
-    .keep_all = .keep_all
+    .keep_all = .keep_all,
+    caller_env = caller_env()
   )
 
   # out <- as_tibble(prep$data)

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -173,7 +173,7 @@ mutate.data.frame <- function(.data, ...,
                               .before = NULL, .after = NULL) {
   keep <- arg_match(.keep)
 
-  cols <- mutate_cols(.data, ...)
+  cols <- mutate_cols(.data, ..., caller_env = caller_env())
   out <- dplyr_col_modify(.data, cols)
 
   .before <- enquo(.before)
@@ -234,8 +234,8 @@ check_transmute_args <- function(..., .keep, .before, .after) {
   enquos(...)
 }
 
-mutate_cols <- function(.data, ...) {
-  mask <- DataMask$new(.data, caller_env())
+mutate_cols <- function(.data, ..., caller_env) {
+  mask <- DataMask$new(.data, caller_env)
   old_current_column <- context_peek_bare("column")
 
   on.exit(context_poke("column", old_current_column), add = TRUE)

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -125,7 +125,7 @@ summarize <- summarise
 
 #' @export
 summarise.data.frame <- function(.data, ..., .groups = NULL) {
-  cols <- summarise_cols(.data, ...)
+  cols <- summarise_cols(.data, ..., caller_env = caller_env())
   out <- summarise_build(.data, cols)
   if (identical(.groups, "rowwise")) {
     out <- rowwise_df(out, character())
@@ -135,7 +135,7 @@ summarise.data.frame <- function(.data, ..., .groups = NULL) {
 
 #' @export
 summarise.grouped_df <- function(.data, ..., .groups = NULL) {
-  cols <- summarise_cols(.data, ...)
+  cols <- summarise_cols(.data, ..., caller_env = caller_env())
   out <- summarise_build(.data, cols)
   verbose <- summarise_verbose(.groups, caller_env())
 
@@ -177,7 +177,7 @@ summarise.grouped_df <- function(.data, ..., .groups = NULL) {
 
 #' @export
 summarise.rowwise_df <- function(.data, ..., .groups = NULL) {
-  cols <- summarise_cols(.data, ...)
+  cols <- summarise_cols(.data, ..., caller_env = caller_env())
   out <- summarise_build(.data, cols)
   verbose <- summarise_verbose(.groups, caller_env())
 
@@ -204,8 +204,8 @@ summarise.rowwise_df <- function(.data, ..., .groups = NULL) {
   out
 }
 
-summarise_cols <- function(.data, ...) {
-  mask <- DataMask$new(.data, caller_env())
+summarise_cols <- function(.data, ..., caller_env) {
+  mask <- DataMask$new(.data, caller_env)
   old_current_column <- context_peek_bare("column")
 
   on.exit(context_poke("column", old_current_column), add = TRUE)

--- a/man/group_by_prepare.Rd
+++ b/man/group_by_prepare.Rd
@@ -6,11 +6,18 @@
 \title{Same basic philosophy as group_by_prepare(): lazy_dots comes in, list of data and
 vars (character vector) comes out.}
 \usage{
-distinct_prepare(.data, vars, group_vars = character(), .keep_all = FALSE)
+distinct_prepare(
+  .data,
+  vars,
+  group_vars = character(),
+  .keep_all = FALSE,
+  caller_env = caller_env(2)
+)
 
 group_by_prepare(
   .data,
   ...,
+  caller_env = caller_env(2),
   .add = FALSE,
   .dots = deprecated(),
   add = deprecated()

--- a/tests/testthat/helper-dplyr.R
+++ b/tests/testthat/helper-dplyr.R
@@ -4,3 +4,15 @@ expect_no_error <- function(object, ...) {
 expect_no_warning <- function(object, ...) {
   expect_warning({{ object }}, NA, ...)
 }
+
+sig_caller_env <- function() {
+  signal(
+    "",
+    "dplyr:::test_caller_env",
+    out = peek_mask()$get_caller_env()
+  )
+}
+expect_caller_env <- function(expr) {
+  env <- catch_cnd(expr, "dplyr:::test_caller_env")$out
+  expect_equal(env, caller_env())
+}

--- a/tests/testthat/test-distinct.R
+++ b/tests/testthat/test-distinct.R
@@ -152,6 +152,11 @@ test_that("distinct preserves grouping", {
   expect_equal(group_vars(out), "x")
 })
 
+test_that("distinct() propagates caller env", {
+  expect_caller_env(distinct(mtcars, sig_caller_env()))
+})
+
+
 # Errors ------------------------------------------------------------------
 
 

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -556,6 +556,10 @@ test_that("group_by() works with quosures (tidyverse/lubridate#959)", {
   expect_equal(g(), tibble(x = 1, g = NA) %>% group_by(g))
 })
 
+test_that("group_by() propagates caller env", {
+  expect_caller_env(group_by(mtcars, sig_caller_env()))
+})
+
 
 # Errors ------------------------------------------------------------------
 

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -472,6 +472,11 @@ test_that("mutate() supports empty list columns in rowwise data frames (#5804", 
   expect_equal(res$n, integer())
 })
 
+test_that("mutate() propagates caller env", {
+  expect_caller_env(mutate(mtcars, sig_caller_env()))
+})
+
+
 # Error messages ----------------------------------------------------------
 
 test_that("mutate() give meaningful errors", {

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -217,6 +217,12 @@ test_that("summarise() silently skips when all results are NULL (#5708)", {
   expect_error(summarise(df, x = if(g == 1) 42))
 })
 
+test_that("summarise() propagates caller env", {
+  expect_caller_env(summarise(mtcars, sig_caller_env()))
+  expect_caller_env(summarise(group_by(mtcars, cyl), sig_caller_env()))
+})
+
+
 # errors -------------------------------------------------------------------
 
 test_that("summarise() preserves the call stack on error (#5308)", {


### PR DESCRIPTION
Usually does not matter but the caller env will be useful for fixing #5815.

Since they are exported, `group_by_prepare()` and `distinct_prepare()` use `caller_env(2)` as default. Best to supply the caller env explicitly though.