### PR TITLE
add_count() always calls dplyr_reconstruct()

### DIFF
--- a/R/count-tally.R
+++ b/R/count-tally.R
@@ -123,10 +123,7 @@ add_count <- function(x, ..., wt = NULL, sort = FALSE, name = NULL, .drop = depr
     out <- x
   }
   out <- add_tally(out, wt = !!enquo(wt), sort = sort, name = name)
-  if (is.data.frame(x)) {
-    out <- dplyr_reconstruct(out, x)
-  }
-  out
+  dplyr_reconstruct(out, x)
 }
 
 #' @rdname count

--- a/tests/testthat/test-count-tally.r
+++ b/tests/testthat/test-count-tally.r
@@ -64,6 +64,7 @@ test_that("works with dbplyr", {
   df1 <- db %>% count(x) %>% as_tibble()
   expect_equal(df1, tibble(x = c(1, 2), n = c(3, 2)))
 
+  skip("until dplyr_reconsruct() implemented for tbl_lazy")
   df2 <- db %>% add_count(x) %>% as_tibble()
   expect_equal(df2, tibble(x = c(1, 1, 1, 2, 2), n = c(3, 3, 3, 2, 2)))
 })


### PR DESCRIPTION
closes #5837

This probably needs `dplyr_reconstruct()` dispatch to be simplified: 

```r
dplyr_reconstruct <- function(data, template) {
  # Strip attributes before dispatch to make it easier to implement
  # methods and prevent unexpected leaking of irrelevant attributes.
  data <- dplyr_new_data_frame(data)
  return(dplyr_reconstruct_dispatch(data, template))
  UseMethod("dplyr_reconstruct", template)
}
```

so that it can be implemented for `tbl_lazy` in `dbplyr`, or perhaps `dplyr_new_data_frame()` should work for `tbl_lazy`: 

``` r
library(dplyr, warn.conflicts = FALSE)
db <- dbplyr::memdb_frame(x = c(1, 1, 1, 2, 2))
dplyr:::dplyr_new_data_frame(db)
#> Error: Input must be a vector, not a <src_SQLiteConnection/src_dbi/src_sql/src> object.
```

<sup>Created on 2021-04-09 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
