### PR TITLE
Forbid ~predicates in `across/if_any/if_all(.cols = )`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,6 @@
 
 * `select()` no longer creates duplicate variables when renaming a variable to the same name as a grouping variable (#5841).
 
-
 * Fixed behaviour of `...` in top-level `across()` calls (#5813, #5832).
 
 * `dplyr_col_select()` keeps attributes for bare data frames (#5294, #5831).
@@ -27,6 +26,8 @@
 * row-wise data frames of 0 rows and list columns are supported again (#5804).
 
 * `add_count()` is now generic (#5837).
+
+* `if_any()` and `if_all()` abort when a predicate is mistakingly used as `.cols=` (#5732).
 
 # dplyr 1.0.5
 

--- a/R/across.R
+++ b/R/across.R
@@ -176,17 +176,45 @@ across <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
   new_data_frame(out, n = size, class = c("tbl_df", "tbl"))
 }
 
+
+check_cols_arg <- function(.cols, .fns, fn = "if_any") {
+  if (is.null(.fns) && quo_is_call(.cols, "~")) {
+    abort(c(
+      "Predicate used in lieu of column selection.",
+      i = "The first argument (`.cols=`) selects a set of columns.",
+      i = "The second argument (`.fns=`) operates on each selected columns to choose rows.",
+      i = glue("You most likely meant: `{fn}(everything(), {as_label(.cols)})`."),
+      i = glue("If this was truly meant as a column selection, you must wrap with: `{fn}(where({as_label(.cols)}))`.")
+    ))
+  }
+  .cols
+}
+
 #' @rdname across
 #' @export
 if_any <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
+<<<<<<< HEAD
   if_across(`|`, across({{ .cols }}, .fns, ..., .names = .names))
+=======
+  .cols <- check_cols_arg(enquo(.cols), .fns, "if_any")
+  df <- across(!!.cols, .fns = .fns, ..., .names = .names, .call = .call)
+  n <- nrow(df)
+  df <- vec_cast_common(!!!df, .to = logical())
+  .Call(dplyr_reduce_lgl_or, df, n)
+>>>>>>> 7ebb164b4 (only do it in if_any() and if_all())
 }
 #' @rdname across
 #' @export
 if_all <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
+<<<<<<< HEAD
   if_across(`&`, across({{ .cols }}, .fns, ..., .names = .names))
 }
 if_across <- function(op, df) {
+=======
+  df <- across({{ .cols }}, .fns, ..., .names = .names)
+  .cols <- check_cols_arg(enquo(.cols), .fns, "if_all")
+  df <- across(!!.cols, .fns = .fns, ..., .names = .names, .call = .call)
+>>>>>>> 7ebb164b4 (only do it in if_any() and if_all())
   n <- nrow(df)
 
   if (!length(df)) {
@@ -272,18 +300,6 @@ across_setup <- function(cols,
   # `across()` is evaluated in a data mask so we need to remove the
   # mask layer from the quosure environment (#5460)
   cols <- quo_set_env(cols, data_mask_top(quo_get_env(cols), recursive = FALSE, inherit = FALSE))
-
-  # TODO: it would be interesting to mention if_any() in the error
-  #       if this is what calls `across()`
-  if (is.null(fns) && quo_is_call(cols, "~")) {
-    abort(c(
-      "Predicate used in lieu of column selection.",
-      i = "The first argument (`.cols=`) selects a set of columns",
-      i = "The second argument (`.fns=`) operates on each selected columns",
-      i = glue("You most likely meant to use `.fns = {as_label(cols)}` or use `everything()` as the first argument"),
-      i = glue("If this was truly meant as a column selection, you must wrap with: `where({as_label(cols)})`")
-    ))
-  }
 
   vars <- tidyselect::eval_select(cols, data = mask$across_cols())
   vars <- names(vars)

--- a/R/across.R
+++ b/R/across.R
@@ -282,10 +282,9 @@ across_setup <- function(cols,
     if_fn <- context_peek_bare("across_if_fn") %||% "across"
     abort(c(
       "Predicate used in lieu of column selection.",
-      i = "The first argument `.cols` selects a set of columns.",
-      i = "The second argument `.fns` operates on each selected columns.",
       i = glue("You most likely meant: `{if_fn}(everything(), {as_label(cols)})`."),
-      i = glue("If this was truly meant as a column selection, you must wrap with: `{if_fn}(where({as_label(cols)}))`.")
+      i = "The first argument `.cols` selects a set of columns.",
+      i = "The second argument `.fns` operates on each selected columns."
     ))
   }
   vars <- tidyselect::eval_select(cols, data = mask$across_cols())

--- a/R/across.R
+++ b/R/across.R
@@ -176,45 +176,17 @@ across <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
   new_data_frame(out, n = size, class = c("tbl_df", "tbl"))
 }
 
-
-check_cols_arg <- function(.cols, .fns, fn = "if_any") {
-  if (is.null(.fns) && quo_is_call(.cols, "~")) {
-    abort(c(
-      "Predicate used in lieu of column selection.",
-      i = "The first argument (`.cols=`) selects a set of columns.",
-      i = "The second argument (`.fns=`) operates on each selected columns to choose rows.",
-      i = glue("You most likely meant: `{fn}(everything(), {as_label(.cols)})`."),
-      i = glue("If this was truly meant as a column selection, you must wrap with: `{fn}(where({as_label(.cols)}))`.")
-    ))
-  }
-  .cols
-}
-
 #' @rdname across
 #' @export
 if_any <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
-<<<<<<< HEAD
   if_across(`|`, across({{ .cols }}, .fns, ..., .names = .names))
-=======
-  .cols <- check_cols_arg(enquo(.cols), .fns, "if_any")
-  df <- across(!!.cols, .fns = .fns, ..., .names = .names, .call = .call)
-  n <- nrow(df)
-  df <- vec_cast_common(!!!df, .to = logical())
-  .Call(dplyr_reduce_lgl_or, df, n)
->>>>>>> 7ebb164b4 (only do it in if_any() and if_all())
 }
 #' @rdname across
 #' @export
 if_all <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
-<<<<<<< HEAD
   if_across(`&`, across({{ .cols }}, .fns, ..., .names = .names))
 }
 if_across <- function(op, df) {
-=======
-  df <- across({{ .cols }}, .fns, ..., .names = .names)
-  .cols <- check_cols_arg(enquo(.cols), .fns, "if_all")
-  df <- across(!!.cols, .fns = .fns, ..., .names = .names, .call = .call)
->>>>>>> 7ebb164b4 (only do it in if_any() and if_all())
   n <- nrow(df)
 
   if (!length(df)) {
@@ -300,6 +272,9 @@ across_setup <- function(cols,
   # `across()` is evaluated in a data mask so we need to remove the
   # mask layer from the quosure environment (#5460)
   cols <- quo_set_env(cols, data_mask_top(quo_get_env(cols), recursive = FALSE, inherit = FALSE))
+  if (is.null(fns) && quo_is_call(cols, "~")) {
+    abort_invalid_cols_arg(cols, "across")
+  }
 
   vars <- tidyselect::eval_select(cols, data = mask$across_cols())
   vars <- names(vars)

--- a/R/across.R
+++ b/R/across.R
@@ -282,10 +282,12 @@ across_setup <- function(cols,
   # `across()` is evaluated in a data mask so we need to remove the
   # mask layer from the quosure environment (#5460)
   cols <- quo_set_env(cols, data_mask_top(quo_get_env(cols), recursive = FALSE, inherit = FALSE))
+
+  # TODO: call eval_select with a calling handler to intercept
+  #       classed error, after https://github.com/r-lib/tidyselect/issues/233
   if (is.null(fns) && quo_is_call(cols, "~")) {
     abort_invalid_cols_arg(cols, "across")
   }
-
   vars <- tidyselect::eval_select(cols, data = mask$across_cols())
   vars <- names(vars)
 

--- a/R/across.R
+++ b/R/across.R
@@ -245,6 +245,16 @@ across_glue_mask <- function(.col, .fn, .caller_env) {
   glue_mask
 }
 
+abort_invalid_cols_arg <- function(.cols, fn = "across") {
+  abort(c(
+    "Predicate used in lieu of column selection.",
+    i = "The first argument `.cols` selects a set of columns.",
+    i = "The second argument `.fns` operates on each selected columns to choose rows.",
+    i = glue("You most likely meant: `{fn}(everything(), {as_label(.cols)})`."),
+    i = glue("If this was truly meant as a column selection, you must wrap with: `{fn}(where({as_label(.cols)}))`.")
+  ), class = "dplyr:::across_cols_formula")
+}
+
 # TODO: The usage of a cache in `c_across_setup()` is a stopgap solution, and
 # this idea should not be used anywhere else. This should be replaced by either
 # expansions of expressions (as we now use for `across()`) or the

--- a/R/across.R
+++ b/R/across.R
@@ -249,7 +249,7 @@ abort_invalid_cols_arg <- function(.cols, fn = "across") {
   abort(c(
     "Predicate used in lieu of column selection.",
     i = "The first argument `.cols` selects a set of columns.",
-    i = "The second argument `.fns` operates on each selected columns to choose rows.",
+    i = "The second argument `.fns` operates on each selected columns.",
     i = glue("You most likely meant: `{fn}(everything(), {as_label(.cols)})`."),
     i = glue("If this was truly meant as a column selection, you must wrap with: `{fn}(where({as_label(.cols)}))`.")
   ), class = "dplyr:::across_cols_formula")

--- a/R/across.R
+++ b/R/across.R
@@ -179,14 +179,35 @@ across <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
 #' @rdname across
 #' @export
 if_any <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
+<<<<<<< HEAD
   if_across(`|`, across({{ .cols }}, .fns, ..., .names = .names))
+=======
+  .cols <- enquo(.cols)
+  df <- withCallingHandlers(
+    across(!!.cols, .fns = .fns, ..., .names = .names),
+    "dplyr:::across_cols_formula" = function(e) {
+      abort_invalid_cols_arg(.cols, "if_any")
+    })
+  n <- nrow(df)
+  df <- vec_cast_common(!!!df, .to = logical())
+  .Call(dplyr_reduce_lgl_or, df, n)
+>>>>>>> 781d9e361 (rebase hickup)
 }
 #' @rdname across
 #' @export
 if_all <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
+<<<<<<< HEAD
   if_across(`&`, across({{ .cols }}, .fns, ..., .names = .names))
 }
 if_across <- function(op, df) {
+=======
+  .cols <- enquo(.cols)
+  df <- withCallingHandlers(
+    across(!!.cols, .fns = .fns, ..., .names = .names),
+    "dplyr:::across_cols_formula" = function(e) {
+      abort_invalid_cols_arg(.cols, "if_all")
+    })
+>>>>>>> 781d9e361 (rebase hickup)
   n <- nrow(df)
 
   if (!length(df)) {

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -1,6 +1,6 @@
 arg_name <- function(quos, index) {
   name  <- names(quos)[index]
-  if (name == "") {
+  if (is.null(name) || name == "") {
     name <- glue("..{index}")
   }
   name

--- a/tests/testthat/_snaps/across.md
+++ b/tests/testthat/_snaps/across.md
@@ -22,54 +22,39 @@
     Error <rlang_error>
       `c_across()` must only be used inside dplyr verbs.
 
-# if_any() and if_all() enforce logical
-
-    Code
-      filter(d, if_all(x:y, identity))
-    Error <dplyr_error>
-      Problem with `filter()` input `..1`.
-      i Input `..1` is `if_all(x:y, identity)`.
-      x Can't convert from <double> to <logical> due to loss of precision.
-      * Locations: 1
-    Code
-      filter(d, if_any(x:y, identity))
-    Error <dplyr_error>
-      Problem with `filter()` input `..1`.
-      i Input `..1` is `if_any(x:y, identity)`.
-      x Can't convert from <double> to <logical> due to loss of precision.
-      * Locations: 1
-    Code
-      mutate(d, ok = if_any(x:y, identity))
-    Error <dplyr:::mutate_error>
-      Problem with `mutate()` column `ok`.
-      i `ok = if_any(x:y, identity)`.
-      x Can't convert from <double> to <logical> due to loss of precision.
-      * Locations: 1
-    Code
-      mutate(d, ok = if_all(x:y, identity))
-    Error <dplyr:::mutate_error>
-      Problem with `mutate()` column `ok`.
-      i `ok = if_all(x:y, identity)`.
-      x Can't convert from <double> to <logical> due to loss of precision.
-      * Locations: 1
-
 # if_any() and if_all() aborts when predicate mistakingly used in .cols= (#5732)
 
     Code
       filter(df, if_any(~.x > 5))
-    Error <dplyr_error>
-      Problem with `filter()` input `..1`.
-      i Input `..1` is `if_any(~.x > 5)`.
-      x Predicate used in lieu of column selection.
+    Error <rlang_error>
+      Predicate used in lieu of column selection.
       i The first argument `.cols` selects a set of columns.
       i The second argument `.fns` operates on each selected columns.
       i You most likely meant: `if_any(everything(), ~.x > 5)`.
       i If this was truly meant as a column selection, you must wrap with: `if_any(where(~.x > 5))`.
     Code
       filter(df, if_all(~.x > 5))
+    Error <rlang_error>
+      Predicate used in lieu of column selection.
+      i The first argument `.cols` selects a set of columns.
+      i The second argument `.fns` operates on each selected columns.
+      i You most likely meant: `if_all(everything(), ~.x > 5)`.
+      i If this was truly meant as a column selection, you must wrap with: `if_all(where(~.x > 5))`.
+    Code
+      filter(df, !if_any(~.x > 5))
     Error <dplyr_error>
       Problem with `filter()` input `..1`.
-      i Input `..1` is `if_all(~.x > 5)`.
+      i Input `..1` is `!if_any(~.x > 5)`.
+      x Predicate used in lieu of column selection.
+      i The first argument `.cols` selects a set of columns.
+      i The second argument `.fns` operates on each selected columns.
+      i You most likely meant: `if_any(everything(), ~.x > 5)`.
+      i If this was truly meant as a column selection, you must wrap with: `if_any(where(~.x > 5))`.
+    Code
+      filter(df, !if_all(~.x > 5))
+    Error <dplyr_error>
+      Problem with `filter()` input `..1`.
+      i Input `..1` is `!if_all(~.x > 5)`.
       x Predicate used in lieu of column selection.
       i The first argument `.cols` selects a set of columns.
       i The second argument `.fns` operates on each selected columns.

--- a/tests/testthat/_snaps/across.md
+++ b/tests/testthat/_snaps/across.md
@@ -25,24 +25,27 @@
 # if_any() and if_all() aborts when predicate mistakingly used in .cols= (#5732)
 
     Code
-      filter(df, if_any(~.x > 5))
-    Error <rlang_error>
+      (expect_error(filter(df, if_any(~.x > 5))))
+    Output
+      <error/rlang_error>
       Predicate used in lieu of column selection.
       i The first argument `.cols` selects a set of columns.
       i The second argument `.fns` operates on each selected columns.
       i You most likely meant: `if_any(everything(), ~.x > 5)`.
       i If this was truly meant as a column selection, you must wrap with: `if_any(where(~.x > 5))`.
     Code
-      filter(df, if_all(~.x > 5))
-    Error <rlang_error>
+      (expect_error(filter(df, if_all(~.x > 5))))
+    Output
+      <error/rlang_error>
       Predicate used in lieu of column selection.
       i The first argument `.cols` selects a set of columns.
       i The second argument `.fns` operates on each selected columns.
       i You most likely meant: `if_all(everything(), ~.x > 5)`.
       i If this was truly meant as a column selection, you must wrap with: `if_all(where(~.x > 5))`.
     Code
-      filter(df, !if_any(~.x > 5))
-    Error <dplyr_error>
+      (expect_error(filter(df, !if_any(~.x > 5))))
+    Output
+      <error/dplyr_error>
       Problem with `filter()` input `..1`.
       i Input `..1` is `!if_any(~.x > 5)`.
       x Predicate used in lieu of column selection.
@@ -51,8 +54,9 @@
       i You most likely meant: `if_any(everything(), ~.x > 5)`.
       i If this was truly meant as a column selection, you must wrap with: `if_any(where(~.x > 5))`.
     Code
-      filter(df, !if_all(~.x > 5))
-    Error <dplyr_error>
+      (expect_error(filter(df, !if_all(~.x > 5))))
+    Output
+      <error/dplyr_error>
       Problem with `filter()` input `..1`.
       i Input `..1` is `!if_all(~.x > 5)`.
       x Predicate used in lieu of column selection.

--- a/tests/testthat/_snaps/across.md
+++ b/tests/testthat/_snaps/across.md
@@ -27,21 +27,23 @@
     Code
       (expect_error(filter(df, if_any(~.x > 5))))
     Output
-      <error/rlang_error>
-      Predicate used in lieu of column selection.
+      <error/dplyr_error>
+      Problem with `filter()` input `..1`.
+      i Input `..1` is `if_any(~.x > 5)`.
+      x Predicate used in lieu of column selection.
+      i You most likely meant: `if_any(everything(), ~.x > 5)`.
       i The first argument `.cols` selects a set of columns.
       i The second argument `.fns` operates on each selected columns.
-      i You most likely meant: `if_any(everything(), ~.x > 5)`.
-      i If this was truly meant as a column selection, you must wrap with: `if_any(where(~.x > 5))`.
     Code
       (expect_error(filter(df, if_all(~.x > 5))))
     Output
-      <error/rlang_error>
-      Predicate used in lieu of column selection.
+      <error/dplyr_error>
+      Problem with `filter()` input `..1`.
+      i Input `..1` is `if_all(~.x > 5)`.
+      x Predicate used in lieu of column selection.
+      i You most likely meant: `if_all(everything(), ~.x > 5)`.
       i The first argument `.cols` selects a set of columns.
       i The second argument `.fns` operates on each selected columns.
-      i You most likely meant: `if_all(everything(), ~.x > 5)`.
-      i If this was truly meant as a column selection, you must wrap with: `if_all(where(~.x > 5))`.
     Code
       (expect_error(filter(df, !if_any(~.x > 5))))
     Output
@@ -49,10 +51,9 @@
       Problem with `filter()` input `..1`.
       i Input `..1` is `!if_any(~.x > 5)`.
       x Predicate used in lieu of column selection.
+      i You most likely meant: `if_any(everything(), ~.x > 5)`.
       i The first argument `.cols` selects a set of columns.
       i The second argument `.fns` operates on each selected columns.
-      i You most likely meant: `if_any(everything(), ~.x > 5)`.
-      i If this was truly meant as a column selection, you must wrap with: `if_any(where(~.x > 5))`.
     Code
       (expect_error(filter(df, !if_all(~.x > 5))))
     Output
@@ -60,8 +61,7 @@
       Problem with `filter()` input `..1`.
       i Input `..1` is `!if_all(~.x > 5)`.
       x Predicate used in lieu of column selection.
+      i You most likely meant: `if_all(everything(), ~.x > 5)`.
       i The first argument `.cols` selects a set of columns.
       i The second argument `.fns` operates on each selected columns.
-      i You most likely meant: `if_all(everything(), ~.x > 5)`.
-      i If this was truly meant as a column selection, you must wrap with: `if_all(where(~.x > 5))`.
 

--- a/tests/testthat/_snaps/across.md
+++ b/tests/testthat/_snaps/across.md
@@ -22,3 +22,57 @@
     Error <rlang_error>
       `c_across()` must only be used inside dplyr verbs.
 
+# if_any() and if_all() enforce logical
+
+    Code
+      filter(d, if_all(x:y, identity))
+    Error <dplyr_error>
+      Problem with `filter()` input `..1`.
+      i Input `..1` is `if_all(x:y, identity)`.
+      x Can't convert from <double> to <logical> due to loss of precision.
+      * Locations: 1
+    Code
+      filter(d, if_any(x:y, identity))
+    Error <dplyr_error>
+      Problem with `filter()` input `..1`.
+      i Input `..1` is `if_any(x:y, identity)`.
+      x Can't convert from <double> to <logical> due to loss of precision.
+      * Locations: 1
+    Code
+      mutate(d, ok = if_any(x:y, identity))
+    Error <dplyr:::mutate_error>
+      Problem with `mutate()` column `ok`.
+      i `ok = if_any(x:y, identity)`.
+      x Can't convert from <double> to <logical> due to loss of precision.
+      * Locations: 1
+    Code
+      mutate(d, ok = if_all(x:y, identity))
+    Error <dplyr:::mutate_error>
+      Problem with `mutate()` column `ok`.
+      i `ok = if_all(x:y, identity)`.
+      x Can't convert from <double> to <logical> due to loss of precision.
+      * Locations: 1
+
+# if_any() and if_all() aborts when predicate mistakingly used in .cols= (#5732)
+
+    Code
+      filter(df, if_any(~.x > 5))
+    Error <dplyr_error>
+      Problem with `filter()` input `..1`.
+      i Input `..1` is `if_any(~.x > 5)`.
+      x Predicate used in lieu of column selection.
+      i The first argument `.cols` selects a set of columns.
+      i The second argument `.fns` operates on each selected columns.
+      i You most likely meant: `if_any(everything(), ~.x > 5)`.
+      i If this was truly meant as a column selection, you must wrap with: `if_any(where(~.x > 5))`.
+    Code
+      filter(df, if_all(~.x > 5))
+    Error <dplyr_error>
+      Problem with `filter()` input `..1`.
+      i Input `..1` is `if_all(~.x > 5)`.
+      x Predicate used in lieu of column selection.
+      i The first argument `.cols` selects a set of columns.
+      i The second argument `.fns` operates on each selected columns.
+      i You most likely meant: `if_all(everything(), ~.x > 5)`.
+      i If this was truly meant as a column selection, you must wrap with: `if_all(where(~.x > 5))`.
+

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -399,6 +399,14 @@ test_that("if_any() and if_all() respect filter()-like NA handling", {
   )
 })
 
+test_that("if_any() and if_all() aborts when predicate mistakingly used in .cols= (#5732)", {
+  df <- data.frame(x = 1:10, y = 1:10)
+  expect_snapshot(error = TRUE, {
+    filter(df, if_any(~ .x > 5))
+    filter(df, if_all(~ .x > 5))
+  })
+})
+
 test_that("across() correctly reset column", {
   expect_error(cur_column())
   res <- data.frame(x = 1) %>%

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -401,14 +401,14 @@ test_that("if_any() and if_all() respect filter()-like NA handling", {
 
 test_that("if_any() and if_all() aborts when predicate mistakingly used in .cols= (#5732)", {
   df <- data.frame(x = 1:10, y = 1:10)
-  expect_snapshot(error = TRUE, {
+  expect_snapshot({
     # expanded case
-    filter(df, if_any(~ .x > 5))
-    filter(df, if_all(~ .x > 5))
+    (expect_error(filter(df, if_any(~ .x > 5))))
+    (expect_error(filter(df, if_all(~ .x > 5))))
 
     # non expanded case
-    filter(df, !if_any(~ .x > 5))
-    filter(df, !if_all(~ .x > 5))
+    (expect_error(filter(df, !if_any(~ .x > 5))))
+    (expect_error(filter(df, !if_all(~ .x > 5))))
   })
 })
 

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -402,8 +402,13 @@ test_that("if_any() and if_all() respect filter()-like NA handling", {
 test_that("if_any() and if_all() aborts when predicate mistakingly used in .cols= (#5732)", {
   df <- data.frame(x = 1:10, y = 1:10)
   expect_snapshot(error = TRUE, {
+    # expanded case
     filter(df, if_any(~ .x > 5))
     filter(df, if_all(~ .x > 5))
+
+    # non expanded case
+    filter(df, !if_any(~ .x > 5))
+    filter(df, !if_all(~ .x > 5))
   })
 })
 


### PR DESCRIPTION
closes #5732

on the original example, this gives: 

``` r
library(dplyr, warn.conflicts = FALSE)

mtcars %>% 
  filter(if_any(~.x == 39.1))
#> Error: Problem with `filter()` input `..1`.
#> x Misplaced formula shorthand.
#> ℹ You most likely meant to use `.fns = ~.x == 39.1`
#> ℹ ... or perhaps `where(~.x == 39.1)`
#> ℹ Input `..1` is `if_any(~.x == 39.1)`.
```

<sup>Created on 2021-04-09 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
