### PR TITLE
Remove caching of `across()` selections

### DIFF
--- a/R/across.R
+++ b/R/across.R
@@ -235,8 +235,9 @@ across_glue_mask <- function(.col, .fn, .caller_env) {
   glue_mask
 }
 
-# TODO: The usage of a cache in `across_setup()` and `c_across_setup()` is a stopgap solution, and
-# this idea should not be used anywhere else. This should be replaced by the
+# TODO: The usage of a cache in `c_across_setup()` is a stopgap solution, and
+# this idea should not be used anywhere else. This should be replaced by either
+# expansions of expressions (as we now use for `across()`) or the
 # next version of hybrid evaluation, which should offer a way for any function
 # to do any required "set up" work (like the `eval_select()` call) a single
 # time per top-level call, rather than once per group.

--- a/man/across.Rd
+++ b/man/across.Rd
@@ -6,29 +6,11 @@
 \alias{if_all}
 \title{Apply a function (or functions) across multiple columns}
 \usage{
-across(
-  .cols = everything(),
-  .fns = NULL,
-  ...,
-  .names = NULL,
-  .call = sys.call()
-)
+across(.cols = everything(), .fns = NULL, ..., .names = NULL)
 
-if_any(
-  .cols = everything(),
-  .fns = NULL,
-  ...,
-  .names = NULL,
-  .call = sys.call()
-)
+if_any(.cols = everything(), .fns = NULL, ..., .names = NULL)
 
-if_all(
-  .cols = everything(),
-  .fns = NULL,
-  ...,
-  .names = NULL,
-  .call = sys.call()
-)
+if_all(.cols = everything(), .fns = NULL, ..., .names = NULL)
 }
 \arguments{
 \item{.fns}{Functions to apply to each of the selected columns.
@@ -51,9 +33,6 @@ columns. This can use \code{{.col}} to stand for the selected column name, and
 \code{{.fn}} to stand for the name of the function being applied. The default
 (\code{NULL}) is equivalent to \code{"{.col}"} for the single function case and
 \code{"{.col}_{.fn}"} for the case where a list is used for \code{.fns}.}
-
-\item{.call}{Call used by the caching mechanism. This is only useful when \code{across()}
-is called from another function, and should mostly just be ignored.}
 
 \item{cols, .cols}{<\code{\link[=dplyr_tidy_select]{tidy-select}}> Columns to transform.
 Because \code{across()} is used within functions like \code{summarise()} and


### PR DESCRIPTION
- Caching `.fns` is too perilous. The function might produce side effects or depend on state.
- Caching `.cols` is no longer as useful with the top-level `across()` expansion that Romain implemented.

We still cache for `c_across()` as it doesn't have any expansion yet. The caching takes into account the quosure env to improve correctness. Should be further improved by not caching any selection that includes env-expressions since these might have side effects and depend on state.

Future actions:
- Expand top-level `if_any()` and `if_all()` calls.
- Think about macro-expansion approach. Maybe features like `if_any()`, `across()`, etc should be thought of as macros.

Closes #5835.