### PR TITLE
Follow up to #5843, using input instead of column for ..{i}

### DIFF
--- a/R/conditions.R
+++ b/R/conditions.R
@@ -53,8 +53,15 @@ peek_call_step <- function() {
   context_peek("dplyr_call_step", "peek_call_step", "dplyr error handling")
 }
 
-cnd_bullet_header <- function(name = "input") {
-  glue("Problem with `{fn}()` {name} `{error_name}`.", .envir = env(name = name, peek_call_step()))
+cnd_bullet_header <- function() {
+  call_step <- peek_call_step()
+
+  input_name <- "column"
+  if (call_step[["fn"]] == "filter" || grepl("^[.][.]", call_step[["error_name"]])) {
+    input_name <- "input"
+  }
+
+  glue("Problem with `{fn}()` {name} `{error_name}`.", .envir = env(name = input_name, call_step))
 }
 
 cnd_bullet_column_info <- function(){

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -403,7 +403,7 @@ mutate_cols <- function(.data, ..., caller_env) {
     }
 
     bullets <- c(
-      cnd_bullet_header("column"),
+      cnd_bullet_header(),
       bullets,
       i = if(show_group_details) cnd_bullet_cur_group_label()
     )
@@ -428,7 +428,7 @@ mutate_cols <- function(.data, ..., caller_env) {
     local_call_step(dots = dots, .index = i, .fn = "mutate")
 
     warn(c(
-      cnd_bullet_header("column"),
+      cnd_bullet_header(),
       i = cnd_bullet_column_info(),
       i = conditionMessage(w),
       i = cnd_bullet_cur_group_label(what = "warning")

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -340,7 +340,7 @@ summarise_cols <- function(.data, ..., caller_env) {
     }
 
     bullets <- c(
-      cnd_bullet_header("column"),
+      cnd_bullet_header(),
       i = cnd_bullet_column_info(),
       bullets,
       i = if (show_group_details) cnd_bullet_cur_group_label()

--- a/tests/testthat/_snaps/mutate.md
+++ b/tests/testthat/_snaps/mutate.md
@@ -73,7 +73,7 @@
     Code
       tibble(a = 1:3, b = 4:6) %>% group_by(a) %>% mutate(if (a == 1) NULL else "foo")
     Error <dplyr:::mutate_error>
-      Problem with `mutate()` column `..1`.
+      Problem with `mutate()` input `..1`.
       i `..1 = if (a == 1) NULL else "foo"`.
       x `..1` must return compatible vectors across groups.
       i Cannot combine NULL and non NULL results.
@@ -171,7 +171,7 @@
     Code
       tibble() %>% mutate(stop("{"))
     Error <dplyr:::mutate_error>
-      Problem with `mutate()` column `..1`.
+      Problem with `mutate()` input `..1`.
       i `..1 = stop("{")`.
       x {
 

--- a/tests/testthat/_snaps/summarise.md
+++ b/tests/testthat/_snaps/summarise.md
@@ -191,7 +191,7 @@
     Code
       tibble() %>% summarise(stop("{"))
     Error <dplyr_error>
-      Problem with `summarise()` column `..1`.
+      Problem with `summarise()` input `..1`.
       i `..1 = stop("{")`.
       x {
 


### PR DESCRIPTION
``` r
library(tidyverse)
df <- data.frame(a = 1, b = 2, c = 3)
df %>% 
  summarise(across(c(a, b), ~stop("oh no")))
#> Error: Problem with `summarise()` input `..1`.
#> ℹ `..1 = across(c(a, b), ~stop("oh no"))`.
#> x oh no
```

<sup>Created on 2021-04-20 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>