### PR TITLE
expand_across() can access lexical scope.

### DIFF
--- a/R/across.R
+++ b/R/across.R
@@ -502,7 +502,7 @@ expand_across <- function(quo) {
 
   setup <- across_setup(
     !!cols,
-    fns = eval_tidy(expr$.fns, mask),
+    fns = eval_tidy(expr$.fns, mask, env = env),
     names = eval_tidy(expr$.names, mask),
     .caller_env = dplyr_mask$get_caller_env(),
     .top_level = TRUE,

--- a/R/across.R
+++ b/R/across.R
@@ -503,7 +503,7 @@ expand_across <- function(quo) {
   setup <- across_setup(
     !!cols,
     fns = eval_tidy(expr$.fns, mask, env = env),
-    names = eval_tidy(expr$.names, mask),
+    names = eval_tidy(expr$.names, mask, env = env),
     .caller_env = dplyr_mask$get_caller_env(),
     .top_level = TRUE,
     inline = TRUE

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -541,16 +541,16 @@ test_that("across() inlines formulas", {
 })
 
 test_that("across() can access lexical scope (#5862)", {
-  f_across <- function(data, cols, params) {
+  f_across <- function(data, cols, fn) {
     data %>%
       summarise(
-        across({{ cols }}, params$funs)
+        across({{ cols }}, fn)
       )
   }
 
   df <- data.frame(x = 1:10, y = 1:10)
   expect_equal(
-    f_across(df, c(x, y), list(funs = mean)),
+    f_across(df, c(x, y), mean),
     summarise(df, across(c(x, y), mean))
   )
 })

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -540,6 +540,21 @@ test_that("across() inlines formulas", {
   )
 })
 
+test_that("across() can access lexical scope (#5862)", {
+  f_across <- function(data, cols, params) {
+    data %>%
+      summarise(
+        across({{ cols }}, params$funs)
+      )
+  }
+
+  df <- data.frame(x = 1:10, y = 1:10)
+  expect_equal(
+    f_across(df, c(x, y), list(funs = mean)),
+    summarise(df, across(c(x, y), mean))
+  )
+})
+
 test_that("if_any() and if_all() expansions deal with no inputs or single inputs", {
   d <- data.frame(x = 1)
 


### PR DESCRIPTION
closes #5862

``` r
library(dplyr, warn.conflicts = FALSE)

f <- function(data, cols, fn_list) {
  data %>% 
    summarise(
      across({{ cols }}, fn_list$funs)
    )
}

f(mtcars, c(mpg, cyl), list(funs = mean))
#>        mpg    cyl
#> 1 20.09062 6.1875
```

<sup>Created on 2021-04-22 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

seems to fix `skimr::skim()` too: 

``` r
skimr::skim(iris)
```

|                                                  |      |
| :----------------------------------------------- | :--- |
| Name                                             | iris |
| Number of rows                                   | 150  |
| Number of columns                                | 5    |
| \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_   |      |
| Column type frequency:                           |      |
| factor                                           | 1    |
| numeric                                          | 4    |
| \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_ |      |
| Group variables                                  | None |

Data summary

**Variable type: factor**

| skim\_variable | n\_missing | complete\_rate | ordered | n\_unique | top\_counts               |
| :------------- | ---------: | -------------: | :------ | --------: | :------------------------ |
| Species        |          0 |              1 | FALSE   |         3 | set: 50, ver: 50, vir: 50 |

**Variable type: numeric**

| skim\_variable | n\_missing | complete\_rate | mean |   sd |  p0 | p25 |  p50 | p75 | p100 | hist  |
| :------------- | ---------: | -------------: | ---: | ---: | --: | --: | ---: | --: | ---: | :---- |
| Sepal.Length   |          0 |              1 | 5.84 | 0.83 | 4.3 | 5.1 | 5.80 | 6.4 |  7.9 | ▆▇▇▅▂ |
| Sepal.Width    |          0 |              1 | 3.06 | 0.44 | 2.0 | 2.8 | 3.00 | 3.3 |  4.4 | ▁▆▇▂▁ |
| Petal.Length   |          0 |              1 | 3.76 | 1.77 | 1.0 | 1.6 | 4.35 | 5.1 |  6.9 | ▇▁▆▇▂ |
| Petal.Width    |          0 |              1 | 1.20 | 0.76 | 0.1 | 0.3 | 1.30 | 1.8 |  2.5 | ▇▁▇▅▃ |

<sup>Created on 2021-04-22 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>