### PR TITLE
making sure key_deparse() returns a single string

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr (development version)
 
+* `c_across()` and `across()` key deparsing not confused by long calls (#5883).
+
 # dplyr 1.0.6
 
 * `add_count()` is now generic (#5837).

--- a/R/across.R
+++ b/R/across.R
@@ -373,7 +373,7 @@ c_across_setup <- function(cols, key) {
 # https://github.com/r-lib/tidyselect/issues/235
 key_deparse <- function(cols) {
   paste(
-    deparse(quo_get_expr(cols)),
+    paste0(deparse(quo_get_expr(cols)), collapse = "\n"),
     format(quo_get_env(cols))
   )
 }

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -611,3 +611,10 @@ test_that("selects and combines columns", {
   out <- df %>% summarise(z = list(c_across(x:y)))
   expect_equal(out$z, list(1:4))
 })
+
+test_that("key_deparse() collapses (#5883)", {
+  expect_equal(
+    length(key_deparse(quo(all_of(c("aaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbb", "cccccccccccccc", "ddddddddddddddddddd"))))),
+    1
+  )
+})


### PR DESCRIPTION
closes #5883

original example from #5883

``` r
library(tidyverse)

FOOBAR.df <- data.frame(matrix(rnorm(50), nrow = 10))
colnames(FOOBAR.df) <- c("Prevotella", "Streptococcus", "Gemella", "Rothia", "Haemophilus")
FOOBAR.df %>% 
  rowwise() %>% 
  transmute(sum(c_across(all_of(c("Prevotella", "Streptococcus", "Gemella", "Rothia", "Haemophilus")))))
#> # A tibble: 10 x 1
#> # Rowwise: 
#>    `sum(...)`
#>         <dbl>
#>  1      0.673
#>  2      3.51 
#>  3     -0.463
#>  4     -3.28 
#>  5     -1.43 
#>  6     -2.56 
#>  7     -4.42 
#>  8     -2.06 
#>  9      0.473
#> 10      0.297
```

<sup>Created on 2021-05-17 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>