### PR TITLE
use the formula environment as the newly created quosure environment.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr (development version)
 
+* `across()` uses the formula environment when inlining them (#5886).
+
 # dplyr 1.0.6
 
 * `add_count()` is now generic (#5837).

--- a/R/across.R
+++ b/R/across.R
@@ -571,26 +571,11 @@ expand_across <- function(quo) {
 }
 
 # TODO: Take unevaluated `.fns` and inline calls to `function`. This
-# will enable support for R 4.1 lambdas. This plan is somewhat at odds
-# with the current UI of `across()` which takes a list of function. We
-# would need to intepret calls to `list()` specially. And then we
-# would miss calls to `list2()` etc. This is another way in which the
-# current UI is unsatisfactory from the viewpoint of optimisation.
-#
-# Note that the current implementation is not 100% correct in that
-# regard as we ignore the environment of formulas and instead use the
-# quosure environment. This means this doesn't work as expected:
-#
-# ```
-# local({
-#   prefix <- "foo"
-#   f <- ~ paste(prefix, .x)
-# })
-# mutate(data, across(sel, f))
-# ```
-#
-# If we inspected unevaluated calls instead, we would see a symbol `f`
-# and fall through the `as_function()` branch.
+# will enable support for R 4.1 lambdas. Note that unlike formulas,
+# only unevaluated `function` calls can be inlined. This will have
+# performance implications for lists of lambdas where formulas will
+# have better performance. It is possible that we will be able to
+# inline evaluated functions with strictness annotations.
 as_across_fn_call <- function(fn, var, env) {
   if (is_formula(fn, lhs = FALSE)) {
     # Don't need to worry about arguments passed through `...`

--- a/R/across.R
+++ b/R/across.R
@@ -597,7 +597,7 @@ as_across_fn_call <- function(fn, var, env) {
     # because we cancel expansion in that case
     fn <- expr_substitute(fn, quote(.), sym(var))
     fn <- expr_substitute(fn, quote(.x), sym(var))
-    new_quosure(f_rhs(fn), env)
+    new_quosure(f_rhs(fn), f_env(fn))
   } else {
     fn_call <- call2(as_function(fn), sym(var))
     new_quosure(fn_call, env)

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -542,6 +542,25 @@ test_that("across() inlines formulas", {
   )
 })
 
+test_that("across() uses local formula environment (#5881)", {
+  f <- local({
+    prefix <- "foo"
+    ~ paste(prefix, .x)
+  })
+  df <- data.frame(x = "x")
+  expect_equal(
+    mutate(df, across(x, f)),
+    data.frame(x = "foo x")
+  )
+})
+
+test_that("unevaluated formulas (currently) fail", {
+  df <- data.frame(x = "x")
+  expect_error(
+    mutate(df, across(x, quote(~ paste("foo", .x))))
+  )
+})
+
 test_that("across() can access lexical scope (#5862)", {
   f_across <- function(data, cols, fn) {
     data %>%

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -547,15 +547,15 @@ test_that("across() uses local formula environment (#5881)", {
     prefix <- "foo"
     ~ paste(prefix, .x)
   })
-  df <- data.frame(x = "x")
+  df <- tibble(x = "x")
   expect_equal(
     mutate(df, across(x, f)),
-    data.frame(x = "foo x")
+    tibble(x = "foo x")
   )
 })
 
 test_that("unevaluated formulas (currently) fail", {
-  df <- data.frame(x = "x")
+  df <- tibble(x = "x")
   expect_error(
     mutate(df, across(x, quote(~ paste("foo", .x))))
   )

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -528,15 +528,17 @@ test_that("can pass quosure through `across()`", {
 
 test_that("across() inlines formulas", {
   env <- env()
+  f <- ~ toupper(.x)
 
   expect_equal(
-    as_across_fn_call(~ toupper(.x), quote(foo), env),
-    new_quosure(quote(toupper(foo)), env)
+    as_across_fn_call(f, quote(foo), env),
+    new_quosure(quote(toupper(foo)), f_env(f))
   )
 
+  f <- ~ list(.x, ., .x)
   expect_equal(
-    as_across_fn_call(~ list(.x, ., .x), quote(foo), env),
-    new_quosure(quote(list(foo, foo, foo)), env)
+    as_across_fn_call(f, quote(foo), env),
+    new_quosure(quote(list(foo, foo, foo)), f_env(f))
   )
 })
 


### PR DESCRIPTION
closes #5881

``` r
# pak::pak("msberends/AMR@v1.6.0")
library(AMR)
library(skimr)

skim(example_isolates)
```

|                                                  |                   |
| :----------------------------------------------- | :---------------- |
| Name                                             | example\_isolates |
| Number of rows                                   | 2000              |
| Number of columns                                | 49                |
| \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_   |                   |
| Column type frequency:                           |                   |
| character                                        | 2                 |
| Date                                             | 1                 |
| factor                                           | 1                 |
| logical                                          | 3                 |
| mo                                               | 1                 |
| numeric                                          | 1                 |
| rsi                                              | 40                |
| \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_ |                   |
| Group variables                                  | None              |

Data summary

**Variable type: character**

| skim\_variable | n\_missing | complete\_rate | min | max | empty | n\_unique | whitespace |
| :------------- | ---------: | -------------: | --: | --: | ----: | --------: | ---------: |
| gender         |          0 |              1 |   1 |   1 |     0 |         2 |          0 |
| patient\_id    |          0 |              1 |   6 |   6 |     0 |       981 |          0 |

**Variable type: Date**

| skim\_variable | n\_missing | complete\_rate | min        | max        | median     | n\_unique |
| :------------- | ---------: | -------------: | :--------- | :--------- | :--------- | --------: |
| date           |          0 |              1 | 2002-01-02 | 2017-12-28 | 2009-07-31 |      1140 |

**Variable type: factor**

| skim\_variable | n\_missing | complete\_rate | ordered | n\_unique | top\_counts                    |
| :------------- | ---------: | -------------: | :------ | --------: | :----------------------------- |
| hospital\_id   |          0 |              1 | FALSE   |         4 | D: 762, B: 663, A: 321, C: 254 |

**Variable type: logical**

| skim\_variable   | n\_missing | complete\_rate | mean | count               |
| :--------------- | ---------: | -------------: | ---: | :------------------ |
| ward\_icu        |          0 |              1 | 0.32 | FAL: 1354, TRU: 646 |
| ward\_clinical   |          0 |              1 | 0.73 | TRU: 1464, FAL: 536 |
| ward\_outpatient |          0 |              1 | 0.06 | FAL: 1880, TRU: 120 |

**Variable type: mo**

| skim\_variable | n\_missing | complete\_rate | unique\_total | gram\_negative | gram\_positive | top\_genus     | top\_species     |
| :------------- | ---------: | -------------: | ------------: | -------------: | -------------: | :------------- | :--------------- |
| mo             |          0 |              1 |            90 |             NA |             NA | Staphylococcus | Escherichia coli |

**Variable type: numeric**

| skim\_variable | n\_missing | complete\_rate |  mean |    sd | p0 | p25 | p50 | p75 | p100 | hist  |
| :------------- | ---------: | -------------: | ----: | ----: | -: | --: | --: | --: | ---: | :---- |
| age            |          0 |              1 | 71.06 | 14.12 | 14 |  63 |  74 |  82 |   97 | ▁▁▃▇▅ |

**Variable type: rsi**

| skim\_variable | n\_missing | complete\_rate | ab\_name | count\_R | count\_S | count\_I | prop\_R | prop\_S | prop\_I |
| :------------- | ---------: | -------------: | :------- | -------: | -------: | -------: | ------: | ------: | ------: |
| PEN            |        371 |           0.81 | NA       |     1201 |      428 |       11 |    0.74 |    0.26 |    0.01 |
| OXA            |       1635 |           0.18 | NA       |      114 |      251 |        0 |    0.31 |    0.69 |    0.00 |
| FLC            |       1057 |           0.47 | NA       |      278 |      665 |        0 |    0.29 |    0.71 |    0.00 |
| AMX            |        650 |           0.68 | NA       |      804 |      546 |        3 |    0.60 |    0.40 |    0.00 |
| AMC            |        121 |           0.94 | NA       |      446 |     1433 |       91 |    0.24 |    0.76 |    0.05 |
| AMP            |        650 |           0.68 | NA       |      804 |      546 |        3 |    0.60 |    0.40 |    0.00 |
| TZP            |        999 |           0.50 | NA       |      126 |      875 |       13 |    0.13 |    0.87 |    0.01 |
| CZO            |       1554 |           0.22 | NA       |      199 |      247 |        2 |    0.45 |    0.55 |    0.00 |
| FEP            |       1276 |           0.36 | NA       |      103 |      621 |        1 |    0.14 |    0.86 |    0.00 |
| CXM            |        211 |           0.89 | NA       |      470 |     1319 |       22 |    0.26 |    0.74 |    0.01 |
| FOX            |       1182 |           0.41 | NA       |      224 |      594 |        8 |    0.27 |    0.73 |    0.01 |
| CTX            |       1057 |           0.47 | NA       |      146 |      797 |        1 |    0.15 |    0.85 |    0.00 |
| CAZ            |        189 |           0.91 | NA       |     1204 |      607 |        0 |    0.66 |    0.34 |    0.00 |
| CRO            |       1057 |           0.47 | NA       |      146 |      797 |        1 |    0.15 |    0.85 |    0.00 |
| GEN            |        145 |           0.93 | NA       |      456 |     1399 |       27 |    0.25 |    0.75 |    0.01 |
| TOB            |        649 |           0.68 | NA       |      465 |      886 |        7 |    0.34 |    0.66 |    0.01 |
| AMK            |       1308 |           0.35 | NA       |      441 |      251 |        0 |    0.64 |    0.36 |    0.00 |
| KAN            |       1529 |           0.24 | NA       |      471 |        0 |        0 |    1.00 |    0.00 |    0.00 |
| TMP            |        501 |           0.75 | NA       |      571 |      928 |       10 |    0.38 |    0.62 |    0.01 |
| SXT            |        241 |           0.88 | NA       |      361 |     1398 |        6 |    0.21 |    0.79 |    0.00 |
| NIT            |       1257 |           0.37 | NA       |      127 |      616 |       51 |    0.17 |    0.83 |    0.07 |
| FOS            |       1649 |           0.18 | NA       |      148 |      203 |        0 |    0.42 |    0.58 |    0.00 |
| LNZ            |        977 |           0.51 | NA       |      709 |      314 |        0 |    0.69 |    0.31 |    0.00 |
| CIP            |        591 |           0.70 | NA       |      228 |     1181 |       69 |    0.16 |    0.84 |    0.05 |
| MFX            |       1789 |           0.11 | NA       |       71 |      140 |        4 |    0.34 |    0.66 |    0.02 |
| VAN            |        139 |           0.93 | NA       |      712 |     1149 |        0 |    0.38 |    0.62 |    0.00 |
| TEC            |       1024 |           0.49 | NA       |      739 |      237 |        0 |    0.76 |    0.24 |    0.00 |
| TCY            |        800 |           0.60 | NA       |      357 |      843 |       23 |    0.30 |    0.70 |    0.02 |
| TGC            |       1202 |           0.40 | NA       |      101 |      697 |        0 |    0.13 |    0.87 |    0.00 |
| DOX            |        864 |           0.57 | NA       |      315 |      821 |        7 |    0.28 |    0.72 |    0.01 |
| ERY            |        106 |           0.95 | NA       |     1084 |      810 |        9 |    0.57 |    0.43 |    0.00 |
| CLI            |        480 |           0.76 | NA       |      930 |      590 |        4 |    0.61 |    0.39 |    0.00 |
| AZM            |        106 |           0.95 | NA       |     1084 |      810 |        9 |    0.57 |    0.43 |    0.00 |
| IPM            |       1111 |           0.44 | NA       |       55 |      834 |       10 |    0.06 |    0.94 |    0.01 |
| MEM            |       1171 |           0.41 | NA       |       49 |      780 |        0 |    0.06 |    0.94 |    0.00 |
| MTR            |       1966 |           0.02 | NA       |        5 |       29 |        0 |    0.15 |    0.85 |    0.00 |
| CHL            |       1846 |           0.08 | NA       |       33 |      121 |        0 |    0.21 |    0.79 |    0.00 |
| COL            |        360 |           0.82 | NA       |     1331 |      309 |        0 |    0.81 |    0.19 |    0.00 |
| MUP            |       1730 |           0.14 | NA       |       16 |      254 |        3 |    0.06 |    0.94 |    0.01 |
| RIF            |        997 |           0.50 | NA       |      698 |      305 |        2 |    0.70 |    0.30 |    0.00 |

<sup>Created on 2021-05-17 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>