### PR TITLE
`across()` handles named selections, part of #5207

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * `c_across()` and `across()` key deparsing not confused by long calls (#5883).
 
+* `across()` handles named selections (#5207).
+
 # dplyr 1.0.6
 
 * `add_count()` is now generic (#5837).

--- a/R/across.R
+++ b/R/across.R
@@ -287,13 +287,17 @@ across_setup <- function(cols,
       i = "The second argument `.fns` operates on each selected columns."
     ))
   }
-  vars <- tidyselect::eval_select(cols, data = mask$across_cols())
-  vars <- names(vars)
+  across_cols <- mask$across_cols()
+  vars <- tidyselect::eval_select(cols, data = across_cols)
+  names_vars <- names(vars)
+  vars <- names(across_cols)[vars]
 
   if (is.null(fns)) {
     if (!is.null(names)) {
-      glue_mask <- across_glue_mask(.caller_env, .col = vars, .fn = "1")
+      glue_mask <- across_glue_mask(.caller_env, .col = names_vars, .fn = "1")
       names <- vec_as_names(glue(names, .envir = glue_mask), repair = "check_unique")
+    } else {
+      names <- names_vars
     }
 
     value <- list(vars = vars, fns = fns, names = names)
@@ -326,8 +330,8 @@ across_setup <- function(cols,
   }
 
   glue_mask <- glue_mask <- across_glue_mask(.caller_env,
-    .col = rep(vars, each = length(fns)),
-    .fn  = rep(names_fns, length(vars))
+    .col = rep(names_vars, each = length(fns)),
+    .fn  = rep(names_fns , length(vars))
   )
   names <- vec_as_names(glue(names, .envir = glue_mask), repair = "check_unique")
 

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -603,6 +603,70 @@ test_that("if_any() and if_all() wrapped deal with no inputs or single inputs", 
   )
 })
 
+test_that("across() can use named selections", {
+  df <- data.frame(x = 1, y = 2)
+
+  # no fns
+  expect_equal(
+    df %>% summarise(across(c(a = x, b = y))),
+    data.frame(a = 1, b = 2)
+  )
+  expect_equal(
+    df %>% summarise(across(all_of(c(a = "x", b = "y")))),
+    data.frame(a = 1, b = 2)
+  )
+
+  # no fns, non expanded
+  expect_equal(
+    df %>% summarise((across(c(a = x, b = y)))),
+    data.frame(a = 1, b = 2)
+  )
+  expect_equal(
+    df %>% summarise((across(all_of(c(a = "x", b = "y"))))),
+    data.frame(a = 1, b = 2)
+  )
+
+  # one fn
+  expect_equal(
+    df %>% summarise(across(c(a = x, b = y), mean)),
+    data.frame(a = 1, b = 2)
+  )
+  expect_equal(
+    df %>% summarise(across(all_of(c(a = "x", b = "y")), mean)),
+    data.frame(a = 1, b = 2)
+  )
+
+  # one fn - non expanded
+  expect_equal(
+    df %>% summarise((across(c(a = x, b = y), mean))),
+    data.frame(a = 1, b = 2)
+  )
+  expect_equal(
+    df %>% summarise((across(all_of(c(a = "x", b = "y")), mean))),
+    data.frame(a = 1, b = 2)
+  )
+
+  # multiple fns
+  expect_equal(
+    df %>% summarise(across(c(a = x, b = y), list(mean = mean, sum = sum))),
+    data.frame(a_mean = 1, a_sum = 1, b_mean = 2, b_sum = 2)
+  )
+  expect_equal(
+    df %>% summarise(across(all_of(c(a = "x", b = "y")), list(mean = mean, sum = sum))),
+    data.frame(a_mean = 1, a_sum = 1, b_mean = 2, b_sum = 2)
+  )
+
+  # multiple fns - non expanded
+  expect_equal(
+    df %>% summarise((across(c(a = x, b = y), list(mean = mean, sum = sum)))),
+    data.frame(a_mean = 1, a_sum = 1, b_mean = 2, b_sum = 2)
+  )
+  expect_equal(
+    df %>% summarise((across(all_of(c(a = "x", b = "y")), list(mean = mean, sum = sum)))),
+    data.frame(a_mean = 1, a_sum = 1, b_mean = 2, b_sum = 2)
+  )
+})
+
 
 # c_across ----------------------------------------------------------------
 


### PR DESCRIPTION
This is the `across()` related part of #5207: 

``` r
library(dplyr, warn.conflicts = FALSE)

df <- data.frame(x = 1, y = 2)
df %>% 
  summarise(across(c(z = x)))
#>   z
#> 1 1
df %>% 
  summarise(across(all_of(c(z = "x"))))
#>   z
#> 1 1

df %>% 
  summarise(across(c(z = x), mean))
#>   z
#> 1 1
df %>% 
  summarise(across(all_of(c(z = "x")), mean))
#>   z
#> 1 1

df %>% 
  summarise(across(c(z = x), list(mean = mean)))
#>   z_mean
#> 1      1
df %>% 
  summarise(across(all_of(c(z = "x")), list(mean = mean)))
#>   z_mean
#> 1      1
```

<sup>Created on 2021-05-19 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>