### PR TITLE
Fixes for `across()` substitution

### DIFF
--- a/R/across.R
+++ b/R/across.R
@@ -509,7 +509,7 @@ expand_across <- function(quo) {
 
   setup <- across_setup(
     !!cols,
-    fns = eval_tidy(expr$.fns, mask, env = env),
+    fns = eval_tidy(expr$.fns, mask, env = env(env, ....expand_across = TRUE)),
     names = eval_tidy(expr$.names, mask, env = env),
     .caller_env = dplyr_mask$get_caller_env(),
     .top_level = TRUE,
@@ -557,7 +557,7 @@ expand_across <- function(quo) {
     var <- vars[[i]]
 
     for (j in seq_fns) {
-      fn_call <- as_across_fn_call(fns[[j]], var, env, is_call(expr$.fns, "~"))
+      fn_call <- as_across_fn_call(fns[[j]], var, env)
 
       name <- names[[k]]
       expressions[[k]] <- new_dplyr_quosure(
@@ -583,13 +583,19 @@ expand_across <- function(quo) {
 # performance implications for lists of lambdas where formulas will
 # have better performance. It is possible that we will be able to
 # inline evaluated functions with strictness annotations.
-as_across_fn_call <- function(fn, var, env, is_unevaluated_formula = FALSE) {
+as_across_fn_call <- function(fn, var, env) {
   if (is_formula(fn, lhs = FALSE)) {
     # Don't need to worry about arguments passed through `...`
     # because we cancel expansion in that case
     fn <- expr_substitute(fn, quote(.), sym(var))
     fn <- expr_substitute(fn, quote(.x), sym(var))
-    new_quosure(f_rhs(fn), if(is_unevaluated_formula) env else f_env(fn))
+
+    f_env <- f_env(fn)
+    if (!is.null(f_env$.__tidyeval_data_mask__.)) {
+      f_env <- env
+    }
+
+    new_quosure(f_rhs(fn), f_env)
   } else {
     fn_call <- call2(as_function(fn), sym(var))
     new_quosure(fn_call, env)

--- a/R/across.R
+++ b/R/across.R
@@ -428,12 +428,13 @@ expand_if_across <- function(quo) {
   if (!quo_is_call(quo, c("if_any", "if_all"), ns = c("", "dplyr"))) {
     return(list(quo))
   }
+  quo_env <- quo_get_env(quo)
 
   call <- match.call(
     definition = if_any,
     call = quo_get_expr(quo),
     expand.dots = FALSE,
-    envir = quo_get_env(quo)
+    envir = quo_env
   )
   if (!is_null(call$...)) {
     return(list(quo))
@@ -467,7 +468,7 @@ expand_if_across <- function(quo) {
 
   # Use `as_quosure()` instead of `new_quosure()` to avoid rewrapping
   # quosure in case of single input
-  list(as_quosure(expr, env = baseenv()))
+  list(as_quosure(expr, env = quo_env))
 }
 
 expand_across <- function(quo) {

--- a/R/across.R
+++ b/R/across.R
@@ -428,13 +428,12 @@ expand_if_across <- function(quo) {
   if (!quo_is_call(quo, c("if_any", "if_all"), ns = c("", "dplyr"))) {
     return(list(quo))
   }
-  quo_env <- quo_get_env(quo)
 
   call <- match.call(
     definition = if_any,
     call = quo_get_expr(quo),
     expand.dots = FALSE,
-    envir = quo_env
+    envir = quo_get_env(quo)
   )
   if (!is_null(call$...)) {
     return(list(quo))

--- a/R/across.R
+++ b/R/across.R
@@ -586,8 +586,9 @@ as_across_fn_call <- function(fn, var, env, mask) {
   if (is_formula(fn, lhs = FALSE)) {
     # Don't need to worry about arguments passed through `...`
     # because we cancel expansion in that case
-    fn <- expr_substitute(fn, quote(.), sym(var))
-    fn <- expr_substitute(fn, quote(.x), sym(var))
+    expr <- f_rhs(fn)
+    expr <- expr_substitute(expr, quote(.), sym(var))
+    expr <- expr_substitute(expr, quote(.x), sym(var))
 
     # if the formula environment is the data mask
     # it means the formula was unevaluated, and in that case
@@ -599,7 +600,7 @@ as_across_fn_call <- function(fn, var, env, mask) {
       f_env <- env
     }
 
-    new_quosure(f_rhs(fn), f_env)
+    new_quosure(expr, f_env)
   } else {
     fn_call <- call2(as_function(fn), sym(var))
     new_quosure(fn_call, env)

--- a/R/across.R
+++ b/R/across.R
@@ -509,7 +509,7 @@ expand_across <- function(quo) {
 
   setup <- across_setup(
     !!cols,
-    fns = eval_tidy(expr$.fns, mask, env = env(env, ....expand_across = TRUE)),
+    fns = eval_tidy(expr$.fns, mask, env = env),
     names = eval_tidy(expr$.names, mask, env = env),
     .caller_env = dplyr_mask$get_caller_env(),
     .top_level = TRUE,
@@ -557,7 +557,7 @@ expand_across <- function(quo) {
     var <- vars[[i]]
 
     for (j in seq_fns) {
-      fn_call <- as_across_fn_call(fns[[j]], var, env)
+      fn_call <- as_across_fn_call(fns[[j]], var, env, mask)
 
       name <- names[[k]]
       expressions[[k]] <- new_dplyr_quosure(
@@ -583,7 +583,7 @@ expand_across <- function(quo) {
 # performance implications for lists of lambdas where formulas will
 # have better performance. It is possible that we will be able to
 # inline evaluated functions with strictness annotations.
-as_across_fn_call <- function(fn, var, env) {
+as_across_fn_call <- function(fn, var, env, mask) {
   if (is_formula(fn, lhs = FALSE)) {
     # Don't need to worry about arguments passed through `...`
     # because we cancel expansion in that case
@@ -591,7 +591,7 @@ as_across_fn_call <- function(fn, var, env) {
     fn <- expr_substitute(fn, quote(.x), sym(var))
 
     f_env <- f_env(fn)
-    if (!is.null(f_env$.__tidyeval_data_mask__.)) {
+    if (identical(f_env, mask)) {
       f_env <- env
     }
 

--- a/R/across.R
+++ b/R/across.R
@@ -590,6 +590,11 @@ as_across_fn_call <- function(fn, var, env, mask) {
     fn <- expr_substitute(fn, quote(.), sym(var))
     fn <- expr_substitute(fn, quote(.x), sym(var))
 
+    # if the formula environment is the data mask
+    # it means the formula was unevaluated, and in that case
+    # we can use the original quosure environment
+    # otherwise, use the formula environment, as it was previously
+    # evaluated and might include data that is not reacha
     f_env <- f_env(fn)
     if (identical(f_env, mask)) {
       f_env <- env

--- a/R/across.R
+++ b/R/across.R
@@ -507,17 +507,9 @@ expand_across <- function(quo) {
   }
   cols <- as_quosure(cols, env)
 
-  # Cancel expansions when a list of functions is used
-  # because we can't easily make the distinction between
-  # unevaluated formulas and evaluated formulas
-  evaluated_fns <- eval_tidy(expr$.fns, mask, env = env)
-  if (is.list(evaluated_fns)) {
-    return(list(quo))
-  }
-
   setup <- across_setup(
     !!cols,
-    fns = evaluated_fns,
+    fns = eval_tidy(expr$.fns, mask, env = env),
     names = eval_tidy(expr$.names, mask, env = env),
     .caller_env = dplyr_mask$get_caller_env(),
     .top_level = TRUE,

--- a/R/filter.R
+++ b/R/filter.R
@@ -111,15 +111,15 @@ filter <- function(.data, ..., .preserve = FALSE) {
 
 #' @export
 filter.data.frame <- function(.data, ..., .preserve = FALSE) {
-  loc <- filter_rows(.data, ...)
+  loc <- filter_rows(.data, ..., caller_env = caller_env())
   dplyr_row_slice(.data, loc, preserve = .preserve)
 }
 
-filter_rows <- function(.data, ...) {
+filter_rows <- function(.data, ..., caller_env) {
   dots <- dplyr_quosures(...)
   check_filter(dots)
 
-  mask <- DataMask$new(.data, caller_env())
+  mask <- DataMask$new(.data, caller_env)
   on.exit(mask$forget("filter"), add = TRUE)
 
   env_filter <- env()

--- a/R/utils.r
+++ b/R/utils.r
@@ -144,9 +144,8 @@ expr_substitute <- function(expr, old, new) {
 }
 node_walk_replace <- function(node, old, new) {
   while (!is_null(node)) {
-    switch(
-      typeof(node_car(node)),
-      language = node_walk_replace(node_cdar(node), old, new),
+    switch(typeof(node_car(node)),
+      language = if (!is_call(node_car(node), c("~", "function"))) node_walk_replace(node_cdar(node), old, new),
       symbol = if (identical(node_car(node), old)) node_poke_car(node, new)
     )
     node <- node_cdr(node)

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -1,34 +1,37 @@
 # Revdeps
 
-## Failed to check (20)
+## Failed to check (22)
 
-|package      |version |error |warning |note |
-|:------------|:-------|:-----|:-------|:----|
-|bayesdfa     |1.0.0   |1     |        |     |
-|CausalImpact |?       |      |        |     |
-|CB2          |?       |      |        |     |
-|cbar         |?       |      |        |     |
-|crossmap     |?       |      |        |     |
-|diceR        |?       |      |        |     |
-|glmmfields   |0.1.4   |1     |        |     |
-|loon.shiny   |?       |      |        |     |
-|metagam      |?       |      |        |     |
-|mlbstatsR    |0.1.0   |1     |        |     |
-|pencal       |?       |      |        |     |
-|rabhit       |?       |      |        |     |
-|rmdcev       |1.2.4   |1     |        |     |
-|NA           |?       |      |        |     |
-|rstap        |1.0.3   |1     |        |     |
-|scoper       |?       |      |        |     |
-|tigger       |?       |      |        |     |
-|trackr       |?       |      |        |     |
-|vivid        |?       |      |        |     |
-|wrswoR       |?       |      |        |     |
+|package        |version |error |warning |note |
+|:--------------|:-------|:-----|:-------|:----|
+|bayesdfa       |1.1.0   |1     |        |     |
+|CausalImpact   |?       |      |        |     |
+|CB2            |?       |      |        |     |
+|crossmap       |?       |      |        |     |
+|diceR          |?       |      |        |     |
+|glmmfields     |0.1.4   |1     |        |     |
+|loon.shiny     |?       |      |        |     |
+|MarketMatching |?       |      |        |     |
+|metagam        |?       |      |        |     |
+|mlbstatsR      |0.1.0   |1     |        |     |
+|NA             |?       |      |        |     |
+|pencal         |?       |      |        |     |
+|rabhit         |?       |      |        |     |
+|raw            |?       |      |        |     |
+|rmdcev         |1.2.4   |1     |        |     |
+|rstap          |1.0.3   |1     |        |     |
+|scoper         |?       |      |        |     |
+|SynthETIC      |?       |      |        |     |
+|tigger         |?       |      |        |     |
+|trackr         |?       |      |        |     |
+|vivid          |?       |      |        |     |
+|wrswoR         |?       |      |        |     |
 
-## New problems (2)
+## New problems (3)
 
-|package                              |version |error  |warning |note |
-|:------------------------------------|:-------|:------|:-------|:----|
-|[finreportr](problems.md#finreportr) |1.0.2   |__+2__ |        |     |
-|[readabs](problems.md#readabs)       |0.4.9   |__+2__ |        |     |
+|package                              |version |error    |warning |note |
+|:------------------------------------|:-------|:--------|:-------|:----|
+|[finreportr](problems.md#finreportr) |1.0.2   |1 __+1__ |        |     |
+|[SwimmeR](problems.md#swimmer)       |0.10.0  |__+1__   |        |     |
+|[xray](problems.md#xray)             |0.2     |__+1__   |        |     |
 

--- a/revdep/cran.md
+++ b/revdep/cran.md
@@ -1,9 +1,9 @@
 ## revdepcheck results
 
-We checked 2520 reverse dependencies (2519 from CRAN + 1 from Bioconductor), comparing R CMD check results across CRAN and dev versions of this package.
+We checked 2545 reverse dependencies (2544 from CRAN + 1 from Bioconductor), comparing R CMD check results across CRAN and dev versions of this package.
 
- * We saw 2 new problems
- * We failed to check 19 packages
+ * We saw 3 new problems
+ * We failed to check 21 packages
 
 Issues with CRAN packages are summarised below.
 
@@ -11,31 +11,34 @@ Issues with CRAN packages are summarised below.
 (This reports the first line of each new failure)
 
 * finreportr
-  checking examples ... ERROR
   checking tests ... ERROR
 
-* readabs
-  checking examples ... ERROR
+* SwimmeR
   checking tests ... ERROR
+
+* xray
+  checking examples ... ERROR
 
 ### Failed to check
 
-* bayesdfa     (NA)
-* CausalImpact (NA)
-* CB2          (NA)
-* cbar         (NA)
-* crossmap     (NA)
-* diceR        (NA)
-* glmmfields   (NA)
-* loon.shiny   (NA)
-* metagam      (NA)
-* mlbstatsR    (NA)
-* pencal       (NA)
-* rabhit       (NA)
-* rmdcev       (NA)
-* rstap        (NA)
-* scoper       (NA)
-* tigger       (NA)
-* trackr       (NA)
-* vivid        (NA)
-* wrswoR       (NA)
+* bayesdfa       (NA)
+* CausalImpact   (NA)
+* CB2            (NA)
+* crossmap       (NA)
+* diceR          (NA)
+* glmmfields     (NA)
+* loon.shiny     (NA)
+* MarketMatching (NA)
+* metagam        (NA)
+* mlbstatsR      (NA)
+* pencal         (NA)
+* rabhit         (NA)
+* raw            (NA)
+* rmdcev         (NA)
+* rstap          (NA)
+* scoper         (NA)
+* SynthETIC      (NA)
+* tigger         (NA)
+* trackr         (NA)
+* vivid          (NA)
+* wrswoR         (NA)

--- a/revdep/failures.md
+++ b/revdep/failures.md
@@ -2,10 +2,10 @@
 
 <details>
 
-* Version: 1.0.0
+* Version: 1.1.0
 * GitHub: https://github.com/fate-ewi/bayesdfa
 * Source code: https://github.com/cran/bayesdfa
-* Date/Publication: 2021-05-19 02:00:02 UTC
+* Date/Publication: 2021-05-28 18:10:05 UTC
 * Number of recursive dependencies: 81
 
 Run `cloud_details(, "bayesdfa")` for more info
@@ -197,72 +197,6 @@ Status: 1 ERROR
 * checking package namespace information ... OK
 * checking package dependencies ... ERROR
 Package required but not available: ‘metap’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# cbar
-
-<details>
-
-* Version: 0.1.3
-* GitHub: https://github.com/zedoul/cbar
-* Source code: https://github.com/cran/cbar
-* Date/Publication: 2017-10-24 13:20:22 UTC
-* Number of recursive dependencies: 63
-
-Run `cloud_details(, "cbar")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/cbar/new/cbar.Rcheck’
-* using R version 4.0.3 (2020-10-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using options ‘--no-manual --no-build-vignettes’
-* checking for file ‘cbar/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘cbar’ version ‘0.1.3’
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Packages required but not available: 'Boom', 'bsts'
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/cbar/old/cbar.Rcheck’
-* using R version 4.0.3 (2020-10-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using options ‘--no-manual --no-build-vignettes’
-* checking for file ‘cbar/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘cbar’ version ‘0.1.3’
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Packages required but not available: 'Boom', 'bsts'
 
 See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
 manual.
@@ -544,6 +478,72 @@ Status: 1 ERROR
 
 
 ```
+# MarketMatching
+
+<details>
+
+* Version: 1.2.0
+* GitHub: NA
+* Source code: https://github.com/cran/MarketMatching
+* Date/Publication: 2021-01-08 20:10:02 UTC
+* Number of recursive dependencies: 67
+
+Run `cloud_details(, "MarketMatching")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/MarketMatching/new/MarketMatching.Rcheck’
+* using R version 4.0.3 (2020-10-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘MarketMatching/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘MarketMatching’ version ‘1.2.0’
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Packages required but not available: 'CausalImpact', 'bsts', 'Boom'
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/MarketMatching/old/MarketMatching.Rcheck’
+* using R version 4.0.3 (2020-10-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘MarketMatching/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘MarketMatching’ version ‘1.2.0’
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Packages required but not available: 'CausalImpact', 'bsts', 'Boom'
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
 # metagam
 
 <details>
@@ -552,7 +552,7 @@ Status: 1 ERROR
 * GitHub: https://github.com/Lifebrain/metagam
 * Source code: https://github.com/cran/metagam
 * Date/Publication: 2020-11-12 08:10:02 UTC
-* Number of recursive dependencies: 144
+* Number of recursive dependencies: 145
 
 Run `cloud_details(, "metagam")` for more info
 
@@ -676,14 +676,49 @@ ERROR: lazy loading failed for package ‘mlbstatsR’
 
 
 ```
+# NA
+
+<details>
+
+* Version: NA
+* GitHub: NA
+* Source code: https://github.com/cran/NA
+* Number of recursive dependencies: 0
+
+Run `cloud_details(, "NA")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+
+
+
+```
+### CRAN
+
+```
+
+
+
+
+
+
+```
 # pencal
 
 <details>
 
-* Version: 0.4.1
+* Version: 0.4.2
 * GitHub: NA
 * Source code: https://github.com/cran/pencal
-* Date/Publication: 2021-04-19 14:50:02 UTC
+* Date/Publication: 2021-05-28 09:30:02 UTC
 * Number of recursive dependencies: 149
 
 Run `cloud_details(, "pencal")` for more info
@@ -701,7 +736,7 @@ Run `cloud_details(, "pencal")` for more info
 * using session charset: UTF-8
 * using options ‘--no-manual --no-build-vignettes’
 * checking for file ‘pencal/DESCRIPTION’ ... OK
-* this is package ‘pencal’ version ‘0.4.1’
+* this is package ‘pencal’ version ‘0.4.2’
 * package encoding: UTF-8
 * checking package namespace information ... OK
 * checking package dependencies ... ERROR
@@ -728,7 +763,7 @@ Status: 1 ERROR
 * using session charset: UTF-8
 * using options ‘--no-manual --no-build-vignettes’
 * checking for file ‘pencal/DESCRIPTION’ ... OK
-* this is package ‘pencal’ version ‘0.4.1’
+* this is package ‘pencal’ version ‘0.4.2’
 * package encoding: UTF-8
 * checking package namespace information ... OK
 * checking package dependencies ... ERROR
@@ -814,6 +849,82 @@ Status: 1 ERROR
 
 
 ```
+# raw
+
+<details>
+
+* Version: 0.1.8
+* GitHub: NA
+* Source code: https://github.com/cran/raw
+* Date/Publication: 2021-02-05 15:40:03 UTC
+* Number of recursive dependencies: 159
+
+Run `cloud_details(, "raw")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/raw/new/raw.Rcheck’
+* using R version 4.0.3 (2020-10-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘raw/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘raw’ version ‘0.1.8’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+...
+* checking installed files from ‘inst/doc’ ... OK
+* checking files in ‘vignettes’ ... OK
+* checking examples ... OK
+* checking for unstated dependencies in vignettes ... OK
+* checking package vignettes in ‘inst/doc’ ... OK
+* checking running R code from vignettes ... NONE
+  ‘raw.Rmd’ using ‘UTF-8’... OK
+* checking re-building of vignette outputs ... SKIPPED
+* DONE
+Status: 1 NOTE
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/raw/old/raw.Rcheck’
+* using R version 4.0.3 (2020-10-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘raw/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘raw’ version ‘0.1.8’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+...
+* checking installed files from ‘inst/doc’ ... OK
+* checking files in ‘vignettes’ ... OK
+* checking examples ... OK
+* checking for unstated dependencies in vignettes ... OK
+* checking package vignettes in ‘inst/doc’ ... OK
+* checking running R code from vignettes ... NONE
+  ‘raw.Rmd’ using ‘UTF-8’... OK
+* checking re-building of vignette outputs ... SKIPPED
+* DONE
+Status: 1 NOTE
+
+
+
+
+
+```
 # rmdcev
 
 <details>
@@ -889,41 +1000,6 @@ compilation terminated.
 make: *** [/opt/R/4.0.3/lib/R/etc/Makeconf:179: stanExports_mdcev.o] Error 1
 ERROR: compilation failed for package ‘rmdcev’
 * removing ‘/tmp/workdir/rmdcev/old/rmdcev.Rcheck/rmdcev’
-
-
-```
-# NA
-
-<details>
-
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `cloud_details(, "NA")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
 
 
 ```
@@ -1067,6 +1143,82 @@ See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
 manual.
 * DONE
 Status: 1 ERROR
+
+
+
+
+
+```
+# SynthETIC
+
+<details>
+
+* Version: 1.0.0
+* GitHub: https://github.com/agi-lab/SynthETIC
+* Source code: https://github.com/cran/SynthETIC
+* Date/Publication: 2021-04-02 12:10:02 UTC
+* Number of recursive dependencies: 105
+
+Run `cloud_details(, "SynthETIC")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/SynthETIC/new/SynthETIC.Rcheck’
+* using R version 4.0.3 (2020-10-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘SynthETIC/DESCRIPTION’ ... OK
+* this is package ‘SynthETIC’ version ‘1.0.0’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... NOTE
+...
+* checking installed files from ‘inst/doc’ ... OK
+* checking files in ‘vignettes’ ... OK
+* checking examples ... OK
+* checking for unstated dependencies in vignettes ... OK
+* checking package vignettes in ‘inst/doc’ ... OK
+* checking running R code from vignettes ... NONE
+  ‘SynthETIC-demo.Rmd’ using ‘UTF-8’... OK
+* checking re-building of vignette outputs ... SKIPPED
+* DONE
+Status: 1 NOTE
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/SynthETIC/old/SynthETIC.Rcheck’
+* using R version 4.0.3 (2020-10-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘SynthETIC/DESCRIPTION’ ... OK
+* this is package ‘SynthETIC’ version ‘1.0.0’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... NOTE
+...
+* checking installed files from ‘inst/doc’ ... OK
+* checking files in ‘vignettes’ ... OK
+* checking examples ... OK
+* checking for unstated dependencies in vignettes ... OK
+* checking package vignettes in ‘inst/doc’ ... OK
+* checking running R code from vignettes ... NONE
+  ‘SynthETIC-demo.Rmd’ using ‘UTF-8’... OK
+* checking re-building of vignette outputs ... SKIPPED
+* DONE
+Status: 1 NOTE
 
 
 

--- a/revdep/problems.md
+++ b/revdep/problems.md
@@ -14,23 +14,6 @@ Run `cloud_details(, "finreportr")` for more info
 
 ## Newly broken
 
-*   checking examples ... ERROR
-    ```
-    Running examples in ‘finreportr-Ex.R’ failed
-    The error most likely occurred in:
-    
-    > ### Name: AnnualReports
-    > ### Title: Acquire listing of company annual reports.
-    > ### Aliases: AnnualReports
-    > 
-    > ### ** Examples
-    > 
-    > AnnualReports("TSLA")
-    Error in open.connection(x, "rb") : HTTP error 403.
-    Calls: AnnualReports -> <Anonymous> -> read_html.default
-    Execution halted
-    ```
-
 *   checking tests ... ERROR
     ```
       Running ‘testthat.R’
@@ -53,17 +36,74 @@ Run `cloud_details(, "finreportr")` for more info
       Execution halted
     ```
 
-# readabs
+## In both
+
+*   checking examples ... ERROR
+    ```
+    Running examples in ‘finreportr-Ex.R’ failed
+    The error most likely occurred in:
+    
+    > ### Name: CompanyInfo
+    > ### Title: Acquire basic company information.
+    > ### Aliases: CompanyInfo
+    > 
+    > ### ** Examples
+    > 
+    > CompanyInfo("GOOG")
+    Error in open.connection(x, "rb") : HTTP error 403.
+    Calls: CompanyInfo -> <Anonymous> -> read_html.default
+    Execution halted
+    ```
+
+# SwimmeR
 
 <details>
 
-* Version: 0.4.9
-* GitHub: https://github.com/mattcowgill/readabs
-* Source code: https://github.com/cran/readabs
-* Date/Publication: 2021-05-24 04:10:03 UTC
-* Number of recursive dependencies: 83
+* Version: 0.10.0
+* GitHub: NA
+* Source code: https://github.com/cran/SwimmeR
+* Date/Publication: 2021-06-02 15:30:02 UTC
+* Number of recursive dependencies: 63
 
-Run `cloud_details(, "readabs")` for more info
+Run `cloud_details(, "SwimmeR")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking tests ... ERROR
+    ```
+      Running ‘testthat.R’
+    Running the tests in ‘tests/testthat.R’ failed.
+    Last 13 lines of output:
+       20. │   └─dplyr:::check_length_val(...)
+       21. │     └─length_x %in% c(1L, n)
+       22. ├─dplyr::mutate(...)
+       23. ├─dplyr:::mutate.data.frame(...)
+       24. │ └─dplyr:::mutate_cols(.data, ..., caller_env = caller_env())
+       25. │   ├─base::withCallingHandlers(...)
+       26. │   └─mask$eval_all_mutate(quo)
+       27. └─dplyr::case_when(...)
+       28.   └─dplyr:::replace_with(...)
+       29.     └─dplyr:::check_type(val, x, name)
+       30.       └─dplyr:::glubort(header, "must be {friendly_type_of(template)}, not {friendly_type_of(x)}.")
+      
+      [ FAIL 1 | WARN 1 | SKIP 13 | PASS 21 ]
+      Error: Test failures
+      Execution halted
+    ```
+
+# xray
+
+<details>
+
+* Version: 0.2
+* GitHub: https://github.com/sicarul/xray
+* Source code: https://github.com/cran/xray
+* Date/Publication: 2017-12-08 05:15:59 UTC
+* Number of recursive dependencies: 40
+
+Run `cloud_details(, "xray")` for more info
 
 </details>
 
@@ -71,48 +111,26 @@ Run `cloud_details(, "readabs")` for more info
 
 *   checking examples ... ERROR
     ```
-    Running examples in ‘readabs-Ex.R’ failed
+    Running examples in ‘xray-Ex.R’ failed
     The error most likely occurred in:
     
-    > ### Name: search_catalogues
-    > ### Title: Search for ABS catalogues that match a string
-    > ### Aliases: search_catalogues
+    > ### Name: anomalies
+    > ### Title: Analyze a dataset and search for anomalies
+    > ### Aliases: anomalies
     > 
     > ### ** Examples
     > 
     > 
     ...
-      3. ├─dplyr::filter(...)
-      4. ├─dplyr:::filter.data.frame(...)
-      5. │ └─dplyr:::filter_rows(.data, ...)
-      6. │   ├─base::withCallingHandlers(...)
-      7. │   └─mask$eval_all_filter(dots, env_filter)
-      8. ├─rlang:::grepl(string, heading, perl = TRUE, ignore.case = TRUE)
-      9. ├─base::grepl(string, heading, perl = TRUE, ignore.case = TRUE)
-     10. └─base::.handleSimpleError(...)
-     11.   └─dplyr:::h(simpleError(msg, call))
+     16. │ ├─dplyr::mutate(.tbl, !!!funs)
+     17. │ └─dplyr:::mutate.data.frame(.tbl, !!!funs)
+     18. │   └─dplyr:::mutate_cols(.data, ..., caller_env = caller_env())
+     19. │     ├─base::withCallingHandlers(...)
+     20. │     └─mask$eval_all_mutate(quo)
+     21. └─dplyr::case_when(...)
+     22.   └─dplyr:::validate_case_when_length(query, value, fs)
+     23.     └─dplyr:::bad_calls(...)
+     24.       └─dplyr:::glubort(fmt_calls(calls), ..., .envir = .envir)
     Execution halted
-    ```
-
-*   checking tests ... ERROR
-    ```
-      Running ‘testthat.R’
-    Running the tests in ‘tests/testthat.R’ failed.
-    Last 13 lines of output:
-        1. ├─readabs::search_catalogues("labour") test-search_catalogues.R:4:2
-        2. │ └─`%>%`(...)
-        3. ├─dplyr::filter(...)
-        4. ├─dplyr:::filter.data.frame(...)
-        5. │ └─dplyr:::filter_rows(.data, ...)
-        6. │   ├─base::withCallingHandlers(...)
-        7. │   └─mask$eval_all_filter(dots, env_filter)
-        8. ├─rlang:::grepl(string, heading, perl = TRUE, ignore.case = TRUE)
-        9. ├─base::grepl(string, heading, perl = TRUE, ignore.case = TRUE)
-       10. └─base::.handleSimpleError(...)
-       11.   └─dplyr:::h(simpleError(msg, call))
-      
-      [ FAIL 1 | WARN 0 | SKIP 26 | PASS 52 ]
-      Error: Test failures
-      Execution halted
     ```
 

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -527,18 +527,17 @@ test_that("can pass quosure through `across()`", {
 })
 
 test_that("across() inlines formulas", {
-  skip("until adapted to mask= argument")
   env <- env()
   f <- ~ toupper(.x)
 
   expect_equal(
-    as_across_fn_call(f, quote(foo), env),
+    as_across_fn_call(f, quote(foo), env, env),
     new_quosure(quote(toupper(foo)), f_env(f))
   )
 
   f <- ~ list(.x, ., .x)
   expect_equal(
-    as_across_fn_call(f, quote(foo), env),
+    as_across_fn_call(f, quote(foo), env, env),
     new_quosure(quote(list(foo, foo, foo)), f_env(f))
   )
 })
@@ -552,6 +551,20 @@ test_that("across() uses local formula environment (#5881)", {
   expect_equal(
     mutate(df, across(x, f)),
     tibble(x = "foo x")
+  )
+  expect_equal(
+    mutate(df, across(x, list(f = f))),
+    tibble(x = "x", x_f = "foo x")
+  )
+
+  prefix <- "foo"
+  expect_equal(
+    mutate(df, across(x, ~paste(prefix, .x))),
+    tibble(x = "foo x")
+  )
+  expect_equal(
+    mutate(df, across(x, list(f = ~paste(prefix, .x)))),
+    tibble(x = "x", x_f = "foo x")
   )
 })
 

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -527,6 +527,7 @@ test_that("can pass quosure through `across()`", {
 })
 
 test_that("across() inlines formulas", {
+  skip("until adapted to mask= argument")
   env <- env()
   f <- ~ toupper(.x)
 

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -557,15 +557,19 @@ test_that("across() uses local formula environment (#5881)", {
     tibble(x = "x", x_f = "foo x")
   )
 
-  prefix <- "foo"
-  expect_equal(
-    mutate(df, across(x, ~paste(prefix, .x))),
-    tibble(x = "foo x")
-  )
-  expect_equal(
-    mutate(df, across(x, list(f = ~paste(prefix, .x)))),
-    tibble(x = "x", x_f = "foo x")
-  )
+  local({
+    # local() here is not necessary, it's just in case the
+    # code is run directly without the test_that()
+    prefix <- "foo"
+    expect_equal(
+      mutate(df, across(x, ~paste(prefix, .x))),
+      tibble(x = "foo x")
+    )
+    expect_equal(
+      mutate(df, across(x, list(f = ~paste(prefix, .x)))),
+      tibble(x = "x", x_f = "foo x")
+    )
+  })
 })
 
 test_that("unevaluated formulas (currently) fail", {

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -630,7 +630,7 @@ test_that("expanded if_any() finds local data", {
 
   expect_identical(
     filter(df, if_any(everything(), ~ .x > limit)),
-    filter(df, x > 7 | y > 7)
+    filter(df, x > limit | y > limit)
   )
 })
 

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -624,6 +624,16 @@ test_that("if_any() and if_all() wrapped deal with no inputs or single inputs", 
   )
 })
 
+test_that("expanded if_any() finds local data", {
+  limit <- 7
+  df <- data.frame(x = 1:10, y = 10:1)
+
+  expect_identical(
+    filter(df, if_any(everything(), ~ .x > limit)),
+    filter(df, x > 7 | y > 7)
+  )
+})
+
 test_that("across() can use named selections", {
   df <- data.frame(x = 1, y = 2)
 

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -716,6 +716,16 @@ test_that("across() can use named selections", {
   )
 })
 
+test_that("expr_subtitute() stops at lambdas (#5896)", {
+  expect_identical(
+    expr_substitute(expr(map(.x, ~mean(.x))), quote(.x), quote(a)),
+    expr(map(a, ~mean(.x)))
+  )
+  expect_identical(
+    expr_substitute(expr(map(.x, function(.x) mean(.x))), quote(.x), quote(a)),
+    expr(map(a, function(.x) mean(.x)))
+  )
+})
 
 # c_across ----------------------------------------------------------------
 


### PR DESCRIPTION
identified as part of rev dep checks for release 1.0.7 #5894 

original problem: 

``` r
library(dplyr, warn.conflicts = FALSE)

local({
  limit <- 7
  df <- data.frame(x = 1:10, y = 10:1)
  
  filter(df, if_any(everything(), ~ .x > limit))
})
#> Error: Problem with `filter()` input `..1`.
#> ℹ Input `..1` is `x > limit | y > limit`.
#> x object 'limit' not found
```

this breaks package `readabs`. 

```
> revdepcheck::cloud_details(, "readabs")
══ Reverse dependency check ═══════════════════════════════════════════════════════════════════════════════════ readabs 0.4.9 ══

Status: BROKEN

── Newly failing

x checking examples ... ERROR
x checking tests ... ERROR

── Before ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
0 errors ✓ | 0 warnings ✓ | 0 notes ✓

── After ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
> checking examples ... ERROR
  Running examples in ‘readabs-Ex.R’ failed
  The error most likely occurred in:
  
  > ### Name: search_catalogues
  > ### Title: Search for ABS catalogues that match a string
  > ### Aliases: search_catalogues
  > 
  > ### ** Examples
  > 
  > 
  > search_catalogues("labour")
  Error: Problem with `filter()` input `..1`.
  ℹ Input `..1` is `|...`.
  ✖ object 'string' not found
  Backtrace:
       █
    1. ├─readabs::search_catalogues("labour")
    2. │ └─`%>%`(...)
    3. ├─dplyr::filter(...)
    4. ├─dplyr:::filter.data.frame(...)
    5. │ └─dplyr:::filter_rows(.data, ...)
    6. │   ├─base::withCallingHandlers(...)
    7. │   └─mask$eval_all_filter(dots, env_filter)
    8. ├─rlang:::grepl(string, heading, perl = TRUE, ignore.case = TRUE)
    9. ├─base::grepl(string, heading, perl = TRUE, ignore.case = TRUE)
   10. └─base::.handleSimpleError(...)
   11.   └─dplyr:::h(simpleError(msg, call))
  Execution halted

> checking tests ... ERROR
  See below...

── Test failures ───────────────────────────────────────────────────────────────────────────────────────────────── testthat ────

> library(testthat)
> library(readabs)
Environment variable 'R_READABS_PATH' is unset. Downloaded files will be saved in a temporary directory.
You can set 'R_READABS_PATH' at any time. To set it for the rest of this session, use
	Sys.setenv(R_READABS_PATH = <path>)
> 
> test_check("readabs")
══ Skipped tests ═══════════════════════════════════════════════════════════════
• On CRAN (26)

══ Failed tests ════════════════════════════════════════════════════════════════
── Error (test-search_catalogues.R:4:3): search_catalogues() returns appropriate output ──
Error: Problem with `filter()` input `..1`.
ℹ Input `..1` is `|...`.
✖ object 'string' not found
Backtrace:
     █
  1. ├─readabs::search_catalogues("labour") test-search_catalogues.R:4:2
  2. │ └─`%>%`(...)
  3. ├─dplyr::filter(...)
  4. ├─dplyr:::filter.data.frame(...)
  5. │ └─dplyr:::filter_rows(.data, ...)
  6. │   ├─base::withCallingHandlers(...)
  7. │   └─mask$eval_all_filter(dots, env_filter)
  8. ├─rlang:::grepl(string, heading, perl = TRUE, ignore.case = TRUE)
  9. ├─base::grepl(string, heading, perl = TRUE, ignore.case = TRUE)
 10. └─base::.handleSimpleError(...)
 11.   └─dplyr:::h(simpleError(msg, call))

[ FAIL 1 | WARN 0 | SKIP 26 | PASS 52 ]
Error: Test failures
Execution halted

2 errors x | 0 warnings ✓ | 0 notes ✓
```