### PR TITLE
expr_substitute() does substitute double sided formula

### DIFF
--- a/R/utils.r
+++ b/R/utils.r
@@ -145,7 +145,7 @@ expr_substitute <- function(expr, old, new) {
 node_walk_replace <- function(node, old, new) {
   while (!is_null(node)) {
     switch(typeof(node_car(node)),
-      language = if (!is_call(node_car(node), c("~", "function"))) node_walk_replace(node_cdar(node), old, new),
+      language = if (!is_call(node_car(node), c("~", "function")) || is_call(node_car(node), "~", n = 2)) node_walk_replace(node_cdar(node), old, new),
       symbol = if (identical(node_car(node), old)) node_poke_car(node, new)
     )
     node <- node_cdr(node)

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -1,6 +1,6 @@
 # Revdeps
 
-## Failed to check (18)
+## Failed to check (21)
 
 |package        |version |error |warning |note |
 |:--------------|:-------|:-----|:-------|:----|
@@ -8,27 +8,27 @@
 |CausalImpact   |?       |      |        |     |
 |CB2            |?       |      |        |     |
 |cbar           |?       |      |        |     |
-|CGPfunctions   |?       |      |        |     |
-|crossmap       |?       |      |        |     |
 |diceR          |?       |      |        |     |
+|glmmfields     |0.1.4   |1     |        |     |
+|loon.shiny     |?       |      |        |     |
 |MarketMatching |?       |      |        |     |
+|metagam        |?       |      |        |     |
+|mlbstatsR      |0.1.0   |1     |        |     |
+|pencal         |?       |      |        |     |
+|rabhit         |?       |      |        |     |
 |raw            |?       |      |        |     |
 |rmdcev         |1.2.4   |1     |        |     |
 |rstap          |1.0.3   |1     |        |     |
 |scoper         |?       |      |        |     |
-|SimplyAgree    |?       |      |        |     |
 |SynthETIC      |?       |      |        |     |
 |tigger         |?       |      |        |     |
 |trackr         |?       |      |        |     |
 |vivid          |?       |      |        |     |
 |wrswoR         |?       |      |        |     |
 
-## New problems (4)
+## New problems (1)
 
-|package                              |version |error    |warning |note     |
-|:------------------------------------|:-------|:--------|:-------|:--------|
-|[finreportr](problems.md#finreportr) |1.0.2   |1 __+1__ |        |         |
-|[MoMPCA](problems.md#mompca)         |1.0.1   |1        |        |1 __+1__ |
-|[SwimmeR](problems.md#swimmer)       |0.10.0  |__+1__   |        |         |
-|[xray](problems.md#xray)             |0.2     |__+1__   |        |         |
+|package                  |version |error  |warning |note |
+|:------------------------|:-------|:------|:-------|:----|
+|[imfr](problems.md#imfr) |0.1.9.1 |__+1__ |        |     |
 

--- a/revdep/cran.md
+++ b/revdep/cran.md
@@ -1,26 +1,17 @@
 ## revdepcheck results
 
-We checked 2131 reverse dependencies, comparing R CMD check results across CRAN and dev versions of this package.
+We checked 2518 reverse dependencies, comparing R CMD check results across CRAN and dev versions of this package.
 
- * We saw 4 new problems
- * We failed to check 18 packages
+ * We saw 1 new problems
+ * We failed to check 21 packages
 
 Issues with CRAN packages are summarised below.
 
 ### New problems
 (This reports the first line of each new failure)
 
-* finreportr
-  checking examples ... ERROR
-
-* MoMPCA
-  checking dependencies in R code ... NOTE
-
-* SwimmeR
+* imfr
   checking tests ... ERROR
-
-* xray
-  checking examples ... ERROR
 
 ### Failed to check
 
@@ -28,15 +19,18 @@ Issues with CRAN packages are summarised below.
 * CausalImpact   (NA)
 * CB2            (NA)
 * cbar           (NA)
-* CGPfunctions   (NA)
-* crossmap       (NA)
 * diceR          (NA)
+* glmmfields     (NA)
+* loon.shiny     (NA)
 * MarketMatching (NA)
+* metagam        (NA)
+* mlbstatsR      (NA)
+* pencal         (NA)
+* rabhit         (NA)
 * raw            (NA)
 * rmdcev         (NA)
 * rstap          (NA)
 * scoper         (NA)
-* SimplyAgree    (NA)
 * SynthETIC      (NA)
 * tigger         (NA)
 * trackr         (NA)

--- a/revdep/failures.md
+++ b/revdep/failures.md
@@ -274,128 +274,6 @@ Status: 1 ERROR
 
 
 ```
-# CGPfunctions
-
-<details>
-
-* Version: 0.6.3
-* GitHub: https://github.com/ibecav/CGPfunctions
-* Source code: https://github.com/cran/CGPfunctions
-* Date/Publication: 2020-11-12 14:50:09 UTC
-* Number of recursive dependencies: 143
-
-Run `cloud_details(, "CGPfunctions")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/CGPfunctions/new/CGPfunctions.Rcheck’
-* using R version 4.0.3 (2020-10-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using options ‘--no-manual --no-build-vignettes’
-* checking for file ‘CGPfunctions/DESCRIPTION’ ... OK
-* this is package ‘CGPfunctions’ version ‘0.6.3’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sjstats’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/CGPfunctions/old/CGPfunctions.Rcheck’
-* using R version 4.0.3 (2020-10-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using options ‘--no-manual --no-build-vignettes’
-* checking for file ‘CGPfunctions/DESCRIPTION’ ... OK
-* this is package ‘CGPfunctions’ version ‘0.6.3’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sjstats’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# crossmap
-
-<details>
-
-* Version: 0.3.0
-* GitHub: https://github.com/rossellhayes/crossmap
-* Source code: https://github.com/cran/crossmap
-* Date/Publication: 2021-04-02 06:10:02 UTC
-* Number of recursive dependencies: 57
-
-Run `cloud_details(, "crossmap")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/crossmap/old/crossmap.Rcheck’
-* using R version 4.0.3 (2020-10-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using options ‘--no-manual --no-build-vignettes’
-* checking for file ‘crossmap/DESCRIPTION’ ... OK
-* this is package ‘crossmap’ version ‘0.3.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... OK
-...
-* checking for code/documentation mismatches ... OK
-* checking Rd \usage sections ... OK
-* checking Rd contents ... OK
-* checking for unstated dependencies in examples ... OK
-* checking examples ... OK
-* checking for unstated dependencies in ‘tests’ ... OK
-* checking tests ... ERROR
-  Running ‘testthat.R’
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
 # diceR
 
 <details>
@@ -464,6 +342,152 @@ Status: 1 ERROR
 
 
 ```
+# glmmfields
+
+<details>
+
+* Version: 0.1.4
+* GitHub: https://github.com/seananderson/glmmfields
+* Source code: https://github.com/cran/glmmfields
+* Date/Publication: 2020-07-09 05:50:03 UTC
+* Number of recursive dependencies: 95
+
+Run `cloud_details(, "glmmfields")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘glmmfields’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/tmp/workdir/glmmfields/new/glmmfields.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘glmmfields’ ...
+** package ‘glmmfields’ successfully unpacked and MD5 sums checked
+** using staged installation
+** libs
+"/opt/R/4.0.3/lib/R/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/glmmfields.stan
+Wrote C++ file "stan_files/glmmfields.cc"
+
+
+g++ -std=gnu++14 -I"/opt/R/4.0.3/lib/R/include" -DNDEBUG -I"../inst/include" -I"/opt/R/4.0.3/lib/R/site-library/StanHeaders/include/src" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error -I'/opt/R/4.0.3/lib/R/site-library/BH/include' -I'/opt/R/4.0.3/lib/R/site-library/Rcpp/include' -I'/opt/R/4.0.3/lib/R/site-library/RcppEigen/include' -I'/opt/R/4.0.3/lib/R/site-library/rstan/include' -I'/opt/R/4.0.3/lib/R/site-library/StanHeaders/include' -I/usr/local/include   -fpic  -g -O2  -c stan_files/glmmfields.cc -o stan_files/glmmfields.o
+In file included from /opt/R/4.0.3/lib/R/site-library/RcppEigen/include/Eigen/Core:397,
+...
+/opt/R/4.0.3/lib/R/site-library/RcppEigen/include/Eigen/src/Core/Product.h:132:22:   required from ‘Eigen::internal::dense_product_base<Lhs, Rhs, Option, 6>::operator const Scalar() const [with Lhs = Eigen::Product<Eigen::CwiseBinaryOp<Eigen::internal::scalar_product_op<double, double>, const Eigen::CwiseNullaryOp<Eigen::internal::scalar_constant_op<double>, const Eigen::Matrix<double, 1, -1> >, const Eigen::Transpose<Eigen::Matrix<double, -1, 1> > >, Eigen::Matrix<double, -1, -1>, 0>; Rhs = Eigen::Matrix<double, -1, 1>; int Option = 0; Eigen::internal::dense_product_base<Lhs, Rhs, Option, 6>::Scalar = double]’
+/opt/R/4.0.3/lib/R/site-library/StanHeaders/include/src/stan/mcmc/hmc/hamiltonians/dense_e_metric.hpp:23:56:   required from ‘double stan::mcmc::dense_e_metric<Model, BaseRNG>::T(stan::mcmc::dense_e_point&) [with Model = model_glmmfields_namespace::model_glmmfields; BaseRNG = boost::random::additive_combine_engine<boost::random::linear_congruential_engine<unsigned int, 40014, 0, 2147483563>, boost::random::linear_congruential_engine<unsigned int, 40692, 0, 2147483399> >]’
+/opt/R/4.0.3/lib/R/site-library/StanHeaders/include/src/stan/mcmc/hmc/hamiltonians/dense_e_metric.hpp:22:10:   required from here
+/opt/R/4.0.3/lib/R/site-library/RcppEigen/include/Eigen/src/Core/DenseCoeffsBase.h:55:30: warning: ignoring attributes on template argument ‘Eigen::internal::packet_traits<double>::type’ {aka ‘__vector(2) double’} [-Wignored-attributes]
+g++: fatal error: Killed signal terminated program cc1plus
+compilation terminated.
+make: *** [/opt/R/4.0.3/lib/R/etc/Makeconf:179: stan_files/glmmfields.o] Error 1
+rm stan_files/glmmfields.cc
+ERROR: compilation failed for package ‘glmmfields’
+* removing ‘/tmp/workdir/glmmfields/new/glmmfields.Rcheck/glmmfields’
+
+
+```
+### CRAN
+
+```
+* installing *source* package ‘glmmfields’ ...
+** package ‘glmmfields’ successfully unpacked and MD5 sums checked
+** using staged installation
+** libs
+"/opt/R/4.0.3/lib/R/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/glmmfields.stan
+Wrote C++ file "stan_files/glmmfields.cc"
+
+
+g++ -std=gnu++14 -I"/opt/R/4.0.3/lib/R/include" -DNDEBUG -I"../inst/include" -I"/opt/R/4.0.3/lib/R/site-library/StanHeaders/include/src" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error -I'/opt/R/4.0.3/lib/R/site-library/BH/include' -I'/opt/R/4.0.3/lib/R/site-library/Rcpp/include' -I'/opt/R/4.0.3/lib/R/site-library/RcppEigen/include' -I'/opt/R/4.0.3/lib/R/site-library/rstan/include' -I'/opt/R/4.0.3/lib/R/site-library/StanHeaders/include' -I/usr/local/include   -fpic  -g -O2  -c stan_files/glmmfields.cc -o stan_files/glmmfields.o
+In file included from /opt/R/4.0.3/lib/R/site-library/RcppEigen/include/Eigen/Core:397,
+...
+/opt/R/4.0.3/lib/R/site-library/RcppEigen/include/Eigen/src/Core/Product.h:132:22:   required from ‘Eigen::internal::dense_product_base<Lhs, Rhs, Option, 6>::operator const Scalar() const [with Lhs = Eigen::Product<Eigen::CwiseBinaryOp<Eigen::internal::scalar_product_op<double, double>, const Eigen::CwiseNullaryOp<Eigen::internal::scalar_constant_op<double>, const Eigen::Matrix<double, 1, -1> >, const Eigen::Transpose<Eigen::Matrix<double, -1, 1> > >, Eigen::Matrix<double, -1, -1>, 0>; Rhs = Eigen::Matrix<double, -1, 1>; int Option = 0; Eigen::internal::dense_product_base<Lhs, Rhs, Option, 6>::Scalar = double]’
+/opt/R/4.0.3/lib/R/site-library/StanHeaders/include/src/stan/mcmc/hmc/hamiltonians/dense_e_metric.hpp:23:56:   required from ‘double stan::mcmc::dense_e_metric<Model, BaseRNG>::T(stan::mcmc::dense_e_point&) [with Model = model_glmmfields_namespace::model_glmmfields; BaseRNG = boost::random::additive_combine_engine<boost::random::linear_congruential_engine<unsigned int, 40014, 0, 2147483563>, boost::random::linear_congruential_engine<unsigned int, 40692, 0, 2147483399> >]’
+/opt/R/4.0.3/lib/R/site-library/StanHeaders/include/src/stan/mcmc/hmc/hamiltonians/dense_e_metric.hpp:22:10:   required from here
+/opt/R/4.0.3/lib/R/site-library/RcppEigen/include/Eigen/src/Core/DenseCoeffsBase.h:55:30: warning: ignoring attributes on template argument ‘Eigen::internal::packet_traits<double>::type’ {aka ‘__vector(2) double’} [-Wignored-attributes]
+g++: fatal error: Killed signal terminated program cc1plus
+compilation terminated.
+make: *** [/opt/R/4.0.3/lib/R/etc/Makeconf:179: stan_files/glmmfields.o] Error 1
+rm stan_files/glmmfields.cc
+ERROR: compilation failed for package ‘glmmfields’
+* removing ‘/tmp/workdir/glmmfields/old/glmmfields.Rcheck/glmmfields’
+
+
+```
+# loon.shiny
+
+<details>
+
+* Version: 1.0.0
+* GitHub: NA
+* Source code: https://github.com/cran/loon.shiny
+* Date/Publication: 2021-06-10 16:30:06 UTC
+* Number of recursive dependencies: 130
+
+Run `cloud_details(, "loon.shiny")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/loon.shiny/new/loon.shiny.Rcheck’
+* using R version 4.0.3 (2020-10-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘loon.shiny/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘loon.shiny’ version ‘1.0.0’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Packages required but not available: 'loon', 'loon.ggplot'
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/loon.shiny/old/loon.shiny.Rcheck’
+* using R version 4.0.3 (2020-10-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘loon.shiny/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘loon.shiny’ version ‘1.0.0’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Packages required but not available: 'loon', 'loon.ggplot'
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
 # MarketMatching
 
 <details>
@@ -519,6 +543,276 @@ Status: 1 ERROR
 * checking package namespace information ... OK
 * checking package dependencies ... ERROR
 Packages required but not available: 'CausalImpact', 'bsts', 'Boom'
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+# metagam
+
+<details>
+
+* Version: 0.2.0
+* GitHub: https://github.com/Lifebrain/metagam
+* Source code: https://github.com/cran/metagam
+* Date/Publication: 2020-11-12 08:10:02 UTC
+* Number of recursive dependencies: 145
+
+Run `cloud_details(, "metagam")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/metagam/new/metagam.Rcheck’
+* using R version 4.0.3 (2020-10-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘metagam/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘metagam’ version ‘0.2.0’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘metap’
+
+Package suggested but not available for checking: ‘multtest’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/metagam/old/metagam.Rcheck’
+* using R version 4.0.3 (2020-10-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘metagam/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘metagam’ version ‘0.2.0’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘metap’
+
+Package suggested but not available for checking: ‘multtest’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+# mlbstatsR
+
+<details>
+
+* Version: 0.1.0
+* GitHub: NA
+* Source code: https://github.com/cran/mlbstatsR
+* Date/Publication: 2021-05-17 07:30:14 UTC
+* Number of recursive dependencies: 105
+
+Run `cloud_details(, "mlbstatsR")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘mlbstatsR’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/tmp/workdir/mlbstatsR/new/mlbstatsR.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘mlbstatsR’ ...
+** package ‘mlbstatsR’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+4 MLB ESPN logos in png!
+Error in open.connection(con, "rb") : HTTP error 403.
+Error: unable to load R code in package ‘mlbstatsR’
+Execution halted
+ERROR: lazy loading failed for package ‘mlbstatsR’
+* removing ‘/tmp/workdir/mlbstatsR/new/mlbstatsR.Rcheck/mlbstatsR’
+
+
+```
+### CRAN
+
+```
+* installing *source* package ‘mlbstatsR’ ...
+** package ‘mlbstatsR’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+4 MLB ESPN logos in png!
+Error in open.connection(con, "rb") : HTTP error 403.
+Error: unable to load R code in package ‘mlbstatsR’
+Execution halted
+ERROR: lazy loading failed for package ‘mlbstatsR’
+* removing ‘/tmp/workdir/mlbstatsR/old/mlbstatsR.Rcheck/mlbstatsR’
+
+
+```
+# pencal
+
+<details>
+
+* Version: 0.4.2
+* GitHub: NA
+* Source code: https://github.com/cran/pencal
+* Date/Publication: 2021-05-28 09:30:02 UTC
+* Number of recursive dependencies: 149
+
+Run `cloud_details(, "pencal")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/pencal/new/pencal.Rcheck’
+* using R version 4.0.3 (2020-10-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘pencal/DESCRIPTION’ ... OK
+* this is package ‘pencal’ version ‘0.4.2’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘survcomp’
+
+Package suggested but not available for checking: ‘ptmixed’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/pencal/old/pencal.Rcheck’
+* using R version 4.0.3 (2020-10-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘pencal/DESCRIPTION’ ... OK
+* this is package ‘pencal’ version ‘0.4.2’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘survcomp’
+
+Package suggested but not available for checking: ‘ptmixed’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+# rabhit
+
+<details>
+
+* Version: 0.1.5
+* GitHub: NA
+* Source code: https://github.com/cran/rabhit
+* Date/Publication: 2020-07-11 22:40:02 UTC
+* Number of recursive dependencies: 123
+
+Run `cloud_details(, "rabhit")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/rabhit/new/rabhit.Rcheck’
+* using R version 4.0.3 (2020-10-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘rabhit/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘rabhit’ version ‘0.1.5’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Packages required but not available: 'alakazam', 'tigger'
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/rabhit/old/rabhit.Rcheck’
+* using R version 4.0.3 (2020-10-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘rabhit/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘rabhit’ version ‘0.1.5’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Packages required but not available: 'alakazam', 'tigger'
 
 See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
 manual.
@@ -819,74 +1113,6 @@ Status: 1 ERROR
 * checking package namespace information ... OK
 * checking package dependencies ... ERROR
 Packages required but not available: 'alakazam', 'shazam'
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# SimplyAgree
-
-<details>
-
-* Version: 0.0.2
-* GitHub: NA
-* Source code: https://github.com/cran/SimplyAgree
-* Date/Publication: 2021-05-18 14:10:16 UTC
-* Number of recursive dependencies: 154
-
-Run `cloud_details(, "SimplyAgree")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/SimplyAgree/new/SimplyAgree.Rcheck’
-* using R version 4.0.3 (2020-10-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using options ‘--no-manual --no-build-vignettes’
-* checking for file ‘SimplyAgree/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘SimplyAgree’ version ‘0.0.2’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sjstats’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/SimplyAgree/old/SimplyAgree.Rcheck’
-* using R version 4.0.3 (2020-10-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using options ‘--no-manual --no-build-vignettes’
-* checking for file ‘SimplyAgree/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘SimplyAgree’ version ‘0.0.2’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sjstats’
 
 See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
 manual.

--- a/revdep/problems.md
+++ b/revdep/problems.md
@@ -1,177 +1,38 @@
-# finreportr
+# imfr
 
 <details>
 
-* Version: 1.0.2
-* GitHub: https://github.com/sewardlee337/finreportr
-* Source code: https://github.com/cran/finreportr
-* Date/Publication: 2020-06-13 06:10:02 UTC
-* Number of recursive dependencies: 57
+* Version: 0.1.9.1
+* GitHub: https://github.com/christophergandrud/imfr
+* Source code: https://github.com/cran/imfr
+* Date/Publication: 2020-10-03 06:20:02 UTC
+* Number of recursive dependencies: 41
 
-Run `cloud_details(, "finreportr")` for more info
+Run `cloud_details(, "imfr")` for more info
 
 </details>
 
 ## Newly broken
-
-*   checking examples ... ERROR
-    ```
-    Running examples in ‘finreportr-Ex.R’ failed
-    The error most likely occurred in:
-    
-    > ### Name: AnnualReports
-    > ### Title: Acquire listing of company annual reports.
-    > ### Aliases: AnnualReports
-    > 
-    > ### ** Examples
-    > 
-    > AnnualReports("TSLA")
-    ...
-    9         10-K  2015-02-26 0001564590-15-001031
-    10        10-K  2014-02-26 0001193125-14-069681
-    11        10-K  2013-03-07 0001193125-13-096241
-    12      10-K/A  2012-03-28 0001193125-12-137560
-    13        10-K  2012-02-27 0001193125-12-081990
-    14        10-K  2011-03-03 0001193125-11-054847
-    > AnnualReports("BABA", foreign = TRUE)
-    Error in open.connection(x, "rb") : HTTP error 403.
-    Calls: AnnualReports -> <Anonymous> -> read_html.default
-    Execution halted
-    ```
-
-## In both
 
 *   checking tests ... ERROR
     ```
       Running ‘testthat.R’
     Running the tests in ‘tests/testthat.R’ failed.
     Last 13 lines of output:
-        3. │   └─rlang::eval_bare(expr, quo_get_env(quo))
-        4. └─finreportr::CompanyInfo("TSLA")
-        5.   ├─xml2::read_html(url)
-        6.   └─xml2:::read_html.default(url)
-        7.     ├─base::suppressWarnings(...)
-        8.     │ └─base::withCallingHandlers(...)
-        9.     ├─xml2::read_xml(x, encoding = encoding, ..., as_html = TRUE, options = options)
-       10.     └─xml2:::read_xml.character(...)
-       11.       └─xml2:::read_xml.connection(...)
-       12.         ├─base::open(x, "rb")
-       13.         └─base::open.connection(x, "rb")
+        3. │   ├─testthat:::.capture(...)
+        4. │   │ └─base::withCallingHandlers(...)
+        5. │   └─rlang::eval_bare(quo_get_expr(.quo), quo_get_env(.quo))
+        6. ├─imfr::imf_data(...)
+        7. │ └─imfr:::imf_data_one(...)
+        8. │   └─imfr:::download_parse(URL)
+        9. │     ├─`%>%`(...)
+       10. │     └─httr::RETRY("GET", URL, user_agent(""), progress(), times = times)
+       11. └─httr::content(., type = "text", encoding = "UTF-8")
+       12.   ├─base::stopifnot(is.response(x))
+       13.   └─httr:::is.response(x)
       
       [ FAIL 1 | WARN 0 | SKIP 0 | PASS 1 ]
       Error: Test failures
       Execution halted
-    ```
-
-# MoMPCA
-
-<details>
-
-* Version: 1.0.1
-* GitHub: NA
-* Source code: https://github.com/cran/MoMPCA
-* Date/Publication: 2021-01-21 13:10:03 UTC
-* Number of recursive dependencies: 82
-
-Run `cloud_details(, "MoMPCA")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking dependencies in R code ... NOTE
-    ```
-    Killed
-    ```
-
-## In both
-
-*   checking tests ... ERROR
-    ```
-      Running ‘testthat.R’
-    ```
-
-*   checking data for non-ASCII characters ... NOTE
-    ```
-      Note: found 16 marked UTF-8 strings
-    ```
-
-# SwimmeR
-
-<details>
-
-* Version: 0.10.0
-* GitHub: NA
-* Source code: https://github.com/cran/SwimmeR
-* Date/Publication: 2021-06-02 15:30:02 UTC
-* Number of recursive dependencies: 63
-
-Run `cloud_details(, "SwimmeR")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking tests ... ERROR
-    ```
-      Running ‘testthat.R’
-    Running the tests in ‘tests/testthat.R’ failed.
-    Last 13 lines of output:
-       20. │   └─dplyr:::check_length_val(...)
-       21. │     └─length_x %in% c(1L, n)
-       22. ├─dplyr::mutate(...)
-       23. ├─dplyr:::mutate.data.frame(...)
-       24. │ └─dplyr:::mutate_cols(.data, ..., caller_env = caller_env())
-       25. │   ├─base::withCallingHandlers(...)
-       26. │   └─mask$eval_all_mutate(quo)
-       27. └─dplyr::case_when(...)
-       28.   └─dplyr:::replace_with(...)
-       29.     └─dplyr:::check_type(val, x, name)
-       30.       └─dplyr:::glubort(header, "must be {friendly_type_of(template)}, not {friendly_type_of(x)}.")
-      
-      [ FAIL 1 | WARN 1 | SKIP 13 | PASS 21 ]
-      Error: Test failures
-      Execution halted
-    ```
-
-# xray
-
-<details>
-
-* Version: 0.2
-* GitHub: https://github.com/sicarul/xray
-* Source code: https://github.com/cran/xray
-* Date/Publication: 2017-12-08 05:15:59 UTC
-* Number of recursive dependencies: 40
-
-Run `cloud_details(, "xray")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking examples ... ERROR
-    ```
-    Running examples in ‘xray-Ex.R’ failed
-    The error most likely occurred in:
-    
-    > ### Name: anomalies
-    > ### Title: Analyze a dataset and search for anomalies
-    > ### Aliases: anomalies
-    > 
-    > ### ** Examples
-    > 
-    > 
-    ...
-     16. │ ├─dplyr::mutate(.tbl, !!!funs)
-     17. │ └─dplyr:::mutate.data.frame(.tbl, !!!funs)
-     18. │   └─dplyr:::mutate_cols(.data, ..., caller_env = caller_env())
-     19. │     ├─base::withCallingHandlers(...)
-     20. │     └─mask$eval_all_mutate(quo)
-     21. └─dplyr::case_when(...)
-     22.   └─dplyr:::validate_case_when_length(query, value, fs)
-     23.     └─dplyr:::bad_calls(...)
-     24.       └─dplyr:::glubort(fmt_calls(calls), ..., .envir = .envir)
-    Execution halted
     ```
 

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -730,12 +730,12 @@ test_that("expr_subtitute() stops at lambdas (#5896)", {
 test_that("expr_subtitute() keeps at double-sided formula (#5894)", {
   expect_identical(
     expr_substitute(expr(case_when(.x < 5 ~ 5, TRUE ~ .x)), quote(.x), quote(a)),
-    expr(case_when(a < 5, TRUE ~ a))
+    expr(case_when(a < 5 ~ 5, TRUE ~ a))
   )
 
   expect_identical(
     expr_substitute(expr(case_when(. < 5 ~ 5, TRUE ~ .)), quote(.), quote(a)),
-    expr(case_when(a < 5, TRUE ~ a))
+    expr(case_when(a < 5 ~ 5, TRUE ~ a))
   )
 })
 

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -727,6 +727,18 @@ test_that("expr_subtitute() stops at lambdas (#5896)", {
   )
 })
 
+test_that("expr_subtitute() keeps at double-sided formula (#5894)", {
+  expect_identical(
+    expr_substitute(expr(case_when(.x < 5 ~ 5, TRUE ~ .x)), quote(.x), quote(a)),
+    expr(case_when(a < 5, TRUE ~ a))
+  )
+
+  expect_identical(
+    expr_substitute(expr(case_when(. < 5 ~ 5, TRUE ~ .)), quote(.), quote(a)),
+    expr(case_when(a < 5, TRUE ~ a))
+  )
+})
+
 # c_across ----------------------------------------------------------------
 
 test_that("selects and combines columns", {


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)

tibble(x = 1:10) %>% 
  mutate(across(x, ~ case_when(
    . < 5 ~ 5L, 
    TRUE  ~ .
  )))  
#> # A tibble: 10 x 1
#>        x
#>    <int>
#>  1     5
#>  2     5
#>  3     5
#>  4     5
#>  5     5
#>  6     6
#>  7     7
#>  8     8
#>  9     9
#> 10    10
```

<sup>Created on 2021-06-10 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>