### PR TITLE
coalesce() support 1-D arrays (#5557)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dplyr 1.0.8
+
+*  `coalesce()` accepts 1-D arrays (#5557).
+
 # dplyr 1.0.7
 
 * `across()` uses the formula environment when inlining them (#5886).

--- a/R/coalesce.R
+++ b/R/coalesce.R
@@ -41,8 +41,8 @@ coalesce <- function(...) {
   x <- values[[1]]
   values <- values[-1]
 
-  if (!is_null(attr(x, "dim"))) {
-    abort("Can't coalesce matrices or arrays.")
+  if (is.array(x) && length(dim(x)) > 1) {
+    abort("Can't coalesce matrices.")
   }
   if (is.data.frame(x)) {
     df_coalesce(x, values)

--- a/tests/testthat/test-coalesce.R
+++ b/tests/testthat/test-coalesce.R
@@ -47,3 +47,9 @@ test_that("coalesce() supports data frames (#5326)", {
 
   expect_error(coalesce(as.matrix(mtcars), as.matrix(mtcars)), "matrices")
 })
+
+test_that("coalesce() supports one-dimensional arrays (#5557)", {
+  x <- array(1:10)
+  out <- coalesce(x, 0)
+  expect_equal(out, x)
+})


### PR DESCRIPTION
This implements @FrancoisGuillem's proposed fix for 1-dimensional arrays.