### PR TITLE
`across()` expansion: also check the ancestry of the formula environment.

### DIFF
--- a/R/across.R
+++ b/R/across.R
@@ -594,9 +594,9 @@ as_across_fn_call <- function(fn, var, env, mask) {
     # it means the formula was unevaluated, and in that case
     # we can use the original quosure environment
     # otherwise, use the formula environment, as it was previously
-    # evaluated and might include data that is not reacha
+    # evaluated and might include data that is not reachable
     f_env <- f_env(fn)
-    if (identical(f_env, mask)) {
+    if (!is.null(f_env) && (identical(f_env, mask) || any(map_lgl(env_parents(f_env), identical, mask)))) {
       f_env <- env
     }
 

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -572,10 +572,17 @@ test_that("across() uses local formula environment (#5881)", {
   })
 
   expect_equal(
-    data.frame(x = 1) %>% mutate(across(where(is.numeric), lst(f = ~ . + 1))),
+    data.frame(x = 1) %>% mutate(across(1, list(f = local(~ . + 1)))),
     data.frame(x = 1, x_f = 2)
   )
 
+  expect_equal(
+    data.frame(x = 1) %>% mutate(across(1, local({
+      `_local_var` <- 1
+      ~ . + `_local_var`
+    }))),
+    data.frame(x = 2)
+  )
 })
 
 test_that("unevaluated formulas (currently) fail", {

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -570,6 +570,12 @@ test_that("across() uses local formula environment (#5881)", {
       tibble(x = "x", x_f = "foo x")
     )
   })
+
+  expect_equal(
+    data.frame(x = 1) %>% mutate(across(where(is.numeric), lst(f = ~ . + 1))),
+    data.frame(x = 1, x_f = 2)
+  )
+
 })
 
 test_that("unevaluated formulas (currently) fail", {


### PR DESCRIPTION
closes #5924

``` r
library(tidyverse)

data.frame(x = 1) %>% 
  mutate(across(where(is.numeric), lst(f = ~ . + 1)))
#>   x x_f
#> 1 1   2
```

<sup>Created on 2021-06-25 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>