### PR TITLE
check slice_min/max(order_by) and slice_sample(weight_by=)

### DIFF
--- a/R/slice.R
+++ b/R/slice.R
@@ -153,11 +153,11 @@ slice_tail.data.frame <- function(.data, ..., n, prop) {
   slice(.data, idx(dplyr::n()))
 }
 
-check_slice_by <- function(idx, arg, x, n) {
-  if (!is.null(x)) {
-    vec_assert(x, size = n, arg = arg)
+check_slice_by <- function(idx, order_by, n) {
+  if (!is.null(order_by)) {
+    vec_assert(order_by, size = n)
   }
-  idx(x, n)
+  idx(order_by, n)
 }
 
 #' @export
@@ -183,7 +183,7 @@ slice_min.data.frame <- function(.data, order_by, ..., n, prop, with_ties = TRUE
   } else {
     idx <- function(x, n) head(order(x), size(n))
   }
-  slice(.data, check_slice_by(idx, "slice_min(order_by=)", {{ order_by }}, dplyr::n()))
+  slice(.data, check_slice_by(idx, {{ order_by }}, dplyr::n()))
 }
 
 #' @export
@@ -207,7 +207,7 @@ slice_max.data.frame <- function(.data, order_by, ..., n, prop, with_ties = TRUE
     idx <- function(x, n) head(order(x, decreasing = TRUE), size(n))
   }
 
-  slice(.data, check_slice_by(idx, "slice_max(order_by=)", {{ order_by }}, dplyr::n()))
+  slice(.data, check_slice_by(idx, {{ order_by }}, dplyr::n()))
 }
 
 #' @export

--- a/R/slice.R
+++ b/R/slice.R
@@ -153,6 +153,13 @@ slice_tail.data.frame <- function(.data, ..., n, prop) {
   slice(.data, idx(dplyr::n()))
 }
 
+check_slice_by <- function(idx, arg, x, n) {
+  if (!is.null(x)) {
+    vec_assert(x, size = n, arg = arg)
+  }
+  idx(x, n)
+}
+
 #' @export
 #' @rdname slice
 #' @param order_by Variable or function of variables to order by.
@@ -176,7 +183,7 @@ slice_min.data.frame <- function(.data, order_by, ..., n, prop, with_ties = TRUE
   } else {
     idx <- function(x, n) head(order(x), size(n))
   }
-  slice(.data, idx({{ order_by }}, dplyr::n()))
+  slice(.data, check_slice_by(idx, "slice_min(order_by=)", {{ order_by }}, dplyr::n()))
 }
 
 #' @export
@@ -200,7 +207,7 @@ slice_max.data.frame <- function(.data, order_by, ..., n, prop, with_ties = TRUE
     idx <- function(x, n) head(order(x, decreasing = TRUE), size(n))
   }
 
-  slice(.data, idx({{ order_by }}, dplyr::n()))
+  slice(.data, check_slice_by(idx, "slice_max(order_by=)", {{ order_by }}, dplyr::n()))
 }
 
 #' @export
@@ -217,6 +224,7 @@ slice_sample <- function(.data, ..., n, prop, weight_by = NULL, replace = FALSE)
 #' @export
 slice_sample.data.frame <- function(.data, ..., n, prop, weight_by = NULL, replace = FALSE) {
   ellipsis::check_dots_empty()
+
   size <- get_slice_size(n, prop, "slice_sample")
   idx <- function(x, n) sample_int(n, size(n), replace = replace, wt = x)
   slice(.data, idx({{ weight_by }}, dplyr::n()))

--- a/R/slice.R
+++ b/R/slice.R
@@ -155,7 +155,7 @@ slice_tail.data.frame <- function(.data, ..., n, prop) {
 
 check_slice_by <- function(idx, order_by, n) {
   if (!is.null(order_by)) {
-    vec_assert(order_by, size = n)
+    vec_assert(order_by, size = n, arg = "order_by")
   }
   idx(order_by, n)
 }

--- a/R/slice.R
+++ b/R/slice.R
@@ -153,13 +153,6 @@ slice_tail.data.frame <- function(.data, ..., n, prop) {
   slice(.data, idx(dplyr::n()))
 }
 
-check_slice_by <- function(idx, order_by, n) {
-  if (!is.null(order_by)) {
-    vec_assert(order_by, size = n, arg = "order_by")
-  }
-  idx(order_by, n)
-}
-
 #' @export
 #' @rdname slice
 #' @param order_by Variable or function of variables to order by.
@@ -183,7 +176,12 @@ slice_min.data.frame <- function(.data, order_by, ..., n, prop, with_ties = TRUE
   } else {
     idx <- function(x, n) head(order(x), size(n))
   }
-  slice(.data, check_slice_by(idx, {{ order_by }}, dplyr::n()))
+
+  slice(.data, {
+    n <- dplyr::n()
+    x <- vec_assert({{ order_by }}, size = n, arg = "order_by")
+    idx(x, n)
+  })
 }
 
 #' @export
@@ -207,7 +205,11 @@ slice_max.data.frame <- function(.data, order_by, ..., n, prop, with_ties = TRUE
     idx <- function(x, n) head(order(x, decreasing = TRUE), size(n))
   }
 
-  slice(.data, check_slice_by(idx, {{ order_by }}, dplyr::n()))
+  slice(.data, {
+    n <- dplyr::n()
+    x <- vec_assert({{ order_by }}, size = n, arg = "order_by")
+    idx(x, n)
+  })
 }
 
 #' @export
@@ -226,7 +228,12 @@ slice_sample.data.frame <- function(.data, ..., n, prop, weight_by = NULL, repla
   ellipsis::check_dots_empty()
 
   size <- get_slice_size(n, prop, "slice_sample")
-  idx <- function(x, n) sample_int(n, size(n), replace = replace, wt = x)
+  idx <- function(x, n) {
+    if (!is.null(x)) {
+      x <- vec_assert(x, size = n, arg = "weight_by")
+    }
+    sample_int(n, size(n), replace = replace, wt = x)
+  }
   slice(.data, idx({{ weight_by }}, dplyr::n()))
 }
 

--- a/R/slice.R
+++ b/R/slice.R
@@ -228,13 +228,15 @@ slice_sample.data.frame <- function(.data, ..., n, prop, weight_by = NULL, repla
   ellipsis::check_dots_empty()
 
   size <- get_slice_size(n, prop, "slice_sample")
-  idx <- function(x, n) {
-    if (!is.null(x)) {
-      x <- vec_assert(x, size = n, arg = "weight_by")
+
+  slice(.data, {
+    n <- dplyr::n()
+    weight_by <- {{ weight_by }}
+    if (!is.null(weight_by)) {
+      weight_by <- vec_assert(weight_by, size = n, arg = "weight_by")
     }
-    sample_int(n, size(n), replace = replace, wt = x)
-  }
-  slice(.data, idx({{ weight_by }}, dplyr::n()))
+    sample_int(n, size(n), replace = replace, wt = weight_by)
+  })
 }
 
 # helpers -----------------------------------------------------------------

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -1,3 +1,21 @@
+# slice_min/max() check size of `order_by=` (#5922)
+
+    Code
+      slice_min(data.frame(x = 1:10), 1:6)
+    Error <dplyr_error>
+      `slice_min(order_by=)` must have size 10, not size 6.
+    Code
+      slice_max(data.frame(x = 1:10), 1:6)
+    Error <dplyr_error>
+      `slice_max(order_by=)` must have size 10, not size 6.
+
+# slice_sample() check size of `weight_by=` (#5922)
+
+    Code
+      slice_sample(data.frame(x = 1:10), n = 2, weight_by = 1:6)
+    Error <dplyr_error>
+      incorrect number of probabilities
+
 # rename errors with invalid grouped data frame (#640)
 
     Code

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -3,11 +3,11 @@
     Code
       slice_min(data.frame(x = 1:10), 1:6)
     Error <dplyr_error>
-      `slice_min(order_by=)` must have size 10, not size 6.
+      `order_by` must have size 10, not size 6.
     Code
       slice_max(data.frame(x = 1:10), 1:6)
     Error <dplyr_error>
-      `slice_max(order_by=)` must have size 10, not size 6.
+      `order_by` must have size 10, not size 6.
 
 # slice_sample() check size of `weight_by=` (#5922)
 

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -14,7 +14,7 @@
     Code
       slice_sample(data.frame(x = 1:10), n = 2, weight_by = 1:6)
     Error <dplyr_error>
-      incorrect number of probabilities
+      `weight_by` must have size 10, not size 6.
 
 # rename errors with invalid grouped data frame (#640)
 

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -277,6 +277,19 @@ test_that("slice_*() checks for constant n= and prop=", {
   expect_error(slice_sample(df, prop = n()), "constant")
 })
 
+test_that("slice_min/max() check size of `order_by=` (#5922)", {
+  expect_snapshot(error = TRUE, {
+    slice_min(data.frame(x = 1:10), 1:6)
+    slice_max(data.frame(x = 1:10), 1:6)
+  })
+})
+
+test_that("slice_sample() check size of `weight_by=` (#5922)", {
+  expect_snapshot(error = TRUE, {
+    slice_sample(data.frame(x = 1:10), n = 2, weight_by = 1:6)
+  })
+})
+
 test_that("slice_sample() does not error on zero rows (#5729)", {
   df <- tibble(dummy = character(), weight = numeric(0))
   res <- expect_error(slice_sample(df, prop=0.5, weight_by = weight), NA)


### PR DESCRIPTION
closes #5922

``` r
library(dplyr, warn.conflicts = FALSE)
df <- data.frame(x = 1:10)
slice_min(df, 1:6)
#> Error: `slice_min(order_by=)` must have size 10, not size 6.
slice_max(df, 1:6)
#> Error: `slice_max(order_by=)` must have size 10, not size 6.
slice_sample(df, n = 2, weight_by = 1:6)
#> Error: `slice_sample(weight_by=)` must have size 10, not size 6.
```

<sup>Created on 2021-06-28 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>