### PR TITLE
Adding context to slice() errors, i.e. the group information.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,8 +6,10 @@
   results, especially data frames created from `across()` with a hint 
   to use `if_any()` or `if_all()`. 
 
-*  `slice()` helpers (`slice_head()`, `slice_tail()`, `slice_min()`, `slice_max()` 
+* `slice()` helpers (`slice_head()`, `slice_tail()`, `slice_min()`, `slice_max()` 
    and `slice_sample()`) now accept negative values for `n` and `prop` (#5961).
+
+* `slice()` now indicates which group produces an error (#5931).
 
 # dplyr 1.0.7
 

--- a/tests/testthat/_snaps/sample.md
+++ b/tests/testthat/_snaps/sample.md
@@ -19,7 +19,7 @@
     Code
       mtcars %>% group_by(cyl) %>% sample_n(10)
     Error <dplyr_error>
-      `size` must be less or equal than 7 (size of data), set `replace` = TRUE to use sampling with replacement.
+      `size` must be less than or equal to 7 (size of data), set `replace` = TRUE to use sampling with replacement.
       i The error occurred in group 2: cyl = 6.
 
 ---

--- a/tests/testthat/_snaps/sample.md
+++ b/tests/testthat/_snaps/sample.md
@@ -2,22 +2,25 @@
 
     Code
       sample_n(grp, nrow(df2) / 2, weight = y)
-    Error <simpleError>
+    Error <dplyr_error>
       too few positive probabilities
+      i The error occurred in group 1: g = 1.
 
 ---
 
     Code
       sample_frac(grp, 1, weight = y)
-    Error <simpleError>
+    Error <dplyr_error>
       too few positive probabilities
+      i The error occurred in group 1: g = 1.
 
 ---
 
     Code
       mtcars %>% group_by(cyl) %>% sample_n(10)
-    Error <rlang_error>
-      `size` must be less than or equal to 7 (size of data), set `replace` = TRUE to use sampling with replacement.
+    Error <dplyr_error>
+      `size` must be less or equal than 7 (size of data), set `replace` = TRUE to use sampling with replacement.
+      i The error occurred in group 2: cyl = 6.
 
 ---
 
@@ -58,27 +61,28 @@
 
     Code
       sample_n(df, 2, weight = y)
-    Error <simpleError>
+    Error <dplyr_error>
       too few positive probabilities
 
 ---
 
     Code
       sample_frac(df, 2)
-    Error <rlang_error>
+    Error <dplyr_error>
       `size` of sampled fraction must be less or equal to one, set `replace` = TRUE to use sampling with replacement.
 
 ---
 
     Code
       sample_frac(df %>% group_by(y), 2)
-    Error <rlang_error>
+    Error <dplyr_error>
       `size` of sampled fraction must be less or equal to one, set `replace` = TRUE to use sampling with replacement.
+      i The error occurred in group 1: y = 0.
 
 ---
 
     Code
       sample_frac(df, 1, weight = y)
-    Error <simpleError>
+    Error <dplyr_error>
       too few positive probabilities
 

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -2,28 +2,28 @@
 
     Code
       slice(df, TRUE)
-    Error <rlang_error>
+    Error <dplyr_error>
       `slice()` expressions should return indices (positive or negative integers).
 
 ---
 
     Code
       slice(df, FALSE)
-    Error <rlang_error>
+    Error <dplyr_error>
       `slice()` expressions should return indices (positive or negative integers).
 
 ---
 
     Code
       mtcars %>% slice(c(-1, 2))
-    Error <rlang_error>
+    Error <dplyr_error>
       `slice()` expressions should return either all positive or all negative.
 
 ---
 
     Code
       mtcars %>% slice(c(2:3, -1))
-    Error <rlang_error>
+    Error <dplyr_error>
       `slice()` expressions should return either all positive or all negative.
 
 ---


### PR DESCRIPTION
closes #5931

``` r
library(dplyr, warn.conflicts = FALSE)

data.frame(x = 1:10, g = rep(1:5, each = 2)) %>% 
  group_by(g) %>% 
  slice(stop("boom"))
#> Error: boom
#> ℹ The error occurred in group 1: g = 1.
```

<sup>Created on 2021-06-28 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

Maybe this should follow the lead of other verbs and use the conditionMessage as a `x`, e.g. something like: 

```r
#> Error: Problem with `slice()` <...>
#> x boom
#> ℹ The error occurred in group 1: g = 1.
```

but because all `...` are collapsed with `quo <- quo(c(!!!dots))` we can't be specific about which of them generates the error, we cannot do e.g. `Problem with `slice()` input ..1`

This change will probably be interesting together with https://github.com/tidyverse/dplyr/pull/5932 
