### PR TITLE
fix warning message. related to #5969

### DIFF
--- a/R/group_data.R
+++ b/R/group_data.R
@@ -102,7 +102,7 @@ group_indices <- function(.data, ...) {
 group_indices.data.frame <- function(.data, ...) {
   if (dots_n(...) > 0) {
     lifecycle::deprecate_warn(
-      "1.0.0", "group_keys(... = )",
+      "1.0.0", "group_indices(... = )",
       details = "Please `group_by()` first"
     )
     .data <- group_by(.data, ...)


### PR DESCRIPTION
this does not address the issue from #5969 because the warning is legit, but at least it should warn about the right function: 

``` r
dplyr::group_indices(mtcars, cyl)
#> Warning: The `...` argument of `group_indices()` is deprecated as of dplyr 1.0.0.
#> Please `group_by()` first
#>  [1] 2 2 1 2 3 2 3 1 1 2 2 3 3 3 3 3 3 1 1 1 1 3 3 3 3 1 1 1 3 2 3 1
```

<sup>Created on 2021-08-05 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>