### PR TITLE
`filter()` forbid matrices

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 # dplyr (development version)
 
-*  `coalesce()` accepts 1-D arrays (#5557).
+* `coalesce()` accepts 1-D arrays (#5557).
+
+* `filter()` forbids matrix results (#5973) and warns about data frame 
+  results, especially data frames created from `across()` with a hint 
+  to use `if_any()` or `if_all()`. 
 
 # dplyr 1.0.7
 

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -114,17 +114,13 @@ SEXP eval_filter_one(SEXP quos, SEXP mask, SEXP caller, R_xlen_t n, SEXP env_fil
     if (TYPEOF(res) == LGLSXP) {
       reduce_lgl_and(reduced, res, n);
     } else if(Rf_inherits(res, "data.frame")) {
-      // disable the warnings entirely for now, so that we can first release
-      // if_any() and if_all(), will start warning later
-      bool warn = false;
-
-      if (first && warn) {
+      if (first) {
         SEXP expr = rlang::quo_get_expr(VECTOR_ELT(quos, i));
         bool across = TYPEOF(expr) == LANGSXP && CAR(expr) == dplyr::symbols::across;
         if (across) {
-          Rf_warningcall(R_NilValue, "Using `across()` in `filter()` is deprecated, use `if_any()` or `if_all()`");
+          Rf_warningcall(R_NilValue, "Using `across()` in `filter()` is deprecated, use `if_any()` or `if_all()`.");
         } else {
-          Rf_warningcall(R_NilValue, "data frame results in `filter()` are deprecated, use `if_any()` or `if_all()`");
+          Rf_warningcall(R_NilValue, "data frame results in `filter()` are deprecated, use `if_any()` or `if_all()`.");
         }
       }
 

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -69,7 +69,7 @@ void filter_check_size(SEXP res, int i, R_xlen_t n, SEXP quos) {
 }
 
 void filter_check_type(SEXP res, R_xlen_t i, SEXP quos) {
-  if (TYPEOF(res) == LGLSXP) return;
+  if (TYPEOF(res) == LGLSXP && !Rf_isMatrix(res)) return;
 
   if (Rf_inherits(res, "data.frame")) {
     R_xlen_t ncol = XLENGTH(res);

--- a/tests/testthat/_snaps/filter.md
+++ b/tests/testthat/_snaps/filter.md
@@ -174,6 +174,8 @@
 
     Code
       data.frame(x = 1, y = 1) %>% filter(across(everything(), ~.x > 0))
+    Warning <simpleWarning>
+      Using `across()` in `filter()` is deprecated, use `if_any()` or `if_all()`.
     Output
         x y
       1 1 1
@@ -182,6 +184,8 @@
 
     Code
       data.frame(x = 1, y = 1) %>% filter(data.frame(x > 0, y > 0))
+    Warning <simpleWarning>
+      data frame results in `filter()` are deprecated, use `if_any()` or `if_all()`.
     Output
         x y
       1 1 1

--- a/tests/testthat/test-filter.r
+++ b/tests/testthat/test-filter.r
@@ -376,6 +376,12 @@ test_that("filter() allows named constants that resolve to logical vectors (#461
   )
 })
 
+test_that("filter() forbids matrices (#5973)", {
+  df <- data.frame(x = 1:2)
+
+  expect_error(filter(df, matrix(c(TRUE, FALSE), nrow = 2)))
+})
+
 test_that("filter() gives useful error messages", {
   # wrong type
   expect_snapshot(error = TRUE,


### PR DESCRIPTION
closes #5973

original code from #5972 gives: 

``` r
library(dplyr, warn.conflicts = FALSE)

tibble(
  y = tibble(
    b = c(1, 2),
    a = c(NA, 1),
  )
) %>% 
  filter(is.na(y))
#> Error: Problem with `filter()` input `..1`.
#> ℹ Input `..1` is `is.na(y)`.
#> x Input `..1` must be a logical vector, not a logical[,2].
```

<sup>Created on 2021-08-06 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>