### PR TITLE
group_by() short-circuit calling grouped_df() when not necessary

### DIFF
--- a/R/group-by.r
+++ b/R/group-by.r
@@ -88,7 +88,11 @@ group_by <- function(.data, ..., .add = FALSE, .drop = group_by_drop_default(.da
 #' @export
 group_by.data.frame <- function(.data, ..., .add = FALSE, .drop = group_by_drop_default(.data)) {
   groups <- group_by_prepare(.data, ..., .add = .add, caller_env = caller_env())
-  grouped_df(groups$data, groups$group_names, .drop)
+  if (is_grouped_df(.data) && identical(group_vars(groups$data), groups$group_names) && identical(.drop, group_by_drop_default(.data))) {
+    groups$data
+  } else {
+    grouped_df(groups$data, groups$group_names, .drop)
+  }
 }
 
 #' @rdname group_by


### PR DESCRIPTION
Not sure this is worth it to support the pattern described in #5952, but this pr implements it, just in case. 

closes #5952

``` r
library(dplyr, warn.conflicts = FALSE)

df <- tibble(id = sample(1:100e3, 1e6, replace = TRUE))

bench::mark(
  group = df %>% 
    group_by(id),
  group_group = df %>% 
    group_by(id) %>% 
    group_by(id),
  group_ungroup_group = df %>% 
    group_by(id) %>% 
    ungroup() %>% 
    group_by(id),
  iterations = 3
)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 3 x 6
#>   expression               min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>          <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 group                 89.6ms  115.2ms      7.67    27.2MB    12.8 
#> 2 group_group           82.1ms   88.3ms      9.84    26.3MB     9.84
#> 3 group_ungroup_group  190.2ms  203.1ms      4.54    52.7MB    10.6
```

<sup>Created on 2021-08-16 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>