### PR TITLE
Prevent construction of non-tibble data frames with tibble columns

### DIFF
--- a/R/generics.R
+++ b/R/generics.R
@@ -198,7 +198,7 @@ dplyr_reconstruct.data.frame <- function(data, template) {
 
   attributes(data) <- attrs
   if (!is.tbl(data) && any(map_lgl(data, is.tbl))) {
-    as_tibble(data, .name_repair = "minimal", rownames = NA)
+    new_tibble(data, nrow = nrow(data))
   } else {
     data
   }

--- a/R/generics.R
+++ b/R/generics.R
@@ -197,11 +197,7 @@ dplyr_reconstruct.data.frame <- function(data, template) {
   attrs$row.names <- .row_names_info(data, type = 0L)
 
   attributes(data) <- attrs
-  if (!is.tbl(data) && any(map_lgl(data, is.tbl))) {
-    new_tibble(data, nrow = nrow(data))
-  } else {
-    data
-  }
+  data
 }
 
 #' @export

--- a/R/generics.R
+++ b/R/generics.R
@@ -197,7 +197,11 @@ dplyr_reconstruct.data.frame <- function(data, template) {
   attrs$row.names <- .row_names_info(data, type = 0L)
 
   attributes(data) <- attrs
-  data
+  if (!is.tbl(data) && any(map_lgl(data, is.tbl))) {
+    as_tibble(data)
+  } else {
+    data
+  }
 }
 
 #' @export

--- a/R/generics.R
+++ b/R/generics.R
@@ -198,7 +198,7 @@ dplyr_reconstruct.data.frame <- function(data, template) {
 
   attributes(data) <- attrs
   if (!is.tbl(data) && any(map_lgl(data, is.tbl))) {
-    as_tibble(data)
+    as_tibble(data, .name_repair = "minimal", rownames = NA)
   } else {
     data
   }

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -174,6 +174,9 @@ mutate.data.frame <- function(.data, ...,
   keep <- arg_match(.keep)
 
   cols <- mutate_cols(.data, ..., caller_env = caller_env())
+  if (!is.tbl(.data) && any(map_lgl(cols, is.tbl))) {
+    .data <- new_tibble(.data, nrow = nrow(.data))
+  }
   out <- dplyr_col_modify(.data, cols)
 
   .before <- enquo(.before)

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -353,6 +353,9 @@ summarise_build <- function(.data, cols) {
   if (!cols$all_one) {
     out <- vec_slice(out, rep(seq_len(nrow(out)), cols$size))
   }
+  if (!is.tbl(out) && any(map_lgl(cols$new, is.tbl))) {
+    out <- new_tibble(out, nrow = nrow(out))
+  }
   dplyr_col_modify(out, cols$new)
 }
 


### PR DESCRIPTION
Closes #5947

Not sure if this is worth fixing since the issue is really with `print.data.frame` and not dplyr (as @DavisVaughan kindly explained to me), but the change is pretty small so I thought I'd submit in case.

Currently, using `mutate` or `summarise` to create a non-tibble data frame with a tibble column results in a warning and confusing output when the result is printed. This PR just checks if `dplyr_reconstruct` is about to output a non-tibble with a tibble column, and if so outputs a tibble instead.

Current output:

``` r
data.frame(a = 1) %>% 
  summarise(b = tibble(bb = 1))
#                                         b
# 1 \033[38;5;246m# A tibble: 1 × 1\033[39m
# Warning message:
# In format.data.frame(if (omit) x[seq_len(n0), , drop = FALSE] else x,  :
#   corrupt data frame: columns will be truncated or padded with NAs
```

This PR:

``` r
data.frame(a = 1) %>% 
  summarise(b = tibble(bb = 1))
# # A tibble: 1 × 1
#    b$bb
#   <dbl>
# 1     1
```
