### PR TITLE
Require dev rlang

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Imports:
     magrittr (>= 1.5),
     methods,
     R6,
-    rlang (>= 0.4.10),
+    rlang (>= 0.4.11.9001),
     tibble (>= 2.1.3),
     tidyselect (>= 1.1.0),
     utils,
@@ -75,3 +75,5 @@ Config/Needs/website:
     shiny,
     r-lib/pkgdown,
     tidyverse/tidytemplate
+Remotes:
+    r-lib/rlang

--- a/R/arrange.R
+++ b/R/arrange.R
@@ -122,6 +122,10 @@ arrange_rows <- function(.data, dots) {
     if (inherits(cnd, "dplyr:::mutate_error")) {
       # reverse the name mangling
       bullets <- gsub("^^--arrange_quosure_", "..", cnd$bullets, fixed = TRUE)
+      # only name bullets that aren't already named
+      names <- names2(bullets)
+      names[names == ""] <- "x"
+      bullets <- set_names(bullets, names)
     } else {
       bullets <- c(x = conditionMessage(cnd))
     }

--- a/R/group-by.r
+++ b/R/group-by.r
@@ -172,7 +172,7 @@ group_by_prepare <- function(.data,
   if (length(unknown) > 0) {
     abort(c(
       "Must group by variables found in `.data`.",
-      glue("Column `{unknown}` is not found.")
+      x = glue("Column `{unknown}` is not found.")
     ))
   }
 

--- a/tests/testthat/_snaps/across.md
+++ b/tests/testthat/_snaps/across.md
@@ -25,7 +25,7 @@
 # if_any() and if_all() aborts when predicate mistakingly used in .cols= (#5732)
 
     Code
-      (expect_error(filter(df, if_any(~.x > 5))))
+      (expect_error(filter(df, if_any(~ .x > 5))))
     Output
       <error/dplyr_error>
       Problem with `filter()` input `..1`.
@@ -35,7 +35,7 @@
       i The first argument `.cols` selects a set of columns.
       i The second argument `.fns` operates on each selected columns.
     Code
-      (expect_error(filter(df, if_all(~.x > 5))))
+      (expect_error(filter(df, if_all(~ .x > 5))))
     Output
       <error/dplyr_error>
       Problem with `filter()` input `..1`.
@@ -45,7 +45,7 @@
       i The first argument `.cols` selects a set of columns.
       i The second argument `.fns` operates on each selected columns.
     Code
-      (expect_error(filter(df, !if_any(~.x > 5))))
+      (expect_error(filter(df, !if_any(~ .x > 5))))
     Output
       <error/dplyr_error>
       Problem with `filter()` input `..1`.
@@ -55,7 +55,7 @@
       i The first argument `.cols` selects a set of columns.
       i The second argument `.fns` operates on each selected columns.
     Code
-      (expect_error(filter(df, !if_all(~.x > 5))))
+      (expect_error(filter(df, !if_all(~ .x > 5))))
     Output
       <error/dplyr_error>
       Problem with `filter()` input `..1`.

--- a/tests/testthat/_snaps/arrange.md
+++ b/tests/testthat/_snaps/arrange.md
@@ -12,7 +12,7 @@
       tibble(x = 1) %>% arrange(y)
     Error <dplyr_error>
       arrange() failed at implicit mutate() step. 
-      * Problem with `mutate()` column `..1`.
+      Problem with `mutate()` column `..1`.
       i `..1 = y`.
       x object 'y' not found
 
@@ -22,7 +22,7 @@
       tibble(x = 1) %>% arrange(rep(x, 2))
     Error <dplyr_error>
       arrange() failed at implicit mutate() step. 
-      * Problem with `mutate()` column `..1`.
+      Problem with `mutate()` column `..1`.
       i `..1 = rep(x, 2)`.
       i `..1` must be size 1, not 2.
 

--- a/tests/testthat/_snaps/arrange.md
+++ b/tests/testthat/_snaps/arrange.md
@@ -12,7 +12,7 @@
       tibble(x = 1) %>% arrange(y)
     Error <dplyr_error>
       arrange() failed at implicit mutate() step. 
-      Problem with `mutate()` column `..1`.
+      x Problem with `mutate()` column `..1`.
       i `..1 = y`.
       x object 'y' not found
 
@@ -22,7 +22,7 @@
       tibble(x = 1) %>% arrange(rep(x, 2))
     Error <dplyr_error>
       arrange() failed at implicit mutate() step. 
-      Problem with `mutate()` column `..1`.
+      x Problem with `mutate()` column `..1`.
       i `..1 = rep(x, 2)`.
       i `..1` must be size 1, not 2.
 

--- a/tests/testthat/_snaps/colwise-filter.md
+++ b/tests/testthat/_snaps/colwise-filter.md
@@ -8,7 +8,7 @@
 ---
 
     Code
-      filter_all(mtcars, list(~. > 0))
+      filter_all(mtcars, list(~ . > 0))
     Error <rlang_error>
       `.vars_predicate` must be a function or a call to `all_vars()` or `any_vars()`, not a list.
 

--- a/tests/testthat/_snaps/deprec-funs.md
+++ b/tests/testthat/_snaps/deprec-funs.md
@@ -32,7 +32,7 @@
 ---
 
     Code
-      funs(~mp[.])
+      funs(~ mp[.])
     Error <rlang_error>
       `~mp[.]` must be a function name (quoted or unquoted) or an unquoted call, not `~`.
 

--- a/tests/testthat/_snaps/filter.md
+++ b/tests/testthat/_snaps/filter.md
@@ -173,7 +173,7 @@
 ---
 
     Code
-      data.frame(x = 1, y = 1) %>% filter(across(everything(), ~.x > 0))
+      data.frame(x = 1, y = 1) %>% filter(across(everything(), ~ .x > 0))
     Warning <simpleWarning>
       Using `across()` in `filter()` is deprecated, use `if_any()` or `if_all()`.
     Output

--- a/tests/testthat/_snaps/group-by.md
+++ b/tests/testthat/_snaps/group-by.md
@@ -18,7 +18,7 @@
       df %>% group_by(unknown)
     Error <rlang_error>
       Must group by variables found in `.data`.
-      Column `unknown` is not found.
+      x Column `unknown` is not found.
 
 ---
 

--- a/tests/testthat/_snaps/group-by.md
+++ b/tests/testthat/_snaps/group-by.md
@@ -18,7 +18,7 @@
       df %>% group_by(unknown)
     Error <rlang_error>
       Must group by variables found in `.data`.
-      * Column `unknown` is not found.
+      Column `unknown` is not found.
 
 ---
 
@@ -26,12 +26,10 @@
       df %>% ungroup(x)
     Error <rlib_error_dots_nonempty>
       `...` is not empty.
-      
-      We detected these problematic arguments:
+      i These dots only exist to allow future extensions and should be empty.
+      x We detected these problematic arguments:
       * `..1`
-      
-      These dots only exist to allow future extensions and should be empty.
-      Did you misspecify an argument?
+      i Did you misspecify an argument?
 
 ---
 

--- a/tests/testthat/_snaps/group_map.md
+++ b/tests/testthat/_snaps/group_map.md
@@ -1,7 +1,7 @@
 # group_map() give meaningful errors
 
     Code
-      mtcars %>% group_by(cyl) %>% group_modify(~data.frame(cyl = 19))
+      mtcars %>% group_by(cyl) %>% group_modify(~ data.frame(cyl = 19))
     Error <rlang_error>
       The returned data frame cannot contain the original grouping variables: cyl.
 


### PR DESCRIPTION
Closes r-lib/rlang#1254

This was coming with https://github.com/tidyverse/dplyr/pull/5942, which is close to being ready to merge, but doing this in its own PR is much cleaner since there are a few changes:

- A few snapshot tests are changed since now there is a space in anonymous functions between `~` and the body
- The `check_dots_empty()` error comes from rlang now and is a little different
- In two places, we relied on `abort()` auto-naming the non-header bullets. It no longer does this, so I've added explicit `x` names on these bullets. See also https://github.com/r-lib/rlang/issues/1254

@lionel- I imagine that rlang will probably be sent to CRAN before dplyr, so there will be a short period where the two places we weren't explicitly naming the bullets will now emit unbulleted messages, but they are fairly rare errors so I think that is okay (grouping by a nonexistent variable and having an error with the implicit mutate() inside an arrange() call)