### PR TITLE
+ regression test that mutate() fails on named empty argument.

### DIFF
--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -484,6 +484,12 @@ test_that("rowwise() + mutate(across()) correctly handles list columns (#5951)",
   )
 })
 
+test_that("mutate() fails on named empty arguments (#5925)", {
+  expect_error(
+    mutate(tibble(), bogus = )
+  )
+})
+
 # Error messages ----------------------------------------------------------
 
 test_that("mutate() give meaningful errors", {


### PR DESCRIPTION
closes #5925