### PR TITLE
mutate(.keep = "none") not changing the order of the variables.

### DIFF
--- a/R/generics.R
+++ b/R/generics.R
@@ -137,6 +137,12 @@ dplyr_col_modify.data.frame <- function(data, cols) {
   # Must be implemented from first principles to avoiding edge cases in
   # [.data.frame and [.tibble (2.1.3 and earlier).
 
+  # deal with the special case of mutate(.keep = "none")
+  # where columns are all added to the right in their order of
+  # appearance in ..., independently from them being in the original
+  # data or not
+  reset <- identical(attr(cols, "keep"), "none")
+
   # Apply tidyverse recycling rules
   cols <- vec_recycle_common(!!!cols, .size = nrow(data))
 
@@ -148,6 +154,9 @@ dplyr_col_modify.data.frame <- function(data, cols) {
 
   for (i in seq_along(cols)) {
     nm <- nms[[i]]
+    if (reset) {
+      out[[nm]] <- NULL
+    }
     out[[nm]] <- cols[[i]]
   }
 

--- a/R/generics.R
+++ b/R/generics.R
@@ -137,12 +137,6 @@ dplyr_col_modify.data.frame <- function(data, cols) {
   # Must be implemented from first principles to avoiding edge cases in
   # [.data.frame and [.tibble (2.1.3 and earlier).
 
-  # deal with the special case of mutate(.keep = "none")
-  # where columns are all added to the right in their order of
-  # appearance in ..., independently from them being in the original
-  # data or not
-  reset <- identical(attr(cols, "keep"), "none")
-
   # Apply tidyverse recycling rules
   cols <- vec_recycle_common(!!!cols, .size = nrow(data))
 
@@ -154,9 +148,6 @@ dplyr_col_modify.data.frame <- function(data, cols) {
 
   for (i in seq_along(cols)) {
     nm <- nms[[i]]
-    if (reset) {
-      out[[nm]] <- NULL
-    }
     out[[nm]] <- cols[[i]]
   }
 

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -197,12 +197,7 @@ mutate.data.frame <- function(.data, ...,
     keep <- intersect(names(out), c(group_vars(.data), used, names(cols)))
     dplyr_col_select(out, keep)
   } else if (keep == "none") {
-    keep <- c(
-      # ensure group vars present
-      setdiff(group_vars(.data), names(cols)),
-      # cols might contain NULLs
-      intersect(names(cols), names(out))
-    )
+    keep <- intersect(names(out), c(group_vars(.data), names(cols)))
     dplyr_col_select(out, keep)
   }
 }

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -345,6 +345,13 @@ test_that(".keep = 'none' prefers new order", {
   # even when grouped
   gf <- group_by(df, x)
   expect_named(gf %>% mutate(y = 1, x = 2, .keep = "none"), c("y", "x"))
+
+  df <- tibble(x = 1, y = 1, z = 1, a = 1, b = 2, c = 3) %>%
+    group_by(a, b)
+
+  expect_named(mutate(df, d = 1, x = 2, .keep = "none"), c("a", "b", "d", "x"))
+  expect_named(mutate(df, d = 1, x = 2, .keep = "none", .before = "a"), c("d", "x", "a", "b"))
+  expect_named(mutate(df, d = 1, x = 2, .keep = "none", .after = "a"), c("a", "d", "x", "b"))
 })
 
 test_that("can use .before and .after to control column position", {


### PR DESCRIPTION
closes #5967

``` r
library(dplyr, warn.conflicts = FALSE)

df <- tibble(x = 1, g = 2)
df %>% 
  group_by(g) %>% 
  transmute(x)
#> # A tibble: 1 x 2
#> # Groups:   g [1]
#>       x     g
#>   <dbl> <dbl>
#> 1     1     2
```

<sup>Created on 2021-09-08 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

however this breaks this test: 

```r
test_that(".keep = 'none' prefers new order", {
  df <- tibble(x = 1, y = 2)
  expect_named(df %>% mutate(y = 1, x = 2, .keep = "none"), c("y", "x"))

  # even when grouped
  gf <- group_by(df, x)
  expect_named(gf %>% mutate(y = 1, x = 2, .keep = "none"), c("y", "x"))
})
```

Also I'm not convinced by the use of `transmute(x)`, i.e. not doing anything to `x`, and when we actually do something to it, perhaps it should go to the right (i.e. be considered a new variable): 

``` r
library(dplyr, warn.conflicts = FALSE)

df <- tibble(x = 1, g = 2)
df %>% 
  group_by(g) %>% 
  transmute(x = x + 1)
#> # A tibble: 1 x 2
#> # Groups:   g [1]
#>       x     g
#>   <dbl> <dbl>
#> 1     2     2
```

<sup>Created on 2021-09-08 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

