### PR TITLE
Give warning for early atomic conditions in `case_when`

### DIFF
--- a/R/case_when.R
+++ b/R/case_when.R
@@ -218,6 +218,7 @@ validate_case_when_length <- function(query, value, fs) {
   all_lengths <- unique(c(lhs_lengths, rhs_lengths))
 
   if (any(lhs_lengths > 1)) {
+    # TRUE ~ RHS is okay for last case
     early_atomic_condition <- head(lhs_lengths == 1, -1)
     if (any(early_atomic_condition)) {
       i <- which.max(early_atomic_condition)

--- a/R/case_when.R
+++ b/R/case_when.R
@@ -217,6 +217,14 @@ validate_case_when_length <- function(query, value, fs) {
   rhs_lengths <- lengths(value)
   all_lengths <- unique(c(lhs_lengths, rhs_lengths))
 
+  if (any(lhs_lengths > 1)) {
+    atomic_cond_not_last <- head(lhs_lengths == 1, -1)
+    if (any(atomic_cond_not_last)) {
+      i <- which.max(atomic_cond_not_last)
+      warn(glue("LHS of case {i} (`{fs[i]}`) is a single value and will be recycled."))
+    }
+  }
+
   if (length(all_lengths) <= 1) {
     return(all_lengths[[1]])
   }

--- a/R/case_when.R
+++ b/R/case_when.R
@@ -218,9 +218,9 @@ validate_case_when_length <- function(query, value, fs) {
   all_lengths <- unique(c(lhs_lengths, rhs_lengths))
 
   if (any(lhs_lengths > 1)) {
-    atomic_cond_not_last <- head(lhs_lengths == 1, -1)
-    if (any(atomic_cond_not_last)) {
-      i <- which.max(atomic_cond_not_last)
+    early_atomic_condition <- head(lhs_lengths == 1, -1)
+    if (any(early_atomic_condition)) {
+      i <- which.max(early_atomic_condition)
       warn(glue("LHS of case {i} (`{fs[i]}`) is a single value and will be recycled."))
     }
   }

--- a/tests/testthat/_snaps/case-when.md
+++ b/tests/testthat/_snaps/case-when.md
@@ -1,3 +1,12 @@
+# warn when recycling atomic conditions
+
+    Code
+      case_when(rep(FALSE, 3) ~ "first", TRUE ~ "second", TRUE ~ "last")
+    Warning <warning>
+      LHS of case 2 (`TRUE ~ "second"`) is a single value and will be recycled.
+    Output
+      [1] "second" "second" "second"
+
 # case_when() give meaningful errors
 
     Code

--- a/tests/testthat/test-case-when.R
+++ b/tests/testthat/test-case-when.R
@@ -77,6 +77,37 @@ test_that("zero-length conditions and values (#3041)", {
   )
 })
 
+test_that("warn when recycling atomic conditions", {
+  expect_snapshot(
+    case_when(
+      rep(FALSE, 3) ~ 'first',
+      TRUE ~ 'second',
+      TRUE ~ 'last'
+    )
+  )
+
+  # do not warn for final case
+  expect_equal(
+    case_when(
+      rep(FALSE, 3) ~ 'first',
+      rep(TRUE, 3) ~ 'second',
+      TRUE ~ 'last'
+    ),
+    rep("second", 3)
+  )
+
+  # do not warn if all conditions are atomic
+  expect_equal(
+    case_when(
+      FALSE ~ 'first',
+      TRUE ~ 'second',
+      TRUE ~ 'last'
+    ),
+    "second"
+  )
+
+})
+
 test_that("case_when can be used in anonymous functions (#3422)", {
   res <- tibble(a = 1:3) %>%
     mutate(b = (function(x) case_when(x < 2 ~ TRUE, TRUE ~ FALSE))(a)) %>%


### PR DESCRIPTION
To address mistakenly single-valued conditions. For example, single-valued condition caused by using `&&` instead of `&` in https://github.com/tidyverse/dtplyr/issues/300.

Current dplyr:

``` r
library(dplyr, warn.conflicts = FALSE)

df <- data.frame(a = 1:5, b = 11:15)

df %>% 
  mutate(grp = 
    case_when(
      a == 3 && b < 15 ~ 'grp 1',
      b > 15 ~ 'grp 2',
      TRUE ~ 'other'
    )
  )
#>   a  b   grp
#> 1 1 11 other
#> 2 2 12 other
#> 3 3 13 other
#> 4 4 14 other
#> 5 5 15 other
```

<sup>Created on 2021-09-11 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

This PR:

``` r
library(dplyr, warn.conflicts = FALSE)

df <- data.frame(a = 1:5, b = 11:15)

df %>% 
  mutate(grp = 
    case_when(
      a == 3 && b < 15 ~ 'grp 1',
      b > 15 ~ 'grp 2',
      TRUE ~ 'other'
    )
  )
#> Warning: LHS of case 1 (`a == 3 && b < 15 ~ "grp 1"`) is a single value and will
#> be recycled.
#>   a  b   grp
#> 1 1 11 other
#> 2 2 12 other
#> 3 3 13 other
#> 4 4 14 other
#> 5 5 15 other
```

<sup>Created on 2021-09-11 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>