### PR TITLE
Force altrep materialization before calling vec_chop() internally

### DIFF
--- a/R/zzz.r
+++ b/R/zzz.r
@@ -1,5 +1,5 @@
-dplyr_vec_chop <- function(x, indices = NULL) {
-  vec_chop(x[], indices = indices)
+force_altrep_materialization <- function(x) {
+  .Call("dplyr_force_altrep_materialization", x)
 }
 
 .onLoad <- function(libname, pkgname) {

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -1,3 +1,7 @@
+dplyr_vec_chop <- function(x, indices = NULL) {
+  vec_chop(x[], indices = indices)
+}
+
 .onLoad <- function(libname, pkgname) {
   op <- options()
   op.dplyr <- list(

--- a/src/chop.cpp
+++ b/src/chop.cpp
@@ -20,7 +20,9 @@ void dplyr_lazy_vec_chop_grouped(SEXP chops_env, SEXP rows, SEXP data, bool roww
     if (rowwise && vctrs::vec_is_list(column) && Rf_length(column) > 0) {
       SET_PRCODE(prom, column);
     } else {
-      SET_PRCODE(prom, Rf_lang3(dplyr::functions::vec_chop, column, rows));
+      SEXP force_call = PROTECT(Rf_lang2(dplyr::functions::force_altrep_materialization, column));
+      SET_PRCODE(prom, Rf_lang3(dplyr::functions::vec_chop, force_call, rows));
+      UNPROTECT(1);
     }
     SET_PRVALUE(prom, R_UnboundValue);
 

--- a/src/dplyr.h
+++ b/src/dplyr.h
@@ -69,6 +69,7 @@ struct functions {
   static SEXP dot_subset2;
   static SEXP list;
   static SEXP function;
+  static SEXP force_altrep_materialization;
 };
 
 } // namespace dplyr
@@ -122,6 +123,7 @@ SEXP env_resolved(SEXP env, SEXP names);
 void add_mask_binding(SEXP name, SEXP env_bindings, SEXP env_chops);
 
 SEXP dplyr_extract_chunks(SEXP df_list, SEXP df_ptype);
+SEXP dplyr_force_altrep_materialization(SEXP x);
 
 #define DPLYR_MASK_INIT()                                                                    \
 SEXP rows = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::rows));                   \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -70,6 +70,7 @@ SEXP functions::vec_chop = NULL;
 SEXP functions::dot_subset2 = NULL;
 SEXP functions::list = NULL;
 SEXP functions::function = NULL;
+SEXP functions::force_altrep_materialization = NULL;
 
 } // dplyr
 
@@ -77,17 +78,19 @@ SEXP dplyr_init_library(SEXP ns_dplyr, SEXP ns_vctrs, SEXP ns_rlang) {
   dplyr::envs::ns_dplyr = ns_dplyr;
   dplyr::envs::ns_vctrs = ns_vctrs;
   dplyr::envs::ns_rlang = ns_rlang;
-  dplyr::functions::vec_chop = PROTECT(Rf_findVarInFrame(ns_dplyr, Rf_install("dplyr_vec_chop")));
+  dplyr::functions::vec_chop = PROTECT(Rf_findVarInFrame(ns_vctrs, Rf_install("vec_chop")));
   dplyr::functions::dot_subset2 = PROTECT(Rf_findVarInFrame(R_BaseEnv, Rf_install(".subset2")));
   dplyr::functions::list = PROTECT(Rf_findVarInFrame(R_BaseEnv, Rf_install("list")));
   dplyr::functions::function = PROTECT(Rf_eval(Rf_install("function"), R_BaseEnv));
+  dplyr::functions::force_altrep_materialization = PROTECT(Rf_findVarInFrame(ns_dplyr, Rf_install("force_altrep_materialization")));
 
   R_PreserveObject(dplyr::functions::vec_chop);
   R_PreserveObject(dplyr::functions::dot_subset2);
   R_PreserveObject(dplyr::functions::list);
   R_PreserveObject(dplyr::functions::function);
+  R_PreserveObject(dplyr::functions::force_altrep_materialization);
 
-  UNPROTECT(4);
+  UNPROTECT(5);
 
   return R_NilValue;
 }
@@ -121,6 +124,8 @@ static const R_CallMethodDef CallEntries[] = {
   {"env_resolved", (DL_FUNC)& env_resolved, 2},
 
   {"dplyr_extract_chunks", (DL_FUNC)& dplyr_extract_chunks, 2},
+
+  {"dplyr_force_altrep_materialization", (DL_FUNC)& dplyr_force_altrep_materialization, 1},
 
   {NULL, NULL, 0}
 };

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -77,7 +77,7 @@ SEXP dplyr_init_library(SEXP ns_dplyr, SEXP ns_vctrs, SEXP ns_rlang) {
   dplyr::envs::ns_dplyr = ns_dplyr;
   dplyr::envs::ns_vctrs = ns_vctrs;
   dplyr::envs::ns_rlang = ns_rlang;
-  dplyr::functions::vec_chop = PROTECT(Rf_findVarInFrame(ns_vctrs, Rf_install("vec_chop")));
+  dplyr::functions::vec_chop = PROTECT(Rf_findVarInFrame(ns_dplyr, Rf_install("dplyr_vec_chop")));
   dplyr::functions::dot_subset2 = PROTECT(Rf_findVarInFrame(R_BaseEnv, Rf_install(".subset2")));
   dplyr::functions::list = PROTECT(Rf_findVarInFrame(R_BaseEnv, Rf_install("list")));
   dplyr::functions::function = PROTECT(Rf_eval(Rf_install("function"), R_BaseEnv));

--- a/src/mask.cpp
+++ b/src/mask.cpp
@@ -125,3 +125,8 @@ SEXP dplyr_mask_remove(SEXP env_private, SEXP s_name) {
   UNPROTECT(2);
   return R_NilValue;
 }
+
+SEXP dplyr_force_altrep_materialization(SEXP x) {
+  DATAPTR(x);
+  return x;
+}


### PR DESCRIPTION
related to #6015. 

(experimental) this calls `vec_chop(force_altrep_materialzation(x))` instead of `vec_chop(x)` so that `x` is materialized, and the standard subset can be used. 

I get: 

``` r
library(readr)
library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union

url <- url("https://media.githubusercontent.com/media/matanmazor/thesis/main/index/data/RC/RC.csv")

df <- read_csv(url)
#> Rows: 1488000 Columns: 15
#> ── Column specification ────────────────────────────────────────────────────────
#> Delimiter: ","
#> dbl (15): subj_id, trial_id, trial_number, timepoint, detection, direction, ...
#> 
#> ℹ Use `spec()` to retrieve the full column specification for this data.
#> ℹ Specify the column types or set `show_col_types = FALSE` to quiet this message.

df <- df %>%
  mutate(
    confidence = confidence / 1000,
    direction = ifelse(direction == 3,1,0)
  )

gdf <- df %>%
  group_by(subj_id, trial_id)

system.time({
  gdf_result <- summarise(
    gdf,
    detection = detection[timepoint == 1],
    RT = RT[timepoint == 1] - 700
  )
})
#> `summarise()` has grouped output by 'subj_id'. You can override using the `.groups` argument.
#>    user  system elapsed 
#>   0.978   0.044   0.332
```

<sup>Created on 2021-09-16 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

instead of: 

``` r
#> `summarise()` has grouped output by 'subj_id'. You can override using the `.groups` argument.
#>    user  system elapsed 
#>  12.308  15.604  11.247
```

IIRC we already had a situation where getting out of altrep was beneficial. Note that this only forces the columns that are touched. 
