### PR TITLE
Update `group_by()` algorithm to utilize `vec_locate_sorted_groups()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -76,4 +76,5 @@ Config/Needs/website:
     r-lib/pkgdown,
     tidyverse/tidytemplate
 Remotes:
-    r-lib/rlang
+    r-lib/rlang,
+    r-lib/vctrs#1441

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,19 @@
 # dplyr (development version)
 
+* `group_by()` uses a new algorithm for computing and ordering groups. This is
+  often faster than the previous approach, especially when there are many
+  groups. In most cases, there should be no user visible changes. However,
+  character grouping columns are now ordered in the C locale rather than the
+  system locale, for performance. This change shows up in functions that use
+  the group data, such as `summarise()` or `group_split()`, where the order
+  of the results may have changed due to the usage of a different locale. If
+  the ordering of the results of a call to `summarise()` is important (i.e.
+  for constructing a table to be used in a report), you should explicitly call
+  `arrange()` after `summarise()` to sort as needed. If needed, the global
+  option `dplyr.legacy_group_by_locale` can be set to `TRUE` to revert to the
+  old algorithm, but this should be used extremely sparingly and will be
+  removed in a future version of dplyr.
+
 * `coalesce()` accepts 1-D arrays (#5557).
 
 * `filter()` forbids matrix results (#5973) and warns about data frame 

--- a/R/all-equal.r
+++ b/R/all-equal.r
@@ -64,8 +64,8 @@ equal_data_frame <- function(x, y, ignore_col_order = TRUE, ignore_row_order = T
     y <- as_tibble(y, .name_repair = "universal")
   # })
 
-  x_split <- vec_split_id_order(x)
-  y_split <- vec_split_id_order(y[, names(x), drop = FALSE])
+  x_split <- dplyr_locate_sorted_groups(x)
+  y_split <- dplyr_locate_sorted_groups(y[, names(x), drop = FALSE])
 
   # keys must be identical
   msg <- ""

--- a/R/group-by.r
+++ b/R/group-by.r
@@ -31,6 +31,21 @@
 #'
 #' * `group_by()`: \Sexpr[stage=render,results=rd]{dplyr:::methods_rd("group_by")}.
 #' * `ungroup()`: \Sexpr[stage=render,results=rd]{dplyr:::methods_rd("ungroup")}.
+#' @section Ordering:
+#' `group_by()` internally orders the groups in ascending order. This results
+#' in ordered output from functions that aggregate groups, such as
+#' [summarise()].
+#'
+#' When used as grouping columns, character vectors are ordered in
+#' the C locale for performance. This is reflected in downstream calls to
+#' `summarise()`. If order matters after performing a grouped operation, it is
+#' advised to explicitly call [arrange()] after `summarise()`.
+#'
+#' Prior to dplyr 1.1.0, character vectors were ordered in the system locale
+#' when used as grouping columns. If you need to temporarily revert to this
+#' behavior, you can set the global option `dplyr.legacy_group_by_locale` to
+#' `TRUE`, but generally it is better to update existing code to call
+#' `arrange()` where needed instead.
 #' @export
 #' @examples
 #' by_cyl <- mtcars %>% group_by(cyl)

--- a/man/group_by.Rd
+++ b/man/group_by.Rd
@@ -54,6 +54,24 @@ Methods available in currently loaded packages:
 }
 }
 
+\section{Ordering}{
+
+\code{group_by()} internally orders the groups in ascending order. This results
+in ordered output from functions that aggregate groups, such as
+\code{\link[=summarise]{summarise()}}.
+
+When used as grouping columns, character vectors are ordered in
+the C locale for performance. This is reflected in downstream calls to
+\code{summarise()}. If order matters after performing a grouped operation, it is
+advised to explicitly call \code{\link[=arrange]{arrange()}} after \code{summarise()}.
+
+Prior to dplyr 1.1.0, character vectors were ordered in the system locale
+when used as grouping columns. If you need to temporarily revert to this
+behavior, you can set the global option \code{dplyr.legacy_group_by_locale} to
+\code{TRUE}, but generally it is better to update existing code to call
+\code{arrange()} where needed instead.
+}
+
 \examples{
 by_cyl <- mtcars \%>\% group_by(cyl)
 

--- a/tests/testthat/_snaps/bind.md
+++ b/tests/testthat/_snaps/bind.md
@@ -2,21 +2,21 @@
 
     Code
       bound <- bind_cols(df, df)
-    Message <simpleMessage>
+    Message <rlib_message_name_repair>
       New names:
-      * a -> a...1
-      * b -> b...2
-      * a -> a...3
-      * b -> b...4
+      * `a` -> `a...1`
+      * `b` -> `b...2`
+      * `a` -> `a...3`
+      * `b` -> `b...4`
 
 # bind_cols() handles unnamed list with name repair (#3402)
 
     Code
       df <- bind_cols(list(1, 2))
-    Message <simpleMessage>
+    Message <rlib_message_name_repair>
       New names:
-      * NA -> ...1
-      * NA -> ...2
+      * `` -> `...1`
+      * `` -> `...2`
 
 # *_bind() give meaningful errors
 

--- a/tests/testthat/_snaps/grouped-df.md
+++ b/tests/testthat/_snaps/grouped-df.md
@@ -99,3 +99,10 @@
     Error <rlang_error>
       `vars` must be a character vector.
 
+# `dplyr.legacy_group_by_locale` is validated
+
+    Code
+      dplyr_legacy_group_by_locale()
+    Error <rlang_error>
+      Global option `dplyr.legacy_group_by_locale` must be a single `TRUE` or `FALSE`.
+

--- a/tests/testthat/test-grouped-df.r
+++ b/tests/testthat/test-grouped-df.r
@@ -182,3 +182,30 @@ test_that("helper gives meaningful error messages", {
   expect_snapshot(error = TRUE, grouped_df(data.frame(x = 1), "y", FALSE))
   expect_snapshot(error = TRUE, grouped_df(data.frame(x = 1), 1))
 })
+
+test_that("NA and NaN are in separate groups at the end", {
+  df <- tibble(x = c(NA, NaN, NA, 1))
+  result <- compute_groups(df, "x")
+  expect_identical(result$x, c(1, NaN, NA))
+})
+
+test_that("groups are ordered in the C locale", {
+  df <- tibble(x = c("a", "A", "Z", "b"))
+  result <- compute_groups(df, "x")
+  expect_identical(result$x, c("A", "Z", "a", "b"))
+})
+
+test_that("`dplyr.legacy_group_by_locale` orders groups in the system locale", {
+  local_options(dplyr.legacy_group_by_locale = TRUE)
+  withr::local_collate("en_US")
+
+  df <- tibble(x = c("a", "A", "Z", "b"))
+  result <- compute_groups(df, "x")
+  expect_identical(result$x, c("a", "A", "b", "Z"))
+})
+
+test_that("`dplyr.legacy_group_by_locale` is validated", {
+  local_options(dplyr.legacy_group_by_locale = 1)
+  expect_snapshot(error = TRUE, dplyr_legacy_group_by_locale())
+})
+


### PR DESCRIPTION
Probably merge after #5942 when we are working on dplyr 1.1.0

Closes #5808 
Closes #4406