### PR TITLE
Rework `mutate.data.frame()` to better implement `.keep`

### DIFF
--- a/R/mutate.R
+++ b/R/mutate.R
@@ -62,12 +62,13 @@
 #' An object of the same type as `.data`. The output has the following
 #' properties:
 #'
-#' * Rows are not affected.
-#' * Existing columns will be preserved according to the `.keep` argument.
-#'   New columns will be placed according to the `.before` and `.after`
-#'   arguments. If `.keep = "none"` (as in `transmute()`), the output order
-#'   is determined only by `...`, not the order of existing columns.
-#' * Columns given value `NULL` will be removed
+#' * The number of rows is not affected.
+#' * Columns from `.data` will be preserved according to the `.keep` argument.
+#' * Existing columns that are modified by `...` will always be returned in
+#'   their original location.
+#' * New columns created through `...` will be placed according to the
+#'   `.before` and `.after` arguments.
+#' * Columns given the value `NULL` will be removed.
 #' * Groups will be recomputed if a grouping variable is mutated.
 #' * Data frame attributes are preserved.
 #' @section Methods:

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -87,7 +87,7 @@
 #'  mutate(
 #'   mass2 = mass * 2,
 #'   mass2_squared = mass2 * mass2
-#' )
+#'  )
 #'
 #' # As well as adding new variables, you can use mutate() to
 #' # remove variables and modify existing variables.
@@ -96,7 +96,7 @@
 #'  mutate(
 #'   mass = NULL,
 #'   height = height * 0.0328084 # convert to feet
-#' )
+#'  )
 #'
 #' # Use across() with mutate() to apply a transformation
 #' # to multiple columns in a tibble.

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -152,17 +152,19 @@ mutate <- function(.data, ...) {
 
 #' @rdname mutate
 #' @param .keep \Sexpr[results=rd]{lifecycle::badge("experimental")}
-#'   This is an experimental argument that allows you to control which columns
-#'   from `.data` are retained in the output:
+#'   Control which columns from `.data` are retained in the output. Grouping
+#'   columns and columns created by `...` are always kept.
 #'
-#'   * `"all"`, the default, retains all variables.
-#'   * `"used"` keeps any variables used to make new variables; it's useful
-#'     for checking your work as it displays inputs and outputs side-by-side.
-#'   * `"unused"` keeps only existing variables **not** used to make new
-#'     variables.
-#'   * `"none"`, only keeps grouping keys (like [transmute()]).
-#'
-#'   Grouping variables are always kept, unconditional to `.keep`.
+#'   * `"all"` retains all columns from `.data`. This is the default.
+#'   * `"used"` retains only the columns used in `...` to create new
+#'     columns. This is useful for checking your work, as it displays inputs
+#'     and outputs side-by-side.
+#'   * `"unused"` retains only the columns _not_ used in `...` to create new
+#'     columns. This is useful if you generate new columns, but no longer need
+#'     the columns used to generate them.
+#'   * `"none"` doesn't retain any extra columns from `.data`. Only the grouping
+#'     variables and columns created by `...` are kept. This is equivalent to
+#'     using [transmute()].
 #' @param .before,.after \Sexpr[results=rd]{lifecycle::badge("experimental")}
 #'   <[`tidy-select`][dplyr_tidy_select]> Optionally, control where new columns
 #'   should appear (the default is to add to the right hand side). See

--- a/man/mutate.Rd
+++ b/man/mutate.Rd
@@ -60,12 +60,13 @@ should appear (the default is to add to the right hand side). See
 An object of the same type as \code{.data}. The output has the following
 properties:
 \itemize{
-\item Rows are not affected.
-\item Existing columns will be preserved according to the \code{.keep} argument.
-New columns will be placed according to the \code{.before} and \code{.after}
-arguments. If \code{.keep = "none"} (as in \code{transmute()}), the output order
-is determined only by \code{...}, not the order of existing columns.
-\item Columns given value \code{NULL} will be removed
+\item The number of rows is not affected.
+\item Columns from \code{.data} will be preserved according to the \code{.keep} argument.
+\item Existing columns that are modified by \code{...} will always be returned in
+their original location.
+\item New columns created through \code{...} will be placed according to the
+\code{.before} and \code{.after} arguments.
+\item Columns given the value \code{NULL} will be removed.
 \item Groups will be recomputed if a grouping variable is mutated.
 \item Data frame attributes are preserved.
 }

--- a/man/mutate.Rd
+++ b/man/mutate.Rd
@@ -36,18 +36,20 @@ if ungrouped).
 }}
 
 \item{.keep}{\Sexpr[results=rd]{lifecycle::badge("experimental")}
-This is an experimental argument that allows you to control which columns
-from \code{.data} are retained in the output:
+Control which columns from \code{.data} are retained in the output. Grouping
+columns and columns created by \code{...} are always kept.
 \itemize{
-\item \code{"all"}, the default, retains all variables.
-\item \code{"used"} keeps any variables used to make new variables; it's useful
-for checking your work as it displays inputs and outputs side-by-side.
-\item \code{"unused"} keeps only existing variables \strong{not} used to make new
-variables.
-\item \code{"none"}, only keeps grouping keys (like \code{\link[=transmute]{transmute()}}).
-}
-
-Grouping variables are always kept, unconditional to \code{.keep}.}
+\item \code{"all"} retains all columns from \code{.data}. This is the default.
+\item \code{"used"} retains only the columns used in \code{...} to create new
+columns. This is useful for checking your work, as it displays inputs
+and outputs side-by-side.
+\item \code{"unused"} retains only the columns \emph{not} used in \code{...} to create new
+columns. This is useful if you generate new columns, but no longer need
+the columns used to generate them.
+\item \code{"none"} doesn't retain any extra columns from \code{.data}. Only the grouping
+variables and columns created by \code{...} are kept. This is equivalent to
+using \code{\link[=transmute]{transmute()}}.
+}}
 
 \item{.before, .after}{\Sexpr[results=rd]{lifecycle::badge("experimental")}
 <\code{\link[=dplyr_tidy_select]{tidy-select}}> Optionally, control where new columns

--- a/man/mutate.Rd
+++ b/man/mutate.Rd
@@ -131,7 +131,7 @@ starwars \%>\%
  mutate(
   mass2 = mass * 2,
   mass2_squared = mass2 * mass2
-)
+ )
 
 # As well as adding new variables, you can use mutate() to
 # remove variables and modify existing variables.
@@ -140,7 +140,7 @@ starwars \%>\%
  mutate(
   mass = NULL,
   height = height * 0.0328084 # convert to feet
-)
+ )
 
 # Use across() with mutate() to apply a transformation
 # to multiple columns in a tibble.


### PR DESCRIPTION
Closes #6007 
Closes #5967 

I'm hoping that this is a much simpler variant of #6007 that is overall easier to understand and test.

Essentially there are 4 _rules_ that always hold:
- _Group_ variables are always retained and never move
- _Modified_ variables are always retained and never move
- _New_ variables are always retained and move at the whim of `.before` and `.after`. Default is to add them to the end.
- _NULL_ expressions remove columns entirely

This takes care of everything except `.keep`, and we now have a language to refer to the different types of columns. There are two extra column types:
- _Used_ variables are variables from the original data used to generate other columns. The set of used variables excludes group variables and modified variables.
- _Unused_ variables are variables from the original data that were never touched. This again excludes group variables and modified variables.

Now for `.keep`:
- `"all"`: 
  - Retain group, modified, new, used, unused. 
  - Drop nothing.
- `"used"`: 
  - Retain group, modified, new, used. 
  - Drop unused.
- `"unused"`: 
  - Retain group, modified, new, unused. 
  - Drop used.
- `"none"`: 
  - Retain group, modified, new. 
  - Drop used, unused.

So the implementation is:
- We let `dplyr_col_modify()` add modified and new variables to the data frame. This works nicely as modified variables overwrite without changing the location, and new variables are added to the end.
- We let `relocate()` change the position of the new variables as needed.
- We apply the `.keep` rules outlined above to figure out what to drop from the set of used/unused variables. Note that the column order doesn't change at all here. This is strictly about dropping columns.

An important invariant that falls out here is that `.keep` plays no role in the column ordering, and I think that is valuable. I think giving `keep = "none"` special behavior in a few places that changed column order is what made this so hard to get correct before.