### PR TITLE
check empty dots in set operations on data frames

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -69,7 +69,7 @@ VignetteBuilder:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1.9001
+RoxygenNote: 7.1.2
 Config/testthat/edition: 3
 Config/Needs/website:
     tidyverse,

--- a/R/sets.r
+++ b/R/sets.r
@@ -62,7 +62,7 @@ generics::setequal
 
 #' @export
 intersect.data.frame <- function(x, y, ...) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   check_compatible(x, y)
   cast <- vec_cast_common(x, y)
   new_x <- cast[[1L]]
@@ -73,7 +73,7 @@ intersect.data.frame <- function(x, y, ...) {
 
 #' @export
 union.data.frame <- function(x, y, ...) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   check_compatible(x, y)
   out <- vec_unique(vec_rbind(!!!vec_cast_common(x, y)))
   reconstruct_set(out, x)
@@ -81,14 +81,14 @@ union.data.frame <- function(x, y, ...) {
 
 #' @export
 union_all.data.frame <- function(x, y, ...) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   out <- bind_rows(x, y)
   reconstruct_set(out, x)
 }
 
 #' @export
 setdiff.data.frame <- function(x, y, ...) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   check_compatible(x, y)
   cast <- vec_cast_common(x, y)
   new_x <- cast[[1L]]
@@ -99,7 +99,7 @@ setdiff.data.frame <- function(x, y, ...) {
 
 #' @export
 setequal.data.frame <- function(x, y, ...) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   isTRUE(equal_data_frame(x, y))
 }
 

--- a/R/sets.r
+++ b/R/sets.r
@@ -6,7 +6,7 @@
 #' `intersect()`, `union()` and `setdiff()` remove duplicates.
 #'
 #' @param x,y objects to perform set function on (ignoring order)
-#' @param ... other arguments passed on to methods
+#' @inheritParams rlang::args_dot_empty
 #' @name setops
 #' @examples
 #' mtcars$model <- rownames(mtcars)
@@ -42,7 +42,10 @@ NULL
 #' @export
 union_all <- function(x, y, ...) UseMethod("union_all")
 #' @export
-union_all.default <- function(x, y, ...) vec_c(x, y, ...)
+union_all.default <- function (x, y, ...) {
+  check_dots_empty()
+  vec_c(x, y)
+}
 
 #' @importFrom generics intersect
 #' @export

--- a/R/sets.r
+++ b/R/sets.r
@@ -62,7 +62,7 @@ generics::setequal
 
 #' @export
 intersect.data.frame <- function(x, y, ...) {
-  rlang::check_dots_empty()
+  check_dots_empty()
   check_compatible(x, y)
   cast <- vec_cast_common(x, y)
   new_x <- cast[[1L]]
@@ -73,7 +73,7 @@ intersect.data.frame <- function(x, y, ...) {
 
 #' @export
 union.data.frame <- function(x, y, ...) {
-  rlang::check_dots_empty()
+  check_dots_empty()
   check_compatible(x, y)
   out <- vec_unique(vec_rbind(!!!vec_cast_common(x, y)))
   reconstruct_set(out, x)
@@ -81,14 +81,14 @@ union.data.frame <- function(x, y, ...) {
 
 #' @export
 union_all.data.frame <- function(x, y, ...) {
-  rlang::check_dots_empty()
+  check_dots_empty()
   out <- bind_rows(x, y)
   reconstruct_set(out, x)
 }
 
 #' @export
 setdiff.data.frame <- function(x, y, ...) {
-  rlang::check_dots_empty()
+  check_dots_empty()
   check_compatible(x, y)
   cast <- vec_cast_common(x, y)
   new_x <- cast[[1L]]
@@ -99,7 +99,7 @@ setdiff.data.frame <- function(x, y, ...) {
 
 #' @export
 setequal.data.frame <- function(x, y, ...) {
-  rlang::check_dots_empty()
+  check_dots_empty()
   isTRUE(equal_data_frame(x, y))
 }
 

--- a/R/sets.r
+++ b/R/sets.r
@@ -6,7 +6,7 @@
 #' `intersect()`, `union()` and `setdiff()` remove duplicates.
 #'
 #' @param x,y objects to perform set function on (ignoring order)
-#' @inheritParams rlang::args_dot_empty
+#' @inheritParams rlang::args_dots_empty
 #' @name setops
 #' @examples
 #' mtcars$model <- rownames(mtcars)

--- a/R/sets.r
+++ b/R/sets.r
@@ -62,6 +62,7 @@ generics::setequal
 
 #' @export
 intersect.data.frame <- function(x, y, ...) {
+  ellipsis::check_dots_empty()
   check_compatible(x, y)
   cast <- vec_cast_common(x, y)
   new_x <- cast[[1L]]
@@ -72,6 +73,7 @@ intersect.data.frame <- function(x, y, ...) {
 
 #' @export
 union.data.frame <- function(x, y, ...) {
+  ellipsis::check_dots_empty()
   check_compatible(x, y)
   out <- vec_unique(vec_rbind(!!!vec_cast_common(x, y)))
   reconstruct_set(out, x)
@@ -79,12 +81,14 @@ union.data.frame <- function(x, y, ...) {
 
 #' @export
 union_all.data.frame <- function(x, y, ...) {
+  ellipsis::check_dots_empty()
   out <- bind_rows(x, y)
   reconstruct_set(out, x)
 }
 
 #' @export
 setdiff.data.frame <- function(x, y, ...) {
+  ellipsis::check_dots_empty()
   check_compatible(x, y)
   cast <- vec_cast_common(x, y)
   new_x <- cast[[1L]]
@@ -95,6 +99,7 @@ setdiff.data.frame <- function(x, y, ...) {
 
 #' @export
 setequal.data.frame <- function(x, y, ...) {
+  ellipsis::check_dots_empty()
   isTRUE(equal_data_frame(x, y))
 }
 

--- a/man/setops.Rd
+++ b/man/setops.Rd
@@ -10,7 +10,7 @@ union_all(x, y, ...)
 \arguments{
 \item{x, y}{objects to perform set function on (ignoring order)}
 
-\item{...}{other arguments passed on to methods}
+\item{...}{These dots are for future extensions and must be empty.}
 }
 \description{
 These functions override the set functions provided in base to make them

--- a/tests/testthat/test-sets.R
+++ b/tests/testthat/test-sets.R
@@ -90,6 +90,17 @@ test_that("set equality", {
   expect_false(setequal(df2, df1))
 })
 
+test_that("set operations enforce empty ... (#5891)", {
+  a <- tibble(var = 1:3)
+  b <- tibble(var = 2:4)
+  c <- tibble(var = c(1, 3, 4, 5))
+
+  expect_error(intersect(a, b, c))
+  expect_error(setdiff(a, b, c))
+  expect_error(setequal(a, b, c))
+  expect_error(union(a, b, c))
+  expect_error(union_all(a, b, c))
+})
 
 # Errors ------------------------------------------------------------------
 


### PR DESCRIPTION
closes #5891

``` r
library(dplyr, warn.conflicts = FALSE)
a <- tibble(var = 1:3)
b <- tibble(var = 2:4)
c <- tibble(var = c(1, 3, 4, 5))

intersect(a, b, c)
#> Error: `...` is not empty.
#> ℹ These dots only exist to allow future extensions and should be empty.
#> x We detected these problematic arguments:
#> • `..1`
#> ℹ Did you misspecify an argument?
setdiff(a, b, c)
#> Error: `...` is not empty.
#> ℹ These dots only exist to allow future extensions and should be empty.
#> x We detected these problematic arguments:
#> • `..1`
#> ℹ Did you misspecify an argument?
setequal(a, b, c)
#> Error: `...` is not empty.
#> ℹ These dots only exist to allow future extensions and should be empty.
#> x We detected these problematic arguments:
#> • `..1`
#> ℹ Did you misspecify an argument?
union(a, b, c)
#> Error: `...` is not empty.
#> ℹ These dots only exist to allow future extensions and should be empty.
#> x We detected these problematic arguments:
#> • `..1`
#> ℹ Did you misspecify an argument?
union_all(a, b, c)
#> Error: `...` is not empty.
#> ℹ These dots only exist to allow future extensions and should be empty.
#> x We detected these problematic arguments:
#> • `..1`
#> ℹ Did you misspecify an argument?
```

<sup>Created on 2021-10-01 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>