### PR TITLE
Use rlang dots helper instead of ellipsis

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,6 +30,7 @@ BugReports: https://github.com/tidyverse/dplyr/issues
 Depends: 
     R (>= 3.4.0)
 Imports: 
+    ellipsis, 
     generics,
     glue (>= 1.3.2),
     lifecycle (>= 1.0.1),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,6 @@ BugReports: https://github.com/tidyverse/dplyr/issues
 Depends: 
     R (>= 3.4.0)
 Imports: 
-    ellipsis, 
     generics,
     glue (>= 1.3.2),
     lifecycle (>= 1.0.1),
@@ -39,7 +38,7 @@ Imports:
     R6,
     rlang (>= 0.4.11.9001),
     tibble (>= 2.1.3),
-    tidyselect (>= 1.1.0),
+    tidyselect (>= 1.1.1),
     utils,
     vctrs (>= 0.3.5), 
     pillar (>= 1.5.1)
@@ -69,7 +68,7 @@ VignetteBuilder:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1.9001
+RoxygenNote: 7.1.2
 Config/testthat/edition: 3
 Config/Needs/website:
     tidyverse,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,6 @@ BugReports: https://github.com/tidyverse/dplyr/issues
 Depends: 
     R (>= 3.4.0)
 Imports: 
-    ellipsis,
     generics,
     glue (>= 1.3.2),
     lifecycle (>= 1.0.1),

--- a/R/group-by.r
+++ b/R/group-by.r
@@ -131,13 +131,13 @@ ungroup.grouped_df <- function(x, ...) {
 
 #' @export
 ungroup.rowwise_df <- function(x, ...) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   as_tibble(x)
 }
 
 #' @export
 ungroup.data.frame <- function(x, ...) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   x
 }
 

--- a/R/group-by.r
+++ b/R/group-by.r
@@ -131,13 +131,13 @@ ungroup.grouped_df <- function(x, ...) {
 
 #' @export
 ungroup.rowwise_df <- function(x, ...) {
-  rlang::check_dots_empty()
+  check_dots_empty()
   as_tibble(x)
 }
 
 #' @export
 ungroup.data.frame <- function(x, ...) {
-  rlang::check_dots_empty()
+  check_dots_empty()
   x
 }
 

--- a/R/pull.R
+++ b/R/pull.R
@@ -34,7 +34,7 @@
 #' # Pull a named vector
 #' starwars %>% pull(height, name)
 pull <- function(.data, var = -1, name = NULL, ...) {
-  rlang::check_dots_used()
+  check_dots_used()
   UseMethod("pull")
 }
 #' @export

--- a/R/pull.R
+++ b/R/pull.R
@@ -34,7 +34,7 @@
 #' # Pull a named vector
 #' starwars %>% pull(height, name)
 pull <- function(.data, var = -1, name = NULL, ...) {
-  ellipsis::check_dots_used()
+  rlang::check_dots_used()
   UseMethod("pull")
 }
 #' @export

--- a/R/rows.R
+++ b/R/rows.R
@@ -73,14 +73,12 @@ NULL
 #' @rdname rows
 #' @export
 rows_insert <- function(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
-  # Need action = warn, because methods may have
-  # side effects that persist even after we abort
-  check_dots_used(action = warn)
   UseMethod("rows_insert")
 }
 
 #' @export
 rows_insert.data.frame <- function(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
+  check_dots_empty()
   key <- rows_check_key(by, x, y)
   y <- auto_copy(x, y, copy = copy)
   rows_df_in_place(in_place)
@@ -100,14 +98,12 @@ rows_insert.data.frame <- function(x, y, by = NULL, ..., copy = FALSE, in_place 
 #' @rdname rows
 #' @export
 rows_update <- function(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
-  # Need action = warn, because methods may have
-  # side effects that persist even after we abort
-  check_dots_used(action = warn)
   UseMethod("rows_update", x)
 }
 
 #' @export
 rows_update.data.frame <- function(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
+  check_dots_empty()
   key <- rows_check_key(by, x, y)
   y <- auto_copy(x, y, copy = copy)
   rows_df_in_place(in_place)
@@ -128,14 +124,12 @@ rows_update.data.frame <- function(x, y, by = NULL, ..., copy = FALSE, in_place 
 #' @rdname rows
 #' @export
 rows_patch <- function(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
-  # Need action = warn, because methods may have
-  # side effects that persist even after we abort
-  check_dots_used(action = warn)
   UseMethod("rows_patch", x)
 }
 
 #' @export
 rows_patch.data.frame <- function(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
+  check_dots_empty()
   key <- rows_check_key(by, x, y)
   y <- auto_copy(x, y, copy = copy)
   rows_df_in_place(in_place)
@@ -158,14 +152,12 @@ rows_patch.data.frame <- function(x, y, by = NULL, ..., copy = FALSE, in_place =
 #' @rdname rows
 #' @export
 rows_upsert <- function(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
-  # Need action = warn, because methods may have
-  # side effects that persist even after we abort
-  check_dots_used(action = warn)
   UseMethod("rows_upsert", x)
 }
 
 #' @export
 rows_upsert.data.frame <- function(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
+  check_dots_empty()
   key <- rows_check_key(by, x, y)
   y <- auto_copy(x, y, copy = copy)
   rows_df_in_place(in_place)
@@ -184,14 +176,12 @@ rows_upsert.data.frame <- function(x, y, by = NULL, ..., copy = FALSE, in_place 
 #' @rdname rows
 #' @export
 rows_delete <- function(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
-  # Need action = warn, because methods may have
-  # side effects that persist even after we abort
-  check_dots_used(action = warn)
   UseMethod("rows_delete", x)
 }
 
 #' @export
 rows_delete.data.frame <- function(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
+  check_dots_empty()
   key <- rows_check_key(by, x, y)
   y <- auto_copy(x, y, copy = copy)
   rows_df_in_place(in_place)

--- a/R/rows.R
+++ b/R/rows.R
@@ -75,7 +75,7 @@ NULL
 rows_insert <- function(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
   # Need action = warn, because methods may have
   # side effects that persist even after we abort
-  ellipsis::check_dots_used(action = warn)
+  rlang::check_dots_used(action = warn)
   UseMethod("rows_insert")
 }
 
@@ -102,7 +102,7 @@ rows_insert.data.frame <- function(x, y, by = NULL, ..., copy = FALSE, in_place 
 rows_update <- function(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
   # Need action = warn, because methods may have
   # side effects that persist even after we abort
-  ellipsis::check_dots_used(action = warn)
+  rlang::check_dots_used(action = warn)
   UseMethod("rows_update", x)
 }
 
@@ -130,7 +130,7 @@ rows_update.data.frame <- function(x, y, by = NULL, ..., copy = FALSE, in_place 
 rows_patch <- function(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
   # Need action = warn, because methods may have
   # side effects that persist even after we abort
-  ellipsis::check_dots_used(action = warn)
+  rlang::check_dots_used(action = warn)
   UseMethod("rows_patch", x)
 }
 
@@ -160,7 +160,7 @@ rows_patch.data.frame <- function(x, y, by = NULL, ..., copy = FALSE, in_place =
 rows_upsert <- function(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
   # Need action = warn, because methods may have
   # side effects that persist even after we abort
-  ellipsis::check_dots_used(action = warn)
+  rlang::check_dots_used(action = warn)
   UseMethod("rows_upsert", x)
 }
 
@@ -186,7 +186,7 @@ rows_upsert.data.frame <- function(x, y, by = NULL, ..., copy = FALSE, in_place 
 rows_delete <- function(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
   # Need action = warn, because methods may have
   # side effects that persist even after we abort
-  ellipsis::check_dots_used(action = warn)
+  rlang::check_dots_used(action = warn)
   UseMethod("rows_delete", x)
 }
 

--- a/R/rows.R
+++ b/R/rows.R
@@ -75,7 +75,7 @@ NULL
 rows_insert <- function(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
   # Need action = warn, because methods may have
   # side effects that persist even after we abort
-  rlang::check_dots_used(action = warn)
+  check_dots_used(action = warn)
   UseMethod("rows_insert")
 }
 
@@ -102,7 +102,7 @@ rows_insert.data.frame <- function(x, y, by = NULL, ..., copy = FALSE, in_place 
 rows_update <- function(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
   # Need action = warn, because methods may have
   # side effects that persist even after we abort
-  rlang::check_dots_used(action = warn)
+  check_dots_used(action = warn)
   UseMethod("rows_update", x)
 }
 
@@ -130,7 +130,7 @@ rows_update.data.frame <- function(x, y, by = NULL, ..., copy = FALSE, in_place 
 rows_patch <- function(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
   # Need action = warn, because methods may have
   # side effects that persist even after we abort
-  rlang::check_dots_used(action = warn)
+  check_dots_used(action = warn)
   UseMethod("rows_patch", x)
 }
 
@@ -160,7 +160,7 @@ rows_patch.data.frame <- function(x, y, by = NULL, ..., copy = FALSE, in_place =
 rows_upsert <- function(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
   # Need action = warn, because methods may have
   # side effects that persist even after we abort
-  rlang::check_dots_used(action = warn)
+  check_dots_used(action = warn)
   UseMethod("rows_upsert", x)
 }
 
@@ -186,7 +186,7 @@ rows_upsert.data.frame <- function(x, y, by = NULL, ..., copy = FALSE, in_place 
 rows_delete <- function(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
   # Need action = warn, because methods may have
   # side effects that persist even after we abort
-  rlang::check_dots_used(action = warn)
+  check_dots_used(action = warn)
   UseMethod("rows_delete", x)
 }
 

--- a/R/select-helpers.R
+++ b/R/select-helpers.R
@@ -49,9 +49,6 @@ group_cols_legacy <- function(vars = NULL) {
   }
 }
 
-# Flag to disable hotpatching from old tidyselect versions
-peek_vars <- tidyselect::peek_vars
-
 # Alias required for help links in downstream packages
 #' @aliases select_helpers
 #' @importFrom tidyselect contains

--- a/R/slice.R
+++ b/R/slice.R
@@ -133,7 +133,7 @@ slice_head <- function(.data, ..., n, prop) {
 
 #' @export
 slice_head.data.frame <- function(.data, ..., n, prop) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   size <- get_slice_size(n, prop, "slice_head")
   idx <- function(n) seq2(1, size(n))
   slice(.data, idx(dplyr::n()))
@@ -147,7 +147,7 @@ slice_tail <- function(.data, ..., n, prop) {
 
 #' @export
 slice_tail.data.frame <- function(.data, ..., n, prop) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   size <- get_slice_size(n, prop, "slice_tail")
   idx <- function(n) seq2(n - size(n) + 1, n)
   slice(.data, idx(dplyr::n()))
@@ -169,7 +169,7 @@ slice_min.data.frame <- function(.data, order_by, ..., n, prop, with_ties = TRUE
     abort("argument `order_by` is missing, with no default.")
   }
 
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   size <- get_slice_size(n, prop, "slice_min")
   if (with_ties) {
     idx <- function(x, n) head(order(x), smaller_ranks(x, size(n)))
@@ -195,7 +195,7 @@ slice_max.data.frame <- function(.data, order_by, ..., n, prop, with_ties = TRUE
   if (missing(order_by)) {
     abort("argument `order_by` is missing, with no default.")
   }
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   size <- get_slice_size(n, prop, "slice_max")
   if (with_ties) {
     idx <- function(x, n) head(
@@ -225,7 +225,7 @@ slice_sample <- function(.data, ..., n, prop, weight_by = NULL, replace = FALSE)
 
 #' @export
 slice_sample.data.frame <- function(.data, ..., n, prop, weight_by = NULL, replace = FALSE) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
 
   size <- get_slice_size(n, prop, "slice_sample")
 

--- a/R/slice.R
+++ b/R/slice.R
@@ -133,7 +133,8 @@ slice_head <- function(.data, ..., n, prop) {
 
 #' @export
 slice_head.data.frame <- function(.data, ..., n, prop) {
-  rlang::check_dots_empty()
+  check_dots_empty()
+
   size <- get_slice_size(n, prop, "slice_head")
   idx <- function(n) seq2(1, size(n))
   slice(.data, idx(dplyr::n()))
@@ -147,7 +148,8 @@ slice_tail <- function(.data, ..., n, prop) {
 
 #' @export
 slice_tail.data.frame <- function(.data, ..., n, prop) {
-  rlang::check_dots_empty()
+  check_dots_empty()
+
   size <- get_slice_size(n, prop, "slice_tail")
   idx <- function(n) seq2(n - size(n) + 1, n)
   slice(.data, idx(dplyr::n()))
@@ -165,11 +167,11 @@ slice_min <- function(.data, order_by, ..., n, prop, with_ties = TRUE) {
 
 #' @export
 slice_min.data.frame <- function(.data, order_by, ..., n, prop, with_ties = TRUE) {
+  check_dots_empty()
   if (missing(order_by)) {
     abort("argument `order_by` is missing, with no default.")
   }
 
-  rlang::check_dots_empty()
   size <- get_slice_size(n, prop, "slice_min")
   if (with_ties) {
     idx <- function(x, n) head(order(x), smaller_ranks(x, size(n)))
@@ -192,10 +194,11 @@ slice_max <- function(.data, order_by, ..., n, prop, with_ties = TRUE) {
 
 #' @export
 slice_max.data.frame <- function(.data, order_by, ..., n, prop, with_ties = TRUE) {
+  check_dots_empty()
   if (missing(order_by)) {
     abort("argument `order_by` is missing, with no default.")
   }
-  rlang::check_dots_empty()
+
   size <- get_slice_size(n, prop, "slice_max")
   if (with_ties) {
     idx <- function(x, n) head(
@@ -225,7 +228,7 @@ slice_sample <- function(.data, ..., n, prop, weight_by = NULL, replace = FALSE)
 
 #' @export
 slice_sample.data.frame <- function(.data, ..., n, prop, weight_by = NULL, replace = FALSE) {
-  rlang::check_dots_empty()
+check_dots_empty()
 
   size <- get_slice_size(n, prop, "slice_sample")
 


### PR DESCRIPTION
Perhaps this should drop the `rlang::` prefix too since `rlang` is `@import`'ed