### PR TITLE
`across(...)` evaluated more lazily

### DIFF
--- a/R/across.R
+++ b/R/across.R
@@ -31,7 +31,8 @@
 #'
 #'   Within these functions you can use [cur_column()] and [cur_group()]
 #'   to access the current column and grouping keys respectively.
-#' @param ... Additional arguments for the function calls in `.fns`.
+#' @param ... Additional arguments for the function calls in `.fns`. Using these
+#'   `...` is strongly discouraged because of issues of timing of evaluation.
 #' @param .names A glue specification that describes how to name the output
 #'   columns. This can use `{.col}` to stand for the selected column name, and
 #'   `{.fn}` to stand for the name of the function being applied. The default

--- a/R/across.R
+++ b/R/across.R
@@ -166,8 +166,6 @@ across <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
   k <- 1L
   out <- vector("list", n_cols * n_fns)
 
-  dots <- enquos(...)
-
   # Reset `cur_column()` info on exit
   old_var <- context_peek_bare("column")
   on.exit(context_poke("column", old_var), add = TRUE)
@@ -183,7 +181,7 @@ across <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
 
       for (j in seq_fns) {
         fn <- fns[[j]]
-        out[[k]] <- eval_tidy(call2(fn, col, !!!dots))
+        out[[k]] <- fn(col, ...)
         k <- k + 1L
       }
     }, error = function(cnd) {

--- a/R/across.R
+++ b/R/across.R
@@ -166,6 +166,8 @@ across <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
   k <- 1L
   out <- vector("list", n_cols * n_fns)
 
+  dots <- enquos(...)
+
   # Reset `cur_column()` info on exit
   old_var <- context_peek_bare("column")
   on.exit(context_poke("column", old_var), add = TRUE)
@@ -181,7 +183,7 @@ across <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
 
       for (j in seq_fns) {
         fn <- fns[[j]]
-        out[[k]] <- fn(col, ...)
+        out[[k]] <- eval_tidy(call2(fn, col, !!!dots))
         k <- k + 1L
       }
     }, error = function(cnd) {

--- a/man/across.Rd
+++ b/man/across.Rd
@@ -32,7 +32,8 @@ use a function that takes a data frame.
 Within these functions you can use \code{\link[=cur_column]{cur_column()}} and \code{\link[=cur_group]{cur_group()}}
 to access the current column and grouping keys respectively.}
 
-\item{...}{Additional arguments for the function calls in \code{.fns}.}
+\item{...}{Additional arguments for the function calls in \code{.fns}. Using these
+\code{...} is strongly discouraged because of issues of timing of evaluation.}
 
 \item{.names}{A glue specification that describes how to name the output
 columns. This can use \code{{.col}} to stand for the selected column name, and

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -532,6 +532,7 @@ test_that("across() evaluates ... with promise semantics (#5813)", {
   expect_equal(res$x$foo, 2)
   expect_equal(res$y$foo, 3)
 
+  skip("to be discussed")
   # Dots are evaluated only once
   new_counter <- function() {
     n <- 0L

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -501,7 +501,27 @@ test_that("across() correctly reset column", {
   expect_error(cur_column())
 })
 
-test_that("top_across() evaluates ... with promise semantics (#5813)", {
+test_that("across() can omit dots", {
+  df <- tibble(x = tibble(foo = 1), y = tibble(foo = 2))
+
+  # top
+  res <- mutate(df, across(
+    everything(),
+    list
+  ))
+  expect_equal(res$x[[1]]$foo, 1)
+  expect_equal(res$y[[1]]$foo, 2)
+
+  # not top
+  res <- mutate(df, force(across(
+    everything(),
+    list
+  )))
+  expect_equal(res$x[[1]]$foo, 1)
+  expect_equal(res$y[[1]]$foo, 2)
+})
+
+test_that("across() evaluates ... with promise semantics (#5813)", {
   df <- tibble(x = tibble(foo = 1), y = tibble(foo = 2))
 
   res <- mutate(df, across(
@@ -511,14 +531,6 @@ test_that("top_across() evaluates ... with promise semantics (#5813)", {
   ))
   expect_equal(res$x$foo, 2)
   expect_equal(res$y$foo, 3)
-
-  # Can omit dots
-  res <- mutate(df, across(
-    everything(),
-    list
-  ))
-  expect_equal(res$x[[1]]$foo, 1)
-  expect_equal(res$y[[1]]$foo, 2)
 
   # Dots are evaluated only once
   new_counter <- function() {

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -532,7 +532,6 @@ test_that("across() evaluates ... with promise semantics (#5813)", {
   expect_equal(res$x$foo, 2)
   expect_equal(res$y$foo, 3)
 
-  skip("to be discussed")
   # Dots are evaluated only once
   new_counter <- function() {
     n <- 0L


### PR DESCRIPTION
closes #6068 

This goes against what was discussed with @lionel- in #5813 so I'm not really sure. The point raised in #6068 needs to be addressed though. 

This should either fail, maybe with a message saying that `cur_column()` cannot be used in `across(...)` or succeed (the way of this pull request). 

``` r
library(dplyr, warn.conflicts = FALSE)
tibble(a = 1:5, b = 2:6) %>% 
  mutate(across(everything(), paste, cur_column()))
#> # A tibble: 5 × 2
#>   a     b    
#>   <chr> <chr>
#> 1 1 a   2 b  
#> 2 2 a   3 b  
#> 3 3 a   4 b  
#> 4 4 a   5 b  
#> 5 5 a   6 b
```

<sup>Created on 2021-11-08 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1.9000)</sup>

This invalidates a test that was added in #5813 (skipped now):

``` r
test_that("across() evaluates ... with promise semantics (#5813)", {
  df <- tibble(x = tibble(foo = 1), y = tibble(foo = 2))

  res <- mutate(df, across(
    everything(),
    mutate,
    foo = foo + 1
  ))
  expect_equal(res$x$foo, 2)
  expect_equal(res$y$foo, 3)

  skip("to be discussed")
  # Dots are evaluated only once
  new_counter <- function() {
    n <- 0L
    function() {
      n <<- n + 1L
      n
    }
  }
  counter <- new_counter()
  list_second <- function(...) {
    list(..2)
  }
  res <- mutate(df, across(
    everything(),
    list_second,
    counter()
  ))
  expect_equal(res$x[[1]], 1)
  expect_equal(res$y[[1]], 1)
})
```
