### PR TITLE
special case for slice_*() 

### DIFF
--- a/R/slice.R
+++ b/R/slice.R
@@ -363,7 +363,7 @@ check_slice_dots <- function(..., n, prop, error_call = caller_env()) {
       slice_call <- error_call$.Generic
       bullets <- c(
         "`n` must be explicitly named.",
-        i = glue("Did you mean `{slice_call}(n = {as_label(dots[[1]])})` ?")
+        i = glue("Did you mean `{slice_call}(n = {as_label(dots[[1]])})`?")
       )
       abort(bullets, call = error_call)
     }

--- a/R/slice.R
+++ b/R/slice.R
@@ -355,7 +355,7 @@ check_slice_size <- function(..., n, prop, error_call = caller_env()) {
     if (length(dots) == 1L && names2(dots)[1] == "") {
       slice_call <- error_call$.Generic
       bullets <- c(
-        "`n` must be explicitely named.",
+        "`n` must be explicitly named.",
         i = glue("Did you mean `{slice_call}(n = {as_label(dots[[1]])})` ?")
       )
       abort(bullets, call = error_call)

--- a/R/slice.R
+++ b/R/slice.R
@@ -132,9 +132,7 @@ slice_head <- function(.data, ..., n, prop) {
 
 #' @export
 slice_head.data.frame <- function(.data, ..., n, prop) {
-  check_dots_empty()
-
-  size <- get_slice_size(n, prop)
+  size <- get_slice_size(..., n = n, prop = prop)
   idx <- function(n) seq2(1, size(n))
   slice(.data, idx(dplyr::n()))
 }
@@ -147,9 +145,7 @@ slice_tail <- function(.data, ..., n, prop) {
 
 #' @export
 slice_tail.data.frame <- function(.data, ..., n, prop) {
-  check_dots_empty()
-
-  size <- get_slice_size(n, prop)
+  size <- get_slice_size(..., n = n, prop = prop)
   idx <- function(n) seq2(n - size(n) + 1, n)
   slice(.data, idx(dplyr::n()))
 }
@@ -166,10 +162,9 @@ slice_min <- function(.data, order_by, ..., n, prop, with_ties = TRUE) {
 
 #' @export
 slice_min.data.frame <- function(.data, order_by, ..., n, prop, with_ties = TRUE) {
-  check_dots_empty()
   arg_require(order_by)
 
-  size <- get_slice_size(n, prop)
+  size <- get_slice_size(..., n = n, prop = prop)
   if (with_ties) {
     idx <- function(x, n) head(order(x), smaller_ranks(x, size(n)))
   } else {
@@ -192,10 +187,9 @@ slice_max <- function(.data, order_by, ..., n, prop, with_ties = TRUE) {
 
 #' @export
 slice_max.data.frame <- function(.data, order_by, ..., n, prop, with_ties = TRUE) {
-  check_dots_empty()
   arg_require(order_by)
 
-  size <- get_slice_size(n, prop)
+  size <- get_slice_size(..., n = n, prop = prop)
   if (with_ties) {
     idx <- function(x, n) head(
         order(x, decreasing = TRUE), smaller_ranks(desc(x), size(n))
@@ -224,9 +218,7 @@ slice_sample <- function(.data, ..., n, prop, weight_by = NULL, replace = FALSE)
 
 #' @export
 slice_sample.data.frame <- function(.data, ..., n, prop, weight_by = NULL, replace = FALSE) {
-  check_dots_empty()
-
-  size <- get_slice_size(n, prop)
+  size <- get_slice_size(..., n = n, prop = prop)
 
   slice_impl(.data, {
     n <- dplyr::n()
@@ -356,7 +348,9 @@ check_constant <- function(x, name, error_call = caller_env()) {
   })
 }
 
-check_slice_size <- function(n, prop, error_call = caller_env()) {
+check_slice_size <- function(..., n, prop, error_call = caller_env()) {
+  check_dots_empty(call = error_call)
+
   if (missing(n) && missing(prop)) {
     list(type = "n", n = 1L)
   } else if (!missing(n) && missing(prop)) {
@@ -376,8 +370,8 @@ check_slice_size <- function(n, prop, error_call = caller_env()) {
   }
 }
 
-get_slice_size <- function(n, prop, error_call = caller_env()) {
-  slice_input <- check_slice_size(n, prop, error_call = error_call)
+get_slice_size <- function(..., n, prop, error_call = caller_env()) {
+  slice_input <- check_slice_size(..., n = n, prop = prop, error_call = error_call)
 
   if (slice_input$type == "n") {
     if (slice_input$n < 0) {

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -5,31 +5,31 @@
     Output
       <error/rlang_error>
       Error in `slice_head()`: `n` must be explicitly named.
-      i Did you mean `slice_head(n = 5)` ?
+      i Did you mean `slice_head(n = 5)`?
     Code
       (expect_error(slice_tail(df, 5)))
     Output
       <error/rlang_error>
       Error in `slice_tail()`: `n` must be explicitly named.
-      i Did you mean `slice_tail(n = 5)` ?
+      i Did you mean `slice_tail(n = 5)`?
     Code
       (expect_error(slice_min(df, x, 5)))
     Output
       <error/rlang_error>
       Error in `slice_min()`: `n` must be explicitly named.
-      i Did you mean `slice_min(n = 5)` ?
+      i Did you mean `slice_min(n = 5)`?
     Code
       (expect_error(slice_max(df, x, 5)))
     Output
       <error/rlang_error>
       Error in `slice_max()`: `n` must be explicitly named.
-      i Did you mean `slice_max(n = 5)` ?
+      i Did you mean `slice_max(n = 5)`?
     Code
       (expect_error(slice_sample(df, 5)))
     Output
       <error/rlang_error>
       Error in `slice_sample()`: `n` must be explicitly named.
-      i Did you mean `slice_sample(n = 5)` ?
+      i Did you mean `slice_sample(n = 5)`?
 
 # slice_*() checks that for empty `...
 

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -1,4 +1,4 @@
-# slice_*() checks for empty ...
+# slice_*() checks that `n=` is explicitly named
 
     Code
       (expect_error(slice_head(df, 5)))
@@ -30,6 +30,155 @@
       <error/rlang_error>
       Error in `slice_sample()`: `n` must be explicitely named.
       i Did you mean `slice_sample(n = 5)` ?
+
+# slice_*() checks that for empty `...
+
+    Code
+      (expect_error(slice_head(df, 5, 2)))
+    Output
+      <error/rlib_error_dots_nonempty>
+      Error in `slice_head()`: `...` is not empty.
+      i These dots only exist to allow future extensions and should be empty.
+      x We detected these problematic arguments:
+      * `..1`
+      * `..2`
+      i Did you misspecify an argument?
+    Code
+      (expect_error(slice_tail(df, 5, 2)))
+    Output
+      <error/rlib_error_dots_nonempty>
+      Error in `slice_tail()`: `...` is not empty.
+      i These dots only exist to allow future extensions and should be empty.
+      x We detected these problematic arguments:
+      * `..1`
+      * `..2`
+      i Did you misspecify an argument?
+    Code
+      (expect_error(slice_min(df, x, 5, 2)))
+    Output
+      <error/rlib_error_dots_nonempty>
+      Error in `slice_min()`: `...` is not empty.
+      i These dots only exist to allow future extensions and should be empty.
+      x We detected these problematic arguments:
+      * `..1`
+      * `..2`
+      i Did you misspecify an argument?
+    Code
+      (expect_error(slice_max(df, x, 5, 2)))
+    Output
+      <error/rlib_error_dots_nonempty>
+      Error in `slice_max()`: `...` is not empty.
+      i These dots only exist to allow future extensions and should be empty.
+      x We detected these problematic arguments:
+      * `..1`
+      * `..2`
+      i Did you misspecify an argument?
+    Code
+      (expect_error(slice_sample(df, 5, 2)))
+    Output
+      <error/rlib_error_dots_nonempty>
+      Error in `slice_sample()`: `...` is not empty.
+      i These dots only exist to allow future extensions and should be empty.
+      x We detected these problematic arguments:
+      * `..1`
+      * `..2`
+      i Did you misspecify an argument?
+
+---
+
+    Code
+      (expect_error(slice_head(df, n = 5, 2)))
+    Output
+      <error/rlib_error_dots_nonempty>
+      Error in `slice_head()`: `...` is not empty.
+      i These dots only exist to allow future extensions and should be empty.
+      x We detected these problematic arguments:
+      * `..1`
+      i Did you misspecify an argument?
+    Code
+      (expect_error(slice_tail(df, n = 5, 2)))
+    Output
+      <error/rlib_error_dots_nonempty>
+      Error in `slice_tail()`: `...` is not empty.
+      i These dots only exist to allow future extensions and should be empty.
+      x We detected these problematic arguments:
+      * `..1`
+      i Did you misspecify an argument?
+    Code
+      (expect_error(slice_min(df, x, n = 5, 2)))
+    Output
+      <error/rlib_error_dots_nonempty>
+      Error in `slice_min()`: `...` is not empty.
+      i These dots only exist to allow future extensions and should be empty.
+      x We detected these problematic arguments:
+      * `..1`
+      i Did you misspecify an argument?
+    Code
+      (expect_error(slice_max(df, x, n = 5, 2)))
+    Output
+      <error/rlib_error_dots_nonempty>
+      Error in `slice_max()`: `...` is not empty.
+      i These dots only exist to allow future extensions and should be empty.
+      x We detected these problematic arguments:
+      * `..1`
+      i Did you misspecify an argument?
+    Code
+      (expect_error(slice_sample(df, n = 5, 2)))
+    Output
+      <error/rlib_error_dots_nonempty>
+      Error in `slice_sample()`: `...` is not empty.
+      i These dots only exist to allow future extensions and should be empty.
+      x We detected these problematic arguments:
+      * `..1`
+      i Did you misspecify an argument?
+
+---
+
+    Code
+      (expect_error(slice_head(df, prop = 0.5, 2)))
+    Output
+      <error/rlib_error_dots_nonempty>
+      Error in `slice_head()`: `...` is not empty.
+      i These dots only exist to allow future extensions and should be empty.
+      x We detected these problematic arguments:
+      * `..1`
+      i Did you misspecify an argument?
+    Code
+      (expect_error(slice_tail(df, prop = 0.5, 2)))
+    Output
+      <error/rlib_error_dots_nonempty>
+      Error in `slice_tail()`: `...` is not empty.
+      i These dots only exist to allow future extensions and should be empty.
+      x We detected these problematic arguments:
+      * `..1`
+      i Did you misspecify an argument?
+    Code
+      (expect_error(slice_min(df, x, prop = 0.5, 2)))
+    Output
+      <error/rlib_error_dots_nonempty>
+      Error in `slice_min()`: `...` is not empty.
+      i These dots only exist to allow future extensions and should be empty.
+      x We detected these problematic arguments:
+      * `..1`
+      i Did you misspecify an argument?
+    Code
+      (expect_error(slice_max(df, x, prop = 0.5, 2)))
+    Output
+      <error/rlib_error_dots_nonempty>
+      Error in `slice_max()`: `...` is not empty.
+      i These dots only exist to allow future extensions and should be empty.
+      x We detected these problematic arguments:
+      * `..1`
+      i Did you misspecify an argument?
+    Code
+      (expect_error(slice_sample(df, prop = 0.5, 2)))
+    Output
+      <error/rlib_error_dots_nonempty>
+      Error in `slice_sample()`: `...` is not empty.
+      i These dots only exist to allow future extensions and should be empty.
+      x We detected these problematic arguments:
+      * `..1`
+      i Did you misspecify an argument?
 
 # slice_*() checks for constant n= and prop=
 

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -4,31 +4,31 @@
       (expect_error(slice_head(df, 5)))
     Output
       <error/rlang_error>
-      Error in `slice_head()`: `n` must be explicitely named.
+      Error in `slice_head()`: `n` must be explicitly named.
       i Did you mean `slice_head(n = 5)` ?
     Code
       (expect_error(slice_tail(df, 5)))
     Output
       <error/rlang_error>
-      Error in `slice_tail()`: `n` must be explicitely named.
+      Error in `slice_tail()`: `n` must be explicitly named.
       i Did you mean `slice_tail(n = 5)` ?
     Code
       (expect_error(slice_min(df, x, 5)))
     Output
       <error/rlang_error>
-      Error in `slice_min()`: `n` must be explicitely named.
+      Error in `slice_min()`: `n` must be explicitly named.
       i Did you mean `slice_min(n = 5)` ?
     Code
       (expect_error(slice_max(df, x, 5)))
     Output
       <error/rlang_error>
-      Error in `slice_max()`: `n` must be explicitely named.
+      Error in `slice_max()`: `n` must be explicitly named.
       i Did you mean `slice_max(n = 5)` ?
     Code
       (expect_error(slice_sample(df, 5)))
     Output
       <error/rlang_error>
-      Error in `slice_sample()`: `n` must be explicitely named.
+      Error in `slice_sample()`: `n` must be explicitly named.
       i Did you mean `slice_sample(n = 5)` ?
 
 # slice_*() checks that for empty `...

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -3,48 +3,33 @@
     Code
       (expect_error(slice_head(df, 5)))
     Output
-      <error/rlib_error_dots_nonempty>
-      Error in `slice_head()`: `...` is not empty.
-      i These dots only exist to allow future extensions and should be empty.
-      x We detected these problematic arguments:
-      * `..1`
-      i Did you misspecify an argument?
+      <error/rlang_error>
+      Error in `slice_head()`: `n` must be explicitely named.
+      i Did you mean `slice_head(n = 5)` ?
     Code
       (expect_error(slice_tail(df, 5)))
     Output
-      <error/rlib_error_dots_nonempty>
-      Error in `slice_tail()`: `...` is not empty.
-      i These dots only exist to allow future extensions and should be empty.
-      x We detected these problematic arguments:
-      * `..1`
-      i Did you misspecify an argument?
+      <error/rlang_error>
+      Error in `slice_tail()`: `n` must be explicitely named.
+      i Did you mean `slice_tail(n = 5)` ?
     Code
       (expect_error(slice_min(df, x, 5)))
     Output
-      <error/rlib_error_dots_nonempty>
-      Error in `slice_min()`: `...` is not empty.
-      i These dots only exist to allow future extensions and should be empty.
-      x We detected these problematic arguments:
-      * `..1`
-      i Did you misspecify an argument?
+      <error/rlang_error>
+      Error in `slice_min()`: `n` must be explicitely named.
+      i Did you mean `slice_min(n = 5)` ?
     Code
       (expect_error(slice_max(df, x, 5)))
     Output
-      <error/rlib_error_dots_nonempty>
-      Error in `slice_max()`: `...` is not empty.
-      i These dots only exist to allow future extensions and should be empty.
-      x We detected these problematic arguments:
-      * `..1`
-      i Did you misspecify an argument?
+      <error/rlang_error>
+      Error in `slice_max()`: `n` must be explicitely named.
+      i Did you mean `slice_max(n = 5)` ?
     Code
       (expect_error(slice_sample(df, 5)))
     Output
-      <error/rlib_error_dots_nonempty>
-      Error in `slice_sample()`: `...` is not empty.
-      i These dots only exist to allow future extensions and should be empty.
-      x We detected these problematic arguments:
-      * `..1`
-      i Did you misspecify an argument?
+      <error/rlang_error>
+      Error in `slice_sample()`: `n` must be explicitely named.
+      i Did you mean `slice_sample(n = 5)` ?
 
 # slice_*() checks for constant n= and prop=
 
@@ -181,7 +166,7 @@
       (expect_error(slice_head(data.frame(), n = 1, prop = 1)))
     Output
       <error/rlang_error>
-      Error in `slice_head()`: Must supply exactly one of `n` and `prop` arguments.
+      Error in `slice_head()`: Must supply `n` or `prop`, but not both.
     Code
       (expect_error(slice_tail(data.frame(), n = "a")))
     Output

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -250,7 +250,7 @@ test_that("arguments to sample are passed along", {
   expect_equal(df %>% slice_sample(n = 2, weight_by = wt, replace = TRUE) %>% pull(x), c(1, 1))
 })
 
-test_that("slice_*() checks for empty ...", {
+test_that("slice_*() checks that `n=` is explicitly named", {
   df <- data.frame(x = 1:10)
   expect_snapshot({
     (expect_error(
@@ -269,8 +269,65 @@ test_that("slice_*() checks for empty ...", {
       slice_sample(df, 5)
     ))
   })
-
 })
+
+test_that("slice_*() checks that for empty `...", {
+  df <- data.frame(x = 1:10)
+  expect_snapshot({
+    (expect_error(
+      slice_head(df, 5, 2)
+    ))
+    (expect_error(
+      slice_tail(df, 5, 2)
+    ))
+    (expect_error(
+      slice_min(df, x, 5, 2)
+    ))
+    (expect_error(
+      slice_max(df, x, 5, 2)
+    ))
+    (expect_error(
+      slice_sample(df, 5, 2)
+    ))
+  })
+
+  expect_snapshot({
+    (expect_error(
+      slice_head(df, n = 5, 2)
+    ))
+    (expect_error(
+      slice_tail(df, n = 5, 2)
+    ))
+    (expect_error(
+      slice_min(df, x, n = 5, 2)
+    ))
+    (expect_error(
+      slice_max(df, x, n = 5, 2)
+    ))
+    (expect_error(
+      slice_sample(df, n = 5, 2)
+    ))
+  })
+
+  expect_snapshot({
+    (expect_error(
+      slice_head(df, prop = .5, 2)
+    ))
+    (expect_error(
+      slice_tail(df, prop = .5, 2)
+    ))
+    (expect_error(
+      slice_min(df, x, prop = .5, 2)
+    ))
+    (expect_error(
+      slice_max(df, x, prop = .5, 2)
+    ))
+    (expect_error(
+      slice_sample(df, prop = .5, 2)
+    ))
+  })
+})
+
 
 test_that("slice_*() checks for constant n= and prop=", {
   df <- data.frame(x = 1:10)


### PR DESCRIPTION
When neither `n` nor `prop` is given but a single unnamed `...` is given, `..1` is likely meant as `n =`. 

``` r
library(dplyr, warn.conflicts = F)

show_error <- function(expr) tryCatch(expr, error = function(cnd) print(cnd, backtrace = FALSE))
show_error(
  mtcars %>% 
    slice_head(2)  
)
#> <error/rlang_error>
#> Error in `slice_head()`: `n` must be explicitely named.
#> ℹ Did you mean `slice_head(n = 2)` ?
```

<sup>Created on 2021-11-09 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1.9000)</sup>