### PR TITLE
allow matrics with 1 column in filter(), with a warning.

### DIFF
--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -59,7 +59,16 @@ void filter_check_size(SEXP res, int i, R_xlen_t n, SEXP quos) {
 }
 
 void filter_check_type(SEXP res, R_xlen_t i, SEXP quos) {
-  if (TYPEOF(res) == LGLSXP && !Rf_isMatrix(res)) return;
+  if (TYPEOF(res) == LGLSXP) {
+    if (!Rf_isMatrix(res)) {
+      return;
+    }
+
+    if (INTEGER(Rf_getAttrib(res, R_DimSymbol))[1] == 1) {
+      Rf_warningcall(R_NilValue, "Matrices of 1 column are deprecated in `filter()`.");
+      return;
+    }
+  }
 
   if (Rf_inherits(res, "data.frame")) {
     R_xlen_t ncol = XLENGTH(res);

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -65,7 +65,8 @@ void filter_check_type(SEXP res, R_xlen_t i, SEXP quos) {
     }
 
     if (INTEGER(Rf_getAttrib(res, R_DimSymbol))[1] == 1) {
-      Rf_warningcall(R_NilValue, "Matrices of 1 column are deprecated in `filter()`.");
+      // not yet,
+      // Rf_warningcall(R_NilValue, "Matrices of 1 column are deprecated in `filter()`.");
       return;
     }
   }

--- a/tests/testthat/_snaps/filter.md
+++ b/tests/testthat/_snaps/filter.md
@@ -14,6 +14,17 @@
       Error in `filter()`: Problem while computing `..1 = 1:n()`.
       x Input `..1` must be a logical vector, not a integer.
     Code
+      (expect_error(filter(data.frame(x = 1:2), matrix(c(TRUE, FALSE, TRUE, FALSE),
+      nrow = 2))))
+    Output
+      <error/rlang_error>
+      Error in `filter()`: Problem while computing `..1 = matrix(c(TRUE, FALSE, TRUE, FALSE), nrow = 2)`.
+      x Input `..1` must be a logical vector, not a logical[,2].
+    Code
+      (expect_warning(filter(data.frame(x = 1:2), matrix(c(TRUE, FALSE), nrow = 2))))
+    Output
+      <simpleWarning: Matrices of 1 column are deprecated in `filter()`.>
+    Code
       (expect_error(iris %>% group_by(Species) %>% filter(c(TRUE, FALSE))))
     Output
       <error/rlang_error>

--- a/tests/testthat/_snaps/filter.md
+++ b/tests/testthat/_snaps/filter.md
@@ -21,10 +21,6 @@
       Error in `filter()`: Problem while computing `..1 = matrix(c(TRUE, FALSE, TRUE, FALSE), nrow = 2)`.
       x Input `..1` must be a logical vector, not a logical[,2].
     Code
-      (expect_warning(filter(data.frame(x = 1:2), matrix(c(TRUE, FALSE), nrow = 2))))
-    Output
-      <simpleWarning: Matrices of 1 column are deprecated in `filter()`.>
-    Code
       (expect_error(iris %>% group_by(Species) %>% filter(c(TRUE, FALSE))))
     Output
       <error/rlang_error>

--- a/tests/testthat/test-filter.r
+++ b/tests/testthat/test-filter.r
@@ -376,12 +376,6 @@ test_that("filter() allows named constants that resolve to logical vectors (#461
   )
 })
 
-test_that("filter() forbids matrices (#5973)", {
-  df <- data.frame(x = 1:2)
-
-  expect_error(filter(df, matrix(c(TRUE, FALSE), nrow = 2)))
-})
-
 test_that("filter() gives useful error messages", {
   expect_snapshot({
     # wrong type
@@ -393,6 +387,15 @@ test_that("filter() gives useful error messages", {
     (expect_error(
       iris %>%
         filter(1:n())
+    ))
+
+    # matrix with > 1 columns
+    (expect_error(
+      filter(data.frame(x = 1:2), matrix(c(TRUE, FALSE, TRUE, FALSE), nrow = 2))
+    ))
+    # matrix with 1 column
+    (expect_warning(
+      filter(data.frame(x = 1:2), matrix(c(TRUE, FALSE), nrow = 2))
     ))
 
     # wrong size

--- a/tests/testthat/test-filter.r
+++ b/tests/testthat/test-filter.r
@@ -376,6 +376,13 @@ test_that("filter() allows named constants that resolve to logical vectors (#461
   )
 })
 
+test_that("filter() allowing matrices with 1 column", {
+  out <- expect_warning(
+    filter(data.frame(x = 1:2), matrix(c(TRUE, FALSE), nrow = 2)), NA
+  )
+  expect_identical(out, data.frame(x = 1L))
+})
+
 test_that("filter() gives useful error messages", {
   expect_snapshot({
     # wrong type
@@ -392,10 +399,6 @@ test_that("filter() gives useful error messages", {
     # matrix with > 1 columns
     (expect_error(
       filter(data.frame(x = 1:2), matrix(c(TRUE, FALSE, TRUE, FALSE), nrow = 2))
-    ))
-    # matrix with 1 column
-    (expect_warning(
-      filter(data.frame(x = 1:2), matrix(c(TRUE, FALSE), nrow = 2))
     ))
 
     # wrong size


### PR DESCRIPTION
closes #6082

This would fix `ggcharts` against 1.0.8 