### PR TITLE
protect size quosure in `sample_frac()`

### DIFF
--- a/R/sample.R
+++ b/R/sample.R
@@ -86,8 +86,8 @@ sample_n.data.frame <- function(tbl, size, replace = FALSE,
   weight <- enquo(weight)
 
   slice_impl(tbl, {
-    size <- check_size(!!size, n(), replace = replace)
-    sample.int(n(), size, replace = replace, prob = !!weight)
+    .size <- check_size(!!size, n(), replace = replace)
+    sample.int(n(), .size, replace = replace, prob = !!weight)
   })
 
 }
@@ -117,8 +117,8 @@ sample_frac.data.frame <- function(tbl, size = 1, replace = FALSE,
   weight <- enquo(weight)
 
   slice_impl(tbl, {
-    size <- round(n() * check_frac(!!size, replace = replace))
-    sample.int(n(), size, replace = replace, prob = !!weight)
+    .size <- round(n() * check_frac(!!size, replace = replace))
+    sample.int(n(), .size, replace = replace, prob = !!weight)
   })
 }
 


### PR DESCRIPTION
This was causing some failed test in `saeSim`: 

````
══ Failed tests ════════════════════════════════════════════════════════════════
── Error (test-sim_sample.R:26:3): Attributes are preserved ────────────────────
Error in `sample_frac(., size = size, replace = replace, weight = !!weight)`: `size` of sampled fraction must be less or equal to one.
ℹ set `replace = TRUE` to use sampling with replacement.
ℹ The error occurred in group 3: idD = 3.
Backtrace:
     ▆
  1. ├─... %>% expect_equal(2) at test-sim_sample.R:26:2
  2. ├─testthat::expect_equal(., 2)
  3. │ └─testthat::quasi_label(enquo(object), label, arg = "object")
  4. │   └─rlang::eval_bare(expr, quo_get_env(quo))
  5. ├─base::as.data.frame(.)
  6. ├─saeSim:::as.data.frame.sim_setup(.)
  7. │ ├─sim_run_once(x) %>% ...
  8. │ └─saeSim:::sim_run_once(x)
  9. │   └─base::Reduce(function(x, f) f(x), x, x@base)
 10. │     └─saeSim f(init, x[[i]])
 11. │       └─saeSim f(x)
 12. │         └─... %>% as.data.frame
 13. ├─base::as.data.frame(...)
 14. ├─base::as.data.frame(.)
 15. ├─dplyr::sample_frac(., size = size, replace = replace, weight = !!weight)
 16. ├─dplyr:::sample_frac.data.frame(...)
 17. │ └─dplyr:::slice_impl(...)
 18. │   └─dplyr:::slice_rows(.data, ..., caller_env = caller_env(2), error_call = error_call)
 19. │     └─dplyr:::slice_eval(mask, dots, error_call = error_call)
 20. │       ├─base::withCallingHandlers(...)
 21. │       └─mask$eval_all(quo)
 22. ├─dplyr:::check_frac(size, replace = replace)
 23. │ └─rlang::abort(bullets)
 24. │   └─rlang:::signal_abort(cnd, .file)
 25. │     └─base::signalCondition(cnd)
 26. └─dplyr `<fn>`(`<rlng_rrr>`)
── Error (test-sim_sample.R:47:3): Basic sampling functionality ────────────────
Error in `sample_frac(., size = size, replace = replace, weight = !!weight)`: `size` of sampled fraction must be less or equal to one.
ℹ set `replace = TRUE` to use sampling with replacement.
ℹ The error occurred in group 3: idD = 3.
Backtrace:
     ▆
  1. ├─... %>% expect_equal(3) at test-sim_sample.R:47:2
  2. ├─testthat::expect_equal(., 3)
  3. │ └─testthat::quasi_label(enquo(object), label, arg = "object")
  4. │   └─rlang::eval_bare(expr, quo_get_env(quo))
  5. ├─base::nrow(.)
  6. ├─base::as.data.frame(.)
  7. ├─saeSim:::as.data.frame.sim_setup(.)
  8. │ ├─sim_run_once(x) %>% ...
  9. │ └─saeSim:::sim_run_once(x)
 10. │   └─base::Reduce(function(x, f) f(x), x, x@base)
 11. │     └─saeSim f(init, x[[i]])
 12. │       └─saeSim f(x)
 13. │         └─... %>% as.data.frame
 14. ├─base::as.data.frame(...)
 15. ├─base::as.data.frame(.)
 16. ├─dplyr::sample_frac(., size = size, replace = replace, weight = !!weight)
 17. ├─dplyr:::sample_frac.data.frame(...)
 18. │ └─dplyr:::slice_impl(...)
 19. │   └─dplyr:::slice_rows(.data, ..., caller_env = caller_env(2), error_call = error_call)
 20. │     └─dplyr:::slice_eval(mask, dots, error_call = error_call)
 21. │       ├─base::withCallingHandlers(...)
 22. │       └─mask$eval_all(quo)
 23. ├─dplyr:::check_frac(size, replace = replace)
 24. │ └─rlang::abort(bullets)
 25. │   └─rlang:::signal_abort(cnd, .file)
 26. │     └─base::signalCondition(cnd)
 27. └─dplyr `<fn>`(`<rlng_rrr>`)

[ FAIL 2 | WARN 6 | SKIP 0 | PASS 134 ]
Error: Test failures
Execution halted

2 errors x | 0 warnings ✓ | 0 notes ✓
````