### PR TITLE
`mutate()` preserves attributes of grouped data frames

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
   that pre-existing columns are never moved, which aligns more closely with the
   other `.keep` options (#6086).
 
+* `mutate()` preserves attributes when working on grouped data frames (#6100).
+
 * `cur_data()` and `cur_data_all()` don't simplify list columns in rowwise data frames (#5901).
 
 * `storms` data updated to 2020 (@steveharoz, #5899).

--- a/tests/testthat/test-count-tally.r
+++ b/tests/testthat/test-count-tally.r
@@ -54,8 +54,7 @@ test_that("output preserves class & attributes where possible", {
   out <- df %>% group_by(g) %>% count()
   expect_s3_class(out, "grouped_df")
   expect_equal(group_vars(out), "g")
-  # summarise() currently drops attributes
-  expect_equal(attr(out, "my_attr"), NULL)
+  expect_equal(attr(out, "my_attr"), 1)
 })
 
 test_that("works with dbplyr", {

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -171,6 +171,19 @@ test_that("unchop only called for when multiple groups", {
   expect_s3_class(out$x, "ts")
 })
 
+test_that("mutate() keeps attributes for grouped data frames (#6100)", {
+  df <- data.frame(x = 1, g = 1)
+  attr(df, "test") <- "foo"
+  expect_equal(
+    attr(mutate(group_by(df, g)), "test"),
+    "foo"
+  )
+  expect_equal(
+    attr(mutate(rowwise(df)), "test"),
+    "foo"
+  )
+})
+
 # output types ------------------------------------------------------------
 
 test_that("mutate preserves grouping", {


### PR DESCRIPTION
closes #6100 

``` r
library(dplyr, warn.conflicts = FALSE)

library(purrr)
attr(mtcars, "test") <- "foo"
mtcars_grouped <- group_by(mtcars, cyl)

mtcars %>% 
  mutate(new_col = 1) %>% 
  attr("test")
#> [1] "foo"

mtcars_grouped %>% 
  mutate(new_col = 1) %>% 
  attr("test")
#> [1] "foo"
```

<sup>Created on 2021-11-29 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1.9000)</sup>