### PR TITLE
handle matrices in slice()

### DIFF
--- a/R/slice.R
+++ b/R/slice.R
@@ -314,7 +314,10 @@ slice_combine <- function(chunks, mask, error_call = caller_env()) {
     if (is.logical(res) && all(is.na(res))) {
       res <- integer()
     } else if (is.numeric(res)) {
-      res <- vec_cast(res, integer())
+      if (is.matrix(res) && ncol(res) == 1) {
+        res <- as.vector(res)
+      }
+      res <- fix_call(vec_cast(res, integer()), error_call)
     } else if (!is.integer(res)) {
       mask$set_current_group(group)
       msg <- c(

--- a/R/slice.R
+++ b/R/slice.R
@@ -318,7 +318,7 @@ slice_combine <- function(chunks, mask, error_call = caller_env()) {
         res <- as.vector(res)
       }
       res <- fix_call(vec_cast(res, integer()), error_call)
-    } else if (!is.integer(res)) {
+    } else {
       mask$set_current_group(group)
       msg <- c(
         glue("Invalid result of type <{vec_ptype_full(res)}>."),

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -1,3 +1,12 @@
+# slice() handles matrices
+
+    Code
+      (expect_error(slice(df, matrix(c(1, 2), ncol = 2))))
+    Output
+      <error/vctrs_error_incompatible_type>
+      Error in `slice()`: Can't convert <integer[,2]> to <integer>.
+      Cannot decrease dimensions.
+
 # slice_*() checks that `n=` is explicitly named
 
     Code

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -1,4 +1,4 @@
-# slice() handles matrices
+# slice() gives meaningfull errors
 
     Code
       (expect_error(slice(df, matrix(c(1, 2), ncol = 2))))
@@ -6,6 +6,18 @@
       <error/vctrs_error_incompatible_type>
       Error in `slice()`: Can't convert <integer[,2]> to <integer>.
       Cannot decrease dimensions.
+    Code
+      (expect_error(slice(df, "a")))
+    Output
+      <error/rlang_error>
+      Error in `slice()`: Invalid result of type <character>.
+      i Indices must be positive or negative integers.
+    Code
+      (expect_error(slice(df, c(1, -1))))
+    Output
+      <error/rlang_error>
+      Error in `slice()`: Indices must be all positive or all negative.
+      i Got 1 positives, 1 negatives.
 
 # slice_*() checks that `n=` is explicitly named
 

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -256,12 +256,25 @@ test_that("slice() handles matrices", {
     slice(df, 1),
     slice(df, matrix(1))
   )
+})
+
+test_that("slice() gives meaningfull errors", {
+  df <- data.frame(x = 1)
 
   expect_snapshot({
     (expect_error(
       slice(df, matrix(c(1, 2), ncol = 2))
     ))
+
+    (expect_error(
+      slice(df, "a")
+    ))
+
+    (expect_error(
+      slice(df, c(1, -1))
+    ))
   })
+
 })
 
 test_that("slice_*() checks that `n=` is explicitly named", {

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -250,6 +250,20 @@ test_that("arguments to sample are passed along", {
   expect_equal(df %>% slice_sample(n = 2, weight_by = wt, replace = TRUE) %>% pull(x), c(1, 1))
 })
 
+test_that("slice() handles matrices", {
+  df <- data.frame(x = 1)
+  expect_identical(
+    slice(df, 1),
+    slice(df, matrix(1))
+  )
+
+  expect_snapshot({
+    (expect_error(
+      slice(df, matrix(c(1, 2), ncol = 2))
+    ))
+  })
+})
+
 test_that("slice_*() checks that `n=` is explicitly named", {
   df <- data.frame(x = 1:10)
   expect_snapshot({


### PR DESCRIPTION
 - matrices with one column ok
 - more columns : error from vec_cast()

This is similar to what is done for `filter()`, but should be reworked as part of #6091. 

This deals with https://github.com/natydasilva/PPforest/pull/2 from this end. 
