### PR TITLE
wrap slice_combine() errors

### DIFF
--- a/R/slice.R
+++ b/R/slice.R
@@ -365,7 +365,7 @@ slice_combine <- function(chunks, mask, error_call = caller_env()) {
     }, error = function(cnd) {
     mask$set_current_group(group)
     bullets <- c(
-      "Problem while checking indices.",
+      "Problem while computing indices.",
       i = cnd_bullet_cur_group_label()
     )
     abort(bullets, call = error_call, parent = cnd)

--- a/R/slice.R
+++ b/R/slice.R
@@ -335,7 +335,7 @@ slice_combine <- function(chunks, mask, error_call = caller_env()) {
         if (is.matrix(res) && ncol(res) == 1) {
           res <- as.vector(res)
         }
-        res <- fix_call(vec_cast(res, integer()), call = call("vec_cast"))
+        res <- fix_call(vec_cast(res, integer()), NULL)
       } else {
         bullets <- c(
           glue("Invalid result of type <{vec_ptype_full(res)}>."),

--- a/R/slice.R
+++ b/R/slice.R
@@ -335,7 +335,7 @@ slice_combine <- function(chunks, mask, error_call = caller_env()) {
         if (is.matrix(res) && ncol(res) == 1) {
           res <- as.vector(res)
         }
-        res <- fix_call(vec_cast(res, integer()), NULL)
+        res <- fix_call(vec_cast(res, integer()), call = call("vec_cast"))
       } else {
         bullets <- c(
           glue("Invalid result of type <{vec_ptype_full(res)}>."),

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -3,21 +3,60 @@
     Code
       (expect_error(slice(df, matrix(c(1, 2), ncol = 2))))
     Output
-      <error/vctrs_error_incompatible_type>
-      Error in `slice()`: Can't convert <integer[,2]> to <integer>.
-      Cannot decrease dimensions.
+      <error/rlang_error>
+      Error in `slice()`:
+        Problem while checking indices.
+      Caused by error:
+        Can't convert <integer[,2]> to <integer>.
+        Cannot decrease dimensions.
+    Code
+      (expect_error(slice(gdf, matrix(c(1, 2), ncol = 2))))
+    Output
+      <error/rlang_error>
+      Error in `slice()`:
+        Problem while checking indices.
+        i The error occurred in group 1: x = 1.
+      Caused by error:
+        Can't convert <integer[,2]> to <integer>.
+        Cannot decrease dimensions.
     Code
       (expect_error(slice(df, "a")))
     Output
       <error/rlang_error>
-      Error in `slice()`: Invalid result of type <character>.
-      i Indices must be positive or negative integers.
+      Error in `slice()`:
+        Problem while checking indices.
+      Caused by error:
+        Invalid result of type <character>.
+        i Indices must be positive or negative integers.
+    Code
+      (expect_error(slice(gdf, "a")))
+    Output
+      <error/rlang_error>
+      Error in `slice()`:
+        Problem while checking indices.
+        i The error occurred in group 1: x = 1.
+      Caused by error:
+        Invalid result of type <character>.
+        i Indices must be positive or negative integers.
     Code
       (expect_error(slice(df, c(1, -1))))
     Output
       <error/rlang_error>
-      Error in `slice()`: Indices must be all positive or all negative.
-      i Got 1 positives, 1 negatives.
+      Error in `slice()`:
+        Problem while checking indices.
+      Caused by error:
+        Indices must be all positive or all negative.
+        i Got 1 positives, 1 negatives.
+    Code
+      (expect_error(slice(gdf, c(1, -1))))
+    Output
+      <error/rlang_error>
+      Error in `slice()`:
+        Problem while checking indices.
+        i The error occurred in group 1: x = 1.
+      Caused by error:
+        Indices must be all positive or all negative.
+        i Got 1 positives, 1 negatives.
 
 # slice_*() checks that `n=` is explicitly named
 
@@ -329,14 +368,20 @@
       (expect_error(slice(df, TRUE)))
     Output
       <error/rlang_error>
-      Error in `slice()`: Invalid result of type <logical>.
-      i Indices must be positive or negative integers.
+      Error in `slice()`:
+        Problem while checking indices.
+      Caused by error:
+        Invalid result of type <logical>.
+        i Indices must be positive or negative integers.
     Code
       (expect_error(slice(df, FALSE)))
     Output
       <error/rlang_error>
-      Error in `slice()`: Invalid result of type <logical>.
-      i Indices must be positive or negative integers.
+      Error in `slice()`:
+        Problem while checking indices.
+      Caused by error:
+        Invalid result of type <logical>.
+        i Indices must be positive or negative integers.
     Code
       (expect_error(slice(mtcars, 1, 1, "")))
     Output
@@ -358,14 +403,20 @@
       (expect_error(mtcars %>% slice(c(-1, 2))))
     Output
       <error/rlang_error>
-      Error in `slice()`: Indices must be all positive or all negative.
-      i Got 1 positives, 1 negatives.
+      Error in `slice()`:
+        Problem while checking indices.
+      Caused by error:
+        Indices must be all positive or all negative.
+        i Got 1 positives, 1 negatives.
     Code
       (expect_error(mtcars %>% slice(c(2:3, -1))))
     Output
       <error/rlang_error>
-      Error in `slice()`: Indices must be all positive or all negative.
-      i Got 2 positives, 1 negatives.
+      Error in `slice()`:
+        Problem while checking indices.
+      Caused by error:
+        Indices must be all positive or all negative.
+        i Got 2 positives, 1 negatives.
     Code
       (expect_error(slice_head(data.frame(), n = 1, prop = 1)))
     Output

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -6,7 +6,7 @@
       <error/rlang_error>
       Error in `slice()`:
         Problem while computing indices.
-      Caused by error in `vec_cast()`:
+      Caused by error:
         Can't convert <integer[,2]> to <integer>.
         Cannot decrease dimensions.
     Code
@@ -16,7 +16,7 @@
       Error in `slice()`:
         Problem while computing indices.
         i The error occurred in group 1: x = 1.
-      Caused by error in `vec_cast()`:
+      Caused by error:
         Can't convert <integer[,2]> to <integer>.
         Cannot decrease dimensions.
     Code

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -5,7 +5,7 @@
     Output
       <error/rlang_error>
       Error in `slice()`:
-        Problem while checking indices.
+        Problem while computing indices.
       Caused by error in `vec_cast()`:
         Can't convert <integer[,2]> to <integer>.
         Cannot decrease dimensions.
@@ -14,7 +14,7 @@
     Output
       <error/rlang_error>
       Error in `slice()`:
-        Problem while checking indices.
+        Problem while computing indices.
         i The error occurred in group 1: x = 1.
       Caused by error in `vec_cast()`:
         Can't convert <integer[,2]> to <integer>.
@@ -24,7 +24,7 @@
     Output
       <error/rlang_error>
       Error in `slice()`:
-        Problem while checking indices.
+        Problem while computing indices.
       Caused by error:
         Invalid result of type <character>.
         i Indices must be positive or negative integers.
@@ -33,7 +33,7 @@
     Output
       <error/rlang_error>
       Error in `slice()`:
-        Problem while checking indices.
+        Problem while computing indices.
         i The error occurred in group 1: x = 1.
       Caused by error:
         Invalid result of type <character>.
@@ -43,7 +43,7 @@
     Output
       <error/rlang_error>
       Error in `slice()`:
-        Problem while checking indices.
+        Problem while computing indices.
       Caused by error:
         Indices must be all positive or all negative.
         i Got 1 positives, 1 negatives.
@@ -52,7 +52,7 @@
     Output
       <error/rlang_error>
       Error in `slice()`:
-        Problem while checking indices.
+        Problem while computing indices.
         i The error occurred in group 1: x = 1.
       Caused by error:
         Indices must be all positive or all negative.
@@ -369,7 +369,7 @@
     Output
       <error/rlang_error>
       Error in `slice()`:
-        Problem while checking indices.
+        Problem while computing indices.
       Caused by error:
         Invalid result of type <logical>.
         i Indices must be positive or negative integers.
@@ -378,7 +378,7 @@
     Output
       <error/rlang_error>
       Error in `slice()`:
-        Problem while checking indices.
+        Problem while computing indices.
       Caused by error:
         Invalid result of type <logical>.
         i Indices must be positive or negative integers.
@@ -404,7 +404,7 @@
     Output
       <error/rlang_error>
       Error in `slice()`:
-        Problem while checking indices.
+        Problem while computing indices.
       Caused by error:
         Indices must be all positive or all negative.
         i Got 1 positives, 1 negatives.
@@ -413,7 +413,7 @@
     Output
       <error/rlang_error>
       Error in `slice()`:
-        Problem while checking indices.
+        Problem while computing indices.
       Caused by error:
         Indices must be all positive or all negative.
         i Got 2 positives, 1 negatives.

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -6,7 +6,7 @@
       <error/rlang_error>
       Error in `slice()`:
         Problem while checking indices.
-      Caused by error:
+      Caused by error in `vec_cast()`:
         Can't convert <integer[,2]> to <integer>.
         Cannot decrease dimensions.
     Code
@@ -16,7 +16,7 @@
       Error in `slice()`:
         Problem while checking indices.
         i The error occurred in group 1: x = 1.
-      Caused by error:
+      Caused by error in `vec_cast()`:
         Can't convert <integer[,2]> to <integer>.
         Cannot decrease dimensions.
     Code

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -259,19 +259,29 @@ test_that("slice() handles matrices", {
 })
 
 test_that("slice() gives meaningfull errors", {
-  df <- data.frame(x = 1)
+  df <- data.frame(x = 1:2)
+  gdf <- group_by(df, x)
 
   expect_snapshot({
     (expect_error(
       slice(df, matrix(c(1, 2), ncol = 2))
     ))
+    (expect_error(
+      slice(gdf, matrix(c(1, 2), ncol = 2))
+    ))
 
     (expect_error(
       slice(df, "a")
     ))
+    (expect_error(
+      slice(gdf, "a")
+    ))
 
     (expect_error(
       slice(df, c(1, -1))
+    ))
+    (expect_error(
+      slice(gdf, c(1, -1))
     ))
   })
 


### PR DESCRIPTION
``` r
library(dplyr, warn.conflicts = FALSE)
df <- data.frame(x = 1:2)
gdf <- group_by(df, x)

slice(gdf, matrix(c(1, 2), ncol = 2))
#> Error in `slice()`:
#>   Problem while checking indices.
#>   ℹ The error occurred in group 1: x = 1.
#> Caused by error in `vec_cast()`:
#>   Can't convert <integer[,2]> to <integer>.
#>   Cannot decrease dimensions.
slice(gdf, "a")
#> Error in `slice()`:
#>   Problem while checking indices.
#>   ℹ The error occurred in group 1: x = 1.
#> Caused by error:
#>   Invalid result of type <character>.
#>   ℹ Indices must be positive or negative integers.
slice(gdf, c(1, -1))
#> Error in `slice()`:
#>   Problem while checking indices.
#>   ℹ The error occurred in group 1: x = 1.
#> Caused by error:
#>   Indices must be all positive or all negative.
#>   ℹ Got 1 positives, 1 negatives.
```

<sup>Created on 2021-12-10 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1.9000)</sup>