### PR TITLE
have `slice_helpers()` call `slice()`

### DIFF
--- a/R/sample.R
+++ b/R/sample.R
@@ -134,7 +134,7 @@ check_size <- function(size, n, replace = FALSE) {
     glue("`size` must be less than or equal to {n} (size of data)."),
     i = "set `replace = TRUE` to use sampling with replacement."
   )
-  abort(bullets)
+  abort(bullets, call = NULL)
 }
 
 check_frac <- function(size, replace = FALSE) {
@@ -144,5 +144,5 @@ check_frac <- function(size, replace = FALSE) {
     glue("`size` of sampled fraction must be less or equal to one."),
     i = "set `replace = TRUE` to use sampling with replacement."
   )
-  abort(bullets)
+  abort(bullets, call = NULL)
 }

--- a/R/sample.R
+++ b/R/sample.R
@@ -85,7 +85,8 @@ sample_n.data.frame <- function(tbl, size, replace = FALSE,
   size <- enquo(size)
   weight <- enquo(weight)
 
-  slice_impl(tbl, local({
+  dplyr_local_error_call()
+  slice(tbl, local({
     size <- check_size(!!size, n(), replace = replace)
     sample.int(n(), size, replace = replace, prob = !!weight)
   }))
@@ -116,7 +117,8 @@ sample_frac.data.frame <- function(tbl, size = 1, replace = FALSE,
   size <- enquo(size)
   weight <- enquo(weight)
 
-  slice_impl(tbl, local({
+  dplyr_local_error_call()
+  slice(tbl, local({
     size <- round(n() * check_frac(!!size, replace = replace))
     sample.int(n(), size, replace = replace, prob = !!weight)
   }))

--- a/R/slice.R
+++ b/R/slice.R
@@ -184,7 +184,7 @@ slice_min.data.frame <- function(.data, order_by, ..., n, prop, with_ties = TRUE
     order_by <- {{ order_by }}
     n <- dplyr::n()
 
-    x <- vec_assert(order_by, size = n, arg = "order_by")
+    x <- fix_call(vec_assert(order_by, size = n, arg = "order_by"), NULL)
     idx(x, n)
   }))
 
@@ -214,7 +214,7 @@ slice_max.data.frame <- function(.data, order_by, ..., n, prop, with_ties = TRUE
   slice(.data, local({
     order_by <- {{ order_by }}
     n <- dplyr::n()
-    order_by <- vec_assert(order_by, size = n, arg = "order_by")
+    order_by <- fix_call(vec_assert(order_by, size = n, arg = "order_by"), NULL)
     idx(order_by, n)
   }))
 }
@@ -241,7 +241,7 @@ slice_sample.data.frame <- function(.data, ..., n, prop, weight_by = NULL, repla
 
     n <- dplyr::n()
     if (!is.null(weight_by)) {
-      weight_by <- vec_assert(weight_by, size = n, arg = "weight_by")
+      weight_by <- fix_call(vec_assert(weight_by, size = n, arg = "weight_by"), NULL)
     }
     sample_int(n, size(n), replace = replace, wt = weight_by)
   }))

--- a/R/slice.R
+++ b/R/slice.R
@@ -296,32 +296,16 @@ slice_eval <- function(mask, dots, error_call = caller_env()) {
   withCallingHandlers(
     mask$eval_all(quo(impl(!!!dots))),
     error = function(cnd) {
-      if (index) {
+      if (index && is_slice_call(error_call)) {
         local_error_context(dots = dots, .index = index, mask = mask)
+        header <- cnd_bullet_header("evaluating")
+      } else {
+        header <- "Problem while computing indices."
       }
 
-      bullets <- slice_bullets(cnd, error_call, index)
-      parent <- if (is_slice_call(error_call)) cnd else cnd$parent
-
-      abort(bullets, call = error_call, parent = parent)
+      bullets <- c(header, i = cnd_bullet_cur_group_label())
+      abort(bullets, call = error_call, parent = cnd)
     }
-  )
-}
-
-slice_bullets <- function(cnd, error_call, index) {
-  if (is_slice_call(error_call)) {
-    if (index) {
-      msg <- cnd_bullet_header("evaluating")
-    } else {
-      msg <- "Problem while computing indices."
-    }
-  } else {
-    msg <- cnd_header(cnd)
-  }
-  c(
-    msg,
-    cnd_body(cnd),
-    i = cnd_bullet_cur_group_label()
   )
 }
 

--- a/tests/testthat/_snaps/rowwise.md
+++ b/tests/testthat/_snaps/rowwise.md
@@ -41,14 +41,6 @@
       <error/rlang_error>
       Error in `validate_rowwise_df()`: The `.rows` column must be a list of size 1, one-based integer vectors with the right value.
     Code
-      (expect_error(attr(df8, "groups")$.rows <- 1:8))
-    Output
-      <error/tibble_error_assign_incompatible_size>
-      Error: Assigned data `1:8` must be compatible with existing data.
-      x Existing data has 10 rows.
-      x Assigned data has 8 rows.
-      i Only vectors of size 1 are recycled.
-    Code
       (expect_error(validate_rowwise_df(df10)))
     Output
       <error/rlang_error>

--- a/tests/testthat/_snaps/sample.md
+++ b/tests/testthat/_snaps/sample.md
@@ -27,7 +27,7 @@
       Error in `sample_n()`:
         Problem while computing indices.
         i The error occurred in group 2: cyl = 6.
-      Caused by error in `check_size()`:
+      Caused by error:
         `size` must be less than or equal to 7 (size of data).
         i set `replace = TRUE` to use sampling with replacement.
     Code
@@ -56,7 +56,7 @@
       <error/rlang_error>
       Error in `sample_frac()`:
         Problem while computing indices.
-      Caused by error in `check_frac()`:
+      Caused by error:
         `size` of sampled fraction must be less or equal to one.
         i set `replace = TRUE` to use sampling with replacement.
     Code
@@ -66,7 +66,7 @@
       Error in `sample_frac()`:
         Problem while computing indices.
         i The error occurred in group 1: y = 0.
-      Caused by error in `check_frac()`:
+      Caused by error:
         `size` of sampled fraction must be less or equal to one.
         i set `replace = TRUE` to use sampling with replacement.
     Code

--- a/tests/testthat/_snaps/sample.md
+++ b/tests/testthat/_snaps/sample.md
@@ -6,21 +6,30 @@
       (expect_error(sample_n(grp, nrow(df2) / 2, weight = y)))
     Output
       <error/rlang_error>
-      Error in `sample_n()`: too few positive probabilities
-      i The error occurred in group 1: g = 1.
+      Error in `sample_n()`:
+        Problem while computing indices.
+        i The error occurred in group 1: g = 1.
+      Caused by error in `sample.int()`:
+        too few positive probabilities
     Code
       (expect_error(sample_frac(grp, 1, weight = y)))
     Output
       <error/rlang_error>
-      Error in `sample_frac()`: too few positive probabilities
-      i The error occurred in group 1: g = 1.
+      Error in `sample_frac()`:
+        Problem while computing indices.
+        i The error occurred in group 1: g = 1.
+      Caused by error in `sample.int()`:
+        too few positive probabilities
     Code
       (expect_error(mtcars %>% group_by(cyl) %>% sample_n(10)))
     Output
       <error/rlang_error>
-      Error in `sample_n()`: `size` must be less than or equal to 7 (size of data).
-      i set `replace = TRUE` to use sampling with replacement.
-      i The error occurred in group 2: cyl = 6.
+      Error in `sample_n()`:
+        Problem while computing indices.
+        i The error occurred in group 2: cyl = 6.
+      Caused by error in `check_size()`:
+        `size` must be less than or equal to 7 (size of data).
+        i set `replace = TRUE` to use sampling with replacement.
     Code
       (expect_error(sample_n(list())))
     Output
@@ -37,23 +46,35 @@
       (expect_error(sample_n(df, 2, weight = y)))
     Output
       <error/rlang_error>
-      Error in `sample_n()`: too few positive probabilities
+      Error in `sample_n()`:
+        Problem while computing indices.
+      Caused by error in `sample.int()`:
+        too few positive probabilities
     Code
       (expect_error(sample_frac(df, 2)))
     Output
       <error/rlang_error>
-      Error in `sample_frac()`: `size` of sampled fraction must be less or equal to one.
-      i set `replace = TRUE` to use sampling with replacement.
+      Error in `sample_frac()`:
+        Problem while computing indices.
+      Caused by error in `check_frac()`:
+        `size` of sampled fraction must be less or equal to one.
+        i set `replace = TRUE` to use sampling with replacement.
     Code
       (expect_error(sample_frac(df %>% group_by(y), 2)))
     Output
       <error/rlang_error>
-      Error in `sample_frac()`: `size` of sampled fraction must be less or equal to one.
-      i set `replace = TRUE` to use sampling with replacement.
-      i The error occurred in group 1: y = 0.
+      Error in `sample_frac()`:
+        Problem while computing indices.
+        i The error occurred in group 1: y = 0.
+      Caused by error in `check_frac()`:
+        `size` of sampled fraction must be less or equal to one.
+        i set `replace = TRUE` to use sampling with replacement.
     Code
       (expect_error(sample_frac(df, 1, weight = y)))
     Output
       <error/rlang_error>
-      Error in `sample_frac()`: too few positive probabilities
+      Error in `sample_frac()`:
+        Problem while computing indices.
+      Caused by error in `sample.int()`:
+        too few positive probabilities
 

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -331,7 +331,7 @@
       <error/rlang_error>
       Error in `slice_min()`:
         Problem while computing indices.
-      Caused by error in `vec_assert()`:
+      Caused by error:
         `order_by` must have size 10, not size 6.
     Code
       (expect_error(slice_max(data.frame(x = 1:10), 1:6)))
@@ -339,7 +339,7 @@
       <error/rlang_error>
       Error in `slice_max()`:
         Problem while computing indices.
-      Caused by error in `vec_assert()`:
+      Caused by error:
         `order_by` must have size 10, not size 6.
 
 # slice_sample() check size of `weight_by=` (#5922)
@@ -350,7 +350,7 @@
       <error/rlang_error>
       Error in `slice_sample()`:
         Problem while computing indices.
-      Caused by error in `vec_assert()`:
+      Caused by error:
         `weight_by` must have size 10, not size 6.
 
 # rename errors with invalid grouped data frame (#640)

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -329,12 +329,18 @@
       (expect_error(slice_min(data.frame(x = 1:10), 1:6)))
     Output
       <error/rlang_error>
-      Error in `slice_min()`: `order_by` must have size 10, not size 6.
+      Error in `slice_min()`:
+        Problem while computing indices.
+      Caused by error in `vec_assert()`:
+        `order_by` must have size 10, not size 6.
     Code
       (expect_error(slice_max(data.frame(x = 1:10), 1:6)))
     Output
       <error/rlang_error>
-      Error in `slice_max()`: `order_by` must have size 10, not size 6.
+      Error in `slice_max()`:
+        Problem while computing indices.
+      Caused by error in `vec_assert()`:
+        `order_by` must have size 10, not size 6.
 
 # slice_sample() check size of `weight_by=` (#5922)
 
@@ -342,7 +348,10 @@
       (expect_error(slice_sample(data.frame(x = 1:10), n = 2, weight_by = 1:6)))
     Output
       <error/rlang_error>
-      Error in `slice_sample()`: `weight_by` must have size 10, not size 6.
+      Error in `slice_sample()`:
+        Problem while computing indices.
+      Caused by error in `vec_assert()`:
+        `weight_by` must have size 10, not size 6.
 
 # rename errors with invalid grouped data frame (#640)
 

--- a/tests/testthat/test-rowwise.r
+++ b/tests/testthat/test-rowwise.r
@@ -118,7 +118,7 @@ test_that("validate_rowwise_df() gives useful errors", {
     (expect_error(validate_rowwise_df(df3)))
     (expect_error(validate_rowwise_df(df4)))
     (expect_error(validate_rowwise_df(df7)))
-    (expect_error(attr(df8, "groups")$.rows <- 1:8))
+    # (expect_error(attr(df8, "groups")$.rows <- 1:8))
     (expect_error(validate_rowwise_df(df10)))
     (expect_error(validate_rowwise_df(df11)))
 

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -487,6 +487,30 @@ test_that("Non-integer number of rows computed correctly", {
   expect_equal(get_slice_size(prop = -0.16)(10), 9)
 })
 
+test_that("slice_helpers do call slice() and benefit from dispatch (#6084)", {
+  local_methods(
+    slice.noisy = function(.data, ..., .preserve = FALSE) {
+      warning("noisy")
+      NextMethod()
+    }
+  )
+
+  noisy <- function(x) {
+    class(x) <- c("noisy", class(x))
+    x
+  }
+
+  df <- tibble(x = 1:10, g = rep(1:2, each = 5)) %>% group_by(g)
+
+  expect_warning(slice(noisy(df), 1:2), "noisy")
+  expect_warning(slice_sample(noisy(df), n = 2), "noisy")
+  expect_warning(slice_head(noisy(df), n = 2), "noisy")
+  expect_warning(slice_tail(noisy(df), n = 2), "noisy")
+  expect_warning(slice_min(noisy(df), x, n = 2), "noisy")
+  expect_warning(slice_max(noisy(df), x, n = 2), "noisy")
+  expect_warning(sample_n(noisy(df), 2), "noisy")
+  expect_warning(sample_frac(noisy(df), .5), "noisy")
+})
 
 # Errors ------------------------------------------------------------------
 


### PR DESCRIPTION
reboot of #6111 

`slice.sf()` is indeed called when calling `slice_sample(<sf>)`: 
 
``` r
library(sf)
#> Linking to GEOS 3.8.1, GDAL 3.2.1, PROJ 7.2.1
library(dplyr, warn.conflicts = FALSE)

nc <- st_read(system.file("shape/nc.shp", package="sf"))
#> Reading layer `nc' from data source 
#>   `/Users/romainfrancois/.R/library/4.0/sf/shape/nc.shp' using driver `ESRI Shapefile'
#> Simple feature collection with 100 features and 14 fields
#> Geometry type: MULTIPOLYGON
#> Dimension:     XY
#> Bounding box:  xmin: -84.32385 ymin: 33.88199 xmax: -75.45698 ymax: 36.58965
#> Geodetic CRS:  NAD27
nc$area_cl = cut(nc$AREA, c(0, .1, .12, .15, .25))
nc <- nc %>% group_by(area_cl) 

# both benefit from `slice.sf()`
nc %>% slice(1:2)
#> Simple feature collection with 8 features and 15 fields
#> Geometry type: MULTIPOLYGON
#> Dimension:     XY
#> Bounding box:  xmin: -81.74107 ymin: 36.07282 xmax: -75.77316 ymax: 36.58965
#> Geodetic CRS:  NAD27
#> # A tibble: 8 × 16
#> # Groups:   area_cl [4]
#>    AREA PERIMETER CNTY_ CNTY_ID NAME   FIPS  FIPSNO CRESS_ID BIR74 SID74 NWBIR74
#>   <dbl>     <dbl> <dbl>   <dbl> <chr>  <chr>  <dbl>    <int> <dbl> <dbl>   <dbl>
#> 1 0.061      1.23  1827    1827 Alleg… 37005  37005        3   487     0      10
#> 2 0.07       2.97  1831    1831 Curri… 37053  37053       27   508     1     123
#> 3 0.114      1.44  1825    1825 Ashe   37009  37009        5  1091     1      10
#> 4 0.118      1.42  1836    1836 Warren 37185  37185       93   968     4     748
#> 5 0.143      1.63  1828    1828 Surry  37171  37171       86  3188     5     208
#> 6 0.124      1.43  1837    1837 Stokes 37169  37169       85  1612     1     160
#> 7 0.153      2.21  1832    1832 North… 37131  37131       66  1421     9    1066
#> 8 0.153      1.62  1839    1839 Rocki… 37157  37157       79  4449    16    1243
#> # … with 5 more variables: BIR79 <dbl>, SID79 <dbl>, NWBIR79 <dbl>,
#> #   geometry <MULTIPOLYGON [°]>, area_cl <fct>
nc %>% slice_sample(n = 2)
#> Simple feature collection with 8 features and 15 fields
#> Geometry type: MULTIPOLYGON
#> Dimension:     XY
#> Bounding box:  xmin: -82.29067 ymin: 34.81476 xmax: -76.02605 ymax: 36.54606
#> Geodetic CRS:  NAD27
#> # A tibble: 8 × 16
#> # Groups:   area_cl [4]
#>    AREA PERIMETER CNTY_ CNTY_ID NAME   FIPS  FIPSNO CRESS_ID BIR74 SID74 NWBIR74
#>   <dbl>     <dbl> <dbl>   <dbl> <chr>  <chr>  <dbl>    <int> <dbl> <dbl>   <dbl>
#> 1 0.099      1.41  1963    1963 Tyrre… 37177  37177       89   248     0     116
#> 2 0.07       1.10  2016    2016 Greene 37079  37079       40   870     4     534
#> 3 0.116      1.66  1964    1964 McDow… 37111  37111       56  1946     5     134
#> 4 0.109      1.32  1841    1841 Person 37145  37145       73  1556     4     613
#> 5 0.122      1.52  1932    1932 Caldw… 37027  37027       14  3609     6     309
#> 6 0.145      1.79  1951    1951 David… 37057  37057       29  5509     8     736
#> 7 0.219      2.13  1938    1938 Wake   37183  37183       92 14484    16    4397
#> 8 0.163      1.72  2095    2095 Union  37179  37179       90  3915     4    1034
#> # … with 5 more variables: BIR79 <dbl>, SID79 <dbl>, NWBIR79 <dbl>,
#> #   geometry <MULTIPOLYGON [°]>, area_cl <fct>

nc %>% slice_sample(n = 2, weight_by = 1:3)
#> Error in `slice_sample()`:
#>   Problem while computing indices.
#>   ℹ The error occurred in group 1: area_cl = "(0,0.1]".
#> Caused by error in `vec_assert()` at dplyr/R/slice.R:244:6:
#>   `weight_by` must have size 35, not size 3.
```

<sup>Created on 2021-12-10 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1.9000)</sup>

