### PR TITLE
Fix grammar in deprecated do

### DIFF
--- a/R/deprec-do.r
+++ b/R/deprec-do.r
@@ -4,7 +4,7 @@
 #' `r lifecycle::badge("superseded")`
 #'
 #' `do()` is superseded as of dplyr 1.0.0, because its syntax never really
-#' felt like it belong with the rest of dplyr. It's replaced by a combination
+#' felt like it belonged with the rest of dplyr. It's replaced by a combination
 #' of [summarise()] (which can now produce multiple rows and multiple columns),
 #' [nest_by()] (which creates a [rowwise] tibble of nested data),
 #' and [across()] (which allows you to access the data for the "current" group).

--- a/man/do.Rd
+++ b/man/do.Rd
@@ -18,7 +18,7 @@ unnamed arguments.}
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
 
 \code{do()} is superseded as of dplyr 1.0.0, because its syntax never really
-felt like it belong with the rest of dplyr. It's replaced by a combination
+felt like it belonged with the rest of dplyr. It's replaced by a combination
 of \code{\link[=summarise]{summarise()}} (which can now produce multiple rows and multiple columns),
 \code{\link[=nest_by]{nest_by()}} (which creates a \link{rowwise} tibble of nested data),
 and \code{\link[=across]{across()}} (which allows you to access the data for the "current" group).


### PR DESCRIPTION
Hello,

This PR aims to fix a minor grammar issue in the documentation of the now deprecated `do` function.

Thank you,

NelsonGon 

(Failed to redocument due to `rlang` not being uptodate on my side). 