### PR TITLE
Adding an hyphen in How tos

### DIFF
--- a/vignettes/programming.Rmd
+++ b/vignettes/programming.Rmd
@@ -177,7 +177,7 @@ As with data masking, tidy selection makes a common task easier at the cost of m
     mtcars %>% select(!all_of(vars))
     ```
 
-## How tos
+## How-tos
 
 The following examples solve a grab bag of common problems. We show you the minimum amount of code so that you can get the basic idea; most real problems will require more code or combining multiple techniques.
 


### PR DESCRIPTION
Although the hyphen is optional, one can easily argue that 'How-tos' is preferable to 'How tos'. A non-native speaker may not understand that the expression refers to an object (a guide), so it may look up the definition of 'tos'. Using 'How-tos' helps in this sense, as it indicates that it is a single expression.