### PR TITLE
Preserve custom factor metadata in group_by(..., .drop=FALSE)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr (development version)
 
+* `group_by(..., .drop = FALSE)` preserves all metadata on a factor including for subclasses (@gergness, #6164).
+
 * The deprecated `trunc_mat()` is no longer reexported from dplyr, no CRAN packages import it from dplyr (#6141).
 
 * dplyr now uses `rlang::check_installed()` to prompt you whether to install

--- a/R/grouped-df.r
+++ b/R/grouped-df.r
@@ -77,11 +77,7 @@ compute_groups <- function(data, vars, drop = FALSE) {
     # Make the new keys from the old keys and the new_indices
     new_keys <- pmap(list(old_keys, new_indices, uniques), function(key, index, unique) {
       if (is.factor(key)) {
-        if (is.ordered(key)) {
-          new_ordered(index, levels = levels(key))
-        } else {
-          new_factor(index, levels = levels(key))
-        }
+        exec(structure, index, !!!attributes(key))
       } else {
         vec_slice(unique, index)
       }

--- a/tests/testthat/test-group-by.r
+++ b/tests/testthat/test-group-by.r
@@ -429,6 +429,18 @@ test_that("group_by(.drop = FALSE) preserve ordered factors (#5455)", {
   expect_true(is.ordered(nodrop$x))
 })
 
+test_that("group_by(.drop = FALSE) preserves metadata of classes inheriting factor", {
+  df <- tibble(
+    x = structure(1L, levels = "x", extra_info = "xyz", class = c("custom", "factor"))
+  )
+  nodrop <- df %>% group_by(x, .drop = FALSE) %>% group_data()
+
+  expect_equal(
+    attributes(nodrop$x),
+    list(levels = "x", extra_info = "xyz", class = c("custom", "factor"))
+  )
+})
+
 test_that("summarise maintains the .drop attribute (#4061)", {
   df <- tibble(
     f1 = factor("a", levels = c("a", "b", "c")),


### PR DESCRIPTION
Before this PR, the metadata on a factor variable beyond the standard base constructs (the levels attribute, and the "factor" and possibly "ordered" classes) is lost. 

I'm not sure how much this is worth going into, but I was hoping to extend the behavior of factors, especially the `.drop` behavior in https://github.com/gergness/srvyr/issues/134. This is admittedly niche, but it feels in the spirit of recent work in `vctrs` that allows extending base vector classes. Because of the recent advances in preserving metadata, it was surprising to me that this case doesn't.


Before the PR:
``` r
suppressPackageStartupMessages(library(dplyr))

df <- tibble(
  x = structure(1L, levels = "x", extra_info = "xyz", class = c("custom", "factor"))
)
nodrop <- df %>% group_by(x, .drop = FALSE) %>% group_data()

class(nodrop$x)
#> [1] "factor"
attributes(nodrop$x)
#> $levels
#> [1] "x"
#> 
#> $class
#> [1] "factor"
```


After this PR:
``` r
suppressPackageStartupMessages(library(dplyr))

df <- tibble(
  x = structure(1L, levels = "x", extra_info = "xyz", class = c("custom", "factor"))
)
nodrop <- df %>% group_by(x, .drop = FALSE) %>% group_data()

class(nodrop$x)
#> [1] "custom" "factor"
attributes(nodrop$x)
#> $levels
#> [1] "x"
#> 
#> $extra_info
#> [1] "xyz"
#> 
#> $class
#> [1] "custom" "factor"
```