### PR TITLE
`dplyr_col_select()` reconstructs bare data.table objects

### DIFF
--- a/R/generics.R
+++ b/R/generics.R
@@ -215,6 +215,7 @@ dplyr_reconstruct.rowwise_df <- function(data, template) {
 dplyr_col_select <- function(.data, loc, names = NULL, error_call = caller_env()) {
   loc <- vec_as_location(loc, n = ncol(.data), names = names(.data))
 
+  .datatable.aware <- TRUE
   out <- .data[loc]
   if (!inherits(out, "data.frame")) {
     classes_data <- glue_collapse(class(.data), sep = "/")

--- a/R/generics.R
+++ b/R/generics.R
@@ -215,7 +215,6 @@ dplyr_reconstruct.rowwise_df <- function(data, template) {
 dplyr_col_select <- function(.data, loc, names = NULL, error_call = caller_env()) {
   loc <- vec_as_location(loc, n = ncol(.data), names = names(.data))
 
-  .datatable.aware <- TRUE
   out <- .data[loc]
   if (!inherits(out, "data.frame")) {
     classes_data <- glue_collapse(class(.data), sep = "/")
@@ -241,7 +240,7 @@ dplyr_col_select <- function(.data, loc, names = NULL, error_call = caller_env()
 
   # Patch base data frames to restore extra attributes that `[.data.frame` drops.
   # We require `[` methods to keep extra attributes for all data frame subclasses.
-  if (identical(class(.data), "data.frame")) {
+  if (identical(class(.data), "data.frame") || identical(class(.data), c("data.table", "data.frame"))) {
     out <- dplyr_reconstruct(out, .data)
   }
 

--- a/R/generics.R
+++ b/R/generics.R
@@ -238,7 +238,7 @@ dplyr_col_select <- function(.data, loc, names = NULL, error_call = caller_env()
     abort(bullets, call = error_call)
   }
 
-  # Patch base data frames to restore extra attributes that `[.data.frame` drops.
+  # Patch base data frames and data.table (#6171) to restore extra attributes that `[.data.frame` drops.
   # We require `[` methods to keep extra attributes for all data frame subclasses.
   if (identical(class(.data), "data.frame") || identical(class(.data), c("data.table", "data.frame"))) {
     out <- dplyr_reconstruct(out, .data)

--- a/R/reexport-tibble.r
+++ b/R/reexport-tibble.r
@@ -46,7 +46,6 @@ tibble::type_sum
 #' `glimpse()` is provided by the pillar package, and re-exported
 #' by dplyr. See [pillar::glimpse()] for more details.
 #'
-#' @inheritParams pillar::glimpse
 #' @return x original x is (invisibly) returned, allowing `glimpse()` to be
 #'   used within a data pipeline.
 #' @examples


### PR DESCRIPTION
``` r
# pak::pak("Rdatatable/data.table")
library(data.table)
library(dplyr, warn.conflicts = FALSE)

d1 <- data.table(x = 1)
attr(d1, "foo") <- "bar"

d2 <- dplyr:::dplyr_col_select(d1, "x")
attr(d2, "foo")
#> [1] "bar"
```

<sup>Created on 2022-02-02 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

as opposed to losing the attribute: 

``` r
# pak::pak("Rdatatable/data.table")
library(data.table)
library(dplyr, warn.conflicts = FALSE)

d1 <- data.table(x = 1)
attr(d1, "foo") <- "bar"

d2 <- dplyr:::dplyr_col_select(d1, "x")
attr(d2, "foo")
#> NULL
```

<sup>Created on 2022-02-02 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

however, this only works with the dev version of `data.table` thanks to: https://github.com/Rdatatable/data.table/pull/4909

This is related to: https://github.com/fndemarqui/covid19br/pull/1