### PR TITLE
Allow duplicate `x` keys in `rows_*()` (and sometimes allow duplicate `y` keys)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,19 @@
 # dplyr (development version)
 
+* The `rows_*()` functions no longer require that the key values in `x` uniquely
+  identify each row. Additionally, `rows_insert()` and `rows_delete()` no
+  longer require that the key values in `y` uniquely identify each row. Relaxing
+  this restriction should make these functions more practically useful for
+  data frames, and alternative backends can enforce this in other ways as needed
+  (i.e. through primary keys) (#5553).
+  
+* The `rows_*()` functions now fail elegantly if `y` is a zero column data frame
+  and `by` isn't specified (#6179).
+
+* `rows_delete()` no longer requires that the columns of `y` be a strict subset
+  of `x`. Only the columns specified through `by` will be utilized from `y`,
+  all others will be dropped with a message.
+
 # dplyr 1.0.8
 
 * Better display of error messages thanks to rlang 1.0.0.

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -135,10 +135,6 @@ err_locs <- function(x) {
     abort("`x` must have at least 1 location.", .internal = TRUE)
   }
 
-  if (size == 1L) {
-    return(glue("`{x}`"))
-  }
-
   if (size > 5L) {
     x <- x[1:5]
     extra <- glue(" and {size - 5L} more")

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -124,6 +124,33 @@ err_vars <- function(x) {
   glue_collapse(x, sep = ", ", last = if (length(x) <= 2) " and " else ", and ")
 }
 
+err_locs <- function(x) {
+  if (!is.integer(x)) {
+    abort("`x` must be an integer vector of locations.", .internal = TRUE)
+  }
+
+  size <- length(x)
+
+  if (size == 0L) {
+    abort("`x` must have at least 1 location.", .internal = TRUE)
+  }
+
+  if (size == 1L) {
+    return(glue("`{x}`"))
+  }
+
+  if (size > 5L) {
+    x <- x[1:5]
+    extra <- glue(" and {size - 5L} more")
+  } else {
+    extra <- ""
+  }
+
+  x <- glue_collapse(x, sep = ", ")
+
+  glue("`c({x})`{extra}")
+}
+
 dplyr_internal_error <- function(class = NULL, data = list()) {
   abort(class = c(class, "dplyr:::internal_error"), dplyr_error_data = data)
 }

--- a/R/rows.R
+++ b/R/rows.R
@@ -250,7 +250,7 @@ rows_upsert.data.frame <- function(x,
   x_loc <- which(match)
 
   y_size <- vec_size(y_key)
-  y_extra <- setdiff(seq_len(y_size), y_loc)
+  y_extra <- vec_as_location_invert(y_loc, y_size)
   y_extra <- dplyr_row_slice(y, y_extra)
 
   x[x_loc, names(y)] <- dplyr_row_slice(y, y_loc)
@@ -297,7 +297,9 @@ rows_delete.data.frame <- function(x,
   loc <- vec_match(x_key, y_key)
   match <- !is.na(loc)
 
+  x_size <- vec_size(x_key)
   x_loc <- which(match)
+  x_loc <- vec_as_location_invert(x_loc, x_size)
 
   # Have to use `vec_in()` to see if any keys in `y` are unmatched because `y`
   # may have duplicate keys, which the `vec_match()` call above won't pick up
@@ -305,7 +307,7 @@ rows_delete.data.frame <- function(x,
   y_size <- vec_size(y_key)
   rows_check_y_unmatched(y_loc, y_size, "delete")
 
-  dplyr_row_slice(x, -x_loc)
+  dplyr_row_slice(x, x_loc)
 }
 
 # helpers -----------------------------------------------------------------
@@ -396,7 +398,7 @@ rows_check_y_unmatched <- function(loc,
                                    error_call = caller_env()) {
   check_dots_empty()
 
-  unmatched <- setdiff(seq_len(size), loc)
+  unmatched <- vec_as_location_invert(loc, size)
 
   if (is_empty(unmatched)) {
     return(invisible())
@@ -421,4 +423,12 @@ rows_df_in_place <- function(in_place, error_call = caller_env()) {
 
 rows_bind <- function(x, y) {
   dplyr_reconstruct(vctrs::vec_rbind(x, y), x)
+}
+
+vec_as_location_invert <- function(i, n) {
+  if (is_empty(i)) {
+    seq_len(n)
+  } else {
+    vec_as_location(-i, n)
+  }
 }

--- a/R/rows.R
+++ b/R/rows.R
@@ -3,29 +3,29 @@
 #' @description
 #' `r lifecycle::badge("experimental")`
 #'
-#' These functions provide a framework for modifying rows in a table using
-#' a second table of data. The two tables are matched `by` a set of key
-#' variables whose values must uniquely identify each row. The functions are
-#' inspired by SQL's `INSERT`, `UPDATE`, and `DELETE`, and can optionally
-#' modify `in_place` for selected backends.
+#' These functions provide a framework for modifying rows in a table using a
+#' second table of data. The two tables are matched `by` a set of key variables
+#' whose values typically uniquely identify each row. The functions are inspired
+#' by SQL's `INSERT`, `UPDATE`, and `DELETE`, and can optionally modify
+#' `in_place` for selected backends.
 #'
-#' * `rows_insert()` adds new rows (like `INSERT`); key values in `y` must
+#' * `rows_insert()` adds new rows (like `INSERT`). Key values in `y` must
 #'    not occur in `x`.
-#' * `rows_update()` modifies existing rows (like `UPDATE`); key values in
-#'   `y` must occur in `x`.
+#' * `rows_update()` modifies existing rows (like `UPDATE`). Key values in
+#'   `y` must occur in `x`, and key values in `y` must be unique.
 #' * `rows_patch()` works like `rows_update()` but only overwrites `NA` values.
 #' * `rows_upsert()` inserts or updates depending on whether or not the
-#'   key value in `y` already exists in `x`.
-#' * `rows_delete()` deletes rows (like `DELETE`); key values in `y` must
+#'   key value in `y` already exists in `x`. Key values in `y` must be unique.
+#' * `rows_delete()` deletes rows (like `DELETE`). Key values in `y` must
 #'   exist in `x`.
 #'
 #' @inheritParams left_join
 #' @param x,y A pair of data frames or data frame extensions (e.g. a tibble).
 #'   `y` must have the same columns of `x` or a subset.
-#' @param by An unnamed character vector giving the key columns. The key
-#'   values must uniquely identify each row (i.e. each combination of key
-#'   values occurs at most once), and the key columns must exist in both `x`
-#'   and `y`.
+#' @param by An unnamed character vector giving the key columns. The key columns
+#'   must exist in both `x` and `y`. Keys typically uniquely identify each row,
+#'   but this is only enforced for the key values of `y` when `rows_update()`,
+#'   `rows_patch()`, or `rows_upsert()` are used.
 #'
 #'   By default, we use the first column in `y`, since the first column is
 #'   a reasonable place to put an identifier variable.

--- a/R/rows.R
+++ b/R/rows.R
@@ -317,7 +317,7 @@ rows_check_by <- function(by, y, ..., error_call = caller_env()) {
 
   if (is.null(by)) {
     if (ncol(y) == 0L) {
-      abort("`y` must have at least one column to use as a key.")
+      abort("`y` must have at least one column to use as a key.", call = error_call)
     }
 
     by <- names(y)[[1]]

--- a/R/rows.R
+++ b/R/rows.R
@@ -412,41 +412,6 @@ rows_check_y_unmatched <- function(loc,
   abort(message, call = error_call)
 }
 
-rows_check_key <- function(by, x, y, error_call = caller_env()) {
-  if (is.null(by)) {
-    by <- names(y)[[1]]
-    msg <- glue("Matching, by = \"{by}\"")
-    inform(msg, class = c("dplyr_message_matching_by", "dplyr_message"))
-  }
-
-  if (!is.character(by) || length(by) == 0) {
-    abort("`by` must be a character vector.", call = error_call)
-  }
-  # is_named(by) checks all(names2(by) != ""), we need any(...)
-  if (any(names2(by) != "")) {
-    abort("`by` must be unnamed.", call = error_call)
-  }
-
-  bad <- setdiff(colnames(y), colnames(x))
-  if (has_length(bad)) {
-    abort("All columns in `y` must exist in `x`.", call = error_call)
-  }
-
-  by
-}
-
-rows_check_key_df <- function(df, by, df_name, error_call = caller_env()) {
-  y_miss <- setdiff(by, colnames(df))
-  if (length(y_miss) > 0) {
-    msg <- glue("All `by` columns must exist in `{df_name}`.")
-    abort(msg, call = error_call)
-  }
-  if (vctrs::vec_duplicate_any(df[by])) {
-    msg <- glue("`{df_name}` key values must be unique.")
-    abort(msg, call = error_call)
-  }
-}
-
 rows_df_in_place <- function(in_place, error_call = caller_env()) {
   if (is_true(in_place)) {
     msg <- "Data frames only support `in_place = FALSE`."

--- a/R/rows.R
+++ b/R/rows.R
@@ -104,7 +104,8 @@ rows_insert.data.frame <- function(x,
   y_in_x <- vec_in(y_key, x_key)
 
   if (any(y_in_x)) {
-    y_in_x <- err_vars(y_in_x)
+    y_in_x <- which(y_in_x)
+    y_in_x <- err_locs(y_in_x)
 
     message <- c(
       "Can't insert rows with keys that already exist in `x`.",
@@ -409,7 +410,7 @@ rows_check_y_unmatched <- function(loc,
     return(invisible())
   }
 
-  unmatched <- err_vars(unmatched)
+  unmatched <- err_locs(unmatched)
 
   message <- c(
     "`y` can't contain unmatched keys.",

--- a/R/rows.R
+++ b/R/rows.R
@@ -155,7 +155,7 @@ rows_update.data.frame <- function(x,
   x_loc <- which(match)
 
   y_size <- vec_size(y_key)
-  rows_check_y_unmatched(y_loc, y_size, "update")
+  rows_check_y_unmatched(y_loc, y_size)
 
   values_cols <- setdiff(names(y), names(y_key))
 
@@ -202,7 +202,7 @@ rows_patch.data.frame <- function(x,
   x_loc <- which(match)
 
   y_size <- vec_size(y_key)
-  rows_check_y_unmatched(y_loc, y_size, "patch")
+  rows_check_y_unmatched(y_loc, y_size)
 
   values_cols <- setdiff(names(y), names(y_key))
 
@@ -311,7 +311,7 @@ rows_delete.data.frame <- function(x,
   # may have duplicate keys, which the `vec_match()` call above won't pick up
   y_loc <- which(vec_in(y_key, x_key))
   y_size <- vec_size(y_key)
-  rows_check_y_unmatched(y_loc, y_size, "delete")
+  rows_check_y_unmatched(y_loc, y_size)
 
   dplyr_row_slice(x, x_loc)
 }
@@ -399,7 +399,6 @@ rows_select_key <- function(x,
 
 rows_check_y_unmatched <- function(loc,
                                    size,
-                                   verb,
                                    ...,
                                    error_call = caller_env()) {
   check_dots_empty()
@@ -413,7 +412,7 @@ rows_check_y_unmatched <- function(loc,
   unmatched <- err_vars(unmatched)
 
   message <- c(
-    glue("Can't {verb} with `y` keys that don't exist in `x`."),
+    "`y` can't contain unmatched keys.",
     i = glue("The following rows in `y` have keys that don't exist in `x`: {unmatched}.")
   )
 

--- a/R/rows.R
+++ b/R/rows.R
@@ -290,11 +290,9 @@ rows_delete.data.frame <- function(x,
   }
 
   loc <- vec_match(x_key, y_key)
-  match <- !is.na(loc)
+  unmatched <- is.na(loc)
 
-  x_size <- vec_size(x_key)
-  x_loc <- which(match)
-  x_loc <- vec_as_location_invert(x_loc, x_size)
+  x_loc <- which(unmatched)
 
   dplyr_row_slice(x, x_loc)
 }

--- a/R/rows.R
+++ b/R/rows.R
@@ -338,7 +338,7 @@ rows_check_by <- function(by, y, ..., error_call = caller_env()) {
     abort("`by` must be a character vector.", call = error_call)
   }
   if (is_empty(by)) {
-    abort("Must specify at least 1 column in `by`.", call = error_call)
+    abort("`by` must specify at least 1 column.", call = error_call)
   }
   if (!all(names2(by) == "")) {
     abort("`by` must be unnamed.", call = error_call)

--- a/R/rows.R
+++ b/R/rows.R
@@ -108,7 +108,7 @@ rows_insert.data.frame <- function(x,
     y_in_x <- err_locs(y_in_x)
 
     message <- c(
-      "Can't insert rows with keys that already exist in `x`.",
+      "`y` must contain keys that don't exist in `x`.",
       i = glue("The following rows in `y` have keys that already exist in `x`: {y_in_x}.")
     )
 
@@ -413,7 +413,7 @@ rows_check_y_unmatched <- function(loc,
   unmatched <- err_locs(unmatched)
 
   message <- c(
-    "`y` can't contain unmatched keys.",
+    "`y` must contain keys that already exist in `x`.",
     i = glue("The following rows in `y` have keys that don't exist in `x`: {unmatched}.")
   )
 

--- a/R/rows.R
+++ b/R/rows.R
@@ -371,7 +371,15 @@ rows_select_key <- function(x,
   out <- x[by]
 
   if (unique && vec_duplicate_any(out)) {
-    message <- glue("`{arg}` key values must be unique.")
+    duplicated <- vec_duplicate_detect(out)
+    duplicated <- which(duplicated)
+    duplicated <- err_locs(duplicated)
+
+    message <- c(
+      glue("`{arg}` key values must be unique."),
+      i = glue("The following rows contain duplicate key values: {duplicated}.")
+    )
+
     abort(message, call = error_call)
   }
 

--- a/R/rows.R
+++ b/R/rows.R
@@ -157,7 +157,9 @@ rows_update.data.frame <- function(x,
   y_size <- vec_size(y_key)
   rows_check_y_unmatched(y_loc, y_size, "update")
 
-  x[x_loc, names(y)] <- dplyr_row_slice(y, y_loc)
+  values_cols <- setdiff(names(y), names(y_key))
+
+  x[x_loc, values_cols] <- y[y_loc, values_cols]
 
   x
 }
@@ -202,12 +204,14 @@ rows_patch.data.frame <- function(x,
   y_size <- vec_size(y_key)
   rows_check_y_unmatched(y_loc, y_size, "patch")
 
-  x_slice <- x[x_loc, names(y)]
-  y_slice <- dplyr_row_slice(y, y_loc)
+  values_cols <- setdiff(names(y), names(y_key))
 
-  x_patched <- map2(x_slice, y_slice, coalesce)
+  x_values <- x[x_loc, values_cols]
+  y_values <- y[y_loc, values_cols]
 
-  x[x_loc, names(y)] <- x_patched
+  x_patched <- map2(x_values, y_values, coalesce)
+
+  x[x_loc, values_cols] <- x_patched
 
   x
 }
@@ -253,7 +257,9 @@ rows_upsert.data.frame <- function(x,
   y_extra <- vec_as_location_invert(y_loc, y_size)
   y_extra <- dplyr_row_slice(y, y_extra)
 
-  x[x_loc, names(y)] <- dplyr_row_slice(y, y_loc)
+  values_cols <- setdiff(names(y), names(y_key))
+
+  x[x_loc, values_cols] <- y[y_loc, values_cols]
   x <- rows_bind(x, y_extra)
 
   x

--- a/R/rows.R
+++ b/R/rows.R
@@ -101,19 +101,7 @@ rows_insert.data.frame <- function(x,
   x_key <- rows_select_key(x, by, "x")
   y_key <- rows_select_key(y, by, "y")
 
-  y_in_x <- vec_in(y_key, x_key)
-
-  if (any(y_in_x)) {
-    y_in_x <- which(y_in_x)
-    y_in_x <- err_locs(y_in_x)
-
-    message <- c(
-      "`y` must contain keys that don't exist in `x`.",
-      i = glue("The following rows in `y` have keys that already exist in `x`: {y_in_x}.")
-    )
-
-    abort(message)
-  }
+  rows_check_y_matched(x_key, y_key)
 
   rows_bind(x, y)
 }
@@ -396,6 +384,27 @@ rows_select_key <- function(x,
   }
 
   out
+}
+
+rows_check_y_matched <- function(x_key,
+                                 y_key,
+                                 ...,
+                                 error_call = caller_env()) {
+  check_dots_empty()
+
+  matched <- vec_in(y_key, x_key)
+
+  if (any(matched)) {
+    matched <- which(matched)
+    matched <- err_locs(matched)
+
+    message <- c(
+      "`y` must contain keys that don't exist in `x`.",
+      i = glue("The following rows in `y` have keys that already exist in `x`: {matched}.")
+    )
+
+    abort(message, call = error_call)
+  }
 }
 
 rows_check_y_unmatched <- function(loc,

--- a/R/rows.R
+++ b/R/rows.R
@@ -380,7 +380,7 @@ rows_select_key <- function(x,
     missing <- err_vars(missing)
 
     message <- c(
-      glue("All `by` columns must exist in `{arg}`."),
+      "All columns specified through `by` must exist in `x` and `y`.",
       i = glue("The following columns are missing from `{arg}`: {missing}.")
     )
 

--- a/R/rows.R
+++ b/R/rows.R
@@ -323,7 +323,7 @@ rows_check_by <- function(by, y, ..., error_call = caller_env()) {
 
   if (is.null(by)) {
     if (ncol(y) == 0L) {
-      abort("`y` must have at least one column to use as a key.", call = error_call)
+      abort("`y` must have at least one column.", call = error_call)
     }
 
     by <- names(y)[[1]]

--- a/man/rows.Rd
+++ b/man/rows.Rd
@@ -23,10 +23,10 @@ rows_delete(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE)
 \item{x, y}{A pair of data frames or data frame extensions (e.g. a tibble).
 \code{y} must have the same columns of \code{x} or a subset.}
 
-\item{by}{An unnamed character vector giving the key columns. The key
-values must uniquely identify each row (i.e. each combination of key
-values occurs at most once), and the key columns must exist in both \code{x}
-and \code{y}.
+\item{by}{An unnamed character vector giving the key columns. The key columns
+must exist in both \code{x} and \code{y}. Keys typically uniquely identify each row,
+but this is only enforced for the key values of \code{y} when \code{rows_update()},
+\code{rows_patch()}, or \code{rows_upsert()} are used.
 
 By default, we use the first column in \code{y}, since the first column is
 a reasonable place to put an identifier variable.}
@@ -61,20 +61,20 @@ If \code{in_place = TRUE}, the result will be returned invisibly.
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 
-These functions provide a framework for modifying rows in a table using
-a second table of data. The two tables are matched \code{by} a set of key
-variables whose values must uniquely identify each row. The functions are
-inspired by SQL's \code{INSERT}, \code{UPDATE}, and \code{DELETE}, and can optionally
-modify \code{in_place} for selected backends.
+These functions provide a framework for modifying rows in a table using a
+second table of data. The two tables are matched \code{by} a set of key variables
+whose values typically uniquely identify each row. The functions are inspired
+by SQL's \code{INSERT}, \code{UPDATE}, and \code{DELETE}, and can optionally modify
+\code{in_place} for selected backends.
 \itemize{
-\item \code{rows_insert()} adds new rows (like \code{INSERT}); key values in \code{y} must
+\item \code{rows_insert()} adds new rows (like \code{INSERT}). Key values in \code{y} must
 not occur in \code{x}.
-\item \code{rows_update()} modifies existing rows (like \code{UPDATE}); key values in
-\code{y} must occur in \code{x}.
+\item \code{rows_update()} modifies existing rows (like \code{UPDATE}). Key values in
+\code{y} must occur in \code{x}, and key values in \code{y} must be unique.
 \item \code{rows_patch()} works like \code{rows_update()} but only overwrites \code{NA} values.
 \item \code{rows_upsert()} inserts or updates depending on whether or not the
-key value in \code{y} already exists in \code{x}.
-\item \code{rows_delete()} deletes rows (like \code{DELETE}); key values in \code{y} must
+key value in \code{y} already exists in \code{x}. Key values in \code{y} must be unique.
+\item \code{rows_delete()} deletes rows (like \code{DELETE}). Key values in \code{y} must
 exist in \code{x}.
 }
 }

--- a/tests/testthat/_snaps/conditions.md
+++ b/tests/testthat/_snaps/conditions.md
@@ -158,3 +158,40 @@
       ! Problem while computing `.result = cyl * c(am, vs)`.
       x `.result` must be size 32 or 1, not 64.
 
+# `err_locs()` works as expected
+
+    Code
+      err_locs(1.5)
+    Condition
+      Error in `err_locs()`:
+      ! `x` must be an integer vector of locations.
+      i This is an internal error, please report it to the package authors.
+
+---
+
+    Code
+      err_locs(integer())
+    Condition
+      Error in `err_locs()`:
+      ! `x` must have at least 1 location.
+      i This is an internal error, please report it to the package authors.
+
+---
+
+    Code
+      err_locs(1L)
+    Output
+      `1`
+    Code
+      err_locs(1:5)
+    Output
+      `c(1, 2, 3, 4, 5)`
+    Code
+      err_locs(1:6)
+    Output
+      `c(1, 2, 3, 4, 5)` and 1 more
+    Code
+      err_locs(1:7)
+    Output
+      `c(1, 2, 3, 4, 5)` and 2 more
+

--- a/tests/testthat/_snaps/conditions.md
+++ b/tests/testthat/_snaps/conditions.md
@@ -181,7 +181,7 @@
     Code
       err_locs(1L)
     Output
-      `1`
+      `c(1)`
     Code
       err_locs(1:5)
     Output

--- a/tests/testthat/_snaps/rows.md
+++ b/tests/testthat/_snaps/rows.md
@@ -131,7 +131,7 @@
     Output
       <error/rlang_error>
       Error:
-      ! Must specify at least 1 column in `by`.
+      ! `by` must specify at least 1 column.
     Code
       (expect_error(rows_check_by(by = c(x = "y"), y = y)))
     Output

--- a/tests/testthat/_snaps/rows.md
+++ b/tests/testthat/_snaps/rows.md
@@ -18,6 +18,25 @@
       ! Can't insert rows with keys that already exist in `x`.
       i The following rows in `y` have keys that already exist in `x`: 1, 2, and 3.
 
+# rows_update() requires `y` keys to exist in `x`
+
+    Code
+      (expect_error(rows_update(x, y, "a")))
+    Output
+      <error/rlang_error>
+      Error in `rows_update()`:
+      ! Can't update with `y` keys that don't exist in `x`.
+      i The following rows in `y` have keys that don't exist in `x`: 1 and 3.
+
+# rows_update() doesn't allow `y` keys to be duplicated (#5553)
+
+    Code
+      (expect_error(rows_update(x, y, by = "a")))
+    Output
+      <error/rlang_error>
+      Error in `rows_update()`:
+      ! `y` key values must be unique.
+
 # rows_delete()
 
     Code
@@ -108,12 +127,6 @@
 
     Code
       data <- tibble(a = 1:3, b = letters[c(1:2, NA)], c = 0.5 + 0:2)
-      (expect_error(rows_update(data, tibble(a = 2:3, b = "z"), by = c("a", "b"))))
-    Output
-      <error/rlang_error>
-      Error in `rows_update()`:
-      ! Attempting to update missing rows.
-    Code
       (expect_error(rows_patch(data, tibble(a = 2:3, b = "z"), by = c("a", "b"))))
     Output
       <error/rlang_error>

--- a/tests/testthat/_snaps/rows.md
+++ b/tests/testthat/_snaps/rows.md
@@ -1,3 +1,23 @@
+# rows_insert() doesn't allow insertion of duplicate keys
+
+    Code
+      (expect_error(rows_insert(x, y, by = "a")))
+    Output
+      <error/rlang_error>
+      Error in `rows_insert()`:
+      ! Can't insert rows with keys that already exist in `x`.
+      i The following rows in `y` have keys that already exist in `x`: 1.
+
+---
+
+    Code
+      (expect_error(rows_insert(x, y, by = "a")))
+    Output
+      <error/rlang_error>
+      Error in `rows_insert()`:
+      ! Can't insert rows with keys that already exist in `x`.
+      i The following rows in `y` have keys that already exist in `x`: 1, 2, and 3.
+
 # rows_delete()
 
     Code
@@ -5,40 +25,89 @@
     Message
       Ignoring extra columns: b
 
+# rows_check_containment() checks that `y` columns are in `x`
+
+    Code
+      (expect_error(rows_check_containment(x, y)))
+    Output
+      <error/rlang_error>
+      Error:
+      ! All columns in `y` must exist in `x`.
+      i The following columns only exist in `y`: `b`.
+
+# rows_check_by() checks that `y` has at least 1 column before using it (#6061)
+
+    Code
+      (expect_error(rows_check_by(by = NULL, y = y)))
+    Output
+      <error/rlang_error>
+      Error in `rows_check_by()`:
+      ! `y` must have at least one column to use as a key.
+
+# rows_check_by() uses the first column from `y` by default, with a message
+
+    Code
+      by <- rows_check_by(by = NULL, y = y)
+    Message
+      Matching, by = "a"
+
+# rows_check_by() validates `by`
+
+    Code
+      (expect_error(rows_check_by(by = 1, y = y)))
+    Output
+      <error/rlang_error>
+      Error:
+      ! `by` must be a character vector.
+    Code
+      (expect_error(rows_check_by(by = character(), y = y)))
+    Output
+      <error/rlang_error>
+      Error:
+      ! Must specify at least 1 column in `by`.
+    Code
+      (expect_error(rows_check_by(by = c(x = "y"), y = y)))
+    Output
+      <error/rlang_error>
+      Error:
+      ! `by` must be unnamed.
+
+# rows_select_key() checks that all `by` columns are in `x`
+
+    Code
+      (expect_error(rows_select_key(x, "y", arg = "x")))
+    Output
+      <error/rlang_error>
+      Error:
+      ! All `by` columns must exist in `x`.
+      i The following columns are missing from `x`: `y`.
+    Code
+      (expect_error(rows_select_key(x, c("y", "x", "z"), arg = "y")))
+    Output
+      <error/rlang_error>
+      Error:
+      ! All `by` columns must exist in `y`.
+      i The following columns are missing from `y`: `y` and `z`.
+
+# rows_select_key() optionally requires uniqueness
+
+    Code
+      (expect_error(rows_select_key(x, "x", arg = "x", unique = TRUE)))
+    Output
+      <error/rlang_error>
+      Error:
+      ! `x` key values must be unique.
+    Code
+      (expect_error(rows_select_key(x, c("x", "y"), arg = "y", unique = TRUE)))
+    Output
+      <error/rlang_error>
+      Error:
+      ! `y` key values must be unique.
+
 # rows_*() errors
 
     Code
       data <- tibble(a = 1:3, b = letters[c(1:2, NA)], c = 0.5 + 0:2)
-      (expect_error(rows_insert(data, tibble(a = 3, b = "z"))))
-    Message
-      Matching, by = "a"
-    Output
-      <error/rlang_error>
-      Error in `rows_insert()`:
-      ! Attempting to insert duplicate rows.
-    Code
-      (expect_error(rows_insert(data[c(1, 1), ], tibble(a = 3))))
-    Message
-      Matching, by = "a"
-    Output
-      <error/rlang_error>
-      Error in `rows_insert()`:
-      ! `x` key values must be unique.
-    Code
-      (expect_error(rows_insert(data, tibble(a = 4, b = "z"), by = "e")))
-    Output
-      <error/rlang_error>
-      Error in `rows_insert()`:
-      ! All `by` columns must exist in `x`.
-    Code
-      (expect_error(rows_insert(data, tibble(d = 4))))
-    Message
-      Matching, by = "d"
-    Output
-      <error/rlang_error>
-      Error in `rows_insert()`:
-      ! All columns in `y` must exist in `x`.
-    Code
       (expect_error(rows_update(data, tibble(a = 2:3, b = "z"), by = c("a", "b"))))
     Output
       <error/rlang_error>

--- a/tests/testthat/_snaps/rows.md
+++ b/tests/testthat/_snaps/rows.md
@@ -109,7 +109,7 @@
     Output
       <error/rlang_error>
       Error:
-      ! `y` must have at least one column to use as a key.
+      ! `y` must have at least one column.
 
 # rows_check_by() uses the first column from `y` by default, with a message
 

--- a/tests/testthat/_snaps/rows.md
+++ b/tests/testthat/_snaps/rows.md
@@ -65,12 +65,32 @@
       Error in `rows_upsert()`:
       ! `y` key values must be unique.
 
-# rows_delete()
+# rows_delete() ignores extra `y` columns, with a message
 
     Code
-      res <- rows_delete(data, tibble(a = 2:3, b = "b"), by = "a")
+      out <- rows_delete(x, y)
     Message
-      Ignoring extra columns: b
+      Matching, by = "a"
+      Ignoring extra `y` columns: b
+
+---
+
+    Code
+      out <- rows_delete(x, y, by = "a")
+    Message
+      Ignoring extra `y` columns: b
+
+# rows_delete() requires `y` keys to exist in `x`
+
+    Code
+      (expect_error(rows_delete(x, y, "a")))
+    Message
+      Ignoring extra `y` columns: b
+    Output
+      <error/rlang_error>
+      Error in `rows_delete()`:
+      ! Can't delete with `y` keys that don't exist in `x`.
+      i The following rows in `y` have keys that don't exist in `x`: 1 and 3.
 
 # rows_check_containment() checks that `y` columns are in `x`
 
@@ -150,41 +170,4 @@
       <error/rlang_error>
       Error:
       ! `y` key values must be unique.
-
-# rows_*() errors
-
-    Code
-      data <- tibble(a = 1:3, b = letters[c(1:2, NA)], c = 0.5 + 0:2)
-      (expect_error(rows_delete(data, tibble(a = 2:4))))
-    Message
-      Matching, by = "a"
-    Output
-      <error/rlang_error>
-      Error in `rows_delete()`:
-      ! Can't delete missing row.
-    Code
-      (expect_error(rows_delete(data, tibble(a = 2:3, b = "b"), by = c("a", "b"))))
-    Output
-      <error/rlang_error>
-      Error in `rows_delete()`:
-      ! Can't delete missing row.
-    Code
-      rows_delete(data, tibble(a = 2:3))
-    Message
-      Matching, by = "a"
-    Output
-      # A tibble: 1 x 3
-            a b         c
-        <int> <chr> <dbl>
-      1     1 a       0.5
-    Code
-      rows_delete(data, tibble(a = 2:3, b = "b"))
-    Message
-      Matching, by = "a"
-      Ignoring extra columns: b
-    Output
-      # A tibble: 1 x 3
-            a b         c
-        <int> <chr> <dbl>
-      1     1 a       0.5
 

--- a/tests/testthat/_snaps/rows.md
+++ b/tests/testthat/_snaps/rows.md
@@ -25,7 +25,7 @@
     Output
       <error/rlang_error>
       Error in `rows_update()`:
-      ! Can't update with `y` keys that don't exist in `x`.
+      ! `y` can't contain unmatched keys.
       i The following rows in `y` have keys that don't exist in `x`: 1 and 3.
 
 # rows_update() doesn't allow `y` keys to be duplicated (#5553)
@@ -44,7 +44,7 @@
     Output
       <error/rlang_error>
       Error in `rows_patch()`:
-      ! Can't patch with `y` keys that don't exist in `x`.
+      ! `y` can't contain unmatched keys.
       i The following rows in `y` have keys that don't exist in `x`: 1 and 3.
 
 # rows_patch() doesn't allow `y` keys to be duplicated (#5553)
@@ -89,7 +89,7 @@
     Output
       <error/rlang_error>
       Error in `rows_delete()`:
-      ! Can't delete with `y` keys that don't exist in `x`.
+      ! `y` can't contain unmatched keys.
       i The following rows in `y` have keys that don't exist in `x`: 1 and 3.
 
 # rows_check_containment() checks that `y` columns are in `x`

--- a/tests/testthat/_snaps/rows.md
+++ b/tests/testthat/_snaps/rows.md
@@ -6,7 +6,7 @@
       <error/rlang_error>
       Error in `rows_insert()`:
       ! `y` must contain keys that don't exist in `x`.
-      i The following rows in `y` have keys that already exist in `x`: `1`.
+      i The following rows in `y` have keys that already exist in `x`: `c(1)`.
 
 ---
 

--- a/tests/testthat/_snaps/rows.md
+++ b/tests/testthat/_snaps/rows.md
@@ -6,7 +6,7 @@
       <error/rlang_error>
       Error in `rows_insert()`:
       ! Can't insert rows with keys that already exist in `x`.
-      i The following rows in `y` have keys that already exist in `x`: 1.
+      i The following rows in `y` have keys that already exist in `x`: `1`.
 
 ---
 
@@ -16,7 +16,7 @@
       <error/rlang_error>
       Error in `rows_insert()`:
       ! Can't insert rows with keys that already exist in `x`.
-      i The following rows in `y` have keys that already exist in `x`: 1, 2, and 3.
+      i The following rows in `y` have keys that already exist in `x`: `c(1, 2, 3)`.
 
 # rows_update() requires `y` keys to exist in `x`
 
@@ -26,7 +26,7 @@
       <error/rlang_error>
       Error in `rows_update()`:
       ! `y` can't contain unmatched keys.
-      i The following rows in `y` have keys that don't exist in `x`: 1 and 3.
+      i The following rows in `y` have keys that don't exist in `x`: `c(1, 3)`.
 
 # rows_update() doesn't allow `y` keys to be duplicated (#5553)
 
@@ -45,7 +45,7 @@
       <error/rlang_error>
       Error in `rows_patch()`:
       ! `y` can't contain unmatched keys.
-      i The following rows in `y` have keys that don't exist in `x`: 1 and 3.
+      i The following rows in `y` have keys that don't exist in `x`: `c(1, 3)`.
 
 # rows_patch() doesn't allow `y` keys to be duplicated (#5553)
 
@@ -90,7 +90,7 @@
       <error/rlang_error>
       Error in `rows_delete()`:
       ! `y` can't contain unmatched keys.
-      i The following rows in `y` have keys that don't exist in `x`: 1 and 3.
+      i The following rows in `y` have keys that don't exist in `x`: `c(1, 3)`.
 
 # rows_check_containment() checks that `y` columns are in `x`
 

--- a/tests/testthat/_snaps/rows.md
+++ b/tests/testthat/_snaps/rows.md
@@ -146,14 +146,14 @@
     Output
       <error/rlang_error>
       Error:
-      ! All `by` columns must exist in `x`.
+      ! All columns specified through `by` must exist in `x` and `y`.
       i The following columns are missing from `x`: `y`.
     Code
       (expect_error(rows_select_key(x, c("y", "x", "z"), arg = "y")))
     Output
       <error/rlang_error>
       Error:
-      ! All `by` columns must exist in `y`.
+      ! All columns specified through `by` must exist in `x` and `y`.
       i The following columns are missing from `y`: `y` and `z`.
 
 # rows_select_key() optionally requires uniqueness

--- a/tests/testthat/_snaps/rows.md
+++ b/tests/testthat/_snaps/rows.md
@@ -36,6 +36,7 @@
       <error/rlang_error>
       Error in `rows_update()`:
       ! `y` key values must be unique.
+      i The following rows contain duplicate key values: `c(1, 2)`.
 
 # rows_patch() requires `y` keys to exist in `x`
 
@@ -55,6 +56,7 @@
       <error/rlang_error>
       Error in `rows_patch()`:
       ! `y` key values must be unique.
+      i The following rows contain duplicate key values: `c(1, 2)`.
 
 # rows_upsert() doesn't allow `y` keys to be duplicated (#5553)
 
@@ -64,6 +66,7 @@
       <error/rlang_error>
       Error in `rows_upsert()`:
       ! `y` key values must be unique.
+      i The following rows contain duplicate key values: `c(1, 2)`.
 
 # rows_delete() ignores extra `y` columns, with a message
 
@@ -162,10 +165,12 @@
       <error/rlang_error>
       Error:
       ! `x` key values must be unique.
+      i The following rows contain duplicate key values: `c(1, 2, 3)`.
     Code
       (expect_error(rows_select_key(x, c("x", "y"), arg = "y", unique = TRUE)))
     Output
       <error/rlang_error>
       Error:
       ! `y` key values must be unique.
+      i The following rows contain duplicate key values: `c(1, 3)`.
 

--- a/tests/testthat/_snaps/rows.md
+++ b/tests/testthat/_snaps/rows.md
@@ -5,7 +5,7 @@
     Output
       <error/rlang_error>
       Error in `rows_insert()`:
-      ! Can't insert rows with keys that already exist in `x`.
+      ! `y` must contain keys that don't exist in `x`.
       i The following rows in `y` have keys that already exist in `x`: `1`.
 
 ---
@@ -15,7 +15,7 @@
     Output
       <error/rlang_error>
       Error in `rows_insert()`:
-      ! Can't insert rows with keys that already exist in `x`.
+      ! `y` must contain keys that don't exist in `x`.
       i The following rows in `y` have keys that already exist in `x`: `c(1, 2, 3)`.
 
 # rows_update() requires `y` keys to exist in `x`
@@ -25,7 +25,7 @@
     Output
       <error/rlang_error>
       Error in `rows_update()`:
-      ! `y` can't contain unmatched keys.
+      ! `y` must contain keys that already exist in `x`.
       i The following rows in `y` have keys that don't exist in `x`: `c(1, 3)`.
 
 # rows_update() doesn't allow `y` keys to be duplicated (#5553)
@@ -44,7 +44,7 @@
     Output
       <error/rlang_error>
       Error in `rows_patch()`:
-      ! `y` can't contain unmatched keys.
+      ! `y` must contain keys that already exist in `x`.
       i The following rows in `y` have keys that don't exist in `x`: `c(1, 3)`.
 
 # rows_patch() doesn't allow `y` keys to be duplicated (#5553)
@@ -89,7 +89,7 @@
     Output
       <error/rlang_error>
       Error in `rows_delete()`:
-      ! `y` can't contain unmatched keys.
+      ! `y` must contain keys that already exist in `x`.
       i The following rows in `y` have keys that don't exist in `x`: `c(1, 3)`.
 
 # rows_check_containment() checks that `y` columns are in `x`

--- a/tests/testthat/_snaps/rows.md
+++ b/tests/testthat/_snaps/rows.md
@@ -108,7 +108,7 @@
       (expect_error(rows_check_by(by = NULL, y = y)))
     Output
       <error/rlang_error>
-      Error in `rows_check_by()`:
+      Error:
       ! `y` must have at least one column to use as a key.
 
 # rows_check_by() uses the first column from `y` by default, with a message

--- a/tests/testthat/_snaps/rows.md
+++ b/tests/testthat/_snaps/rows.md
@@ -56,6 +56,15 @@
       Error in `rows_patch()`:
       ! `y` key values must be unique.
 
+# rows_upsert() doesn't allow `y` keys to be duplicated (#5553)
+
+    Code
+      (expect_error(rows_upsert(x, y, by = "a")))
+    Output
+      <error/rlang_error>
+      Error in `rows_upsert()`:
+      ! `y` key values must be unique.
+
 # rows_delete()
 
     Code

--- a/tests/testthat/_snaps/rows.md
+++ b/tests/testthat/_snaps/rows.md
@@ -37,6 +37,25 @@
       Error in `rows_update()`:
       ! `y` key values must be unique.
 
+# rows_patch() requires `y` keys to exist in `x`
+
+    Code
+      (expect_error(rows_patch(x, y, "a")))
+    Output
+      <error/rlang_error>
+      Error in `rows_patch()`:
+      ! Can't patch with `y` keys that don't exist in `x`.
+      i The following rows in `y` have keys that don't exist in `x`: 1 and 3.
+
+# rows_patch() doesn't allow `y` keys to be duplicated (#5553)
+
+    Code
+      (expect_error(rows_patch(x, y, by = "a")))
+    Output
+      <error/rlang_error>
+      Error in `rows_patch()`:
+      ! `y` key values must be unique.
+
 # rows_delete()
 
     Code
@@ -127,12 +146,6 @@
 
     Code
       data <- tibble(a = 1:3, b = letters[c(1:2, NA)], c = 0.5 + 0:2)
-      (expect_error(rows_patch(data, tibble(a = 2:3, b = "z"), by = c("a", "b"))))
-    Output
-      <error/rlang_error>
-      Error in `rows_patch()`:
-      ! Can't patch missing row.
-    Code
       (expect_error(rows_delete(data, tibble(a = 2:4))))
     Message
       Matching, by = "a"

--- a/tests/testthat/_snaps/rows.md
+++ b/tests/testthat/_snaps/rows.md
@@ -84,8 +84,6 @@
 
     Code
       (expect_error(rows_delete(x, y, "a")))
-    Message
-      Ignoring extra `y` columns: b
     Output
       <error/rlang_error>
       Error in `rows_delete()`:

--- a/tests/testthat/test-conditions.R
+++ b/tests/testthat/test-conditions.R
@@ -43,3 +43,15 @@ test_that("can pass verb-level error call (example case)", {
     my_verb(mtcars, cyl, c(am, vs))
   })
 })
+
+test_that("`err_locs()` works as expected", {
+  expect_snapshot(error = TRUE, err_locs(1.5))
+  expect_snapshot(error = TRUE, err_locs(integer()))
+
+  expect_snapshot({
+    err_locs(1L)
+    err_locs(1:5)
+    err_locs(1:6)
+    err_locs(1:7)
+  })
+})

--- a/tests/testthat/test-rows.R
+++ b/tests/testthat/test-rows.R
@@ -1,16 +1,52 @@
-test_that("rows_insert()", {
+# ------------------------------------------------------------------------------
+# rows_insert()
+
+test_that("rows_insert() works", {
   data <- tibble(a = 1:3, b = letters[c(1:2, NA)], c = 0.5 + 0:2)
 
   expect_identical(
     rows_insert(data, tibble(a = 4L, b = "z"), by = "a"),
     tibble(a = 1:4, b = c("a", "b", NA, "z"), c = c(0.5, 1.5, 2.5, NA))
   )
+})
 
-  expect_error(
-    rows_insert(data, tibble(a = 3, b = "z"), by = "a"),
-    "insert duplicate"
+test_that("rows_insert() doesn't allow insertion of duplicate keys", {
+  x <- tibble(a = 1, b = 2)
+
+  y <- tibble(a = 1, b = 3)
+
+  expect_snapshot(
+    (expect_error(rows_insert(x, y, by = "a")))
+  )
+
+  y <- tibble(a = c(1, 1, 1), b = c(3, 4, 5))
+
+  expect_snapshot(
+    (expect_error(rows_insert(x, y, by = "a")))
   )
 })
+
+test_that("rows_insert() allows `x` keys to be duplicated (#5553)", {
+  x <- tibble(a = c(1, 1), b = c(2, 3))
+  y <- tibble(a = 2, b = 4)
+
+  expect_identical(
+    rows_insert(x, y, by = "a"),
+    tibble(a = c(1, 1, 2), b = c(2, 3, 4))
+  )
+})
+
+test_that("rows_insert() allows `y` keys to be duplicated (#5553)", {
+  x <- tibble(a = 2, b = 4)
+  y <- tibble(a = c(1, 1), b = c(2, 3))
+
+  expect_identical(
+    rows_insert(x, y, by = "a"),
+    tibble(a = c(2, 1, 1), b = c(4, 2, 3))
+  )
+})
+
+# ------------------------------------------------------------------------------
 
 test_that("rows_update()", {
   data <- tibble(a = 1:3, b = letters[c(1:2, NA)], c = 0.5 + 0:2)
@@ -85,24 +121,74 @@ test_that("rows_delete()", {
   )
 })
 
+# ------------------------------------------------------------------------------
+# Common errors
+
+test_that("rows_check_containment() checks that `y` columns are in `x`", {
+  x <- tibble(a = 1)
+  y <- tibble(a = 1, b = 2)
+
+  expect_snapshot((expect_error(rows_check_containment(x, y))))
+})
+
+test_that("rows_check_by() checks that `y` has at least 1 column before using it (#6061)", {
+  y <- tibble()
+
+  expect_snapshot((expect_error(rows_check_by(by = NULL, y = y))))
+})
+
+test_that("rows_check_by() uses the first column from `y` by default, with a message", {
+  y <- tibble(a = 1, b = 2)
+
+  expect_snapshot(
+    by <- rows_check_by(by = NULL, y = y)
+  )
+
+  expect_identical(by, "a")
+})
+
+test_that("rows_check_by() validates `by`", {
+  y <- tibble(x = 1)
+
+  expect_snapshot({
+    (expect_error(rows_check_by(by = 1, y = y)))
+    (expect_error(rows_check_by(by = character(), y = y)))
+    (expect_error(rows_check_by(by = c(x = "y"), y = y)))
+  })
+})
+
+test_that("rows_select_key() selects the key columns", {
+  x <- tibble(x = 1, y = 2, z = 3)
+
+  expect_identical(
+    rows_select_key(x, c("z", "x"), "x"),
+    x[c("z", "x")]
+  )
+})
+
+test_that("rows_select_key() checks that all `by` columns are in `x`", {
+  x <- tibble(x = 1)
+
+  expect_snapshot({
+    (expect_error(rows_select_key(x, "y", arg = "x")))
+    (expect_error(rows_select_key(x, c("y", "x", "z"), arg = "y")))
+  })
+})
+
+test_that("rows_select_key() optionally requires uniqueness", {
+  x <- tibble(x = c(1, 1, 1), y = c(2, 3, 2), z = c(1, 2, 3))
+
+  expect_identical(rows_select_key(x, "z", arg = "x", unique = TRUE), x["z"])
+
+  expect_snapshot({
+    (expect_error(rows_select_key(x, "x", arg = "x", unique = TRUE)))
+    (expect_error(rows_select_key(x, c("x", "y"), arg = "y", unique = TRUE)))
+  })
+})
+
 test_that("rows_*() errors", {
   expect_snapshot({
     data <- tibble(a = 1:3, b = letters[c(1:2, NA)], c = 0.5 + 0:2)
-
-    # Insert
-    (expect_error(
-                    rows_insert(data, tibble(a = 3, b = "z"))
-    ))
-    (expect_error(
-                    rows_insert(data[c(1, 1), ], tibble(a = 3))
-    ))
-    (expect_error(
-                    rows_insert(data, tibble(a = 4, b = "z"), by = "e")
-    ))
-
-    (expect_error(
-                    rows_insert(data, tibble(d = 4))
-    ))
 
     # Update
     (expect_error(

--- a/tests/testthat/test-rows.R
+++ b/tests/testthat/test-rows.R
@@ -48,17 +48,12 @@ test_that("rows_insert() allows `y` keys to be duplicated (#5553)", {
 
 # ------------------------------------------------------------------------------
 
-test_that("rows_update()", {
+test_that("rows_update() works", {
   data <- tibble(a = 1:3, b = letters[c(1:2, NA)], c = 0.5 + 0:2)
 
   expect_identical(
     rows_update(data, tibble(a = 2:3, b = "z"), by = "a"),
     tibble(a = 1:3, b = c("a", "z", "z"), c = data$c)
-  )
-
-  expect_error(
-    rows_update(data, tibble(a = 2:3, b = "z"), by = c("a", "b")),
-    "update missing"
   )
 
   expect_silent(
@@ -68,6 +63,32 @@ test_that("rows_update()", {
     )
   )
 })
+
+test_that("rows_update() requires `y` keys to exist in `x`", {
+  x <- tibble(a = 1, b = 2)
+  y <- tibble(a = c(2, 1, 3), b = c(1, 1, 1))
+
+  expect_snapshot((expect_error(rows_update(x, y, "a"))))
+})
+
+test_that("rows_update() allows `x` keys to be duplicated (#5553)", {
+  x <- tibble(a = c(1, 2, 1, 3), b = c(2, 3, 4, 5), c = letters[1:4])
+  y <- tibble(a = c(1, 3), b = c(99, 88))
+
+  expect_identical(
+    rows_update(x, y, by = "a"),
+    tibble(a = c(1, 2, 1, 3), b = c(99, 3, 99, 88), c = letters[1:4])
+  )
+})
+
+test_that("rows_update() doesn't allow `y` keys to be duplicated (#5553)", {
+  x <- tibble(a = 2, b = 4)
+  y <- tibble(a = c(1, 1), b = c(2, 3))
+
+  expect_snapshot((expect_error(rows_update(x, y, by = "a"))))
+})
+
+# ------------------------------------------------------------------------------
 
 test_that("rows_patch()", {
   data <- tibble(a = 1:3, b = letters[c(1:2, NA)], c = 0.5 + 0:2)
@@ -189,11 +210,6 @@ test_that("rows_select_key() optionally requires uniqueness", {
 test_that("rows_*() errors", {
   expect_snapshot({
     data <- tibble(a = 1:3, b = letters[c(1:2, NA)], c = 0.5 + 0:2)
-
-    # Update
-    (expect_error(
-                    rows_update(data, tibble(a = 2:3, b = "z"), by = c("a", "b"))
-    ))
 
     # Variants: patch
     (expect_error(

--- a/tests/testthat/test-rows.R
+++ b/tests/testthat/test-rows.R
@@ -132,7 +132,7 @@ test_that("rows_patch() doesn't allow `y` keys to be duplicated (#5553)", {
 
 # ------------------------------------------------------------------------------
 
-test_that("rows_upsert()", {
+test_that("rows_upsert() works", {
   data <- tibble(a = 1:3, b = letters[c(1:2, NA)], c = 0.5 + 0:2)
 
   expect_identical(
@@ -140,6 +140,25 @@ test_that("rows_upsert()", {
     tibble(a = 1:4, b = c("a", "z", "z", "z"), c = c(data$c, NA))
   )
 })
+
+test_that("rows_upsert() allows `x` keys to be duplicated (#5553)", {
+  x <- tibble(a = c(1, 2, 1, 3), b = c(NA, 3, 4, NA), c = letters[1:4])
+  y <- tibble(a = c(1, 3, 4), b = c(99, 88, 100))
+
+  expect_identical(
+    rows_upsert(x, y, by = "a"),
+    tibble(a = c(1, 2, 1, 3, 4), b = c(99, 3, 99, 88, 100), c = c(letters[1:4], NA))
+  )
+})
+
+test_that("rows_upsert() doesn't allow `y` keys to be duplicated (#5553)", {
+  x <- tibble(a = 2, b = 4)
+  y <- tibble(a = c(1, 1), b = c(2, 3))
+
+  expect_snapshot((expect_error(rows_upsert(x, y, by = "a"))))
+})
+
+# ------------------------------------------------------------------------------
 
 test_that("rows_delete()", {
   data <- tibble(a = 1:3, b = letters[c(1:2, NA)], c = 0.5 + 0:2)


### PR DESCRIPTION
Closes #5588 (supersedes it)
Closes #5553 

Related to an error when `y` has zero columns that I fixed:
Closes #6179 
Closes #6061

This PR updates the rows functions using part of the plan outlined at the bottom of this comment https://github.com/tidyverse/dplyr/pull/5588#issuecomment-1048373544. Specifically, it mainly does two things:

- Allows duplicate keys in `x` unconditionally
- Allows duplicate keys in `y` for `rows_insert()` and `rows_delete()`

I also refreshed the error messages to be more descriptive.

This is motivated by practical usefulness of these functions on local data frames (i.e. #5553).

The important thing to think about here is that if these checks are required, then they can be done ahead of time outside the `rows_*()` function using something like:
- `enforce()` for local data frames
- Primary keys for databases
- Primary keys for {dm} tables 

This aligns with what we learned about the join API. For the most part, new arguments should not be added for checks that can be performed independently of the function itself.

There will be a follow up PR to this one for the proposed `matched` and `unmatched` arguments.