### PR TITLE
Include `<algorithm>` header since we use `std::fill()`

### DIFF
--- a/src/group_by.cpp
+++ b/src/group_by.cpp
@@ -1,4 +1,5 @@
 #include "dplyr.h"
+#include <algorithm>
 #include <vector>
 
 // support for expand_groups()


### PR DESCRIPTION
Closes #6192 

On my Mac, `<vector>` includes `<algorithm>` (I can see it in the vector header file itself), but it isn't good practice to rely on this hidden dependency