### PR TITLE
Implement `conflict` and `unmatched` arguments for the `rows_*()` family

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,19 @@
 # dplyr (development version)
 
+* `rows_insert()`, `rows_update()`, `rows_patch()`, and `rows_delete()` have
+  gained a new `conflict` argument allowing you greater control over rows in
+  `y` with keys that conflict with keys in `x`.
+  
+  For `rows_insert()`, a conflict arises if a key in `y` already exists in `x`.
+  
+  For `rows_update()`, `rows_patch()`, and `rows_delete()`, a conflict arises
+  if a key in `y` doesn't exist in `x`.
+  
+  By default, a conflict of any kind is an error, but you can now also
+  `"ignore"` the rows in `y` where a conflict occurs. In particular, for
+  `rows_insert()` this is very similar to the `ON CONFLICT DO NOTHING` command
+  from SQL (#5588, #5984, #5699, with helpful additions from @mgirlich).
+
 * The `rows_*()` functions no longer require that the key values in `x` uniquely
   identify each row. Additionally, `rows_insert()` and `rows_delete()` no
   longer require that the key values in `y` uniquely identify each row. Relaxing

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,18 +1,16 @@
 # dplyr (development version)
 
-* `rows_insert()`, `rows_update()`, `rows_patch()`, and `rows_delete()` have
-  gained a new `conflict` argument allowing you greater control over rows in
-  `y` with keys that conflict with keys in `x`.
-  
-  For `rows_insert()`, a conflict arises if a key in `y` already exists in `x`.
-  
-  For `rows_update()`, `rows_patch()`, and `rows_delete()`, a conflict arises
-  if a key in `y` doesn't exist in `x`.
-  
-  By default, a conflict of any kind is an error, but you can now also
-  `"ignore"` the rows in `y` where a conflict occurs. In particular, for
-  `rows_insert()` this is very similar to the `ON CONFLICT DO NOTHING` command
-  from SQL (#5588, #5984, #5699, with helpful additions from @mgirlich).
+* `rows_insert()` gained a new `conflict` argument allowing you greater control
+  over rows in `y` with keys that conflict with keys in `x`. A conflict arises
+  if a key in `y` already exists in `x`. By default, a conflict results in an
+  error, but you can now also `"ignore"` these `y` rows. This is very similar to
+  the `ON CONFLICT DO NOTHING` command from SQL (#5588, with helpful additions
+  from @mgirlich and @krlmlr).
+
+* `rows_update()`, `rows_patch()`, and `rows_delete()` gained a new `unmatched`
+  argument allowing you greater control over rows in `y` with keys that are
+  unmatched by the keys in `x`. By default, an unmatched key results in an
+  error, but you can now also `"ignore"` these `y` rows (#5984, #5699).
 
 * The `rows_*()` functions no longer require that the key values in `x` uniquely
   identify each row. Additionally, `rows_insert()` and `rows_delete()` no

--- a/R/rows.R
+++ b/R/rows.R
@@ -103,7 +103,7 @@ rows_insert <- function(x,
                         y,
                         by = NULL,
                         ...,
-                        conflict = "error",
+                        conflict = c("error", "ignore"),
                         copy = FALSE,
                         in_place = FALSE) {
   lifecycle::signal_stage("experimental", "rows_insert()")
@@ -115,7 +115,7 @@ rows_insert.data.frame <- function(x,
                                    y,
                                    by = NULL,
                                    ...,
-                                   conflict = "error",
+                                   conflict = c("error", "ignore"),
                                    copy = FALSE,
                                    in_place = FALSE) {
   check_dots_empty()
@@ -145,7 +145,7 @@ rows_update <- function(x,
                         y,
                         by = NULL,
                         ...,
-                        conflict = "error",
+                        conflict = c("error", "ignore"),
                         copy = FALSE,
                         in_place = FALSE) {
   lifecycle::signal_stage("experimental", "rows_update()")
@@ -157,7 +157,7 @@ rows_update.data.frame <- function(x,
                                    y,
                                    by = NULL,
                                    ...,
-                                   conflict = "error",
+                                   conflict = c("error", "ignore"),
                                    copy = FALSE,
                                    in_place = FALSE) {
   check_dots_empty()
@@ -198,7 +198,7 @@ rows_patch <- function(x,
                        y,
                        by = NULL,
                        ...,
-                       conflict = "error",
+                       conflict = c("error", "ignore"),
                        copy = FALSE,
                        in_place = FALSE) {
   lifecycle::signal_stage("experimental", "rows_patch()")
@@ -210,7 +210,7 @@ rows_patch.data.frame <- function(x,
                                   y,
                                   by = NULL,
                                   ...,
-                                  conflict = "error",
+                                  conflict = c("error", "ignore"),
                                   copy = FALSE,
                                   in_place = FALSE) {
   check_dots_empty()
@@ -305,7 +305,7 @@ rows_delete <- function(x,
                         y,
                         by = NULL,
                         ...,
-                        conflict = "error",
+                        conflict = c("error", "ignore"),
                         copy = FALSE,
                         in_place = FALSE) {
   lifecycle::signal_stage("experimental", "rows_delete()")
@@ -317,7 +317,7 @@ rows_delete.data.frame <- function(x,
                                    y,
                                    by = NULL,
                                    ...,
-                                   conflict = "error",
+                                   conflict = c("error", "ignore"),
                                    copy = FALSE,
                                    in_place = FALSE) {
   check_dots_empty()

--- a/R/rows.R
+++ b/R/rows.R
@@ -461,8 +461,9 @@ rows_check_y_conflict <- function(x_key,
       rows_matched <- err_locs(rows_matched)
 
       message <- c(
-        "`y` must contain keys that don't exist in `x`.",
-        i = glue("The following rows in `y` have keys that already exist in `x`: {rows_matched}.")
+        "`y` can't contain keys that already exist in `x`.",
+        i = glue("The following rows in `y` have keys that already exist in `x`: {rows_matched}."),
+        i = "Use `conflict = \"ignore\"` if you want to ignore these `y` rows."
       )
 
       abort(message, call = error_call)
@@ -495,7 +496,8 @@ rows_check_y_unmatched <- function(x_key,
 
       message <- c(
         "`y` must contain keys that already exist in `x`.",
-        i = glue("The following rows in `y` have keys that don't exist in `x`: {rows_unmatched}.")
+        i = glue("The following rows in `y` have keys that don't exist in `x`: {rows_unmatched}."),
+        i = "Use `unmatched = \"ignore\"` if you want to ignore these `y` rows."
       )
 
       abort(message, call = error_call)

--- a/man/rows.Rd
+++ b/man/rows.Rd
@@ -14,7 +14,7 @@ rows_insert(
   y,
   by = NULL,
   ...,
-  conflict = "error",
+  conflict = c("error", "ignore"),
   copy = FALSE,
   in_place = FALSE
 )
@@ -24,7 +24,7 @@ rows_update(
   y,
   by = NULL,
   ...,
-  conflict = "error",
+  conflict = c("error", "ignore"),
   copy = FALSE,
   in_place = FALSE
 )
@@ -34,7 +34,7 @@ rows_patch(
   y,
   by = NULL,
   ...,
-  conflict = "error",
+  conflict = c("error", "ignore"),
   copy = FALSE,
   in_place = FALSE
 )
@@ -46,7 +46,7 @@ rows_delete(
   y,
   by = NULL,
   ...,
-  conflict = "error",
+  conflict = c("error", "ignore"),
   copy = FALSE,
   in_place = FALSE
 )

--- a/man/rows.Rd
+++ b/man/rows.Rd
@@ -24,7 +24,7 @@ rows_update(
   y,
   by = NULL,
   ...,
-  conflict = c("error", "ignore"),
+  unmatched = c("error", "ignore"),
   copy = FALSE,
   in_place = FALSE
 )
@@ -34,7 +34,7 @@ rows_patch(
   y,
   by = NULL,
   ...,
-  conflict = c("error", "ignore"),
+  unmatched = c("error", "ignore"),
   copy = FALSE,
   in_place = FALSE
 )
@@ -46,7 +46,7 @@ rows_delete(
   y,
   by = NULL,
   ...,
-  conflict = c("error", "ignore"),
+  unmatched = c("error", "ignore"),
   copy = FALSE,
   in_place = FALSE
 )
@@ -65,14 +65,9 @@ a reasonable place to put an identifier variable.}
 
 \item{...}{Other parameters passed onto methods.}
 
-\item{conflict}{How should keys in \code{y} that conflict with keys in \code{x} be
-handled?
-
-For \code{rows_insert()}, a conflict arises if there is a key in \code{y} that
-already exists in \code{x}.
-
-For \code{rows_patch()}, \code{rows_delete()}, and \code{rows_update()}, a conflict arises
-if there is a key in \code{y} that doesn't exist in \code{x}.
+\item{conflict}{For \code{rows_insert()}, how should keys in \code{y} that conflict
+with keys in \code{x} be handled? A conflict arises if there is a key in \code{y}
+that already exists in \code{x}.
 
 One of:
 \itemize{
@@ -92,6 +87,17 @@ relevant for mutable backends (e.g. databases, data.tables).
 
 When \code{TRUE}, a modified version of \code{x} is returned invisibly;
 when \code{FALSE}, a new object representing the resulting changes is returned.}
+
+\item{unmatched}{For \code{rows_update()}, \code{rows_patch()}, and \code{rows_delete()},
+how should keys in \code{y} that are unmatched by the keys in \code{x} be handled?
+
+One of:
+\itemize{
+\item \code{"error"}, the default, will error if there are any keys in \code{y} that
+are unmatched by the keys in \code{x}.
+\item \code{"ignore"} will ignore rows in \code{y} with keys that are unmatched by the
+keys in \code{x}.
+}}
 }
 \value{
 An object of the same type as \code{x}. The order of the rows and columns of \code{x}
@@ -100,7 +106,8 @@ is preserved as much as possible. The output has the following properties:
 \item \code{rows_update()} preserves rows as is; \code{rows_insert()} and \code{rows_upsert()}
 return all existing rows and potentially new rows; \code{rows_delete()} returns
 a subset of the rows.
-\item Columns are not added, removed, or relocated, though the data may be updated.
+\item Columns are not added, removed, or relocated, though the data may be
+updated.
 \item Groups are taken from \code{x}.
 \item Data frame attributes are taken from \code{x}.
 }
@@ -154,10 +161,10 @@ rows_delete(data, tibble(a = 2:3, b = "b"))
 
 # By default, for update, patch, and delete it is an error if a key in `y`
 # doesn't exist in `x`. You can ignore rows in `y` that have unmatched keys
-# with `conflict = "ignore"`.
+# with `unmatched = "ignore"`.
 y <- tibble(a = 3:4, b = "z")
 try(rows_update(data, y, by = "a"))
-rows_update(data, y, by = "a", conflict = "ignore")
-rows_patch(data, y, by = "a", conflict = "ignore")
-rows_delete(data, y, by = "a", conflict = "ignore")
+rows_update(data, y, by = "a", unmatched = "ignore")
+rows_patch(data, y, by = "a", unmatched = "ignore")
+rows_delete(data, y, by = "a", unmatched = "ignore")
 }

--- a/man/rows.Rd
+++ b/man/rows.Rd
@@ -9,15 +9,47 @@
 \alias{rows_delete}
 \title{Manipulate individual rows}
 \usage{
-rows_insert(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE)
+rows_insert(
+  x,
+  y,
+  by = NULL,
+  ...,
+  conflict = "error",
+  copy = FALSE,
+  in_place = FALSE
+)
 
-rows_update(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE)
+rows_update(
+  x,
+  y,
+  by = NULL,
+  ...,
+  conflict = "error",
+  copy = FALSE,
+  in_place = FALSE
+)
 
-rows_patch(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE)
+rows_patch(
+  x,
+  y,
+  by = NULL,
+  ...,
+  conflict = "error",
+  copy = FALSE,
+  in_place = FALSE
+)
 
 rows_upsert(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE)
 
-rows_delete(x, y, by = NULL, ..., copy = FALSE, in_place = FALSE)
+rows_delete(
+  x,
+  y,
+  by = NULL,
+  ...,
+  conflict = "error",
+  copy = FALSE,
+  in_place = FALSE
+)
 }
 \arguments{
 \item{x, y}{A pair of data frames or data frame extensions (e.g. a tibble).
@@ -32,6 +64,23 @@ By default, we use the first column in \code{y}, since the first column is
 a reasonable place to put an identifier variable.}
 
 \item{...}{Other parameters passed onto methods.}
+
+\item{conflict}{How should keys in \code{y} that conflict with keys in \code{x} be
+handled?
+
+For \code{rows_insert()}, a conflict arises if there is a key in \code{y} that
+already exists in \code{x}.
+
+For \code{rows_patch()}, \code{rows_delete()}, and \code{rows_update()}, a conflict arises
+if there is a key in \code{y} that doesn't exist in \code{x}.
+
+One of:
+\itemize{
+\item \code{"error"}, the default, will error if there are any keys in \code{y} that
+conflict with keys in \code{x}.
+\item \code{"ignore"} will ignore rows in \code{y} with keys that conflict with keys in
+\code{x}.
+}}
 
 \item{copy}{If \code{x} and \code{y} are not from the same data source,
 and \code{copy} is \code{TRUE}, then \code{y} will be copied into the
@@ -67,15 +116,15 @@ whose values typically uniquely identify each row. The functions are inspired
 by SQL's \code{INSERT}, \code{UPDATE}, and \code{DELETE}, and can optionally modify
 \code{in_place} for selected backends.
 \itemize{
-\item \code{rows_insert()} adds new rows (like \code{INSERT}). Key values in \code{y} must
-not occur in \code{x}.
-\item \code{rows_update()} modifies existing rows (like \code{UPDATE}). Key values in
-\code{y} must occur in \code{x}, and key values in \code{y} must be unique.
+\item \code{rows_insert()} adds new rows (like \code{INSERT}). By default, key values in
+\code{y} must not exist in \code{x}.
+\item \code{rows_update()} modifies existing rows (like \code{UPDATE}). Key values in \code{y}
+must be unique, and, by default, key values in \code{y} must exist in \code{x}.
 \item \code{rows_patch()} works like \code{rows_update()} but only overwrites \code{NA} values.
 \item \code{rows_upsert()} inserts or updates depending on whether or not the
 key value in \code{y} already exists in \code{x}. Key values in \code{y} must be unique.
-\item \code{rows_delete()} deletes rows (like \code{DELETE}). Key values in \code{y} must
-exist in \code{x}.
+\item \code{rows_delete()} deletes rows (like \code{DELETE}). By default, key values in \code{y}
+must exist in \code{x}.
 }
 }
 \examples{
@@ -84,7 +133,12 @@ data
 
 # Insert
 rows_insert(data, tibble(a = 4, b = "z"))
+
+# By default, if a key in `y` matches a key in `x`, then it can't be inserted
+# and will throw an error. Alternatively, you can ignore rows in `y`
+# containing keys that conflict with keys in `x` with `conflict = "ignore"`.
 try(rows_insert(data, tibble(a = 3, b = "z")))
+rows_insert(data, tibble(a = 3, b = "z"), conflict = "ignore")
 
 # Update
 rows_update(data, tibble(a = 2:3, b = "z"))
@@ -97,5 +151,13 @@ rows_upsert(data, tibble(a = 2:4, b = "z"))
 # Delete and truncate
 rows_delete(data, tibble(a = 2:3))
 rows_delete(data, tibble(a = 2:3, b = "b"))
-try(rows_delete(data, tibble(a = 2:3, b = "b"), by = c("a", "b")))
+
+# By default, for update, patch, and delete it is an error if a key in `y`
+# doesn't exist in `x`. You can ignore rows in `y` that have unmatched keys
+# with `conflict = "ignore"`.
+y <- tibble(a = 3:4, b = "z")
+try(rows_update(data, y, by = "a"))
+rows_update(data, y, by = "a", conflict = "ignore")
+rows_patch(data, y, by = "a", conflict = "ignore")
+rows_delete(data, y, by = "a", conflict = "ignore")
 }

--- a/tests/testthat/_snaps/rows.md
+++ b/tests/testthat/_snaps/rows.md
@@ -33,21 +33,6 @@
       Error in `rows_insert()`:
       ! `conflict` must be a character vector, not a number.
 
----
-
-    Code
-      (expect_error(rows_update(x, y, by = "a", conflict = "foo")))
-    Output
-      <error/rlang_error>
-      Error in `rows_update()`:
-      ! `conflict` must be one of "error" or "ignore", not "foo".
-    Code
-      (expect_error(rows_update(x, y, by = "a", conflict = 1)))
-    Output
-      <error/rlang_error>
-      Error in `rows_update()`:
-      ! `conflict` must be a character vector, not a number.
-
 # rows_update() requires `y` keys to exist in `x` by default
 
     Code
@@ -67,6 +52,21 @@
       Error in `rows_update()`:
       ! `y` key values must be unique.
       i The following rows contain duplicate key values: `c(1, 2)`.
+
+# `unmatched` is validated
+
+    Code
+      (expect_error(rows_update(x, y, by = "a", unmatched = "foo")))
+    Output
+      <error/rlang_error>
+      Error in `rows_update()`:
+      ! `unmatched` must be one of "error" or "ignore", not "foo".
+    Code
+      (expect_error(rows_update(x, y, by = "a", unmatched = 1)))
+    Output
+      <error/rlang_error>
+      Error in `rows_update()`:
+      ! `unmatched` must be a character vector, not a number.
 
 # rows_patch() requires `y` keys to exist in `x` by default
 

--- a/tests/testthat/_snaps/rows.md
+++ b/tests/testthat/_snaps/rows.md
@@ -5,8 +5,9 @@
     Output
       <error/rlang_error>
       Error in `rows_insert()`:
-      ! `y` must contain keys that don't exist in `x`.
+      ! `y` can't contain keys that already exist in `x`.
       i The following rows in `y` have keys that already exist in `x`: `c(1)`.
+      i Use `conflict = "ignore"` if you want to ignore these `y` rows.
 
 ---
 
@@ -15,8 +16,9 @@
     Output
       <error/rlang_error>
       Error in `rows_insert()`:
-      ! `y` must contain keys that don't exist in `x`.
+      ! `y` can't contain keys that already exist in `x`.
       i The following rows in `y` have keys that already exist in `x`: `c(1, 2, 3)`.
+      i Use `conflict = "ignore"` if you want to ignore these `y` rows.
 
 # `conflict` is validated
 
@@ -42,6 +44,7 @@
       Error in `rows_update()`:
       ! `y` must contain keys that already exist in `x`.
       i The following rows in `y` have keys that don't exist in `x`: `c(1, 3)`.
+      i Use `unmatched = "ignore"` if you want to ignore these `y` rows.
 
 # rows_update() doesn't allow `y` keys to be duplicated (#5553)
 
@@ -77,6 +80,7 @@
       Error in `rows_patch()`:
       ! `y` must contain keys that already exist in `x`.
       i The following rows in `y` have keys that don't exist in `x`: `c(1, 3)`.
+      i Use `unmatched = "ignore"` if you want to ignore these `y` rows.
 
 # rows_patch() doesn't allow `y` keys to be duplicated (#5553)
 
@@ -122,6 +126,7 @@
       Error in `rows_delete()`:
       ! `y` must contain keys that already exist in `x`.
       i The following rows in `y` have keys that don't exist in `x`: `c(1, 3)`.
+      i Use `unmatched = "ignore"` if you want to ignore these `y` rows.
 
 # rows_check_containment() checks that `y` columns are in `x`
 

--- a/tests/testthat/_snaps/rows.md
+++ b/tests/testthat/_snaps/rows.md
@@ -1,4 +1,4 @@
-# rows_insert() doesn't allow insertion of duplicate keys
+# rows_insert() doesn't allow insertion of matched keys by default
 
     Code
       (expect_error(rows_insert(x, y, by = "a")))
@@ -18,7 +18,37 @@
       ! `y` must contain keys that don't exist in `x`.
       i The following rows in `y` have keys that already exist in `x`: `c(1, 2, 3)`.
 
-# rows_update() requires `y` keys to exist in `x`
+# `conflict` is validated
+
+    Code
+      (expect_error(rows_insert(x, y, by = "a", conflict = "foo")))
+    Output
+      <error/rlang_error>
+      Error in `rows_insert()`:
+      ! `conflict` must be one of "error" or "ignore", not "foo".
+    Code
+      (expect_error(rows_insert(x, y, by = "a", conflict = 1)))
+    Output
+      <error/rlang_error>
+      Error in `rows_insert()`:
+      ! `conflict` must be a character vector, not a number.
+
+---
+
+    Code
+      (expect_error(rows_update(x, y, by = "a", conflict = "foo")))
+    Output
+      <error/rlang_error>
+      Error in `rows_update()`:
+      ! `conflict` must be one of "error" or "ignore", not "foo".
+    Code
+      (expect_error(rows_update(x, y, by = "a", conflict = 1)))
+    Output
+      <error/rlang_error>
+      Error in `rows_update()`:
+      ! `conflict` must be a character vector, not a number.
+
+# rows_update() requires `y` keys to exist in `x` by default
 
     Code
       (expect_error(rows_update(x, y, "a")))
@@ -38,7 +68,7 @@
       ! `y` key values must be unique.
       i The following rows contain duplicate key values: `c(1, 2)`.
 
-# rows_patch() requires `y` keys to exist in `x`
+# rows_patch() requires `y` keys to exist in `x` by default
 
     Code
       (expect_error(rows_patch(x, y, "a")))
@@ -83,7 +113,7 @@
     Message
       Ignoring extra `y` columns: b
 
-# rows_delete() requires `y` keys to exist in `x`
+# rows_delete() requires `y` keys to exist in `x` by default
 
     Code
       (expect_error(rows_delete(x, y, "a")))

--- a/tests/testthat/test-rows.R
+++ b/tests/testthat/test-rows.R
@@ -10,7 +10,7 @@ test_that("rows_insert() works", {
   )
 })
 
-test_that("rows_insert() doesn't allow insertion of duplicate keys", {
+test_that("rows_insert() doesn't allow insertion of matched keys by default", {
   x <- tibble(a = 1, b = 2)
 
   y <- tibble(a = 1, b = 3)
@@ -23,6 +23,21 @@ test_that("rows_insert() doesn't allow insertion of duplicate keys", {
 
   expect_snapshot(
     (expect_error(rows_insert(x, y, by = "a")))
+  )
+})
+
+test_that("rows_insert() allows you to ignore matched keys with `conflict = 'ignore'`", {
+  x <- tibble(a = 1, b = 2)
+
+  y <- tibble(a = 1, b = 3)
+
+  expect_identical(rows_insert(x, y, by = "a", conflict = "ignore"), x)
+
+  y <- tibble(a = c(1, 2, 1), b = c(3, 4, 5))
+
+  expect_identical(
+    rows_insert(x, y, by = "a", conflict = "ignore"),
+    rows_insert(x, y[2,], by = "a")
   )
 })
 
@@ -46,6 +61,16 @@ test_that("rows_insert() allows `y` keys to be duplicated (#5553)", {
   )
 })
 
+test_that("`conflict` is validated", {
+  x <- tibble(a = 1)
+  y <- tibble(a = 2)
+
+  expect_snapshot({
+    (expect_error(rows_insert(x, y, by = "a", conflict = "foo")))
+    (expect_error(rows_insert(x, y, by = "a", conflict = 1)))
+  })
+})
+
 # ------------------------------------------------------------------------------
 
 test_that("rows_update() works", {
@@ -64,11 +89,21 @@ test_that("rows_update() works", {
   )
 })
 
-test_that("rows_update() requires `y` keys to exist in `x`", {
+test_that("rows_update() requires `y` keys to exist in `x` by default", {
   x <- tibble(a = 1, b = 2)
   y <- tibble(a = c(2, 1, 3), b = c(1, 1, 1))
 
   expect_snapshot((expect_error(rows_update(x, y, "a"))))
+})
+
+test_that("rows_update() allows `y` keys that don't exist in `x` to be ignored", {
+  x <- tibble(a = 1, b = 2)
+  y <- tibble(a = c(2, 1, 3), b = c(1, 1, 1))
+
+  expect_identical(
+    rows_update(x, y, "a", conflict = "ignore"),
+    tibble(a = 1, b = 1)
+  )
 })
 
 test_that("rows_update() allows `x` keys to be duplicated (#5553)", {
@@ -86,6 +121,16 @@ test_that("rows_update() doesn't allow `y` keys to be duplicated (#5553)", {
   y <- tibble(a = c(1, 1), b = c(2, 3))
 
   expect_snapshot((expect_error(rows_update(x, y, by = "a"))))
+})
+
+test_that("`conflict` is validated", {
+  x <- tibble(a = 1)
+  y <- tibble(a = 1)
+
+  expect_snapshot({
+    (expect_error(rows_update(x, y, by = "a", conflict = "foo")))
+    (expect_error(rows_update(x, y, by = "a", conflict = 1)))
+  })
 })
 
 # ------------------------------------------------------------------------------
@@ -106,11 +151,21 @@ test_that("rows_patch() works", {
   )
 })
 
-test_that("rows_patch() requires `y` keys to exist in `x`", {
+test_that("rows_patch() requires `y` keys to exist in `x` by default", {
   x <- tibble(a = 1, b = 2)
   y <- tibble(a = c(2, 1, 3), b = c(1, 1, 1))
 
   expect_snapshot((expect_error(rows_patch(x, y, "a"))))
+})
+
+test_that("rows_patch() allows `y` keys that don't exist in `x` to be ignored", {
+  x <- tibble(a = 1, b = NA_real_)
+  y <- tibble(a = c(2, 1, 3), b = c(1, 1, 1))
+
+  expect_identical(
+    rows_patch(x, y, "a", conflict = "ignore"),
+    tibble(a = 1, b = 1)
+  )
 })
 
 test_that("rows_patch() allows `x` keys to be duplicated (#5553)", {
@@ -186,11 +241,21 @@ test_that("rows_delete() ignores extra `y` columns, with a message", {
   expect_identical(out, x[0,])
 })
 
-test_that("rows_delete() requires `y` keys to exist in `x`", {
+test_that("rows_delete() requires `y` keys to exist in `x` by default", {
   x <- tibble(a = 1, b = 2)
   y <- tibble(a = c(2, 1, 3), b = c(1, 1, 1))
 
   expect_snapshot((expect_error(rows_delete(x, y, "a"))))
+})
+
+test_that("rows_delete() allows `y` keys that don't exist in `x` to be ignored", {
+  x <- tibble(a = 1, b = 2)
+  y <- tibble(a = c(2, 1, 3))
+
+  expect_identical(
+    rows_delete(x, y, "a", conflict = "ignore"),
+    tibble(a = double(), b = double())
+  )
 })
 
 test_that("rows_delete() allows `x` keys to be duplicated (#5553)", {

--- a/tests/testthat/test-rows.R
+++ b/tests/testthat/test-rows.R
@@ -101,7 +101,7 @@ test_that("rows_update() allows `y` keys that don't exist in `x` to be ignored",
   y <- tibble(a = c(2, 1, 3), b = c(1, 1, 1))
 
   expect_identical(
-    rows_update(x, y, "a", conflict = "ignore"),
+    rows_update(x, y, "a", unmatched = "ignore"),
     tibble(a = 1, b = 1)
   )
 })
@@ -123,13 +123,13 @@ test_that("rows_update() doesn't allow `y` keys to be duplicated (#5553)", {
   expect_snapshot((expect_error(rows_update(x, y, by = "a"))))
 })
 
-test_that("`conflict` is validated", {
+test_that("`unmatched` is validated", {
   x <- tibble(a = 1)
   y <- tibble(a = 1)
 
   expect_snapshot({
-    (expect_error(rows_update(x, y, by = "a", conflict = "foo")))
-    (expect_error(rows_update(x, y, by = "a", conflict = 1)))
+    (expect_error(rows_update(x, y, by = "a", unmatched = "foo")))
+    (expect_error(rows_update(x, y, by = "a", unmatched = 1)))
   })
 })
 
@@ -163,7 +163,7 @@ test_that("rows_patch() allows `y` keys that don't exist in `x` to be ignored", 
   y <- tibble(a = c(2, 1, 3), b = c(1, 1, 1))
 
   expect_identical(
-    rows_patch(x, y, "a", conflict = "ignore"),
+    rows_patch(x, y, "a", unmatched = "ignore"),
     tibble(a = 1, b = 1)
   )
 })
@@ -253,7 +253,7 @@ test_that("rows_delete() allows `y` keys that don't exist in `x` to be ignored",
   y <- tibble(a = c(2, 1, 3))
 
   expect_identical(
-    rows_delete(x, y, "a", conflict = "ignore"),
+    rows_delete(x, y, "a", unmatched = "ignore"),
     tibble(a = double(), b = double())
   )
 })


### PR DESCRIPTION
Follow-up to #6199 and continuation of the plan from here https://github.com/tidyverse/dplyr/pull/5588#issuecomment-1048373544

Closes #5984 
Closes #5699 

This PR adds a new `conflict` argument to `rows_insert()`, `rows_update()`, `rows_patch()`, and `rows_delete()`, inspired by the `ON CONFLICT *` command from SQL's `INSERT`.

- For `rows_insert()`, a conflict arises if there is a key in `y` that _already_ exists in `x`. By default, it `"error"`s, but you can now also `"ignore"` the rows in `y` where this occurs, which is like `ON CONFLICT DO NOTHING`.

- For `rows_update()`, `rows_patch()`, and `rows_delete()`, a conflict arises if there is a key in `y` that _doesn't_ exist in `x` (because the behavior is then ambiguous). Again, by default it `"error"`s, but you can also `"ignore"` those rows in `y`.

---

A few more notes:

- `conflict` is a bit of a non-standard name for the update/patch/delete behavior, but I think it works well enough. The alternative was to use `conflict` for `rows_insert()` and come up with some other argument name for these 3. Or use `matched` for insert and `unmatched` for update/patch/delete. I am open to suggestions if anyone feels strongly against the current scheme.

- In https://github.com/tidyverse/dplyr/pull/5588#issuecomment-1025599455, @mgirlich mentioned the possibility of `rows_insert(conflict = "insert")` to insert the `y` rows anyways even if there are conflicts, but this felt too similar to `bind_rows()` to me, so I left it out (i.e. it would always insert the `y` rows, no matter what, which is basically just binding the rows together after validating that the `by` columns exist in both inputs). I think we could consider adding it later if people ask for it.

- I've used a default of `"error"` because that is what the current behavior is, and it feels reasonable to opt in to this more lax behavior.