### PR TITLE
use expect_null where appropriate

### DIFF
--- a/tests/testthat/test-count-tally.r
+++ b/tests/testthat/test-count-tally.r
@@ -55,7 +55,7 @@ test_that("output preserves class & attributes where possible", {
   expect_s3_class(out, "grouped_df")
   expect_equal(group_vars(out), "g")
   # summarise() currently drops attributes
-  expect_equal(attr(out, "my_attr"), NULL)
+  expect_null(attr(out, "my_attr"))
 })
 
 test_that("works with dbplyr", {

--- a/tests/testthat/test-nth-value.R
+++ b/tests/testthat/test-nth-value.R
@@ -2,7 +2,7 @@ test_that("nth works with lists", {
   x <- list(1, 2, 3)
 
   expect_equal(nth(x, 1), 1)
-  expect_equal(nth(x, 4), NULL)
+  expect_null(nth(x, 4))
   expect_equal(nth(x, 4, default = 1), 1)
 })
 
@@ -24,7 +24,7 @@ test_that("first uses default value for 0 length vectors", {
   expect_equal(first(integer()), NA_integer_)
   expect_equal(first(numeric()), NA_real_)
   expect_equal(first(character()), NA_character_)
-  expect_equal(first(list()), NULL)
+  expect_null(first(list()))
 })
 
 test_that("firsts uses default value for 0 length augmented vectors", {

--- a/tests/testthat/test-summarise.r
+++ b/tests/testthat/test-summarise.r
@@ -66,11 +66,11 @@ test_that("preserved class, but not attributes", {
 
   out <- df %>% summarise(n = n())
   expect_s3_class(out, "data.frame", exact = TRUE)
-  expect_equal(attr(out, "res"), NULL)
+  expect_null(attr(out, "res"))
 
   out <- df %>% group_by(g1) %>% summarise(n = n())
   # expect_s3_class(out, "data.frame", exact = TRUE)
-  expect_equal(attr(out, "res"), NULL)
+  expect_null(attr(out, "res"))
 })
 
 test_that("works with unquoted values", {


### PR DESCRIPTION
Surfaced by the new `lintr::expect_null_linter()`.

Filing wondering:

 - Interest in applying the upcoming `testthat` consistency linters slated to be added to `lintr` to `dplyr`, see `Expect*` linters in https://github.com/r-lib/lintr/issues/884
 - Interest more generally in these changes for tidyverse repos

And also looking for feedback on how appropriate the lint is for usages in CRAN packages. Thanks.