### PR TITLE
Use expect_type where appropriate

### DIFF
--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -185,8 +185,8 @@ test_that("bind_rows() promotes integer to numeric", {
   df2 <- tibble(a = 1, b = 1L)
 
   res <- bind_rows(df1, df2)
-  expect_equal(typeof(res$a), "double")
-  expect_equal(typeof(res$b), "integer")
+  expect_type(res$a, "double")
+  expect_type(res$b, "integer")
 })
 
 test_that("bind_rows() promotes factor to character with warning", {
@@ -194,7 +194,7 @@ test_that("bind_rows() promotes factor to character with warning", {
   df2 <- tibble(a = "b")
 
   res <- bind_rows(df1, df2)
-  expect_equal(typeof(res$a), "character")
+  expect_type(res$a, "character")
 })
 
 test_that("bind_rows() coerces factor when levels don't match", {

--- a/tests/testthat/test-deprec-funs.R
+++ b/tests/testthat/test-deprec-funs.R
@@ -83,7 +83,7 @@ test_that("can enfun() purrr-style lambdas", {
   my_mean <- as_function(~ mean(.x))
   res <- enfun(~ mean(.x))
   expect_equal(length(res), 1L)
-  expect_true(typeof(res[[1]]) == "closure")
+  expect_type(res[[1]], "closure")
 })
 
 test_that("funs_ works", {


### PR DESCRIPTION
Similar to #6211 -- caught with `lintr::expect_type_linter()`.