### PR TITLE
Slice min/max ignores NA's when with_ties is set to FALSE

### DIFF
--- a/R/slice.R
+++ b/R/slice.R
@@ -188,7 +188,7 @@ slice_min.data.frame <- function(.data, order_by, ..., n, prop, with_ties = TRUE
   if (with_ties) {
     idx <- function(x, n) head(order(x), smaller_ranks(x, size(n)))
   } else {
-    idx <- function(x, n) head(order(x), size(n))
+    idx <- function(x, n) head(order(x[!is.na(x)]), size(n))
   }
 
   dplyr_local_error_call()
@@ -219,7 +219,7 @@ slice_max.data.frame <- function(.data, order_by, ..., n, prop, with_ties = TRUE
         order(x, decreasing = TRUE), smaller_ranks(desc(x), size(n))
     )
   } else {
-    idx <- function(x, n) head(order(x, decreasing = TRUE), size(n))
+    idx <- function(x, n) head(order(x[!is.na(x)], decreasing = TRUE), size(n))
   }
 
   dplyr_local_error_call()

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -270,6 +270,8 @@ test_that("min and max ignore NA's (#4826)", {
   expect_equal(df %>% slice_min(y, n = 2) %>% nrow(), 0)
   expect_equal(df %>% slice_max(x, n = 2) %>% pull(id), c(1, 4))
   expect_equal(df %>% slice_max(y, n = 2) %>% nrow(), 0)
+  expect_equal(df %>% slice_min(y, n = 2, with_ties = FALSE) %>% nrow(), 0)
+  expect_equal(df %>% slice_max(y, n = 2, with_ties = FALSE) %>% nrow(), 0)
 })
 
 test_that("arguments to sample are passed along", {


### PR DESCRIPTION
When the `with_ties` argument was set to `FALSE` `NA`s where not ignored anymore. This PR fixes that. Problem was mentioned here: https://github.com/tidyverse/dplyr/issues/4826#issuecomment-1064040917