### PR TITLE
Update to rlang 1.0.2 snapshots

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,7 @@ Imports:
     tibble (>= 2.1.3),
     tidyselect (>= 1.1.1),
     utils,
-    vctrs (>= 0.3.5), 
+    vctrs (>= 0.4.1), 
     pillar (>= 1.5.1)
 Suggests: 
     bench,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Imports:
     magrittr (>= 1.5),
     methods,
     R6,
-    rlang (>= 1.0.0),
+    rlang (>= 1.0.2),
     tibble (>= 2.1.3),
     tidyselect (>= 1.1.1),
     utils,

--- a/R/slice.R
+++ b/R/slice.R
@@ -336,7 +336,7 @@ slice_combine <- function(chunks, mask, error_call = caller_env()) {
         if (is.matrix(res) && ncol(res) == 1) {
           res <- as.vector(res)
         }
-        res <- fix_call(vec_cast(res, integer()), NULL)
+        res <- fix_call(vec_cast(res, integer(), x_arg = ""), NULL)
       } else {
         bullets <- c(
           glue("Invalid result of type <{vec_ptype_full(res)}>."),

--- a/tests/testthat/_snaps/bind.md
+++ b/tests/testthat/_snaps/bind.md
@@ -4,10 +4,10 @@
       bound <- bind_cols(df, df)
     Message
       New names:
-      * a -> a...1
-      * b -> b...2
-      * a -> a...3
-      * b -> b...4
+      * `a` -> `a...1`
+      * `b` -> `b...2`
+      * `a` -> `a...3`
+      * `b` -> `b...4`
 
 # bind_cols() handles unnamed list with name repair (#3402)
 
@@ -15,8 +15,8 @@
       df <- bind_cols(list(1, 2))
     Message
       New names:
-      * `` -> ...1
-      * `` -> ...2
+      * `` -> `...1`
+      * `` -> `...2`
 
 # *_bind() give meaningful errors
 

--- a/tests/testthat/_snaps/conditions.md
+++ b/tests/testthat/_snaps/conditions.md
@@ -165,7 +165,7 @@
     Condition
       Error in `err_locs()`:
       ! `x` must be an integer vector of locations.
-      i This is an internal error, please report it to the package authors.
+      i This is an internal error in the dplyr package, please report it to the package authors.
 
 ---
 
@@ -174,7 +174,7 @@
     Condition
       Error in `err_locs()`:
       ! `x` must have at least 1 location.
-      i This is an internal error, please report it to the package authors.
+      i This is an internal error in the dplyr package, please report it to the package authors.
 
 ---
 

--- a/tests/testthat/_snaps/select.md
+++ b/tests/testthat/_snaps/select.md
@@ -39,9 +39,9 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error in `select()`:
-      ! Can't subset columns that don't exist.
-      x Location 2 doesn't exist.
-      i There are only 1 column.
+      ! Can't subset columns past the end.
+      i Location 2 doesn't exist.
+      i There is only 1 column.
     Code
       (expect_error(select(df1, 0)))
     Output
@@ -58,9 +58,9 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error in `select()`:
-      ! Can't subset columns that don't exist.
-      x Location 2 doesn't exist.
-      i There are only 1 column.
+      ! Can't subset columns past the end.
+      i Location 2 doesn't exist.
+      i There is only 1 column.
     Code
       (expect_error(select(df1, 1)))
     Output

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -38,7 +38,7 @@
       Error in `slice()`:
       ! Problem while computing indices.
       Caused by error:
-      ! Can't convert <integer[,2]> to <integer>.
+      ! Can't convert `res` <integer[,2]> to <integer>.
       Cannot decrease dimensions.
     Code
       (expect_error(slice(gdf, matrix(c(1, 2), ncol = 2))))
@@ -48,7 +48,7 @@
       ! Problem while computing indices.
       i The error occurred in group 1: x = 1.
       Caused by error:
-      ! Can't convert <integer[,2]> to <integer>.
+      ! Can't convert `res` <integer[,2]> to <integer>.
       Cannot decrease dimensions.
     Code
       (expect_error(slice(df, "a")))

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -38,7 +38,7 @@
       Error in `slice()`:
       ! Problem while computing indices.
       Caused by error:
-      ! Can't convert `res` <integer[,2]> to <integer>.
+      ! Can't convert <integer[,2]> to <integer>.
       Cannot decrease dimensions.
     Code
       (expect_error(slice(gdf, matrix(c(1, 2), ncol = 2))))
@@ -48,7 +48,7 @@
       ! Problem while computing indices.
       i The error occurred in group 1: x = 1.
       Caused by error:
-      ! Can't convert `res` <integer[,2]> to <integer>.
+      ! Can't convert <integer[,2]> to <integer>.
       Cannot decrease dimensions.
     Code
       (expect_error(slice(df, "a")))


### PR DESCRIPTION
- Updated two snapshots related to internal errors now mentioning the package name

- Require rlang >= 1.0.2 as this isn't much to ask of the user, and ensures that we are all developing with a version of rlang that gives consistent snapshots