### PR TITLE
More informative error for `case_when()` RHS type and class mismatches

### DIFF
--- a/R/case_when.R
+++ b/R/case_when.R
@@ -180,6 +180,7 @@ case_when <- function(...) {
     )
     replaced <- replaced | (query[[i]] & !is.na(query[[i]]))
   }
+
   out
 }
 

--- a/R/case_when.R
+++ b/R/case_when.R
@@ -175,7 +175,7 @@ case_when <- function(...) {
       out,
       query[[i]] & !replaced,
       value[[i]],
-      name = fmt_calls(pair$rhs[i]),
+      name = fmt_calls(quos_pairs[[i]]$rhs[2]),
       error_call = error_call
     )
     replaced <- replaced | (query[[i]] & !is.na(query[[i]]))

--- a/R/case_when.R
+++ b/R/case_when.R
@@ -171,10 +171,15 @@ case_when <- function(...) {
   replaced <- rep(FALSE, m)
 
   for (i in seq_len(n)) {
-    out <- replace_with(out, query[[i]] & !replaced, value[[i]], NULL, error_call = error_call)
+    out <- replace_with(
+      out,
+      query[[i]] & !replaced,
+      value[[i]],
+      name = fmt_calls(pair$rhs[i]),
+      error_call = error_call
+    )
     replaced <- replaced | (query[[i]] & !is.na(query[[i]]))
   }
-
   out
 }
 

--- a/tests/testthat/test-case-when.R
+++ b/tests/testthat/test-case-when.R
@@ -208,6 +208,10 @@ test_that("case_when() give meaningful errors", {
     (expect_error(
       case_when(~1:2)
     ))
+
+    (expect_error(
+      case_when(c(TRUE, FALSE) ~ c(3, 4), TRUE ~ c('a', 'b'))
+    ))
   })
 
 })

--- a/tests/testthat/test-case-when.R
+++ b/tests/testthat/test-case-when.R
@@ -210,7 +210,7 @@ test_that("case_when() give meaningful errors", {
     ))
 
     (expect_error(
-      case_when(c(TRUE, FALSE) ~ c(3, 4), TRUE ~ c('a', 'b'))
+      case_when(c(TRUE, FALSE) ~ c(3, 4), TRUE ~ c('a', 'b'), TRUE ~ c(5, 6)) 
     ))
   })
 


### PR DESCRIPTION
closes #6206 

Current
``` r
dplyr::case_when(c(TRUE, FALSE) ~ c(3, 4), TRUE ~ c('a', 'b'))
#> Error in names(message) <- `*vtmp*`: 'names' attribute [1] must be the same length as the vector [0]
```

<sup>Created on 2022-03-31 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

New
``` r
dplyr::case_when(c(TRUE, FALSE) ~ c(3, 4), TRUE ~ c('a', 'b'))
#> Error in `dplyr::case_when()`:
#> ! `c("a", "b")` must be a double vector, not a character vector.
```

<sup>Created on 2022-03-31 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>


I didn't update snapshots because the line-wrapping in my error messages happens earlier than in the snapshot, and I'm not sure why.