### PR TITLE
Add na_rm argument to `nth()`, `first()`, and `last()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,11 @@
 
 # dplyr 1.0.9
 
+
+
+* `nth()`, `first()`, and `last()` gained the `na.rm` argument since they are
+  summary functions (#6242).
+
 * New `rows_append()` which works like `rows_insert()` but ignores keys and
   allows you to insert arbitrary rows with a guarantee that the type of `x`
   won't change (#6249, thanks to @krlmlr for the implementation and @mgirlich

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 
 
-* `nth()`, `first()`, and `last()` gained the `na.rm` argument since they are
+* `nth()`, `first()`, and `last()` gained the `na_rm` argument since they are
   summary functions (#6242).
 
 * New `rows_append()` which works like `rows_insert()` but ignores keys and

--- a/R/nth-value.R
+++ b/R/nth-value.R
@@ -19,7 +19,7 @@
 #'
 #'   For more complicated objects, you'll need to supply this value.
 #'   Make sure it is the same type as `x`.
-#' @param na.rm if `TRUE` missing values don't count
+#' @param na_rm if `TRUE` missing values don't count
 #' @return A single value. `[[` is used to do the subsetting.
 #' @export
 #' @examples
@@ -40,13 +40,13 @@
 #'
 #' # These functions always return a single value
 #' first(integer())
-nth <- function(x, n, order_by = NULL, default = default_missing(x), na.rm = FALSE) {
+nth <- function(x, n, order_by = NULL, default = default_missing(x), na_rm = FALSE) {
   if (length(n) != 1 || !is.numeric(n)) {
     abort("`n` must be a single integer.")
   }
   n <- trunc(n)
 
-  if (na.rm) {
+  if (na_rm) {
     x <- x[!is.na(x)]
   }
 
@@ -68,14 +68,14 @@ nth <- function(x, n, order_by = NULL, default = default_missing(x), na.rm = FAL
 
 #' @export
 #' @rdname nth
-first <- function(x, order_by = NULL, default = default_missing(x), na.rm = FALSE) {
-  nth(x, 1L, order_by = order_by, default = default, na.rm = na.rm)
+first <- function(x, order_by = NULL, default = default_missing(x), na_rm = FALSE) {
+  nth(x, 1L, order_by = order_by, default = default, na_rm = na_rm)
 }
 
 #' @export
 #' @rdname nth
-last <- function(x, order_by = NULL, default = default_missing(x), na.rm = FALSE) {
-  nth(x, -1L, order_by = order_by, default = default, na.rm = na.rm)
+last <- function(x, order_by = NULL, default = default_missing(x), na_rm = FALSE) {
+  nth(x, -1L, order_by = order_by, default = default, na_rm = na_rm)
 }
 
 default_missing <- function(x) {

--- a/R/nth-value.R
+++ b/R/nth-value.R
@@ -19,6 +19,7 @@
 #'
 #'   For more complicated objects, you'll need to supply this value.
 #'   Make sure it is the same type as `x`.
+#' @param na.rm if `TRUE` missing values don't count
 #' @return A single value. `[[` is used to do the subsetting.
 #' @export
 #' @examples

--- a/R/nth-value.R
+++ b/R/nth-value.R
@@ -39,11 +39,15 @@
 #'
 #' # These functions always return a single value
 #' first(integer())
-nth <- function(x, n, order_by = NULL, default = default_missing(x)) {
+nth <- function(x, n, order_by = NULL, default = default_missing(x), na.rm = FALSE) {
   if (length(n) != 1 || !is.numeric(n)) {
     abort("`n` must be a single integer.")
   }
   n <- trunc(n)
+
+  if (na.rm) {
+    x <- x[!is.na(x)]
+  }
 
   if (n == 0 || n > length(x) || n < -length(x)) {
     return(default)
@@ -63,14 +67,14 @@ nth <- function(x, n, order_by = NULL, default = default_missing(x)) {
 
 #' @export
 #' @rdname nth
-first <- function(x, order_by = NULL, default = default_missing(x)) {
-  nth(x, 1L, order_by = order_by, default = default)
+first <- function(x, order_by = NULL, default = default_missing(x), na.rm = FALSE) {
+  nth(x, 1L, order_by = order_by, default = default, na.rm = na.rm)
 }
 
 #' @export
 #' @rdname nth
-last <- function(x, order_by = NULL, default = default_missing(x)) {
-  nth(x, -1L, order_by = order_by, default = default)
+last <- function(x, order_by = NULL, default = default_missing(x), na.rm = FALSE) {
+  nth(x, -1L, order_by = order_by, default = default, na.rm = na.rm)
 }
 
 default_missing <- function(x) {

--- a/man/nth.Rd
+++ b/man/nth.Rd
@@ -6,11 +6,11 @@
 \alias{last}
 \title{Extract the first, last or nth value from a vector}
 \usage{
-nth(x, n, order_by = NULL, default = default_missing(x))
+nth(x, n, order_by = NULL, default = default_missing(x), na.rm = FALSE)
 
-first(x, order_by = NULL, default = default_missing(x))
+first(x, order_by = NULL, default = default_missing(x), na.rm = FALSE)
 
-last(x, order_by = NULL, default = default_missing(x))
+last(x, order_by = NULL, default = default_missing(x), na.rm = FALSE)
 }
 \arguments{
 \item{x}{A vector}
@@ -30,6 +30,8 @@ a \code{NULL} is return.
 
 For more complicated objects, you'll need to supply this value.
 Make sure it is the same type as \code{x}.}
+
+\item{na.rm}{if \code{TRUE} missing values don't count}
 }
 \value{
 A single value. \code{[[} is used to do the subsetting.

--- a/man/nth.Rd
+++ b/man/nth.Rd
@@ -6,11 +6,11 @@
 \alias{last}
 \title{Extract the first, last or nth value from a vector}
 \usage{
-nth(x, n, order_by = NULL, default = default_missing(x), na.rm = FALSE)
+nth(x, n, order_by = NULL, default = default_missing(x), na_rm = FALSE)
 
-first(x, order_by = NULL, default = default_missing(x), na.rm = FALSE)
+first(x, order_by = NULL, default = default_missing(x), na_rm = FALSE)
 
-last(x, order_by = NULL, default = default_missing(x), na.rm = FALSE)
+last(x, order_by = NULL, default = default_missing(x), na_rm = FALSE)
 }
 \arguments{
 \item{x}{A vector}
@@ -31,7 +31,7 @@ a \code{NULL} is return.
 For more complicated objects, you'll need to supply this value.
 Make sure it is the same type as \code{x}.}
 
-\item{na.rm}{if \code{TRUE} missing values don't count}
+\item{na_rm}{if \code{TRUE} missing values don't count}
 }
 \value{
 A single value. \code{[[} is used to do the subsetting.

--- a/tests/testthat/test-nth-value.R
+++ b/tests/testthat/test-nth-value.R
@@ -43,14 +43,14 @@ test_that("nth() gives meaningful error message (#5466)", {
   })
 })
 
-test_that("nth() works with NA values when na.rm = TRUE", {
-  expect_equal(nth(c(as.numeric(NA), 1:3), 1, na.rm = TRUE), 1)
-  expect_equal(nth(c(1, as.numeric(NA), 2, 3), 2, na.rm = TRUE), 2)
-  expect_equal(nth(c(1:3, as.numeric(NA)), -1, na.rm = TRUE), 3)
+test_that("nth() works with NA values when na_rm = TRUE", {
+  expect_equal(nth(c(as.numeric(NA), 1:3), 1, na_rm = TRUE), 1)
+  expect_equal(nth(c(1, as.numeric(NA), 2, 3), 2, na_rm = TRUE), 2)
+  expect_equal(nth(c(1:3, as.numeric(NA)), -1, na_rm = TRUE), 3)
 })
 
-test_that("nth() uses default value when na.rm = TRUE and all NA values", {
-  expect_equal(nth(rep(as.numeric(NA), 3), 1, na.rm = TRUE), as.numeric(NA))
-  expect_equal(nth(rep(as.numeric(NA), 3), 2, na.rm = TRUE), as.numeric(NA))
-  expect_equal(nth(rep(as.numeric(NA), 3), -1, na.rm = TRUE), as.numeric(NA))
+test_that("nth() uses default value when na_rm = TRUE and all NA values", {
+  expect_equal(nth(rep(as.numeric(NA), 3), 1, na_rm = TRUE), as.numeric(NA))
+  expect_equal(nth(rep(as.numeric(NA), 3), 2, na_rm = TRUE), as.numeric(NA))
+  expect_equal(nth(rep(as.numeric(NA), 3), -1, na_rm = TRUE), as.numeric(NA))
 })

--- a/tests/testthat/test-nth-value.R
+++ b/tests/testthat/test-nth-value.R
@@ -42,3 +42,15 @@ test_that("nth() gives meaningful error message (#5466)", {
     (expect_error(nth(1:10, "x")))
   })
 })
+
+test_that("nth() works with NA values when na.rm = TRUE", {
+  expect_equal(nth(c(as.numeric(NA), 1:3), 1, na.rm = TRUE), 1)
+  expect_equal(nth(c(1, as.numeric(NA), 2, 3), 2, na.rm = TRUE), 2)
+  expect_equal(nth(c(1:3, as.numeric(NA)), -1, na.rm = TRUE), 3)
+})
+
+test_that("nth() uses default value when na.rm = TRUE and all NA values", {
+  expect_equal(nth(rep(as.numeric(NA), 3), 1, na.rm = TRUE), as.numeric(NA))
+  expect_equal(nth(rep(as.numeric(NA), 3), 2, na.rm = TRUE), as.numeric(NA))
+  expect_equal(nth(rep(as.numeric(NA), 3), -1, na.rm = TRUE), as.numeric(NA))
+})


### PR DESCRIPTION
Closes #6242. Add in na.rm argument to `nth()`, `first()`, and `last()`.

Note: this is my first time contributing, I tried to follow the guidelines and review previous PRs but please let me know any changes that should be made.
