### PR TITLE
Catch the `slice_sample()` case of `replace = FALSE` and `n < size`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # dplyr (development version)
 
+* `slice_sample()` now gives a more informative error when `replace = FALSE` and
+  the number of rows requested in the sample exceeds the number of rows in the
+  data (#6271).
+
 * `frame_data()` is no longer reexported from tibble (#6278).
 
 * `lst_()` is no longer reexported from tibble (#6276).

--- a/R/slice.R
+++ b/R/slice.R
@@ -462,7 +462,6 @@ sample_int <- function(n, size, replace = FALSE, wt = NULL, call = caller_env())
       i = glue("{n} rows are present in the data."),
       i = "Set `replace = TRUE` to sample with replacement."
     )
-
     abort(message, call = call)
   }
 

--- a/R/slice.R
+++ b/R/slice.R
@@ -247,6 +247,10 @@ slice_sample.data.frame <- function(.data, ..., n, prop, weight_by = NULL, repla
   check_slice_dots(..., n = n, prop = prop)
   size <- get_slice_size(n = n, prop = prop, allow_negative = FALSE)
 
+  if (!is_bool(replace)) {
+    abort("`replace` must be a single `TRUE` or `FALSE`.")
+  }
+
   dplyr_local_error_call()
   slice(.data, local({
     weight_by <- {{ weight_by }}
@@ -446,7 +450,22 @@ get_slice_size <- function(n, prop, allow_negative = TRUE, error_call = caller_e
   }
 }
 
-sample_int <- function(n, size, replace = FALSE, wt = NULL) {
+sample_int <- function(n, size, replace = FALSE, wt = NULL, call = caller_env()) {
+  if (!replace && n < size) {
+    header <- paste0(
+      "Can't sample without replacement using a size that is larger than ",
+      "the number of rows in the data."
+    )
+    message <- c(
+      header,
+      i = glue("{size} rows were requested in the sample."),
+      i = glue("{n} rows are present in the data."),
+      i = "Set `replace = TRUE` to sample with replacement."
+    )
+
+    abort(message, call = call)
+  }
+
   if (size == 0L) {
     integer(0)
   } else {

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -18,16 +18,46 @@
       <error/rlang_error>
       Error in `slice_sample()`:
       ! Problem while computing indices.
-      Caused by error in `sample.int()`:
-      ! cannot take a sample larger than the population when 'replace = FALSE'
+      Caused by error:
+      ! Can't sample without replacement using a size that is larger than the number of rows in the data.
+      i 4 rows were requested in the sample.
+      i 1 rows are present in the data.
+      i Set `replace = TRUE` to sample with replacement.
+    Code
+      (expect_error(gdf %>% slice_sample(n = 4, replace = FALSE)))
+    Output
+      <error/rlang_error>
+      Error in `slice_sample()`:
+      ! Problem while computing indices.
+      i The error occurred in group 1: a = 1.
+      Caused by error:
+      ! Can't sample without replacement using a size that is larger than the number of rows in the data.
+      i 4 rows were requested in the sample.
+      i 1 rows are present in the data.
+      i Set `replace = TRUE` to sample with replacement.
     Code
       (expect_error(df %>% slice_sample(prop = 4, replace = FALSE)))
     Output
       <error/rlang_error>
       Error in `slice_sample()`:
       ! Problem while computing indices.
-      Caused by error in `sample.int()`:
-      ! cannot take a sample larger than the population when 'replace = FALSE'
+      Caused by error:
+      ! Can't sample without replacement using a size that is larger than the number of rows in the data.
+      i 4 rows were requested in the sample.
+      i 1 rows are present in the data.
+      i Set `replace = TRUE` to sample with replacement.
+    Code
+      (expect_error(gdf %>% slice_sample(prop = 4, replace = FALSE)))
+    Output
+      <error/rlang_error>
+      Error in `slice_sample()`:
+      ! Problem while computing indices.
+      i The error occurred in group 1: a = 1.
+      Caused by error:
+      ! Can't sample without replacement using a size that is larger than the number of rows in the data.
+      i 4 rows were requested in the sample.
+      i 1 rows are present in the data.
+      i Set `replace = TRUE` to sample with replacement.
 
 # slice() gives meaningfull errors
 
@@ -506,4 +536,19 @@
       <error/rlang_error>
       Error in `slice_head()`:
       ! `prop` must be a single number.
+
+# `slice_sample()` validates `replace`
+
+    Code
+      (expect_error(slice_sample(data.frame(), replace = 1)))
+    Output
+      <error/rlang_error>
+      Error in `slice_sample()`:
+      ! `replace` must be a single `TRUE` or `FALSE`.
+    Code
+      (expect_error(slice_sample(data.frame(), replace = NA)))
+    Output
+      <error/rlang_error>
+      Error in `slice_sample()`:
+      ! `replace` must be a single `TRUE` or `FALSE`.
 

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -190,7 +190,8 @@ test_that("slice() handles matrix and data frame columns (#3630)", {
 # Slice variants ----------------------------------------------------------
 
 test_that("slice_sample() handles n= and prop=", {
-  df <- data.frame(a = 1)
+  df <- data.frame(a = 1, b = 1)
+  gdf <- group_by(df, a)
 
   expect_equal(
     df %>% slice_sample(n = 4, replace = TRUE),
@@ -213,9 +214,15 @@ test_that("slice_sample() handles n= and prop=", {
     (expect_error(
       df %>% slice_sample(n = 4, replace = FALSE)
     ))
+    (expect_error(
+      gdf %>% slice_sample(n = 4, replace = FALSE)
+    ))
 
     (expect_error(
       df %>% slice_sample(prop = 4, replace = FALSE)
+    ))
+    (expect_error(
+      gdf %>% slice_sample(prop = 4, replace = FALSE)
     ))
   })
 })
@@ -582,5 +589,12 @@ test_that("rename errors with invalid grouped data frame (#640)", {
     (expect_error(slice_head(data.frame(), prop = n())))
     (expect_error(slice_head(data.frame(), n = NA)))
     (expect_error(slice_head(data.frame(), prop = NA)))
+  })
+})
+
+test_that("`slice_sample()` validates `replace`", {
+  expect_snapshot({
+    (expect_error(slice_sample(data.frame(), replace = 1)))
+    (expect_error(slice_sample(data.frame(), replace = NA)))
   })
 })


### PR DESCRIPTION
Closes #6271 

I think that rather than updating the documentation, we could just give a better error in the case where the user isn't sampling with replacement and the number of requested rows exceeds the number of rows in the data.

I feel like the error below is a nice improvement. I'm willing to accept the fact that the case you see below is the edge case of `1 rows are present` rather than `1 row is present` since we haven't gone all in on cli in dplyr yet (with its pluralization features).

``` r
library(dplyr)

df <- tibble(
  group = rep(c("a", "b", "c"), c(1, 2, 4)),
  x = runif(7)
)

df %>% 
  group_by(group) %>% 
  slice_sample(n = 2)
#> Error in `slice_sample()`:
#> ! Problem while computing indices.
#> ℹ The error occurred in group 1: group = "a".
#> Caused by error:
#> ! Can't sample without replacement using a size that is larger than the
#>   number of rows in the data.
#> ℹ 2 rows were requested in the sample.
#> ℹ 1 rows are present in the data.
#> ℹ Set `replace = TRUE` to sample with replacement.
```

<sup>Created on 2022-05-24 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>