### PR TITLE
Rewrite `case_when()` using `vec_case_when()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,55 @@
 # dplyr (development version)
 
+* `case_when()` has a new interface and has been rewritten to utilize vctrs. The
+  existing formula interface will continue to work for awhile, but we now feel
+  that it is suboptimal and encourage you to switch to the new interface
+  (#5106).
+  
+  Where you used to use:
+  
+  ```
+  case_when(
+    condition1 ~ value1,
+    condition2 ~ value2,
+    TRUE ~ default
+  )
+  ```
+  
+  You now supply pairs of inputs (with no `~`) and an explicit `.default`
+  argument:
+  
+  ```
+  case_when(
+    condition1, value1,
+    condition2, value2,
+    .default = default
+  )
+  ```
+  
+  The rewrite with vctrs includes a number of additional benefits:
+  
+  - The types of the values no longer have to match exactly. For example, the
+    following no longer requires you to use `NA_character_` instead of just
+    `NA`.
+  
+    ```
+    case_when(
+      x %in% c("little", "small"), "one"
+      x %in% c("big", "large"), "two",
+      x %in% c("missing", "unknown"), NA
+    )
+    ```
+    
+  - `case_when()` now supports a larger variety of value types. For example,
+    you can use a data frame to create multiple columns at once.
+    
+  - There are new `.ptype` and `.size` arguments which allow you to enforce
+    a particular output type and size. This allows you to construct a completely
+    type and size stable call to `case_when()`.
+  
+  - The error thrown when types or lengths were incorrect has now been
+    improved (#6261, #6206).
+
 * `tbl_sum()` is no longer reexported from tibble (#6284).
 
 * `slice_sample()` now gives a more informative error when `replace = FALSE` and

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,11 @@
   )
   ```
   
+  Additionally, unlike `TRUE ~ default`, the `.default` argument isn't used for
+  cases where an `NA` should have been propagated through. To handle those
+  cases, there is a new `.missing` argument. This should replace most uses
+  of `is.na(x) ~ value`.
+  
   The rewrite with vctrs includes a number of additional benefits:
   
   - The types of the values no longer have to match exactly. For example, the

--- a/R/case_when.R
+++ b/R/case_when.R
@@ -138,6 +138,17 @@
 #'     )
 #'   )
 #'
+#' # You can use data frames to create multiple columns at once.
+#' # The data frames will automatically be unpacked.
+#' starwars %>%
+#'   select(name:mass, gender, species) %>%
+#'   mutate(
+#'     case_when(
+#'       height > 200 | mass > 200, tibble(type = "large", vehicle = "car"),
+#'       species == "Droid", tibble(type = "robot", vehicle = "none"),
+#'       .default = tibble(type = "other", vehicle = "unknown")
+#'     )
+#'   )
 #'
 #' # `case_when()` is not a tidy eval function. If you'd like to reuse
 #' # the same patterns, extract the `case_when()` call in a normal

--- a/R/utils-format.r
+++ b/R/utils-format.r
@@ -31,9 +31,9 @@ wrap <- function(..., indent = 0) {
 ruler <- function(width = getOption("width")) {
   x <- seq_len(width)
   y <- case_when(
-    x %% 10 == 0 ~ as.character((x %/% 10) %% 10),
-    x %% 5 == 0  ~ "+",
-    TRUE         ~ "-"
+    x %% 10 == 0, as.character((x %/% 10) %% 10),
+    x %% 5 == 0, "+",
+    .default = "-"
   )
   cat(y, "\n", sep = "")
   cat(x %% 10, "\n", sep = "")

--- a/R/vec-case-when.R
+++ b/R/vec-case-when.R
@@ -1,0 +1,220 @@
+vec_case_when <- function(...,
+                          .default = NULL,
+                          .default_arg = ".default",
+                          .ptype = NULL,
+                          .size = NULL,
+                          .call = caller_env()) {
+  args <- list2(...)
+  args <- name_unnamed_args(args)
+
+  n_args <- length(args)
+
+  if (n_args == 0L) {
+    abort("`...` can't be empty.", call = .call)
+  }
+  if ((n_args %% 2) != 0L) {
+    message <- c(
+      "`...` must contain an even number of inputs.",
+      i = glue("{n_args} inputs were provided.")
+    )
+    abort(message, call = .call)
+  }
+
+  if (!is_string(.default_arg)) {
+    abort("`.default_arg` must be a string.", call = .call)
+  }
+
+  n_wheres <- n_args / 2L
+  loc_wheres <- seq.int(1L, n_args - 1L, by = 2)
+  wheres <- args[loc_wheres]
+  where_args <- names2(wheres)
+
+  for (i in seq_len(n_wheres)) {
+    where <- wheres[[i]]
+    where_arg <- where_args[[i]]
+
+    vec_assert(
+      x = where,
+      ptype = logical(),
+      arg = where_arg,
+      call = .call
+    )
+  }
+
+  .size <- vec_size_common(
+    !!!wheres,
+    .size = .size,
+    .call = .call
+  )
+
+  n_values <- n_wheres
+  loc_values <- loc_wheres + 1L
+  values <- args[loc_values]
+  value_args <- names2(values)
+
+  # Allow `.default` to participate in common type determination.
+  # In terms of size/ptype behavior it is exactly like any other `values` element.
+  .ptype <- vec_ptype_common(
+    !!!values,
+    "{.default_arg}" := .default,
+    .ptype = .ptype,
+    .call = .call
+  )
+
+  # Cast early to generate correct error message indices
+  values <- vec_cast_common(
+    !!!values,
+    .to = .ptype,
+    .call = .call
+  )
+
+  if (is.null(.default)) {
+    .default <- vec_init(.ptype)
+  } else {
+    .default <- vec_cast(
+      x = .default,
+      to = .ptype,
+      x_arg = .default_arg,
+      call = .call
+    )
+  }
+
+  # Check for correct sizes
+  for (i in seq_len(n_wheres)) {
+    where <- wheres[[i]]
+    where_arg <- where_args[[i]]
+
+    vec_assert(where, size = .size, arg = where_arg, call = .call)
+  }
+
+  value_sizes <- list_sizes(values)
+
+  for (i in seq_len(n_values)) {
+    value_size <- value_sizes[[i]]
+
+    if (value_size != 1L) {
+      value <- values[[i]]
+      value_arg <- value_args[[i]]
+
+      vec_assert(value, size = .size, arg = value_arg, call = .call)
+    }
+  }
+
+  default_size <- vec_size(.default)
+
+  if (default_size != 1L) {
+    vec_assert(.default, size = .size, arg = .default_arg, call = .call)
+  }
+
+  n_used <- 0L
+  locs <- vector("list", n_values)
+
+  # Starts as unused. Any `TRUE` value in `where` flips it to used.
+  unused <- vec_rep(TRUE, times = .size)
+
+  # Track unhandled missings using boolean operations.
+  # If `FALSE`, any `NA` in `where` flips it to `NA`.
+  # Any `TRUE` in `where` overrides both `NA` and `FALSE` to `TRUE`.
+  missing <- vec_rep(FALSE, times = .size)
+
+  for (i in seq_len(n_wheres)) {
+    if (!any(unused)) {
+      break
+    }
+
+    where <- wheres[[i]]
+
+    loc <- unused & where
+    missing <- missing | where
+
+    loc <- which(loc)
+    locs[[i]] <- loc
+
+    unused[loc] <- FALSE
+    n_used <- n_used + 1L
+  }
+
+  if (n_used == n_wheres) {
+    # If all of the `where` conditions are used,
+    # then we check if we need `missing` or `.default`
+
+    missing <- vec_equal_na(missing)
+
+    if (any(missing)) {
+      missing <- which(missing)
+
+      n_used <- n_used + 1L
+      n_values <- n_values + 1L
+      locs[[n_values]] <- missing
+      values[[n_values]] <- vec_init(.ptype)
+      value_sizes[[n_values]] <- 1L
+
+      # Missing locations don't count as unused
+      unused[missing] <- FALSE
+    }
+
+    if (any(unused)) {
+      unused <- which(unused)
+
+      n_used <- n_used + 1L
+      n_values <- n_values + 1L
+      locs[[n_values]] <- unused
+      values[[n_values]] <- .default
+      value_sizes[[n_values]] <- default_size
+    }
+  }
+
+  for (i in seq_len(n_used)) {
+    loc <- locs[[i]]
+    value <- values[[i]]
+    value_size <- value_sizes[[i]]
+
+    if (value_size == 1L) {
+      # Recycle "up"
+      value <- vec_recycle(value, size = vec_size(loc))
+    } else {
+      # Slice "down"
+      value <- vec_slice(value, loc)
+    }
+
+    values[[i]] <- value
+  }
+
+  # Remove names used for error messages. We don't want them in the result.
+  values <- unname(values)
+
+  if (n_used != n_values) {
+    # Trim to only what will be used to fill the result
+    seq_used <- seq_len(n_used)
+    values <- values[seq_used]
+    locs <- locs[seq_used]
+  }
+
+  vec_unchop(
+    x = values,
+    indices = locs,
+    ptype = .ptype
+  )
+}
+
+name_unnamed_args <- function(args) {
+  names <- names2(args)
+  names <- name_unnamed(names)
+  names(args) <- names
+  args
+}
+
+name_unnamed <- function(names) {
+  if (is.null(names)) {
+    return(names)
+  }
+
+  unnamed <- names == ""
+
+  if (any(unnamed)) {
+    unnamed <- which(unnamed)
+    names[unnamed] <- paste0("..", unnamed)
+  }
+
+  names
+}

--- a/data-raw/starwars.R
+++ b/data-raw/starwars.R
@@ -83,9 +83,9 @@ starwars <- mutate(starwars,
   species = ifelse(name == "R4-P17", "Droid", species), # R4-P17 is a droid
   sex = ifelse(species == "Droid", "none", sex), # Droids don't have biological sex
   gender = case_when(
-    sex == "male" ~ "masculine",
-    sex == "female" ~ "feminine",
-    TRUE ~ unname(genders[name])
+    sex == "male", "masculine",
+    sex == "female", "feminine",
+    .default = unname(genders[name])
   )
 )
 

--- a/man/case_when.Rd
+++ b/man/case_when.Rd
@@ -4,7 +4,7 @@
 \alias{case_when}
 \title{A general vectorised if-else}
 \usage{
-case_when(..., .default = NULL, .ptype = NULL, .size = NULL)
+case_when(..., .default = NULL, .missing = NULL, .ptype = NULL, .size = NULL)
 }
 \arguments{
 \item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}>
@@ -20,18 +20,29 @@ inputs must be the same length.
 The \code{value} inputs will be coerced to their common type. All \code{value}
 inputs must be length 1 or the same length as the \code{condition}s.
 
-An \code{NA} in a \code{condition} will result in a missing value in that location
-of the output unless another \code{condition} evaluates to \code{TRUE} for that
-location.
+\code{value} inputs are only used when the condition returns \code{TRUE}. If all
+conditions return \code{FALSE}, then \code{.default} will be used. If at least one
+condition returns \code{NA} and no condition returns \code{TRUE}, then \code{.missing}
+will be used.
 
 If the \code{...} are named, those names will be utilized in any error messages.}
 
-\item{.default}{The default value used when all \code{condition}s return \code{FALSE}
-for a particular location. \code{.default} must be length 1 or the same length
-as the \code{condition}s. \code{.default} participates in the computation of the
-common type alongside the \code{value} inputs.
+\item{.default}{The value used when all \code{condition}s return \code{FALSE}.
 
-If \code{NULL}, the default, a missing value will be placed in the result.}
+\code{.default} must be length 1 or the same length as the \code{condition}s.
+\code{.default} participates in the computation of the common type alongside the
+\code{value} inputs.
+
+If \code{NULL}, the default, a missing value will be used.}
+
+\item{.missing}{The value used when at least one \code{condition} returns \code{NA} and
+none of the conditions are \code{TRUE}.
+
+\code{.missing} must be length 1 or the same length as the \code{condition}s.
+\code{.missing} participates in the computation of the common type alongside the
+\code{value} inputs.
+
+If \code{NULL}, the default, a missing value will be used.}
 
 \item{.ptype}{An optional prototype declaring the desired output type. If
 supplied, this overrides the common type of the \code{value} inputs.}
@@ -75,7 +86,9 @@ we believe that \code{.default} is a safer way to provide a default value, as it
 allows us to require that all of the \code{condition}s have the same size. It is
 also only applied to locations where all of the \code{condition}s have returned
 \code{FALSE}, and doesn't apply to locations where an \code{NA} should have been
-propagated through, unlike the \code{TRUE ~ default} approach.
+propagated through, unlike the \code{TRUE ~ default} approach. For controlling
+the result when \code{NA} values are present in the \code{condition}s, you should now
+use \code{.missing}.
 
 The old interface was also the only place in the tidyverse that we used
 formulas in this way, and it had the potential to be confusing with how we
@@ -114,14 +127,13 @@ case_when(
   .default = as.character(x)
 )
 
-# Use `is.na()` to handle the missing values if you know where they are
-# coming from
+# Use `.missing` to handle the missing values
 case_when(
   x \%\% 35 == 0, "fizz buzz",
   x \%\% 5 == 0, "fizz",
   x \%\% 7 == 0, "buzz",
-  is.na(x), "nope",
-  .default = as.character(x)
+  .default = as.character(x),
+  .missing = "nope"
 )
 
 # case_when() evaluates all value expressions, and then constructs its

--- a/man/case_when.Rd
+++ b/man/case_when.Rd
@@ -2,113 +2,147 @@
 % Please edit documentation in R/case_when.R
 \name{case_when}
 \alias{case_when}
-\title{A general vectorised if}
+\title{A general vectorised if-else}
 \usage{
-case_when(...)
+case_when(..., .default = NULL, .ptype = NULL, .size = NULL)
 }
 \arguments{
-\item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}> A sequence of two-sided formulas. The left hand side (LHS)
-determines which values match this case. The right hand side (RHS)
-provides the replacement value.
+\item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}>
 
-The LHS must evaluate to a logical vector. The RHS does not need to be
-logical, but all RHSs must evaluate to the same type of vector.
+Pairs of inputs supplied like
+\verb{condition1, value1, condition2, value2, ...}. The \code{condition}s determine
+which values match this case, the \code{value}s provide the value to use for
+this case.
 
-Both LHS and RHS may have the same length of either 1 or \code{n}. The
-value of \code{n} must be consistent across all cases. The case of
-\code{n == 0} is treated as a variant of \code{n != 1}.
+Each \code{condition} input must evaluate to a logical vector. All \code{condition}
+inputs must be the same length.
 
-\code{NULL} inputs are ignored.}
+The \code{value} inputs will be coerced to their common type. All \code{value}
+inputs must be length 1 or the same length as the \code{condition}s.
+
+An \code{NA} in a \code{condition} will result in a missing value in that location
+of the output unless another \code{condition} evaluates to \code{TRUE} for that
+location.
+
+If the \code{...} are named, those names will be utilized in any error messages.}
+
+\item{.default}{The default value used when all \code{condition}s return \code{FALSE}
+for a particular location. \code{.default} must be length 1 or the same length
+as the \code{condition}s. \code{.default} participates in the computation of the
+common type alongside the \code{value} inputs.
+
+If \code{NULL}, the default, a missing value will be placed in the result.}
+
+\item{.ptype}{An optional prototype declaring the desired output type. If
+supplied, this overrides the common type of the \code{value} inputs.}
+
+\item{.size}{An optional size declaring the desired output size. If supplied,
+this overrides the size of the \code{condition} inputs.}
 }
 \value{
-A vector of length 1 or \code{n}, matching the length of the logical
-input or output vectors, with the type (and attributes) of the first
-RHS. Inconsistent lengths or types will generate an error.
+A vector with the same length as the \code{condition} inputs and the same
+type as the common type of the \code{value} inputs.
 }
 \description{
-This function allows you to vectorise multiple \code{\link[=if_else]{if_else()}}
-statements. It is an R equivalent of the SQL \verb{CASE WHEN} statement.
-If no cases match, \code{NA} is returned.
+This function allows you to vectorise multiple \code{\link[=if_else]{if_else()}} statements. It is
+an R equivalent of the SQL \verb{CASE WHEN} statement. If no cases match, a
+missing value is returned unless a \code{.default} is supplied.
 }
+\section{Previous interface}{
+
+
+Previously, \code{case_when()} used an interface based on formulas. Rather than:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{case_when(
+  condition1, value1,
+  condition2, value2,
+  .default = default
+)
+}\if{html}{\out{</div>}}
+
+you used to use:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{case_when(
+  condition1 ~ value1,
+  condition2 ~ value2,
+  TRUE ~ default
+)
+}\if{html}{\out{</div>}}
+
+The formula interface currently still works, but we now believe it to be
+suboptimal and encourage you to switch to the new interface. In particular,
+we believe that \code{.default} is a safer way to provide a default value, as it
+allows us to require that all of the \code{condition}s have the same size. It is
+also only applied to locations where all of the \code{condition}s have returned
+\code{FALSE}, and doesn't apply to locations where an \code{NA} should have been
+propagated through, unlike the \code{TRUE ~ default} approach.
+
+The old interface was also the only place in the tidyverse that we used
+formulas in this way, and it had the potential to be confusing with how we
+use formulas for modeling or for generating anonymous functions in purrr,
+like \code{~ .x + 1}. We generally feel that the new interface aligns better with
+other code that you'll write while using the tidyverse.
+}
+
 \examples{
 x <- 1:50
-case_when(
-  x \%\% 35 == 0 ~ "fizz buzz",
-  x \%\% 5 == 0 ~ "fizz",
-  x \%\% 7 == 0 ~ "buzz",
-  TRUE ~ as.character(x)
-)
 
 # Like an if statement, the arguments are evaluated in order, so you must
-# proceed from the most specific to the most general. This won't work:
+# proceed from the most specific to the most general.
 case_when(
-  TRUE ~ as.character(x),
-  x \%\%  5 == 0 ~ "fizz",
-  x \%\%  7 == 0 ~ "buzz",
-  x \%\% 35 == 0 ~ "fizz buzz"
+  x \%\% 35 == 0, "fizz buzz",
+  x \%\% 5 == 0, "fizz",
+  x \%\% 7 == 0, "buzz",
+  .default = as.character(x)
 )
 
-# If none of the cases match, NA is used:
+# If none of the cases match, `NA` is used:
 case_when(
-  x \%\%  5 == 0 ~ "fizz",
-  x \%\%  7 == 0 ~ "buzz",
-  x \%\% 35 == 0 ~ "fizz buzz"
+  x \%\% 5 == 0, "fizz",
+  x \%\% 7 == 0, "buzz",
+  x \%\% 35 == 0, "fizz buzz"
 )
 
-# Note that NA values in the vector x do not get special treatment. If you want
-# to explicitly handle NA values you can use the `is.na` function:
-x[2:4] <- NA_real_
+# An `NA` value in a logical condition gets passed through as `NA` in the
+# output if none of the other conditions return `TRUE`
+x[2:4] <- NA
+
 case_when(
-  x \%\% 35 == 0 ~ "fizz buzz",
-  x \%\% 5 == 0 ~ "fizz",
-  x \%\% 7 == 0 ~ "buzz",
-  is.na(x) ~ "nope",
-  TRUE ~ as.character(x)
+  x \%\% 35 == 0, "fizz buzz",
+  x \%\% 5 == 0, "fizz",
+  x \%\% 7 == 0, "buzz",
+  .default = as.character(x)
 )
 
-# All RHS values need to be of the same type. Inconsistent types will throw an error.
-# This applies also to NA values used in RHS: NA is logical, use
-# typed values like NA_real_, NA_complex, NA_character_, NA_integer_ as appropriate.
+# Use `is.na()` to handle the missing values if you know where they are
+# coming from
 case_when(
-  x \%\% 35 == 0 ~ NA_character_,
-  x \%\% 5 == 0 ~ "fizz",
-  x \%\% 7 == 0 ~ "buzz",
-  TRUE ~ as.character(x)
-)
-case_when(
-  x \%\% 35 == 0 ~ 35,
-  x \%\% 5 == 0 ~ 5,
-  x \%\% 7 == 0 ~ 7,
-  TRUE ~ NA_real_
+  x \%\% 35 == 0, "fizz buzz",
+  x \%\% 5 == 0, "fizz",
+  x \%\% 7 == 0, "buzz",
+  is.na(x), "nope",
+  .default = as.character(x)
 )
 
-# case_when() evaluates all RHS expressions, and then constructs its
-# result by extracting the selected (via the LHS expressions) parts.
-# In particular NaNs are produced in this case:
+# case_when() evaluates all value expressions, and then constructs its
+# result by extracting the selected (via the condition expressions) parts.
+# In particular `NaN`s are produced in this case:
 y <- seq(-2, 2, by = .5)
 case_when(
-  y >= 0 ~ sqrt(y),
-  TRUE   ~ y
+  y >= 0, sqrt(y),
+  .default = y
 )
 
-# This throws an error as NA is logical not numeric
-try(case_when(
-  x \%\% 35 == 0 ~ 35,
-  x \%\% 5 == 0 ~ 5,
-  x \%\% 7 == 0 ~ 7,
-  TRUE ~ NA
-))
-
-# case_when is particularly useful inside mutate when you want to
+# `case_when()` is particularly useful inside `mutate()` when you want to
 # create a new variable that relies on a complex combination of existing
 # variables
 starwars \%>\%
   select(name:mass, gender, species) \%>\%
   mutate(
     type = case_when(
-      height > 200 | mass > 200 ~ "large",
-      species == "Droid"        ~ "robot",
-      TRUE                      ~ "other"
+      height > 200 | mass > 200, "large",
+      species == "Droid", "robot",
+      .default = "other"
     )
   )
 
@@ -118,9 +152,9 @@ starwars \%>\%
 # function:
 case_character_type <- function(height, mass, species) {
   case_when(
-    height > 200 | mass > 200 ~ "large",
-    species == "Droid"        ~ "robot",
-    TRUE                      ~ "other"
+    height > 200 | mass > 200, "large",
+    species == "Droid", "robot",
+    .default = "other"
   )
 }
 
@@ -130,21 +164,5 @@ case_character_type(150, 150, "Droid")
 # Such functions can be used inside `mutate()` as well:
 starwars \%>\%
   mutate(type = case_character_type(height, mass, species)) \%>\%
-  pull(type)
-
-# `case_when()` ignores `NULL` inputs. This is useful when you'd
-# like to use a pattern only under certain conditions. Here we'll
-# take advantage of the fact that `if` returns `NULL` when there is
-# no `else` clause:
-case_character_type <- function(height, mass, species, robots = TRUE) {
-  case_when(
-    height > 200 | mass > 200      ~ "large",
-    if (robots) species == "Droid" ~ "robot",
-    TRUE                           ~ "other"
-  )
-}
-
-starwars \%>\%
-  mutate(type = case_character_type(height, mass, species, robots = FALSE)) \%>\%
   pull(type)
 }

--- a/man/case_when.Rd
+++ b/man/case_when.Rd
@@ -146,6 +146,17 @@ starwars \%>\%
     )
   )
 
+# You can use data frames to create multiple columns at once.
+# The data frames will automatically be unpacked.
+starwars \%>\%
+  select(name:mass, gender, species) \%>\%
+  mutate(
+    case_when(
+      height > 200 | mass > 200, tibble(type = "large", vehicle = "car"),
+      species == "Droid", tibble(type = "robot", vehicle = "none"),
+      .default = tibble(type = "other", vehicle = "unknown")
+    )
+  )
 
 # `case_when()` is not a tidy eval function. If you'd like to reuse
 # the same patterns, extract the `case_when()` call in a normal

--- a/tests/testthat/_snaps/case-when.md
+++ b/tests/testthat/_snaps/case-when.md
@@ -33,6 +33,14 @@
 ---
 
     Code
+      case_when(1 ~ 2, .missing = 3)
+    Condition
+      Error in `case_when()`:
+      ! `.missing` can only be used with the new interface.
+
+---
+
+    Code
       case_when(1 ~ 2, .ptype = integer())
     Condition
       Error in `case_when()`:

--- a/tests/testthat/_snaps/case-when.md
+++ b/tests/testthat/_snaps/case-when.md
@@ -1,40 +1,82 @@
+# passes through `.size` correctly
+
+    Code
+      case_when(TRUE, 1, .size = 2)
+    Condition
+      Error in `case_when()`:
+      ! `..1` must have size 2, not size 1.
+
+# doesn't support quosures in the new interface
+
+    Code
+      case_when(!!!fs)
+    Condition
+      Error:
+      ! Case 1 (`!!!fs`) must be a two-sided formula, not a call.
+
+# trying to mix the old interface with new arguments isn't allowed
+
+    Code
+      case_when(1 ~ 2, .default = 3)
+    Condition
+      Error in `case_when()`:
+      ! `.default` can only be used with the new interface.
+
+---
+
+    Code
+      case_when(1 ~ 2, .ptype = integer())
+    Condition
+      Error in `case_when()`:
+      ! `.ptype` can only be used with the new interface.
+
+---
+
+    Code
+      case_when(1 ~ 2, .size = 1)
+    Condition
+      Error in `case_when()`:
+      ! `.size` can only be used with the new interface.
+
 # case_when() give meaningful errors
 
     Code
       (expect_error(case_when(c(TRUE, FALSE) ~ 1:3, c(FALSE, TRUE) ~ 1:2)))
     Output
-      <error/rlang_error>
-      Error in `case_when()`:
-      ! `c(TRUE, FALSE) ~ 1:3` must be length 2 or one, not 3.
+      <error/vctrs_error_incompatible_size>
+      Error:
+      ! Can't recycle `c(TRUE, FALSE) ~ 1:3` (size 2) to match `c(TRUE, FALSE) ~ 1:3` (size 3).
     Code
       (expect_error(case_when(c(TRUE, FALSE) ~ 1, c(FALSE, TRUE, FALSE) ~ 2, c(FALSE,
         TRUE, FALSE, NA) ~ 3)))
     Output
-      <error/rlang_error>
-      Error in `case_when()`:
-      ! `c(FALSE, TRUE, FALSE) ~ 2`, `c(FALSE, TRUE, FALSE, NA) ~ 3` must be length 2 or one, not 3, 4.
+      <error/vctrs_error_incompatible_size>
+      Error:
+      ! Can't recycle `c(TRUE, FALSE) ~ 1` (size 2) to match `c(FALSE, TRUE, FALSE) ~ 2` (size 3).
     Code
       (expect_error(case_when(50 ~ 1:3)))
     Output
-      <error/rlang_error>
+      <error/vctrs_error_assert_ptype>
       Error in `case_when()`:
-      ! LHS of case 1 (`50`) must be a logical vector, not a double vector.
+      ! `50 ~ 1:3` must be a vector with type <logical>.
+      Instead, it has type <double>.
     Code
       (expect_error(case_when(paste(50))))
     Output
       <error/rlang_error>
       Error in `case_when()`:
-      ! Case 1 (`paste(50)`) must be a two-sided formula, not a character vector.
+      ! `...` must contain an even number of inputs.
+      i 1 inputs were provided.
     Code
       (expect_error(case_when()))
     Output
       <error/rlang_error>
       Error in `case_when()`:
-      ! No cases provided.
+      ! `...` can't be empty.
     Code
       (expect_error(case_when(~ 1:2)))
     Output
       <error/rlang_error>
-      Error in `case_when()`:
+      Error:
       ! Formulas must be two-sided.
 

--- a/tests/testthat/_snaps/case-when.md
+++ b/tests/testthat/_snaps/case-when.md
@@ -14,6 +14,14 @@
       Error:
       ! Case 1 (`!!!fs`) must be a two-sided formula, not a call.
 
+# invalid type errors are correct (#6261) (#6206)
+
+    Code
+      case_when(TRUE ~ 1, TRUE ~ "x")
+    Condition
+      Error in `case_when()`:
+      ! Can't combine `TRUE ~ 1` <double> and `TRUE ~ "x"` <character>.
+
 # trying to mix the old interface with new arguments isn't allowed
 
     Code

--- a/tests/testthat/_snaps/vec-case-when.md
+++ b/tests/testthat/_snaps/vec-case-when.md
@@ -30,6 +30,14 @@
       Error:
       ! `.default` must have size 1, not size 2.
 
+# `.missing` must be size 1 or same size as logical conditions (exact same as any other even numbered input)
+
+    Code
+      vec_case_when(FALSE, 1L, .missing = 2:3)
+    Condition
+      Error:
+      ! `.missing` must have size 1, not size 2.
+
 # `.default_arg` can be customized
 
     Code
@@ -46,6 +54,22 @@
       Error:
       ! Can't combine `..2` <integer> and `foo` <character>.
 
+# `.missing_arg` can be customized
+
+    Code
+      vec_case_when(FALSE, 1L, .missing = 2:3, .missing_arg = "foo")
+    Condition
+      Error:
+      ! `foo` must have size 1, not size 2.
+
+---
+
+    Code
+      vec_case_when(FALSE, 1L, .missing = "x", .missing_arg = "foo")
+    Condition
+      Error:
+      ! Can't combine `..2` <integer> and `foo` <character>.
+
 # `.default_arg` is validated
 
     Code
@@ -53,6 +77,14 @@
     Condition
       Error:
       ! `.default_arg` must be a string.
+
+# `.missing_arg` is validated
+
+    Code
+      vec_case_when(TRUE, 1, .missing_arg = 1)
+    Condition
+      Error:
+      ! `.missing_arg` must be a string.
 
 # odd numbered inputs must all be the same size
 

--- a/tests/testthat/_snaps/vec-case-when.md
+++ b/tests/testthat/_snaps/vec-case-when.md
@@ -1,0 +1,173 @@
+# odd numbered inputs can be size zero
+
+    Code
+      vec_case_when(logical(), 1:2)
+    Condition
+      Error:
+      ! `..2` must have size 0, not size 2.
+
+# even numbered inputs are cast to their common type
+
+    Code
+      vec_case_when(FALSE, 1, TRUE, "x")
+    Condition
+      Error:
+      ! Can't combine `..2` <double> and `..4` <character>.
+
+# even numbered inputs must be size 1 or same size as logical conditions
+
+    Code
+      vec_case_when(c(TRUE, FALSE, TRUE, TRUE), 1:3)
+    Condition
+      Error:
+      ! `..2` must have size 4, not size 3.
+
+# `.default` must be size 1 or same size as logical conditions (exact same as any other even numbered input)
+
+    Code
+      vec_case_when(FALSE, 1L, .default = 2:3)
+    Condition
+      Error:
+      ! `.default` must have size 1, not size 2.
+
+# `.default_arg` can be customized
+
+    Code
+      vec_case_when(FALSE, 1L, .default = 2:3, .default_arg = "foo")
+    Condition
+      Error:
+      ! `foo` must have size 1, not size 2.
+
+---
+
+    Code
+      vec_case_when(FALSE, 1L, .default = "x", .default_arg = "foo")
+    Condition
+      Error:
+      ! Can't combine `..2` <integer> and `foo` <character>.
+
+# `.default_arg` is validated
+
+    Code
+      vec_case_when(TRUE, 1, .default_arg = 1)
+    Condition
+      Error:
+      ! `.default_arg` must be a string.
+
+# odd numbered inputs must all be the same size
+
+    Code
+      vec_case_when(c(TRUE, FALSE), 1, TRUE, 2)
+    Condition
+      Error:
+      ! `..3` must have size 2, not size 1.
+
+---
+
+    Code
+      vec_case_when(c(TRUE, FALSE), 1, c(TRUE, FALSE, TRUE), 2)
+    Condition
+      Error:
+      ! Can't recycle `..1` (size 2) to match `..3` (size 3).
+
+# odd numbered inputs must be logical (and aren't cast to logical!)
+
+    Code
+      vec_case_when(1, 2)
+    Condition
+      Error:
+      ! `..1` must be a vector with type <logical>.
+      Instead, it has type <double>.
+
+---
+
+    Code
+      vec_case_when(TRUE, 2, 3.5, 4)
+    Condition
+      Error:
+      ! `..3` must be a vector with type <logical>.
+      Instead, it has type <double>.
+
+# `.size` overrides the odd numbered input sizes
+
+    Code
+      vec_case_when(TRUE, 1, .size = 5)
+    Condition
+      Error:
+      ! `..1` must have size 5, not size 1.
+
+---
+
+    Code
+      vec_case_when(c(TRUE, FALSE), 1, c(TRUE, FALSE, TRUE), 2, .size = 2)
+    Condition
+      Error:
+      ! `..3` must have size 2, not size 3.
+
+# `.ptype` overrides the even numbered input types
+
+    Code
+      vec_case_when(FALSE, 1, TRUE, 2, .ptype = character())
+    Condition
+      Error:
+      ! Can't convert `..2` <double> to <character>.
+
+# can't have an odd number of inputs
+
+    Code
+      vec_case_when(1)
+    Condition
+      Error:
+      ! `...` must contain an even number of inputs.
+      i 1 inputs were provided.
+
+---
+
+    Code
+      vec_case_when(1, 2, 3)
+    Condition
+      Error:
+      ! `...` must contain an even number of inputs.
+      i 3 inputs were provided.
+
+# can't have empty dots
+
+    Code
+      vec_case_when()
+    Condition
+      Error:
+      ! `...` can't be empty.
+
+---
+
+    Code
+      vec_case_when(.default = 1)
+    Condition
+      Error:
+      ! `...` can't be empty.
+
+# named dots show up in the error message
+
+    Code
+      vec_case_when(x = 1.5, 1)
+    Condition
+      Error:
+      ! `x` must be a vector with type <logical>.
+      Instead, it has type <double>.
+
+---
+
+    Code
+      vec_case_when(x = TRUE, 1, y = c(TRUE, FALSE), 2)
+    Condition
+      Error:
+      ! `x` must have size 2, not size 1.
+
+---
+
+    Code
+      vec_case_when(TRUE, 1, FALSE, x = "y")
+    Condition
+      Error:
+      ! Can't combine `..2` <double> and `x` <character>.
+

--- a/tests/testthat/test-case-when.R
+++ b/tests/testthat/test-case-when.R
@@ -94,6 +94,12 @@ test_that("doesn't support quosures in the new interface", {
   })
 })
 
+test_that("invalid type errors are correct (#6261) (#6206)", {
+  expect_snapshot(error = TRUE, {
+    case_when(TRUE ~ 1, TRUE ~ "x")
+  })
+})
+
 test_that("trying to mix the old interface with new arguments isn't allowed", {
   expect_snapshot(error = TRUE, case_when(1 ~ 2, .default = 3))
   expect_snapshot(error = TRUE, case_when(1 ~ 2, .ptype = integer()))

--- a/tests/testthat/test-colwise-select.R
+++ b/tests/testthat/test-colwise-select.R
@@ -152,7 +152,7 @@ test_that("rename_at() handles empty selection (#4324)", {
 })
 
 test_that("rename_all/at() call the function with simple character vector (#4459)", {
-  fun <- function(x) case_when(x == 'mpg' ~ 'fuel_efficiency', TRUE ~ x)
+  fun <- function(x) case_when(x == 'mpg', 'fuel_efficiency', .default = x)
   out <- rename_all(mtcars,fun)
   expect_equal(names(out)[1L], 'fuel_efficiency')
 

--- a/tests/testthat/test-vec-case-when.R
+++ b/tests/testthat/test-vec-case-when.R
@@ -1,0 +1,277 @@
+test_that("works with data frames", {
+  out <- vec_case_when(
+    c(FALSE, TRUE, FALSE, FALSE), vctrs::data_frame(x = 1, y = 2),
+    c(TRUE, TRUE, FALSE, FALSE), vctrs::data_frame(x = 3, y = 4),
+    c(FALSE, TRUE, FALSE, TRUE), vctrs::data_frame(x = 3:6, y = 4:7),
+  )
+
+  expect_identical(
+    out,
+    vctrs::data_frame(
+      x = c(3, 1, NA, 6),
+      y = c(4, 2, NA, 7)
+    )
+  )
+})
+
+test_that("first `TRUE` case wins", {
+  expect_identical(
+    vec_case_when(c(TRUE, FALSE), 1, c(TRUE, TRUE), 2, c(TRUE, TRUE), 3),
+    c(1, 2)
+  )
+})
+
+test_that("can replace missing values", {
+  x <- c(1:3, NA)
+
+  expect_identical(
+    vec_case_when(
+      x <= 1, 1,
+      x <= 2, 2,
+      is.na(x), 0
+    ),
+    c(1, 2, NA, 0)
+  )
+})
+
+test_that("Unused logical `NA` can still be cast to `...` ptype", {
+  # Requires that casting happen before recycling, because it recycles
+  # to size zero, resulting in a logical rather than an unspecified.
+  expect_identical(vec_case_when(TRUE, "x", FALSE, NA), "x")
+  expect_identical(vec_case_when(FALSE, "x", TRUE, NA), NA_character_)
+})
+
+test_that("odd numbered inputs can be size zero", {
+  expect_identical(
+    vec_case_when(
+      logical(), 1,
+      logical(), 2
+    ),
+    numeric()
+  )
+
+  expect_snapshot(error = TRUE, {
+    vec_case_when(logical(), 1:2)
+  })
+})
+
+test_that("retains names of inputs", {
+  value1 <- c(x = 1, y = 2)
+  value2 <- c(z = 3, w = 4)
+
+  out <- vec_case_when(
+    c(TRUE, FALSE), value1,
+    c(TRUE, TRUE), value2
+  )
+
+  expect_named(out, c("x", "w"))
+})
+
+test_that("even numbered inputs are cast to their common type", {
+  expect_identical(vec_case_when(FALSE, 1, TRUE, 2L), 2)
+  expect_identical(vec_case_when(FALSE, 1, TRUE, NA), NA_real_)
+
+  expect_snapshot(error = TRUE, {
+    vec_case_when(FALSE, 1, TRUE, "x")
+  })
+})
+
+test_that("even numbered inputs must be size 1 or same size as logical conditions", {
+  expect_identical(
+    vec_case_when(c(TRUE, TRUE), 1),
+    c(1, 1)
+  )
+  expect_identical(
+    vec_case_when(c(TRUE, FALSE), c(1, 2), c(TRUE, TRUE), c(3, 4)),
+    c(1, 4)
+  )
+
+  # Make sure input numbering is right in the error message!
+  expect_snapshot(error = TRUE, {
+    vec_case_when(c(TRUE, FALSE, TRUE, TRUE), 1:3)
+  })
+})
+
+test_that("Unhandled `NA` propagates through as a missing value", {
+  expect_identical(
+    vec_case_when(NA, 1, .default = 2),
+    NA_real_
+  )
+
+  expect_identical(
+    vec_case_when(
+      c(FALSE, NA, TRUE),
+      2,
+      c(NA, FALSE, TRUE),
+      3,
+      .default = 4
+    ),
+    c(NA, NA, 2)
+  )
+})
+
+test_that("`NA` is overridden by any `TRUE` values", {
+  x <- c(1, 2, NA, 3)
+  expect <- c("one", "not_one", "missing", "not_one")
+
+  # `TRUE` overriding before the `NA`
+  expect_identical(
+    vec_case_when(
+      is.na(x), "missing",
+      x == 1, "one",
+      .default = "not_one"
+    ),
+    expect
+  )
+
+  # `TRUE` overriding after the `NA`
+  expect_identical(
+    vec_case_when(
+      x == 1, "one",
+      is.na(x), "missing",
+      .default = "not_one"
+    ),
+    expect
+  )
+})
+
+test_that("works when there is a used `.default` and no missing values", {
+  expect_identical(vec_case_when(c(TRUE, FALSE), 1, .default = 3:4), c(1, 4))
+})
+
+test_that("works when there are missing values but no `.default`", {
+  expect_identical(vec_case_when(c(TRUE, NA), 1), c(1, NA))
+})
+
+test_that("A `NULL` `.default` fills in with missing values", {
+  expect_identical(
+    vec_case_when(c(TRUE, FALSE, FALSE), 1),
+    c(1, NA, NA)
+  )
+})
+
+test_that("`.default` fills in all unused slots", {
+  expect_identical(
+    vec_case_when(c(TRUE, FALSE, FALSE), 1, .default = 2),
+    c(1, 2, 2)
+  )
+})
+
+test_that("`.default` is initialized correctly in the logical / unspecified case", {
+  # i.e. `vec_ptype(NA)` is unspecified but the result should be finalized to logical
+  expect_identical(vec_case_when(FALSE, NA), NA)
+})
+
+test_that("`.default` can be vectorized, and is sliced to fit as needed", {
+  out <- vec_case_when(
+    c(FALSE, TRUE, FALSE, TRUE, FALSE), 1:5,
+    c(FALSE, TRUE, FALSE, FALSE, TRUE), 6:10,
+    .default = 11:15
+  )
+
+  expect_identical(out, c(11L, 2L, 13L, 4L, 10L))
+})
+
+test_that("`.default` must be size 1 or same size as logical conditions (exact same as any other even numbered input)", {
+  expect_snapshot(error = TRUE, {
+    vec_case_when(FALSE, 1L, .default = 2:3)
+  })
+})
+
+test_that("`.default` participates in common type determination (exact same as any other even numbered input)", {
+  expect_identical(vec_case_when(FALSE, 1L, .default = 2), 2)
+})
+
+test_that("`.default` that is an unused logical `NA` can still be cast to `...` ptype", {
+  # Requires that casting happen before recycling, because it recycles
+  # to size zero, resulting in a logical rather than an unspecified.
+  expect_identical(vec_case_when(TRUE, "x", .default = NA), "x")
+})
+
+test_that("`.default_arg` can be customized", {
+  expect_snapshot(error = TRUE, {
+    vec_case_when(FALSE, 1L, .default = 2:3, .default_arg = "foo")
+  })
+  expect_snapshot(error = TRUE, {
+    vec_case_when(FALSE, 1L, .default = "x", .default_arg = "foo")
+  })
+})
+
+test_that("`.default_arg` is validated", {
+  expect_snapshot(error = TRUE, {
+    vec_case_when(TRUE, 1, .default_arg = 1)
+  })
+})
+
+test_that("odd numbered inputs must all be the same size", {
+  expect_snapshot(error = TRUE, {
+    vec_case_when(c(TRUE, FALSE), 1, TRUE, 2)
+  })
+  expect_snapshot(error = TRUE, {
+    vec_case_when(c(TRUE, FALSE), 1, c(TRUE, FALSE, TRUE), 2)
+  })
+})
+
+test_that("odd numbered inputs must be logical (and aren't cast to logical!)", {
+  expect_snapshot(error = TRUE, {
+    vec_case_when(1, 2)
+  })
+
+  # Make sure input numbering is right in the error message!
+  expect_snapshot(error = TRUE, {
+    vec_case_when(TRUE, 2, 3.5, 4)
+  })
+})
+
+test_that("`.size` overrides the odd numbered input sizes", {
+  expect_snapshot(error = TRUE, {
+    vec_case_when(TRUE, 1, .size = 5)
+  })
+
+  # Make sure input numbering is right in the error message!
+  expect_snapshot(error = TRUE, {
+    vec_case_when(c(TRUE, FALSE), 1, c(TRUE, FALSE, TRUE), 2, .size = 2)
+  })
+})
+
+test_that("`.ptype` overrides the even numbered input types", {
+  expect_identical(
+    vec_case_when(FALSE, 1, TRUE, 2, .ptype = integer()),
+    2L
+  )
+
+  # Make sure input numbering is right in the error message!
+  expect_snapshot(error = TRUE, {
+    vec_case_when(FALSE, 1, TRUE, 2, .ptype = character())
+  })
+})
+
+test_that("can't have an odd number of inputs", {
+  expect_snapshot(error = TRUE, {
+    vec_case_when(1)
+  })
+  expect_snapshot(error = TRUE, {
+    vec_case_when(1, 2, 3)
+  })
+})
+
+test_that("can't have empty dots", {
+  expect_snapshot(error = TRUE, {
+    vec_case_when()
+  })
+  expect_snapshot(error = TRUE, {
+    vec_case_when(.default = 1)
+  })
+})
+
+test_that("named dots show up in the error message", {
+  expect_snapshot(error = TRUE, {
+    vec_case_when(x = 1.5, 1)
+  })
+  expect_snapshot(error = TRUE, {
+    vec_case_when(x = TRUE, 1, y = c(TRUE, FALSE), 2)
+  })
+  expect_snapshot(error = TRUE, {
+    vec_case_when(TRUE, 1, FALSE, x = "y")
+  })
+})


### PR DESCRIPTION
Closes #6261 
Closes #6206 
Closes #5106
Closes #6145 
Closes #6225 

The intention is to move `vec_case_when()` to vctrs and rewrite in C, but getting the semantics right in R is more important for now.

`vec_case_when()` will also be used to back `if_else()` and `coalesce()` for sure. I think it could also back `na_if()`. It could additionally back `replace_when()` if we want to implement that.

---

`case_when()` has gained a new interface. Formulas are no longer used, instead you pass pairs of `condition/value` inputs. There is also an explicit `.default` argument now, and new `.ptype` and `.size` arguments.

The formula interface still works for now, I'm optimistic that it is 100% backwards compatible. We don't do anything to actively dissuade people from using the formula interface right now. However, you can't use any of the new arguments with the old interface.

---

Open question:

Should we have a `.missing` argument in `case_when()` and `vec_case_when()`? This would:
- Match `if_else()`
- Be easier than supplying `is.na(x), "value"` for most cases
- Provide a way to handle the case where the missing value pops up in the computation rather than in `x` itself (see below)

We decided that `.default` should ONLY handle the case where all `condition`s are `FALSE`. Meaning it doesn't handle the case where no conditions are `TRUE` and at least one of those conditions is `NA` - the `NA` now gets propagated through. This is generally what people want, see this example:

``` r
library(dplyr, warn.conflicts = FALSE)

x <- c(1, 2, NA, 4, 5)

# Confusing because `NA` isn't propagated.
# The `NA` gets assigned to `"high"` which feels wrong.
case_when(
  x <= 2 ~ "low",
  x <= 4 ~ "med",
  TRUE ~ "high"
)
#> [1] "low"  "low"  "high" "med"  "high"

# New interface propagates `NA` - good!
case_when(
  x <= 2, "low",
  x <= 4, "med",
  .default = "high"
)
#> [1] "low"  "low"  NA     "med"  "high"

# Handle `NA` easily because we knew where it came from
case_when(
  x <= 2, "low",
  x <= 4, "med",
  is.na(x), "unknown",
  .default = "high"
)
#> [1] "low"     "low"     "unknown" "med"     "high"
```

The above was the motivating case for this change. But it is a little more frustrating if the `NA`s occur in the computation of the condition rather than in `x` itself. I still think the `.default` behavior is right, the problem is that it is hard to explicitly handle the `NA` cases now. A `.missing` argument would allow us to easily explicitly handle the computed `NA`s.

``` r
library(dplyr, warn.conflicts = FALSE)

x <- c(-1, 0, 1)

# Generated `NA` is treated like `FALSE`.
# `TRUE ~` applies to everything that is left, but does that really make sense?
case_when(
  sqrt(x) > 0 ~ "big",
  TRUE ~ "little"
)
#> Warning in sqrt(x): NaNs produced
#> [1] "little" "little" "big"

# Propagates `NA`, which seems reasonable
case_when(
  sqrt(x) > 0, "big",
  .default = "little"
)
#> Warning in sqrt(x): NaNs produced
#> [1] NA       "little" "big"

# But there is no easy way to "handle" the `NA` because it happens
# in the computation, not in `x`
case_when(
  sqrt(x) > 0, "big",
  is.na(x), "missing",
  .default = "little"
)
#> Warning in sqrt(x): NaNs produced
#> [1] NA       "little" "big"

# Proposal:
# case_when(
#   sqrt(x) > 0, "big",
#   .default = "little",
#   .missing = "missing"
# )
```