### PR TITLE
`mutate_when()` and `revise()`

### DIFF
--- a/R/case.R
+++ b/R/case.R
@@ -1,0 +1,143 @@
+when <- function(.condition, ...) {
+  .condition <- enquo(.condition)
+
+  # quos() not enquos(), for performance, since we only need to collect `...`
+  values <- quos(..., .ignore_empty = "all", .named = NULL)
+  names <- names2(values)
+  named <- names != ""
+
+  n_values <- length(values)
+  n_named <- sum(named)
+
+  if (n_values > 1L && n_values != n_named) {
+    unnamed <- !named
+    unnamed <- which(unnamed)
+    unnamed <- unnamed[[1L]]
+
+    message <- c(
+      "All `...` must be named when >1 inputs are supplied.",
+      i = glue("{n_values} inputs were supplied."),
+      i = glue("{n_named} inputs were named."),
+      i = glue("Input {unnamed} of `...` is not named.")
+    )
+
+    abort(message)
+  }
+
+  structure(
+    list(condition = .condition, values = values),
+    class = "funs_when"
+  )
+}
+
+is_funs_when <- function(x) {
+  inherits(x, "funs_when")
+}
+
+case <- function(...,
+                 .default = NULL,
+                 .ptype = NULL,
+                 .size = NULL) {
+  args <- list2(...)
+  args <- Filter(function(x) !is.null(x), args)
+  n_args <- length(args)
+
+  good <- vapply(args, is_funs_when, logical(1))
+  if (!all(good)) {
+    bad <- !good
+    bad <- which(bad)
+    bad <- bad[[1L]]
+
+    message <- c(
+      "All `...` inputs must be `when()` results.",
+      i = glue("Input {bad} is not a `when()` result.")
+    )
+
+    abort(message)
+  }
+
+  args_conditions <- vector("list", length = n_args)
+  args_values <- vector("list", length = n_args)
+
+  for (i in seq_len(n_args)) {
+    arg <- args[[i]]
+
+    condition <- arg$condition
+    values <- arg$values
+
+    condition <- eval_tidy(condition)
+    values <- lapply(values, eval_tidy)
+
+    if (length(values) == 1L && is.null(names(values))) {
+      # `when()` guaranteed that there is only 1 input in this case
+      values <- values[[1L]]
+      vec_assert(values)
+    } else {
+      size <- vec_size(condition)
+      list_check_all_vectors(values)
+      values <- vec_recycle_common(!!!values, .size = size)
+      values <- new_data_frame(values, n = size)
+    }
+
+    args_conditions[[i]] <- condition
+    args_values[[i]] <- values
+  }
+
+  args <- vec_interleave(args_conditions, args_values)
+
+  vec_case_when(!!!args, .default = .default, .ptype = .ptype, .size = .size)
+}
+
+revise2 <- function(.data, ...) {
+  caller_env <- caller_env()
+
+  args <- list2(...)
+  args <- Filter(function(x) !is.null(x), args)
+  n_args <- length(args)
+
+  good <- vapply(args, is_funs_when, logical(1))
+  if (!all(good)) {
+    bad <- !good
+    bad <- which(bad)
+    bad <- bad[[1L]]
+
+    message <- c(
+      "All `...` inputs must be `when()` results.",
+      i = glue("Input {bad} is not a `when()` result.")
+    )
+
+    abort(message)
+  }
+
+  size <- vec_size(.data)
+  unused <- vec_rep(TRUE, size)
+
+  out <- .data
+
+  for (i in seq_len(n_args)) {
+    arg <- args[[i]]
+
+    condition <- arg$condition
+    values <- arg$values
+    values <- dplyr_quosures(!!!values)
+
+    # Evaluate `condition` on all of `.data`.
+    # This handles `NA`s for us, and converts them to `FALSE`.
+    condition <- filter_rows(.data, !!condition, caller_env = caller_env)
+
+    # Only update in locations we haven't updated before
+    loc <- unused & condition
+    loc <- vec_as_location(loc, n = size)
+
+    # Mark locations as used
+    unused[loc] <- FALSE
+
+    # Evaluate current subset of `...` on the slice of `.data` we are updating
+    updates <- dplyr_row_slice(.data, loc)
+    updates <- mutate_cols(updates, dots = values, caller_env = caller_env)
+
+    out <- df_update(out, loc, updates)
+  }
+
+  out
+}

--- a/R/case.R
+++ b/R/case.R
@@ -1,101 +1,12 @@
-when <- function(.condition, ...) {
-  .condition <- enquo(.condition)
-
-  # quos() not enquos(), for performance, since we only need to collect `...`
-  values <- quos(..., .ignore_empty = "all", .named = NULL)
-  names <- names2(values)
-  named <- names != ""
-
-  n_values <- length(values)
-  n_named <- sum(named)
-
-  if (n_values > 1L && n_values != n_named) {
-    unnamed <- !named
-    unnamed <- which(unnamed)
-    unnamed <- unnamed[[1L]]
-
-    message <- c(
-      "All `...` must be named when >1 inputs are supplied.",
-      i = glue("{n_values} inputs were supplied."),
-      i = glue("{n_named} inputs were named."),
-      i = glue("Input {unnamed} of `...` is not named.")
-    )
-
-    abort(message)
-  }
-
-  structure(
-    list(condition = .condition, values = values),
-    class = "funs_when"
-  )
-}
-
-is_funs_when <- function(x) {
-  inherits(x, "funs_when")
-}
-
-case <- function(...,
-                 .default = NULL,
-                 .ptype = NULL,
-                 .size = NULL) {
-  args <- list2(...)
-  args <- Filter(function(x) !is.null(x), args)
-  n_args <- length(args)
-
-  good <- vapply(args, is_funs_when, logical(1))
-  if (!all(good)) {
-    bad <- !good
-    bad <- which(bad)
-    bad <- bad[[1L]]
-
-    message <- c(
-      "All `...` inputs must be `when()` results.",
-      i = glue("Input {bad} is not a `when()` result.")
-    )
-
-    abort(message)
-  }
-
-  args_conditions <- vector("list", length = n_args)
-  args_values <- vector("list", length = n_args)
-
-  for (i in seq_len(n_args)) {
-    arg <- args[[i]]
-
-    condition <- arg$condition
-    values <- arg$values
-
-    condition <- eval_tidy(condition)
-    values <- lapply(values, eval_tidy)
-
-    if (length(values) == 1L && is.null(names(values))) {
-      # `when()` guaranteed that there is only 1 input in this case
-      values <- values[[1L]]
-      vec_assert(values)
-    } else {
-      size <- vec_size(condition)
-      list_check_all_vectors(values)
-      values <- vec_recycle_common(!!!values, .size = size)
-      values <- new_data_frame(values, n = size)
-    }
-
-    args_conditions[[i]] <- condition
-    args_values[[i]] <- values
-  }
-
-  args <- vec_interleave(args_conditions, args_values)
-
-  vec_case_when(!!!args, .default = .default, .ptype = .ptype, .size = .size)
-}
-
-revise2 <- function(.data, ...) {
+mutate_case <- function(.data, ...) {
   caller_env <- caller_env()
+  error_call <- caller_env
 
   args <- list2(...)
   args <- Filter(function(x) !is.null(x), args)
   n_args <- length(args)
 
-  good <- vapply(args, is_funs_when, logical(1))
+  good <- vapply(args, is_dplyr_when, logical(1))
   if (!all(good)) {
     bad <- !good
     bad <- which(bad)
@@ -132,12 +43,28 @@ revise2 <- function(.data, ...) {
     # Mark locations as used
     unused[loc] <- FALSE
 
-    # Evaluate current subset of `...` on the slice of `.data` we are updating
+    # Evaluate current element of `...` on the slice of `.data` we are updating
     updates <- dplyr_row_slice(.data, loc)
     updates <- mutate_cols(updates, dots = values, caller_env = caller_env)
 
-    out <- df_update(out, loc, updates)
+    out <- df_update(out, loc, updates, error_call = error_call)
   }
 
   out
+}
+
+when <- function(.condition, ...) {
+  condition <- enquo(.condition)
+
+  # quos() not enquos(), for performance, since we only need to collect `...`
+  values <- quos(..., .ignore_empty = "all", .named = NULL)
+
+  structure(
+    list(condition = condition, values = values),
+    class = "dplyr_when"
+  )
+}
+
+is_dplyr_when <- function(x) {
+  inherits(x, "dplyr_when")
 }

--- a/R/mutate-when.R
+++ b/R/mutate-when.R
@@ -26,6 +26,8 @@ mutate_when <- function(.data, ...) {
   size <- vec_size(.data)
   unused <- vec_rep(TRUE, size)
 
+  out <- .data
+
   for (i in seq_len(n_conditions)) {
     condition <- conditions[[i]]
     value <- values[[i]]
@@ -46,10 +48,10 @@ mutate_when <- function(.data, ...) {
     updates <- dplyr_row_slice(.data, loc)
     updates <- mutate_cols(updates, dots = value, caller_env = caller_env)
 
-    .data <- df_update(.data, loc, updates)
+    out <- df_update(out, loc, updates)
   }
 
-  .data
+  out
 }
 
 revise <- function(.data, .when, ...) {

--- a/R/mutate-when.R
+++ b/R/mutate-when.R
@@ -1,0 +1,87 @@
+mutate_when <- function(.data, ...) {
+  caller_env <- caller_env()
+
+  dots <- enquos(..., .ignore_empty = "trailing")
+
+  names <- names2(dots)
+  loc_conditions <- names == ""
+
+  if (length(loc_conditions) >= 1L && is_false(loc_conditions[[1L]])) {
+    # Required for the `cumsum()` below to work correctly
+    abort("The first `...` value must be an unnamed logical condition.")
+  }
+
+  conditions <- dots[loc_conditions]
+  n_conditions <- length(conditions)
+
+  # Isolate the values that go with each `condition`
+  loc <- seq_along(dots)
+  id <- cumsum(loc_conditions)
+
+  # First location of each group points to the condition itself,
+  # the rest are the "updates" that go with it
+  groups <- vec_split(loc, id)$val
+  values <- map(groups, function(group) dots[group[-1L]])
+
+  size <- vec_size(.data)
+  unused <- vec_rep(TRUE, size)
+
+  for (i in seq_len(n_conditions)) {
+    condition <- conditions[[i]]
+    value <- values[[i]]
+    value <- dplyr_quosures(!!!value)
+
+    # Evaluate `condition` on all of `.data`.
+    # This handles `NA`s for us, and converts them to `FALSE`.
+    condition <- filter_rows(.data, !!condition, caller_env = caller_env)
+
+    # Only update in locations we haven't updated before
+    loc <- unused & condition
+    loc <- vec_as_location(loc, n = size)
+
+    # Mark locations as used
+    unused[loc] <- FALSE
+
+    # Evaluate current subset of `...` on the slice of `.data` we are updating
+    updates <- dplyr_row_slice(.data, loc)
+    updates <- mutate_cols(updates, dots = value, caller_env = caller_env)
+
+    .data <- df_update(.data, loc, updates)
+  }
+
+  .data
+}
+
+# Take a data frame and update it at `loc` with `revisions`.
+# Similar in spirit to:
+# x[loc, names(revisions)] <- revisions
+# but built from first principles to only use `dplyr_col_modify()`.
+df_update <- function(x, loc, updates, error_call = caller_env()) {
+  if (any(map_lgl(updates, is.null))) {
+    abort("Can't delete columns when using `mutate_when()`.", call = error_call)
+  }
+
+  names <- names(updates)
+  exists <- names %in% names(x)
+
+  cols <- vector("list", length = length(updates))
+  cols <- set_names(cols, names)
+
+  # Avoid any subclass `[[` methods
+  old <- unclass(x)
+
+  for (i in seq_along(cols)) {
+    name <- names[[i]]
+    update <- updates[[i]]
+
+    if (exists[[i]]) {
+      col <- old[[name]]
+    } else {
+      col <- vec_init(update, n = vec_size(x))
+    }
+
+    cols[[i]] <- vec_assign(col, loc, update, x_arg = name)
+  }
+
+  dplyr_col_modify(x, cols)
+}

--- a/R/vec-case-when.R
+++ b/R/vec-case-when.R
@@ -1,0 +1,230 @@
+vec_case_when <- function(...,
+                          .default = NULL,
+                          .default_arg = ".default",
+                          .ptype = NULL,
+                          .size = NULL,
+                          .call = caller_env()) {
+  args <- list2(...)
+  args <- name_unnamed_args(args)
+
+  n_args <- length(args)
+
+  if (n_args == 0L) {
+    abort("`...` can't be empty.", call = .call)
+  }
+  if ((n_args %% 2) != 0L) {
+    message <- c(
+      "`...` must contain an even number of inputs.",
+      i = glue("{n_args} inputs were provided.")
+    )
+    abort(message, call = .call)
+  }
+
+  if (!is_string(.default_arg)) {
+    abort("`.default_arg` must be a string.", call = .call)
+  }
+
+  n_wheres <- n_args / 2L
+  loc_wheres <- seq.int(1L, n_args - 1L, by = 2)
+  wheres <- args[loc_wheres]
+  where_args <- names2(wheres)
+
+  for (i in seq_len(n_wheres)) {
+    where <- wheres[[i]]
+    where_arg <- where_args[[i]]
+
+    if (typeof(where) != "logical") {
+      vec_assert(
+        x = where,
+        ptype = logical(),
+        arg = where_arg,
+        call = .call
+      )
+    }
+  }
+
+  .size <- vec_size_common(
+    !!!wheres,
+    .size = .size,
+    .call = .call
+  )
+
+  n_values <- n_wheres
+  loc_values <- loc_wheres + 1L
+  values <- args[loc_values]
+  value_args <- names2(values)
+
+  # Allow `.default` to participate in common type determination.
+  # In terms of size/ptype behavior it is exactly like any other `values` element.
+  .ptype <- vec_ptype_common(
+    !!!values,
+    #"{.default_arg}" := .default,
+    .default,
+    .ptype = .ptype,
+    .call = .call
+  )
+
+  # Cast early to generate correct error message indices
+  values <- vec_cast_common(
+    !!!values,
+    .to = .ptype,
+    .call = .call
+  )
+
+  if (is.null(.default)) {
+    .default <- vec_init(.ptype)
+  } else {
+    .default <- vec_cast(
+      x = .default,
+      to = .ptype,
+      x_arg = .default_arg,
+      call = .call
+    )
+  }
+
+  # Check for correct sizes
+  for (i in seq_len(n_wheres)) {
+    where <- wheres[[i]]
+    where_arg <- where_args[[i]]
+
+    if (vec_size(where) != .size) {
+      vec_assert(where, size = .size, arg = where_arg, call = .call)
+    }
+  }
+
+  value_sizes <- list_sizes(values)
+
+  for (i in seq_len(n_values)) {
+    value_size <- value_sizes[[i]]
+
+    if (value_size != 1L && value_size != .size) {
+      value <- values[[i]]
+      value_arg <- value_args[[i]]
+
+      vec_assert(value, size = .size, arg = value_arg, call = .call)
+    }
+  }
+
+  default_size <- vec_size(.default)
+
+  if (default_size != 1L && default_size != .size) {
+    vec_assert(.default, size = .size, arg = .default_arg, call = .call)
+  }
+
+  n_used <- 0L
+  locs <- vector("list", n_values)
+
+  # Starts as unused. Any `TRUE` value in `where` flips it to used.
+  unused <- vec_rep(TRUE, times = .size)
+
+  # Track unhandled missings using boolean operations.
+  # If `FALSE`, any `NA` in `where` flips it to `NA`.
+  # Any `TRUE` in `where` overrides both `NA` and `FALSE` to `TRUE`.
+  missing <- vec_rep(FALSE, times = .size)
+
+  for (i in seq_len(n_wheres)) {
+    if (!any(unused)) {
+      break
+    }
+
+    where <- wheres[[i]]
+
+    loc <- unused & where
+    missing <- missing | where
+
+    loc <- which(loc)
+    locs[[i]] <- loc
+
+    unused[loc] <- FALSE
+    n_used <- n_used + 1L
+  }
+
+  if (n_used == n_wheres) {
+    # If all of the `where` conditions are used,
+    # then we check if we need `missing` or `.default`
+
+    missing <- vec_equal_na(missing)
+
+    if (any(missing)) {
+      missing <- which(missing)
+
+      n_used <- n_used + 1L
+      n_values <- n_values + 1L
+      locs[[n_values]] <- missing
+      values[[n_values]] <- vec_init(.ptype)
+      value_sizes[[n_values]] <- 1L
+
+      # Missing locations don't count as unused
+      unused[missing] <- FALSE
+    }
+
+    if (any(unused)) {
+      unused <- which(unused)
+
+      n_used <- n_used + 1L
+      n_values <- n_values + 1L
+      locs[[n_values]] <- unused
+      values[[n_values]] <- .default
+      value_sizes[[n_values]] <- default_size
+    }
+  }
+
+  for (i in seq_len(n_used)) {
+    loc <- locs[[i]]
+    value <- values[[i]]
+    value_size <- value_sizes[[i]]
+
+    if (value_size == 1L) {
+      # Recycle "up"
+      value <- vec_recycle(value, size = vec_size(loc))
+    } else {
+      # Slice "down"
+      value <- vec_slice(value, loc)
+    }
+
+    values[[i]] <- value
+  }
+
+  # Remove names used for error messages. We don't want them in the result.
+  values <- unname(values)
+
+  if (n_used != n_values) {
+    # Trim to only what will be used to fill the result
+    seq_used <- seq_len(n_used)
+    values <- values[seq_used]
+    locs <- locs[seq_used]
+  }
+
+  vec_unchop(
+    x = values,
+    indices = locs,
+    ptype = .ptype
+  )
+}
+
+name_unnamed_args <- function(args) {
+  names <- names2(args)
+  names <- name_unnamed(names)
+  names(args) <- names
+  args
+}
+
+name_unnamed <- function(names) {
+  if (is.null(names)) {
+    return(names)
+  }
+
+  unnamed <- names == ""
+
+  if (any(unnamed)) {
+    unnamed <- which(unnamed)
+    names[unnamed] <- vec_paste0("..", unnamed)
+  }
+
+  names
+}
+
+vec_paste0 <- function (...) {
+  args <- vec_recycle_common(...)
+  exec(paste0, !!!args)
+}

--- a/tests/testthat/_snaps/case.md
+++ b/tests/testthat/_snaps/case.md
@@ -1,51 +1,51 @@
-# `revise2()` - is type stable on input
+# `mutate_case()` - is type stable on input
 
     Code
-      revise2(df, when(x == 1L, x = "x"))
+      mutate_case(df, when(x == 1L, x = "x"))
     Condition
-      Error in `revise2()`:
+      Error in `mutate_case()`:
       ! Can't convert `x` <character> to <integer>.
 
-# `revise2()` - is size stable on input
+# `mutate_case()` - is size stable on input
 
     Code
-      revise2(df, when(x >= 2, x = 5:7))
+      mutate_case(df, when(x >= 2, x = 5:7))
     Condition
-      Error in `revise2()`:
+      Error in `mutate_case()`:
       ! Problem while computing `x = 5:7`.
       x `x` must be size 2 or 1, not 3.
 
 # conditions must be logical vectors
 
     Code
-      revise2(df, when(x + 1, x = x + 2))
+      mutate_case(df, when(x + 1, x = x + 2))
     Condition
-      Error in `revise2()`:
+      Error in `mutate_case()`:
       ! Problem while computing `..1 = x + 1`.
       x Input `..1` must be a logical vector, not a double.
 
 ---
 
     Code
-      revise2(df, when(x == 1, x = x + 2), when(x + 99, x = x + 2))
+      mutate_case(df, when(x == 1, x = x + 2), when(x + 99, x = x + 2))
     Condition
-      Error in `revise2()`:
+      Error in `mutate_case()`:
       ! Problem while computing `..1 = x + 99`.
       x Input `..1` must be a logical vector, not a double.
 
-# `revise2()` - enforce that columns can't be removed
+# `mutate_case()` - enforce that columns can't be removed
 
     Code
-      revise2(df, when(x > 5, y = NULL))
+      mutate_case(df, when(x > 5, y = NULL))
     Condition
-      Error in `revise2()`:
+      Error in `mutate_case()`:
       ! Can't delete columns.
 
 ---
 
     Code
-      revise2(df, when(x > 5, x = 1), when(y < 5, x = 2, y = NULL))
+      mutate_case(df, when(x > 5, x = 1), when(y < 5, x = 2, y = NULL))
     Condition
-      Error in `revise2()`:
+      Error in `mutate_case()`:
       ! Can't delete columns.
 

--- a/tests/testthat/_snaps/case.md
+++ b/tests/testthat/_snaps/case.md
@@ -1,0 +1,51 @@
+# `revise2()` - is type stable on input
+
+    Code
+      revise2(df, when(x == 1L, x = "x"))
+    Condition
+      Error in `revise2()`:
+      ! Can't convert `x` <character> to <integer>.
+
+# `revise2()` - is size stable on input
+
+    Code
+      revise2(df, when(x >= 2, x = 5:7))
+    Condition
+      Error in `revise2()`:
+      ! Problem while computing `x = 5:7`.
+      x `x` must be size 2 or 1, not 3.
+
+# conditions must be logical vectors
+
+    Code
+      revise2(df, when(x + 1, x = x + 2))
+    Condition
+      Error in `revise2()`:
+      ! Problem while computing `..1 = x + 1`.
+      x Input `..1` must be a logical vector, not a double.
+
+---
+
+    Code
+      revise2(df, when(x == 1, x = x + 2), when(x + 99, x = x + 2))
+    Condition
+      Error in `revise2()`:
+      ! Problem while computing `..1 = x + 99`.
+      x Input `..1` must be a logical vector, not a double.
+
+# `revise2()` - enforce that columns can't be removed
+
+    Code
+      revise2(df, when(x > 5, y = NULL))
+    Condition
+      Error in `revise2()`:
+      ! Can't delete columns.
+
+---
+
+    Code
+      revise2(df, when(x > 5, x = 1), when(y < 5, x = 2, y = NULL))
+    Condition
+      Error in `revise2()`:
+      ! Can't delete columns.
+

--- a/tests/testthat/_snaps/mutate-when.md
+++ b/tests/testthat/_snaps/mutate-when.md
@@ -1,10 +1,19 @@
-# is type stable on input
+# `mutate_when()` - is type stable on input
 
     Code
       mutate_when(df, x == 1L, x = "x")
     Condition
-      Error in `vec_assign()`:
-      ! Can't convert <character> to match type of `x` <integer>.
+      Error in `mutate_when()`:
+      ! Can't convert `x` <character> to <integer>.
+
+# `mutate_when()` - is size stable on input
+
+    Code
+      mutate_when(df, x >= 2, x = 5:7)
+    Condition
+      Error in `mutate_when()`:
+      ! Problem while computing `x = 5:7`.
+      x `x` must be size 2 or 1, not 3.
 
 # conditions must be logical vectors
 
@@ -24,13 +33,13 @@
       ! Problem while computing `..1 = x + 99`.
       x Input `..1` must be a logical vector, not a double.
 
-# enforce that columns can't be removed
+# `mutate_when()` - enforce that columns can't be removed
 
     Code
       mutate_when(df, x > 5, y = NULL)
     Condition
       Error in `mutate_when()`:
-      ! Can't delete columns when using `mutate_when()`.
+      ! Can't delete columns.
 
 ---
 
@@ -38,7 +47,7 @@
       mutate_when(df, x > 5, x = 1, y < 5, x = 2, y = NULL)
     Condition
       Error in `mutate_when()`:
-      ! Can't delete columns when using `mutate_when()`.
+      ! Can't delete columns.
 
 # `...` must start with an unnamed input
 
@@ -47,4 +56,46 @@
     Condition
       Error in `mutate_when()`:
       ! The first `...` value must be an unnamed logical condition.
+
+# `revise()` - is type stable on input
+
+    Code
+      revise(df, x == 1L, x = "x")
+    Condition
+      Error:
+      ! Can't convert `x` <character> to <integer>.
+
+# `revise()` - is size stable on input
+
+    Code
+      revise(df, x >= 2, x = 5:7)
+    Condition
+      Error:
+      ! Problem while computing `x = 5:7`.
+      x `x` must be size 2 or 1, not 3.
+
+# `.when` must be a logical vector
+
+    Code
+      revise(df, x + 1, x = x + 2)
+    Condition
+      Error in `revise()`:
+      ! Problem while computing `..1 = x + 1`.
+      x Input `..1` must be a logical vector, not a double.
+
+# `revise()` - enforce that columns can't be removed
+
+    Code
+      revise(df, x > 5, y = NULL)
+    Condition
+      Error:
+      ! Can't delete columns.
+
+---
+
+    Code
+      revise(df, x > 5, x = 1, y = NULL)
+    Condition
+      Error:
+      ! Can't delete columns.
 

--- a/tests/testthat/_snaps/mutate-when.md
+++ b/tests/testthat/_snaps/mutate-when.md
@@ -1,0 +1,50 @@
+# is type stable on input
+
+    Code
+      mutate_when(df, x == 1L, x = "x")
+    Condition
+      Error in `vec_assign()`:
+      ! Can't convert <character> to match type of `x` <integer>.
+
+# conditions must be logical vectors
+
+    Code
+      mutate_when(df, x + 1, x = x + 2)
+    Condition
+      Error in `mutate_when()`:
+      ! Problem while computing `..1 = x + 1`.
+      x Input `..1` must be a logical vector, not a double.
+
+---
+
+    Code
+      mutate_when(df, x == 1, x = x + 2, x + 99, x = x + 2)
+    Condition
+      Error in `mutate_when()`:
+      ! Problem while computing `..1 = x + 99`.
+      x Input `..1` must be a logical vector, not a double.
+
+# enforce that columns can't be removed
+
+    Code
+      mutate_when(df, x > 5, y = NULL)
+    Condition
+      Error in `mutate_when()`:
+      ! Can't delete columns when using `mutate_when()`.
+
+---
+
+    Code
+      mutate_when(df, x > 5, x = 1, y < 5, x = 2, y = NULL)
+    Condition
+      Error in `mutate_when()`:
+      ! Can't delete columns when using `mutate_when()`.
+
+# `...` must start with an unnamed input
+
+    Code
+      mutate_when(df, x = x)
+    Condition
+      Error in `mutate_when()`:
+      ! The first `...` value must be an unnamed logical condition.
+

--- a/tests/testthat/test-case.R
+++ b/tests/testthat/test-case.R
@@ -1,0 +1,234 @@
+# ------------------------------------------------------------------------------
+
+test_that("can be used to update a column based on condition in another column", {
+  df <- tibble(x = c(1, NA, NA), y = c(2, 3, 4))
+
+  expect_identical(
+    revise2(df, when(is.na(x), y = NA)),
+    tibble(x = c(1, NA, NA), y = c(2, NA, NA))
+  )
+})
+
+test_that("can be used to update multiple named columns", {
+  df <- tibble(x = c(1, NA, NA), y = c(2, 3, 4))
+
+  expect_identical(
+    revise2(df, when(is.na(x), y = 6, x = 5)),
+    tibble(x = c(1, 5, 5), y = c(2, 6, 6))
+  )
+})
+
+test_that("`n()` is evaluated on the slice of data", {
+  df <- tibble(x = c(1, NA, NA))
+
+  expect_identical(
+    revise2(df, when(is.na(x), y = seq_len(n()))),
+    tibble(x = c(1, NA, NA), y = c(NA, 1L, 2L))
+  )
+})
+
+test_that("expressions are evaluated only on the slice of `.data` where the condition is true", {
+  df <- tibble(x = c(1, 2, NA))
+
+  expect_identical(
+    revise2(df, when(!is.na(x), y = mean(x))),
+    tibble(x = c(1, 2, NA), y = c(1.5, 1.5, NA))
+  )
+})
+
+test_that("can technically insert a constant that happens to be the right size", {
+  # This is a side effect of evaluating `...` only on a slice of `.data`.
+  # It isn't ideal, but there is no way to stop it, and we really do want
+  # to evaluate `...` on the slice in most other cases.
+  df <- tibble(x = c(1, 2, NA, NA, NA))
+
+  out <- revise2(df, when(is.na(x), x = c(5, 6, 7)))
+
+  expect_identical(out$x, c(1, 2, 5, 6, 7))
+})
+
+test_that("conditions are computed within groups", {
+  df <- tibble(
+    g = c(1, 1, 1, 2, 2, 2),
+    x = 1:6
+  )
+  gdf <- group_by(df, g)
+
+  out <- revise2(gdf, when(x > mean(x), y = 1))
+
+  expect_identical(out$y, c(NA, NA, 1, NA, NA, 1))
+})
+
+test_that("`...` are computed within groups", {
+  df <- tibble(
+    g = c(1, 1, 1, 2, 2, 2),
+    x = c(1, NA, 3, 1, NA, NA)
+  )
+  gdf <- group_by(df, g)
+
+  out <- revise2(gdf, when(is.na(x), x = length(x), y = n()))
+
+  expect_identical(out$x, c(1, 1, 3, 1, 2, 2))
+  expect_identical(out$y, c(NA, 1L, NA, NA, 2L, 2L))
+})
+
+test_that("can use `cur_data_*()`", {
+  df <- tibble(
+    g = c(1, 1, 1, 2, 2, 2),
+    x = c(1, NA, 3, 1, NA, NA),
+    y = 1:6
+  )
+  gdf <- group_by(df, g)
+
+  out <- revise2(gdf, when(is.na(x), z = cur_data()))
+  expect_identical(out$z, df[c(NA, 2, NA, NA, 5, 6), c("x", "y")])
+
+  out <- revise2(gdf, when(is.na(x), z = cur_data_all()))
+  expect_identical(out$z, df[c(NA, 2, NA, NA, 5, 6), c("g", "x", "y")])
+})
+
+test_that("can use `cur_group_*()", {
+  df <- tibble(
+    g = c(1, 1, 1, 3, 3, 3),
+    x = c(1, NA, 3, 1, NA, NA),
+    y = 1:6
+  )
+  gdf <- group_by(df, g)
+
+  out <- revise2(gdf, when(is.na(x), z = cur_group()))
+  expect_identical(out$z, tibble(g = c(NA, 1, NA, NA, 3, 3)))
+
+  out <- revise2(gdf, when(is.na(x), z = cur_group_id()))
+  expect_identical(out$z, c(NA, 1L, NA, NA, 2L, 2L))
+
+  out <- revise2(gdf, when(is.na(x), z = cur_group_rows()))
+  expect_identical(out$z, c(NA, 1L, NA, NA, 2L, 3L))
+})
+
+test_that("works with `across()`", {
+  df <- tibble(x = 1:3, y = 4:6)
+
+  out <- revise2(df, when(x > 1, across(x:y, sum)))
+
+  expect_identical(out$x, c(1L, 5L, 5L))
+  expect_identical(out$y, c(4L, 11L, 11L))
+})
+
+test_that("works with unnamed data frames", {
+  df <- tibble(x = 1:3, y = 4:6)
+
+  out <- revise2(df, when(x > 1, tibble(y = 99, z = 0L)))
+
+  expect_identical(out$y, c(4L, 99L, 99L))
+  expect_identical(out$z, c(NA, 0L, 0L))
+})
+
+test_that("first `TRUE` value overrides any conditions that come after it", {
+  df <- tibble(x = c(1, 2, 3))
+
+  out <- revise2(
+    df,
+    when(x <= 2, y = 4),
+    when(x <= 3, z = 5)
+  )
+
+  expect_identical(out$y, c(4, 4, NA))
+  expect_identical(out$z, c(NA, NA, 5))
+})
+
+test_that("`NA` values in logical condition are treated as `FALSE`", {
+  df <- tibble(x = c(1, NA, 2))
+
+  out <- revise2(df, when(x > 1, y = 2, x = 0))
+
+  expect_identical(out$x, c(1, NA, 0))
+  expect_identical(out$y, c(NA, NA, 2))
+})
+
+test_that("value dots are vectorized and sliced appropriately", {
+  df <- tibble(x = c(1, 2, 3), y = c(2, 3, 4))
+
+  out <- revise2(df, when(x >= 2, x = x + y))
+
+  expect_identical(out$x, c(1, 5, 7))
+})
+
+test_that("all conditions are evaluated on original data", {
+  df <- tibble(x = 1)
+
+  stop_on_negative_x <- function(x) {
+    if (any(x < 0)) {
+      abort(class = "negative_x")
+    } else {
+      rep_along(x, TRUE)
+    }
+  }
+
+  expect_identical(
+    revise2(
+      df,
+      when(x == 1, x = -1),
+      when(stop_on_negative_x(x), x = 3)
+    ),
+    tibble(x = -1)
+  )
+})
+
+test_that("works with condition but no values", {
+  df <- tibble(x = 1:5)
+  expect_identical(revise2(df, when(x > 3)), df)
+})
+
+test_that("works with no `...`", {
+  df <- tibble(x = 1, y = 2)
+  expect_identical(revise2(df), df)
+})
+
+test_that("`revise2()` - is type stable on input", {
+  df <- tibble(x = 1L)
+
+  expect_identical(
+    revise2(df, when(x == 1L, x = 2)),
+    tibble(x = 2L)
+  )
+
+  expect_snapshot(error = TRUE, {
+    revise2(df, when(x == 1L, x = "x"))
+  })
+})
+
+test_that("`revise2()` - is size stable on input", {
+  df <- tibble(x = 1:3)
+
+  expect_snapshot(error = TRUE, {
+    revise2(df, when(x >= 2, x = 5:7))
+  })
+})
+
+test_that("conditions must be logical vectors", {
+  df <- tibble(x = c(1, 2))
+
+  expect_snapshot(error = TRUE, {
+    revise2(df, when(x + 1, x = x + 2))
+  })
+
+  # TODO: Suboptimal indexing.
+  expect_snapshot(error = TRUE, {
+    revise2(
+      df,
+      when(x == 1, x = x + 2),
+      when(x + 99, x = x + 2)
+    )
+  })
+})
+
+test_that("`revise2()` - enforce that columns can't be removed", {
+  df <- tibble(x = c(1, 2), y = c(3, 4))
+
+  expect_snapshot(error = TRUE, {
+    revise2(df, when(x > 5, y = NULL))
+  })
+  expect_snapshot(error = TRUE, {
+    revise2(df, when(x > 5, x = 1), when(y < 5, x = 2, y = NULL))
+  })
+})

--- a/tests/testthat/test-mutate-when.R
+++ b/tests/testthat/test-mutate-when.R
@@ -74,13 +74,21 @@ test_that("condition can be directly followed by another condition", {
 test_that("all conditions are evaluated on original data", {
   df <- tibble(x = 1)
 
+  stop_on_negative_x <- function(x) {
+    if (any(x < 0)) {
+      abort(class = "negative_x")
+    } else {
+      rep_along(x, TRUE)
+    }
+  }
+
   expect_identical(
     mutate_when(
       df,
-      x == 1, x = 2,
-      x == 2, x = 3
+      x == 1, x = -1,
+      stop_on_negative_x(x), x = 3
     ),
-    tibble(x = 2)
+    tibble(x = -1)
   )
 })
 

--- a/tests/testthat/test-mutate-when.R
+++ b/tests/testthat/test-mutate-when.R
@@ -1,0 +1,145 @@
+test_that("can be used to update a column based on condition in another column", {
+  df <- tibble(x = c(1, NA, NA), y = c(2, 3, 4))
+
+  expect_identical(
+    mutate_when(df, is.na(x), y = NA),
+    tibble(x = c(1, NA, NA), y = c(2, NA, NA))
+  )
+})
+
+test_that("can be used to update multiple named columns", {
+  df <- tibble(x = c(1, NA, NA), y = c(2, 3, 4))
+
+  expect_identical(
+    mutate_when(df, is.na(x), y = 6, x = 5),
+    tibble(x = c(1, 5, 5), y = c(2, 6, 6))
+  )
+})
+
+test_that("first `TRUE` value overrides any conditions that come after it", {
+  df <- tibble(x = c(1, 2, 3))
+
+  out <- mutate_when(
+    df,
+    x <= 2, y = 4,
+    x <= 3, z = 5
+  )
+
+  expect_identical(out$y, c(4, 4, NA))
+  expect_identical(out$z, c(NA, NA, 5))
+})
+
+test_that("`NA` values in logical condition are treated as `FALSE`", {
+  df <- tibble(x = c(1, NA, 2))
+
+  out <- mutate_when(df, x > 1, y = 2, x = 0)
+
+  expect_identical(out$x, c(1, NA, 0))
+  expect_identical(out$y, c(NA, NA, 2))
+})
+
+test_that("value dots are vectorized and sliced appropriately", {
+  df <- tibble(x = c(1, 2, 3), y = c(2, 3, 4))
+
+  out <- mutate_when(df, x >= 2, x = x + y)
+
+  expect_identical(out$x, c(1, 5, 7))
+})
+
+test_that("updates are evaluated only on the slice of `.data` where the condition is true", {
+  df <- tibble(x = c(1, 2, NA))
+
+  expect_identical(
+    mutate_when(df, !is.na(x), y = mean(x)),
+    tibble(x = c(1, 2, NA), y = c(1.5, 1.5, NA))
+  )
+})
+
+test_that("condition can be directly followed by another condition", {
+  df <- tibble(x = c(1, 2))
+
+  expect_identical(
+    mutate_when(
+      df,
+      x == 1,
+      x < 3, y = 1
+    ),
+    tibble(x = c(1, 2), y = c(NA, 1))
+  )
+})
+
+test_that("all conditions are evaluated on original data", {
+  df <- tibble(x = 1)
+
+  expect_identical(
+    mutate_when(
+      df,
+      x == 1, x = 2,
+      x == 2, x = 3
+    ),
+    tibble(x = 2)
+  )
+})
+
+test_that("works with no `...`", {
+  df <- tibble(x = 1, y = 2)
+  expect_identical(mutate_when(df), df)
+})
+
+test_that("is type stable on input", {
+  df <- tibble(x = 1L)
+
+  expect_identical(
+    mutate_when(df, x == 1L, x = 2),
+    tibble(x = 2L)
+  )
+
+  expect_snapshot(error = TRUE, {
+    mutate_when(df, x == 1L, x = "x")
+  })
+})
+
+test_that("is size stable on input", {
+  skip("Haven't figured this out yet")
+
+  df <- tibble(x = 1:3)
+
+  # TODO: This should probably fail? Maybe there is no way to do that.
+  mutate_when(df, x >= 2, x = 5:6)
+})
+
+test_that("conditions must be logical vectors", {
+  df <- tibble(x = c(1, 2))
+
+  expect_snapshot(error = TRUE, {
+    mutate_when(df, x + 1, x = x + 2)
+  })
+
+  # TODO: Suboptimal indexing. Should say `..3`
+  expect_snapshot(error = TRUE, {
+    mutate_when(
+      df,
+      x == 1, x = x + 2,
+      x + 99, x = x + 2
+    )
+  })
+})
+
+test_that("enforce that columns can't be removed", {
+  df <- tibble(x = c(1, 2), y = c(3, 4))
+
+  expect_snapshot(error = TRUE, {
+    mutate_when(df, x > 5, y = NULL)
+  })
+  expect_snapshot(error = TRUE, {
+    mutate_when(df, x > 5, x = 1, y < 5, x = 2, y = NULL)
+  })
+})
+
+test_that("`...` must start with an unnamed input", {
+  df <- tibble(x = 1)
+
+  expect_snapshot(error = TRUE, {
+    mutate_when(df, x = x)
+  })
+})

--- a/tests/testthat/test-mutate-when.R
+++ b/tests/testthat/test-mutate-when.R
@@ -1,3 +1,6 @@
+# ------------------------------------------------------------------------------
+# mutate_when()
+
 test_that("can be used to update a column based on condition in another column", {
   df <- tibble(x = c(1, NA, NA), y = c(2, 3, 4))
 
@@ -86,7 +89,7 @@ test_that("works with no `...`", {
   expect_identical(mutate_when(df), df)
 })
 
-test_that("is type stable on input", {
+test_that("`mutate_when()` - is type stable on input", {
   df <- tibble(x = 1L)
 
   expect_identical(
@@ -99,13 +102,12 @@ test_that("is type stable on input", {
   })
 })
 
-test_that("is size stable on input", {
-  skip("Haven't figured this out yet")
-
+test_that("`mutate_when()` - is size stable on input", {
   df <- tibble(x = 1:3)
 
-  # TODO: This should probably fail? Maybe there is no way to do that.
-  mutate_when(df, x >= 2, x = 5:6)
+  expect_snapshot(error = TRUE, {
+    mutate_when(df, x >= 2, x = 5:7)
+  })
 })
 
 test_that("conditions must be logical vectors", {
@@ -125,7 +127,7 @@ test_that("conditions must be logical vectors", {
   })
 })
 
-test_that("enforce that columns can't be removed", {
+test_that("`mutate_when()` - enforce that columns can't be removed", {
   df <- tibble(x = c(1, 2), y = c(3, 4))
 
   expect_snapshot(error = TRUE, {
@@ -142,4 +144,197 @@ test_that("`...` must start with an unnamed input", {
   expect_snapshot(error = TRUE, {
     mutate_when(df, x = x)
   })
+})
+
+# ------------------------------------------------------------------------------
+# revise()
+
+test_that("can be used to update a column based on condition in another column", {
+  df <- tibble(x = c(1, NA, NA), y = c(2, 3, 4))
+
+  expect_identical(
+    revise(df, is.na(x), y = NA),
+    tibble(x = c(1, NA, NA), y = c(2, NA, NA))
+  )
+})
+
+test_that("can be used to update multiple named columns", {
+  df <- tibble(x = c(1, NA, NA), y = c(2, 3, 4))
+
+  expect_identical(
+    mutate_when(df, is.na(x), y = 6, x = 5),
+    tibble(x = c(1, 5, 5), y = c(2, 6, 6))
+  )
+})
+
+test_that("`n()` is evaluated on the slice of data", {
+  df <- tibble(x = c(1, NA, NA))
+
+  expect_identical(
+    revise(df, is.na(x), y = seq_len(n())),
+    tibble(x = c(1, NA, NA), y = c(NA, 1L, 2L))
+  )
+})
+
+test_that("expressions are evaluated only on the slice of `.data` where the condition is true", {
+  df <- tibble(x = c(1, 2, NA))
+
+  expect_identical(
+    revise(df, !is.na(x), y = mean(x)),
+    tibble(x = c(1, 2, NA), y = c(1.5, 1.5, NA))
+  )
+})
+
+test_that("can technically insert a constant that happens to be the right size", {
+  # This is a side effect of evaluating `...` only on a slice of `.data`.
+  # It isn't ideal, but there is no way to stop it, and we really do want
+  # to evaluate `...` on the slice in most other cases.
+  df <- tibble(x = c(1, 2, NA, NA, NA))
+
+  out <- revise(df, is.na(x), x = c(5, 6, 7))
+
+  expect_identical(out$x, c(1, 2, 5, 6, 7))
+})
+
+test_that("`.when` is computed within groups", {
+  df <- tibble(
+    g = c(1, 1, 1, 2, 2, 2),
+    x = 1:6
+  )
+  gdf <- group_by(df, g)
+
+  out <- revise(gdf, x > mean(x), y = 1)
+
+  expect_identical(out$y, c(NA, NA, 1, NA, NA, 1))
+})
+
+test_that("`...` are computed within groups", {
+  df <- tibble(
+    g = c(1, 1, 1, 2, 2, 2),
+    x = c(1, NA, 3, 1, NA, NA)
+  )
+  gdf <- group_by(df, g)
+
+  out <- revise(gdf, is.na(x), x = length(x), y = n())
+
+  expect_identical(out$x, c(1, 1, 3, 1, 2, 2))
+  expect_identical(out$y, c(NA, 1L, NA, NA, 2L, 2L))
+})
+
+test_that("can use `cur_data_*()`", {
+  df <- tibble(
+    g = c(1, 1, 1, 2, 2, 2),
+    x = c(1, NA, 3, 1, NA, NA),
+    y = 1:6
+  )
+  gdf <- group_by(df, g)
+
+  out <- revise(gdf, is.na(x), z = cur_data())
+  expect_identical(out$z, df[c(NA, 2, NA, NA, 5, 6), c("x", "y")])
+
+  out <- revise(gdf, is.na(x), z = cur_data_all())
+  expect_identical(out$z, df[c(NA, 2, NA, NA, 5, 6), c("g", "x", "y")])
+})
+
+test_that("can use `cur_group_*()", {
+  df <- tibble(
+    g = c(1, 1, 1, 3, 3, 3),
+    x = c(1, NA, 3, 1, NA, NA),
+    y = 1:6
+  )
+  gdf <- group_by(df, g)
+
+  out <- revise(gdf, is.na(x), z = cur_group())
+  expect_identical(out$z, tibble(g = c(NA, 1, NA, NA, 3, 3)))
+
+  out <- revise(gdf, is.na(x), z = cur_group_id())
+  expect_identical(out$z, c(NA, 1L, NA, NA, 2L, 2L))
+
+  out <- revise(gdf, is.na(x), z = cur_group_rows())
+  expect_identical(out$z, c(NA, 1L, NA, NA, 2L, 3L))
+})
+
+test_that("`NA` values in logical condition are treated as `FALSE`", {
+  df <- tibble(x = c(1, NA, 2))
+
+  out <- revise(df, x > 1, y = 2, x = 0)
+
+  expect_identical(out$x, c(1, NA, 0))
+  expect_identical(out$y, c(NA, NA, 2))
+})
+
+test_that("value dots are vectorized and sliced appropriately", {
+  df <- tibble(x = c(1, 2, 3), y = c(2, 3, 4))
+
+  out <- revise(df, x >= 2, x = x + y)
+
+  expect_identical(out$x, c(1, 5, 7))
+})
+
+test_that("works with no `...`", {
+  df <- tibble(x = 1, y = 2)
+  expect_identical(revise(df, x >= 1), df)
+})
+
+test_that("`revise()` - is type stable on input", {
+  df <- tibble(x = 1L)
+
+  expect_identical(
+    revise(df, x == 1L, x = 2),
+    tibble(x = 2L)
+  )
+
+  expect_snapshot(error = TRUE, {
+    revise(df, x == 1L, x = "x")
+  })
+})
+
+test_that("`revise()` - is size stable on input", {
+  df <- tibble(x = 1:3)
+
+  expect_snapshot(error = TRUE, {
+    revise(df, x >= 2, x = 5:7)
+  })
+})
+
+test_that("works with `across()`", {
+  df <- tibble(x = 1:3, y = 4:6)
+
+  out <- revise(df, x > 1, across(x:y, sum))
+
+  expect_identical(out$x, c(1L, 5L, 5L))
+  expect_identical(out$y, c(4L, 11L, 11L))
+})
+
+test_that("works with unnamed data frames", {
+  df <- tibble(x = 1:3, y = 4:6)
+
+  out <- revise(df, x > 1, tibble(y = 99, z = 0L))
+
+  expect_identical(out$y, c(4L, 99L, 99L))
+  expect_identical(out$z, c(NA, 0L, 0L))
+})
+
+test_that("`.when` must be a logical vector", {
+  df <- tibble(x = c(1, 2))
+
+  expect_snapshot(error = TRUE, {
+    revise(df, x + 1, x = x + 2)
+  })
+})
+
+test_that("`revise()` - enforce that columns can't be removed", {
+  df <- tibble(x = c(1, 2), y = c(3, 4))
+
+  expect_snapshot(error = TRUE, {
+    revise(df, x > 5, y = NULL)
+  })
+  expect_snapshot(error = TRUE, {
+    revise(df, x > 5, x = 1, y = NULL)
+  })
+})
+
+test_that("unnamed `NULL`s are compacted", {
+  df <- tibble(x = 1)
+  expect_identical(revise(df, x >= 1, NULL), df)
 })


### PR DESCRIPTION
Unexported for now, so `load_all()` to try them.

---

Some examples:

`mutate_when()` and `revise()` give the same results for simple cases:

``` r
devtools::load_all()
#> ℹ Loading dplyr

# https://stackoverflow.com/questions/34096162/dplyr-mutate-replace-several-columns-on-a-subset-of-rows/34096575#34096575
set.seed(2)

df <- tibble(
  measure = sample(c('cfl', 'led', 'linear', 'exit'), 50, replace=T),
  qty = round(runif(50) * 30),
  qty.exit = 0,
  delta.watts = sample(10.5:100.5, 50, replace=T),
  cf = runif(50)
)

revise(df, measure == "exit", qty.exit = qty, cf = 0, delta.watts = 13)
#> # A tibble: 50 × 5
#>    measure   qty qty.exit delta.watts     cf
#>    <chr>   <dbl>    <dbl>       <dbl>  <dbl>
#>  1 cfl         0        0        18.5 0.0850
#>  2 linear      0        0        62.5 0.975 
#>  3 led        21        0        24.5 0.0136
#>  4 led        28        0        45.5 0.539 
#>  5 exit        8        8        13   0     
#>  6 exit       24       24        13   0     
#>  7 cfl        24        0        89.5 0.257 
#>  8 cfl        30        0        30.5 0.895 
#>  9 cfl        18        0        20.5 0.388 
#> 10 exit       21       21        13   0     
#> # … with 40 more rows

mutate_when(df, measure == "exit", qty.exit = qty, cf = 0, delta.watts = 13)
#> # A tibble: 50 × 5
#>    measure   qty qty.exit delta.watts     cf
#>    <chr>   <dbl>    <dbl>       <dbl>  <dbl>
#>  1 cfl         0        0        18.5 0.0850
#>  2 linear      0        0        62.5 0.975 
#>  3 led        21        0        24.5 0.0136
#>  4 led        28        0        45.5 0.539 
#>  5 exit        8        8        13   0     
#>  6 exit       24       24        13   0     
#>  7 cfl        24        0        89.5 0.257 
#>  8 cfl        30        0        30.5 0.895 
#>  9 cfl        18        0        20.5 0.388 
#> 10 exit       21       21        13   0     
#> # … with 40 more rows
```

`mutate_when()` can't work with `across()`, because it treats unnamed inputs as the conditions and named inputs as the values

``` r
devtools::load_all()
#> ℹ Loading dplyr

df <- tibble(x = 1:3, y = 4:6)

revise(df, x > 1, across(x:y, sum))
#> # A tibble: 3 × 2
#>       x     y
#>   <int> <int>
#> 1     1     4
#> 2     5    11
#> 3     5    11

# Doesn't work because `across()` isn't named
try(mutate_when(df, x > 1, across(x:y, sum)))
#> Error in mutate_when(df, x > 1, across(x:y, sum)) : 
#>   Problem while computing `..1 = across(x:y, sum)`.
#> ✖ Input `..1$x` must be a logical vector, not a integer.
```

Repeated calls to `revise()` are not the same thing as `mutate_when()`, but most of the time I think you should use `case_when()` for this anyways. Generally this involves creating a new column, and `revise()` is _mainly_ for modifying existing columns.

``` r
devtools::load_all()
#> ℹ Loading dplyr

df <- tibble(x = 1:5)

# Not the same as a case-when because conditions aren't evaluated
# in the same sequential manner
df %>%
  revise(x <= 2, y = 3) %>%
  revise(x <= 4, y = 5)
#> # A tibble: 5 × 2
#>       x     y
#>   <int> <dbl>
#> 1     1     5
#> 2     2     5
#> 3     3     5
#> 4     4     5
#> 5     5    NA

df %>%
  mutate_when(
    x <= 2, y = 3,
    x <= 4, y = 5
  )
#> # A tibble: 5 × 2
#>       x     y
#>   <int> <dbl>
#> 1     1     3
#> 2     2     3
#> 3     3     5
#> 4     4     5
#> 5     5    NA

# But I'd argue you should just use `case_when()` here.
# i.e. this isn't what `revise()` is for in my mind.
df %>%
  mutate(
    y = case_when(
      x <= 2 ~ 3,
      x <= 4 ~ 5
    )
  )
#> # A tibble: 5 × 2
#>       x     y
#>   <int> <dbl>
#> 1     1     3
#> 2     2     3
#> 3     3     5
#> 4     4     5
#> 5     5    NA
```