### PR TITLE
[vignettes/base.Rmd] Fix function arguments order

### DIFF
--- a/vignettes/base.Rmd
+++ b/vignettes/base.Rmd
@@ -54,7 +54,7 @@ The following table shows a condensed translation between dplyr verbs and their 
 | `rename(df, y = x)`            | `names(df)[names(df) == "x"] <- "y"`             | 
 | `relocate(df, y)`              | `df[union("y", names(df))]`                      | 
 | `select(df, x, y)`             | `df[c("x", "y")]`, `subset()`                    | 
-| `select(df, starts_with("x"))` | `df[grepl(names(df), "^x")]`                     | 
+| `select(df, starts_with("x"))` | `df[grepl("^x", names(df))]`                     | 
 | `summarise(df, mean(x))`       | `mean(df$x)`, `tapply()`, `aggregate()`, `by()`  | 
 | `slice(df, c(1, 2, 5))`        | `df[c(1, 2, 5), , drop = FALSE]`                 | 
 


### PR DESCRIPTION
When comparing to `select(df, starts_with("x"))`, the grepl function had inverted arguments.