### PR TITLE
Update VignetteIndexEntry for colwise vignette

### DIFF
--- a/vignettes/colwise.Rmd
+++ b/vignettes/colwise.Rmd
@@ -5,7 +5,7 @@ description: >
   columns using `across()`.
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{colwise}
+  %\VignetteIndexEntry{Column-wise operations}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---

--- a/vignettes/rowwise.Rmd
+++ b/vignettes/rowwise.Rmd
@@ -7,7 +7,7 @@ description: >
   and see how you might perform simulations and modelling within dplyr verbs.
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{rowwise}
+  %\VignetteIndexEntry{Row-wise operations}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---


### PR DESCRIPTION
Related to https://github.com/rstudio/rstudio/issues/11273#issuecomment-1150341589

So that `vignette()` gets more interesting data than: 

```r
> v <- vignette("colwise", "dplyr")
> str(v)
List of 7
 $ Package: chr "dplyr"
 $ Dir    : chr "/Users/romainfrancois/.R/library/4.2/dplyr"
 $ Topic  : chr "colwise"
 $ File   : chr "colwise.Rmd"
 $ Title  : chr "colwise"
 $ R      : chr "colwise.R"
 $ PDF    : chr "colwise.html"
 - attr(*, "class")= chr "vignette"
```

In https://github.com/rstudio/rstudio/issues/11273 the vignette title is picked up and displayed in the popup: 

<img width="625" alt="image" src="https://user-images.githubusercontent.com/2625526/172791104-cedf0bc6-5ea7-4799-baba-670924c9e53a.png">
