### PR TITLE
Error if a column is provided twice in `...` of `relocate`

### DIFF
--- a/R/relocate.R
+++ b/R/relocate.R
@@ -52,6 +52,10 @@ relocate <- function(.data, ..., .before = NULL, .after = NULL) {
 #' @export
 relocate.data.frame <- function(.data, ..., .before = NULL, .after = NULL) {
   to_move <- tidyselect::eval_select(expr(c(...)), .data)
+  if (anyDuplicated(to_move)) {
+    duplicated_col <- names(.data)[which.max(duplicated(to_move))]
+    abort(glue("Columns to move must be unique, but `{duplicated_col}` is supplied twice"))
+  }
 
   .before <- enquo(.before)
   .after <- enquo(.after)
@@ -80,7 +84,7 @@ relocate.data.frame <- function(.data, ..., .before = NULL, .after = NULL) {
   lhs <- setdiff(seq2(1, where - 1), to_move)
   rhs <- setdiff(seq2(where + 1, ncol(.data)), to_move)
 
-  pos <- vec_unique(c(lhs, to_move, rhs))
+  pos <- c(lhs, to_move, rhs)
   out <- .data[pos]
   new_names <- names(pos)
 

--- a/R/relocate.R
+++ b/R/relocate.R
@@ -52,9 +52,10 @@ relocate <- function(.data, ..., .before = NULL, .after = NULL) {
 #' @export
 relocate.data.frame <- function(.data, ..., .before = NULL, .after = NULL) {
   to_move <- tidyselect::eval_select(expr(c(...)), .data)
-  if (anyDuplicated(to_move)) {
-    duplicated_col <- names(.data)[which.max(duplicated(to_move))]
-    abort(glue("Columns to move must be unique, but `{duplicated_col}` is supplied twice"))
+  if (vec_duplicate_any(to_move)) {
+    first_duplicate_loc <- first(to_move[vec_duplicate_detect(to_move)])
+    duplicated_col <- names(.data)[first_duplicate_loc]
+    abort(glue("Named arguments must be unique, but `{duplicated_col}` is supplied twice"))
   }
 
   .before <- enquo(.before)

--- a/R/relocate.R
+++ b/R/relocate.R
@@ -53,7 +53,7 @@ relocate <- function(.data, ..., .before = NULL, .after = NULL) {
 relocate.data.frame <- function(.data, ..., .before = NULL, .after = NULL) {
   to_move <- tidyselect::eval_select(expr(c(...)), .data)
   if (vec_duplicate_any(to_move)) {
-    first_duplicate_loc <- first(to_move[vec_duplicate_detect(to_move)])
+    first_duplicate_loc <- to_move[which.max(vec_duplicate_detect(to_move))]
     duplicated_col <- names(.data)[first_duplicate_loc]
     abort(glue("Named arguments must be unique, but `{duplicated_col}` is supplied twice"))
   }

--- a/tests/testthat/test-relocate.R
+++ b/tests/testthat/test-relocate.R
@@ -70,3 +70,8 @@ test_that("relocate() can rename (#5569)", {
     tibble(a = 1, b = 1, c = 1, ffff = "a", d = "a", e = "a")
   )
 })
+
+test_that("cannot supply duplicate cols in ...", {
+  df <- tibble(a = 1, b = 2)
+  expect_error(relocate(df, new = b, new2 = b), "must be unique")
+})


### PR DESCRIPTION
closes #6209 

``` r
library(dplyr, warn.conflicts = FALSE)
#> Warning: package 'dplyr' was built under R version 4.1.2
df <- tibble(a = 1, b = 2)

#### current behavior
df %>% 
  relocate(new = b, new2 = b)
#> # A tibble: 1 × 2
#>     new     a
#>   <dbl> <dbl>
#> 1     2     1

#### this PR
devtools::load_all("~/Documents/GitHub/dplyr_tv")
#> ℹ Loading dplyr
df %>% 
  relocate(new = b, new2 = b)
#> Error in `relocate()`:
#> ! Named arguments must be unique, but `b` is supplied twice

## only errors if duplicated field is named
df %>% 
  relocate(b, b)
#> # A tibble: 1 × 2
#>       b     a
#>   <dbl> <dbl>
#> 1     2     1
```

<sup>Created on 2022-07-18 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
