### PR TITLE
Use chained error created by tidyselect

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,9 +36,9 @@ Imports:
     magrittr (>= 1.5),
     methods,
     R6,
-    rlang (>= 1.0.2),
+    rlang (>= 1.0.3),
     tibble (>= 2.1.3),
-    tidyselect (>= 1.1.1),
+    tidyselect (>= 1.1.3),
     utils,
     vctrs (>= 0.4.1), 
     pillar (>= 1.5.1)
@@ -64,6 +64,9 @@ Suggests:
     testthat (>= 3.1.1),
     tidyr, 
     withr
+Remotes:
+    r-lib/rlang,
+    r-lib/tidyselect
 VignetteBuilder: 
     knitr
 Encoding: UTF-8

--- a/R/select.R
+++ b/R/select.R
@@ -66,9 +66,10 @@ select.list <- function(.data, ...) {
 select.data.frame <- function(.data, ...) {
   error_call <- dplyr_error_call()
 
-  loc <- tidyselect_fix_call(
-    tidyselect::eval_select(expr(c(...)), .data),
-    call = error_call
+  loc <- tidyselect::eval_select(
+    expr(c(...)),
+    data = .data,
+    error_call = error_call
   )
   loc <- ensure_group_vars(loc, .data, notify = TRUE)
 

--- a/tests/testthat/_snaps/conditions.md
+++ b/tests/testthat/_snaps/conditions.md
@@ -33,6 +33,8 @@
       select(mtcars, invisible(999 + ""))
     Condition
       Error in `select()`:
+      ! Problem while evaluating `invisible(999 + "")`.
+      Caused by error in `999 + ""`:
       ! non-numeric argument to binary operator
     Code
       slice(mtcars, invisible(999 + ""))
@@ -74,6 +76,8 @@
       select(mtcars, var = invisible(999 + ""))
     Condition
       Error in `select()`:
+      ! Problem while evaluating `invisible(999 + "")`.
+      Caused by error in `999 + ""`:
       ! non-numeric argument to binary operator
     Code
       slice(mtcars, var = invisible(999 + ""))
@@ -133,6 +137,7 @@
       select(mtcars, 1 + "")
     Condition
       Error in `foo()`:
+      Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
     Code
       slice(mtcars, 1 + "")

--- a/tests/testthat/_snaps/select.md
+++ b/tests/testthat/_snaps/select.md
@@ -30,6 +30,7 @@
     Output
       <error/rlang_error>
       Error in `select()`:
+      Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
 
 # dplyr_col_select() aborts when `[` implementation is broken


### PR DESCRIPTION
Part of #6309

Uses chained errors now created by tidyselect:

```r
f <- function() g()
g <- function() h()
h <- function() abort("foo")

dplyr::select(mtcars, f())
#> Error in `dplyr::select()`:
#> ! Problem while evaluating `f()`.
#> Caused by error in `h()`:
#> ! foo
```

Errors within the selection DSL are borrowed instead of chained, as before:

```r
dplyr::select(mtcars, foobar)
#> Error in `dplyr::select()`:
#> ! Can't subset columns that don't exist.
#> ✖ Column `foobar` doesn't exist.
```

@DavisVaughan @hadley Could you take a look at the wording of these chained errors please? If they look good to you, I'll send tidyselect to CRAN.

(I expect R CMD check to fail as the snapshots in the main branch still need to be updated for the latest rlang, see #6308.)