### PR TITLE
Implement `if_else()` on top of `vec_case_when()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,7 @@ Imports:
     tibble (>= 2.1.3),
     tidyselect (>= 1.1.1),
     utils,
-    vctrs (>= 0.4.1), 
+    vctrs (>= 0.4.1.9000), 
     pillar (>= 1.5.1)
 Suggests: 
     bench,
@@ -64,6 +64,8 @@ Suggests:
     testthat (>= 3.1.1),
     tidyr, 
     withr
+Remotes:
+    r-lib/vctrs
 VignetteBuilder: 
     knitr
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # dplyr (development version)
 
+* `if_else()` has been rewritten to utilize vctrs. This comes with most of the
+  same benefits as the `case_when()` rewrite. In particular, `if_else()` now
+  takes the common type of `true`, `false`, and `missing` when determining what
+  the output type should be, meaning that you no longer have to be quite as
+  strict about types when supplying values for them (for example, you no longer
+  need to supply typed `NA` values, like `NA_character_`) (#6243).
+
 * `case_when()` has been rewritten to utilize vctrs (#5106). This comes with a
   number of useful improvements:
   

--- a/man/if_else.Rd
+++ b/man/if_else.Rd
@@ -2,41 +2,59 @@
 % Please edit documentation in R/if_else.R
 \name{if_else}
 \alias{if_else}
-\title{Vectorised if}
+\title{Vectorised if-else}
 \usage{
-if_else(condition, true, false, missing = NULL)
+if_else(condition, true, false, missing = NULL, ..., ptype = NULL, size = NULL)
 }
 \arguments{
-\item{condition}{Logical vector}
+\item{condition}{A logical vector}
 
 \item{true, false}{Values to use for \code{TRUE} and \code{FALSE} values of
-\code{condition}. They must be either the same length as \code{condition},
-or length 1. They must also be the same type: \code{if_else()} checks that
-they have the same type and same class. All other attributes are
-taken from \code{true}.}
+\code{condition}.
 
-\item{missing}{If not \code{NULL}, will be used to replace missing
-values.}
+Both \code{true} and \code{false} will be \link[vctrs:vector_recycling_rules]{recycled}
+to the size of \code{condition}.
+
+\code{true}, \code{false}, and \code{missing} (if used) will be cast to their common type.}
+
+\item{missing}{If not \code{NULL}, will be used as the value for \code{NA} values of
+\code{condition}. Follows the same size and type rules as \code{true} and \code{false}.}
+
+\item{...}{These dots are for future extensions and must be empty.}
+
+\item{ptype}{An optional prototype declaring the desired output type. If
+supplied, this overrides the common type of \code{true}, \code{false}, and \code{missing}.}
+
+\item{size}{An optional size declaring the desired output size. If supplied,
+this overrides the size of \code{condition}.}
 }
 \value{
-Where \code{condition} is \code{TRUE}, the matching value from
-\code{true}, where it's \code{FALSE}, the matching value from \code{false},
-otherwise \code{NA}.
+A vector with the same size as \code{condition} and the same type as the common
+type of \code{true}, \code{false}, and \code{missing}.
+
+Where \code{condition} is \code{TRUE}, the matching values from \code{true}, where it is
+\code{FALSE}, the matching values from \code{false}, and where it is \code{NA}, the matching
+values from \code{missing}, if provided, otherwise a missing value will be used.
 }
 \description{
-Compared to the base \code{\link[=ifelse]{ifelse()}}, this function is more strict.
-It checks that \code{true} and \code{false} are the same type. This
-strictness makes the output type more predictable, and makes it somewhat
-faster.
+\code{if_else()} is a vectorized \link[=if]{if-else}. Compared to the base R equivalent,
+\code{\link[=ifelse]{ifelse()}}, this function allows you to handle missing values in the
+\code{condition} with \code{missing} and always takes \code{true}, \code{false}, and \code{missing}
+into account when determining what the output type should be.
 }
 \examples{
 x <- c(-5:5, NA)
-if_else(x < 0, NA_integer_, x)
-if_else(x < 0, "negative", "positive", "missing")
+if_else(x < 0, NA, x)
 
-# Unlike ifelse, if_else preserves types
+# Explicitly handle `NA` values in the `condition` with `missing`
+if_else(x < 0, "negative", "positive", missing = "missing")
+
+# Unlike `ifelse()`, `if_else()` preserves types
 x <- factor(sample(letters[1:5], 10, replace = TRUE))
-ifelse(x \%in\% c("a", "b", "c"), x, factor(NA))
-if_else(x \%in\% c("a", "b", "c"), x, factor(NA))
-# Attributes are taken from the `true` vector,
+ifelse(x \%in\% c("a", "b", "c"), x, NA)
+if_else(x \%in\% c("a", "b", "c"), x, NA)
+
+# `if_else()` is often useful for creating new columns inside of `mutate()`
+starwars \%>\%
+  mutate(category = if_else(height < 100, "short", "tall"), .keep = "used")
 }

--- a/tests/testthat/_snaps/if-else.md
+++ b/tests/testthat/_snaps/if-else.md
@@ -1,35 +1,77 @@
-# if_else() give meaningful errors
+# takes the common type of `true` and `false` (#6243)
 
     Code
-      (expect_error(if_else(1:10, 1, 2)))
-    Output
-      <error/rlang_error>
+      if_else(TRUE, 1, "x")
+    Condition
       Error in `if_else()`:
-      ! `condition` must be a logical vector, not an integer vector.
+      ! Can't combine `true` <double> and `false` <character>.
+
+# includes `missing` in the common type computation if used
+
     Code
-      (expect_error(if_else(1:3 < 2, 1:2, 1:3)))
-    Output
-      <error/rlang_error>
+      if_else(TRUE, 1, 2, missing = "x")
+    Condition
       Error in `if_else()`:
-      ! `true` must be length 3 (length of `condition`) or one, not 2.
+      ! Can't combine `true` <double> and `missing` <character>.
+
+# `condition` must be logical (and isn't cast to logical!)
+
     Code
-      (expect_error(if_else(1:3 < 2, 1:3, 1:2)))
-    Output
-      <error/rlang_error>
+      if_else(1:10, 1, 2)
+    Condition
       Error in `if_else()`:
-      ! `false` must be length 3 (length of `condition`) or one, not 2.
+      ! `condition` must be a vector with type <logical>.
+      Instead, it has type <integer>.
+
+# `true`, `false`, and `missing` must recycle to the size of `condition`
+
     Code
-      (expect_error(if_else(1:3 < 2, 1, 1L)))
-    Output
-      <error/rlang_error>
+      if_else(x < 2, bad, x)
+    Condition
       Error in `if_else()`:
-      ! `false` must be a double vector, not an integer vector.
+      ! `true` must have size 3, not size 2.
+
+---
+
     Code
-      x <- factor("x")
-      y <- ordered("x")
-      (expect_error(if_else(1:3 < 2, x, y)))
-    Output
-      <error/rlang_error>
+      if_else(x < 2, x, bad)
+    Condition
       Error in `if_else()`:
-      ! `false` must have class `factor`, not class `ordered/factor`.
+      ! `false` must have size 3, not size 2.
+
+---
+
+    Code
+      if_else(x < 2, x, x, missing = bad)
+    Condition
+      Error in `if_else()`:
+      ! `missing` must have size 3, not size 2.
+
+# must have empty dots
+
+    Code
+      if_else(TRUE, 1, 2, missing = 3, 4)
+    Condition
+      Error in `if_else()`:
+      ! `...` must be empty.
+      x Problematic argument:
+      * ..1 = 4
+      i Did you forget to name an argument?
+
+# `ptype` overrides the common type
+
+    Code
+      if_else(TRUE, 1L, 2.5, ptype = integer())
+    Condition
+      Error in `if_else()`:
+      ! Can't convert from `false` <double> to <integer> due to loss of precision.
+      * Locations: 1
+
+# `size` overrides the `condition` size
+
+    Code
+      if_else(TRUE, 1, 2, size = 2)
+    Condition
+      Error in `if_else()`:
+      ! `condition` must have size 2, not size 1.
 

--- a/tests/testthat/test-if-else.R
+++ b/tests/testthat/test-if-else.R
@@ -23,18 +23,86 @@ test_that("works with lists", {
   )
 })
 
-# Errors ------------------------------------------------------------------
+test_that("works with data frames", {
+  true <- tibble(x = 1, y = 2)
+  false <- tibble(x = 3, y = 4)
 
-test_that("if_else() give meaningful errors", {
-  expect_snapshot({
-    (expect_error(if_else(1:10, 1, 2)))
-    (expect_error(if_else(1:3 < 2, 1:2, 1:3)))
-    (expect_error(if_else(1:3 < 2, 1:3, 1:2)))
-    (expect_error(if_else(1:3 < 2, 1, 1L)))
+  expect_identical(
+    if_else(c(TRUE, FALSE, NA, TRUE), true, false),
+    vec_c(true, false, NA, true)
+  )
+})
 
-    x <- factor("x")
-    y <- ordered("x")
-    (expect_error(if_else(1:3 < 2, x, y)))
+test_that("works with vctrs rcrd types", {
+  true <- new_rcrd(list(x = 1, y = 2))
+  false <- new_rcrd(list(x = 3, y = 4))
+
+  expect_identical(
+    if_else(c(TRUE, FALSE, NA, TRUE), true, false),
+    vec_c(true, false, NA, true)
+  )
+})
+
+test_that("takes the common type of `true` and `false` (#6243)", {
+  expect_identical(if_else(TRUE, 1L, 1.5), 1)
+
+  expect_snapshot(error = TRUE, {
+    if_else(TRUE, 1, "x")
   })
+})
 
+test_that("includes `missing` in the common type computation if used", {
+  expect_identical(if_else(TRUE, 1L, 2L, missing = 3), 1)
+
+  expect_snapshot(error = TRUE, {
+    if_else(TRUE, 1, 2, missing = "x")
+  })
+})
+
+test_that("can recycle to size 0 `condition`", {
+  expect_identical(if_else(logical(), 1, 2, missing = 3), double())
+})
+
+test_that("`condition` must be logical (and isn't cast to logical!)", {
+  expect_snapshot(error = TRUE, {
+    if_else(1:10, 1, 2)
+  })
+})
+
+test_that("`true`, `false`, and `missing` must recycle to the size of `condition`", {
+  x <- 1:3
+  bad <- 1:2
+
+  expect_snapshot(error = TRUE, {
+    if_else(x < 2, bad, x)
+  })
+  expect_snapshot(error = TRUE, {
+    if_else(x < 2, x, bad)
+  })
+  expect_snapshot(error = TRUE, {
+    if_else(x < 2, x, x, missing = bad)
+  })
+})
+
+test_that("must have empty dots", {
+  expect_snapshot(error = TRUE, {
+    if_else(TRUE, 1, 2, missing = 3, 4)
+  })
+})
+
+test_that("`ptype` overrides the common type", {
+  expect_identical(if_else(TRUE, 2, 1L, ptype = integer()), 2L)
+
+  expect_snapshot(error = TRUE, {
+    if_else(TRUE, 1L, 2.5, ptype = integer())
+  })
+})
+
+test_that("`size` overrides the `condition` size", {
+  expect_identical(if_else(c(TRUE, FALSE), 1, 2, size = 2), c(1, 2))
+
+  # Note that `condition` is used as the name in the error message
+  expect_snapshot(error = TRUE, {
+    if_else(TRUE, 1, 2, size = 2)
+  })
 })


### PR DESCRIPTION
Closes #6243 

- Now takes the common type of `true`, `false`, and `missing`
- No longer need strongly typed `NA` values (due to the above point)
- New `size` and `ptype` args
- Now works with more value types, like data frames and rcrds

This PR adds a remote on dev vctrs, to be able to reference `vector_recycling_rules` (yay!)