### PR TITLE
Rewrite `na_if()` using vctrs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,8 +2,11 @@
 
 * `na_if()` has been rewritten to utilize vctrs. It now casts `y` to the type of
   `x` before comparing them, which makes it clearer that this function is type
-  and size stable on `x`. Additionally, it now works with a larger variety of
-  types, like data frames (#6329).
+  and size stable on `x`. In particular, this means that you can no longer do
+  `na_if(<tibble>, 0)`, which previously accidentally allowed you to replace
+  any instance of `0` across every column of the tibble with `NA`. `na_if()`
+  was never intended to work this way, and this is considered off-label usage
+  (#6329).
 
 * `first()`, `last()`, and `nth()` have been rewritten to use vctrs. This comes
   with the following improvements (#6331):

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # dplyr (development version)
 
+* `na_if()` has been rewritten to utilize vctrs. It now casts `y` to the type of
+  `x` before comparing them, which makes it clearer that this function is type
+  and size stable on `x`. Additionally, it now works with a larger variety of
+  types, like data frames (#6329).
+
 * `first()`, `last()`, and `nth()` have been rewritten to use vctrs. This comes
   with the following improvements (#6331):
   

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,16 @@
 # dplyr (development version)
 
-* `na_if()` has been rewritten to utilize vctrs. It now casts `y` to the type of
-  `x` before comparing them, which makes it clearer that this function is type
-  and size stable on `x`. In particular, this means that you can no longer do
-  `na_if(<tibble>, 0)`, which previously accidentally allowed you to replace
-  any instance of `0` across every column of the tibble with `NA`. `na_if()`
-  was never intended to work this way, and this is considered off-label usage
-  (#6329).
+* `na_if()` has been rewritten to utilize vctrs. This comes with the following
+  improvements (#6329):
+
+  * It now casts `y` to the type of `x` before comparing them, which makes it
+    clearer that this function is type and size stable on `x`. In particular,
+    this means that you can no longer do `na_if(<tibble>, 0)`, which previously
+    accidentally allowed you to replace any instance of `0` across every column
+    of the tibble with `NA`. `na_if()` was never intended to work this way, and
+    this is considered off-label usage.
+    
+  * You can now replace `NaN` values in `x` with `NA` through `na_if(x, NaN)`.
 
 * `first()`, `last()`, and `nth()` have been rewritten to use vctrs. This comes
   with the following improvements (#6331):

--- a/R/na_if.R
+++ b/R/na_if.R
@@ -1,18 +1,23 @@
-#' Convert values to NA
+#' Convert values to `NA`
 #'
-#' This is a translation of the SQL command `NULLIF`. It is useful
-#' if you want to convert an annoying value to `NA`.
+#' This is a translation of the SQL command `NULLIF`. It is useful if you want
+#' to convert an annoying value to `NA`.
 #'
 #' @param x Vector to modify
-#' @param y Value to replace with NA
+#' @param y Value or vector to compare against. When `x` and `y` are equal, the
+#'   value in `x` will be replaced with `NA`.
+#'
+#'   `y` is cast to the type of `x` before comparison.
+#'
+#'   `y` is [recycled][vctrs::vector_recycling_rules] to the size of `x` before
+#'   comparison. This means that `y` can be a vector with the same size as `x`,
+#'   but most of the time this will be a single value.
 #' @return A modified version of `x` that replaces any values that
-#'   are equal to `y` with NA.
+#'   are equal to `y` with `NA`.
 #' @seealso [coalesce()] to replace missing values with a specified
 #'   value.
 #'
 #'   [tidyr::replace_na()] to replace `NA` with a value.
-#'
-#'   [recode()] to more generally replace values.
 #' @export
 #' @examples
 #' na_if(1:5, 5:1)
@@ -24,19 +29,25 @@
 #' y <- c("abc", "def", "", "ghi")
 #' na_if(y, "")
 #'
-#' # na_if() is particularly useful inside mutate(),
+#' # `na_if()` is particularly useful inside `mutate()`,
 #' # and is meant for use with vectors rather than entire data frames
 #' starwars %>%
 #'   select(name, eye_color) %>%
 #'   mutate(eye_color = na_if(eye_color, "unknown"))
 #'
-#' # na_if() can also be used with mutate() and across()
-#' # to mutate multiple columns
+#' # `na_if()` can also be used with `mutate()` and `across()`
+#' # to alter multiple columns
 #' starwars %>%
 #'    mutate(across(where(is.character), ~na_if(., "unknown")))
 na_if <- function(x, y) {
-  check_length(y, x, "`y`", glue("same as `x`"))
+  # Type and size stable on `x`
+  y <- vec_cast(x = y, to = x, x_arg = "y", to_arg = "x")
+  y <- vec_recycle(y, size = vec_size(x), x_arg = "y")
 
-  x[x == y] <- NA
+  na <- vec_init(x)
+  where <- vec_equal(x, y)
+
+  x <- vec_assign(x, where, na)
+
   x
 }

--- a/R/na_if.R
+++ b/R/na_if.R
@@ -29,6 +29,11 @@
 #' y <- c("abc", "def", "", "ghi")
 #' na_if(y, "")
 #'
+#' # `na_if()` allows you to replace `NaN` with `NA`,
+#' # even though `NaN == NaN` returns `NA`
+#' z <- c(1, NaN, NA, 2, NaN)
+#' na_if(z, NaN)
+#'
 #' # `na_if()` is particularly useful inside `mutate()`,
 #' # and is meant for use with vectors rather than entire data frames
 #' starwars %>%
@@ -45,7 +50,7 @@ na_if <- function(x, y) {
   y <- vec_recycle(y, size = vec_size(x), x_arg = "y")
 
   na <- vec_init(x)
-  where <- vec_equal(x, y)
+  where <- vec_equal(x, y, na_equal = TRUE)
 
   x <- vec_assign(x, where, na)
 

--- a/man/na_if.Rd
+++ b/man/na_if.Rd
@@ -2,22 +2,29 @@
 % Please edit documentation in R/na_if.R
 \name{na_if}
 \alias{na_if}
-\title{Convert values to NA}
+\title{Convert values to \code{NA}}
 \usage{
 na_if(x, y)
 }
 \arguments{
 \item{x}{Vector to modify}
 
-\item{y}{Value to replace with NA}
+\item{y}{Value or vector to compare against. When \code{x} and \code{y} are equal, the
+value in \code{x} will be replaced with \code{NA}.
+
+\code{y} is cast to the type of \code{x} before comparison.
+
+\code{y} is \link[vctrs:vector_recycling_rules]{recycled} to the size of \code{x} before
+comparison. This means that \code{y} can be a vector with the same size as \code{x},
+but most of the time this will be a single value.}
 }
 \value{
 A modified version of \code{x} that replaces any values that
-are equal to \code{y} with NA.
+are equal to \code{y} with \code{NA}.
 }
 \description{
-This is a translation of the SQL command \code{NULLIF}. It is useful
-if you want to convert an annoying value to \code{NA}.
+This is a translation of the SQL command \code{NULLIF}. It is useful if you want
+to convert an annoying value to \code{NA}.
 }
 \examples{
 na_if(1:5, 5:1)
@@ -29,14 +36,14 @@ x <- c(1, -1, 0, 10)
 y <- c("abc", "def", "", "ghi")
 na_if(y, "")
 
-# na_if() is particularly useful inside mutate(),
+# `na_if()` is particularly useful inside `mutate()`,
 # and is meant for use with vectors rather than entire data frames
 starwars \%>\%
   select(name, eye_color) \%>\%
   mutate(eye_color = na_if(eye_color, "unknown"))
 
-# na_if() can also be used with mutate() and across()
-# to mutate multiple columns
+# `na_if()` can also be used with `mutate()` and `across()`
+# to alter multiple columns
 starwars \%>\%
    mutate(across(where(is.character), ~na_if(., "unknown")))
 }
@@ -45,6 +52,4 @@ starwars \%>\%
 value.
 
 \code{\link[tidyr:replace_na]{tidyr::replace_na()}} to replace \code{NA} with a value.
-
-\code{\link[=recode]{recode()}} to more generally replace values.
 }

--- a/man/na_if.Rd
+++ b/man/na_if.Rd
@@ -36,6 +36,11 @@ x <- c(1, -1, 0, 10)
 y <- c("abc", "def", "", "ghi")
 na_if(y, "")
 
+# `na_if()` allows you to replace `NaN` with `NA`,
+# even though `NaN == NaN` returns `NA`
+z <- c(1, NaN, NA, 2, NaN)
+na_if(z, NaN)
+
 # `na_if()` is particularly useful inside `mutate()`,
 # and is meant for use with vectors rather than entire data frames
 starwars \%>\%

--- a/tests/testthat/_snaps/na-if.md
+++ b/tests/testthat/_snaps/na-if.md
@@ -1,15 +1,49 @@
-# na_if() gives meaningful errors
+# is type stable on `x`
 
     Code
-      (expect_error(na_if(1:3, 1:2)))
-    Output
-      <error/rlang_error>
+      na_if(0L, 1.5)
+    Condition
       Error in `na_if()`:
-      ! `y` must be length 3 (same as `x`) or one, not 2.
+      ! Can't convert from `y` <double> to `x` <integer> due to loss of precision.
+      * Locations: 1
+
+# is size stable on `x`
+
     Code
-      (expect_error(na_if(1, 1:2)))
-    Output
-      <error/rlang_error>
+      na_if(1, integer())
+    Condition
       Error in `na_if()`:
-      ! `y` must be length 1 (same as `x`), not 2.
+      ! Can't recycle `y` (size 0) to size 1.
+
+---
+
+    Code
+      na_if(1, c(1, 2))
+    Condition
+      Error in `na_if()`:
+      ! Can't recycle `y` (size 2) to size 1.
+
+---
+
+    Code
+      na_if(c(1, 2, 3), c(1, 2))
+    Condition
+      Error in `na_if()`:
+      ! Can't recycle `y` (size 2) to size 3.
+
+# requires vector types for `x` and `y`
+
+    Code
+      na_if(environment(), 1)
+    Condition
+      Error in `na_if()`:
+      ! `x` must be a vector, not an environment.
+
+---
+
+    Code
+      na_if(1, environment())
+    Condition
+      Error in `na_if()`:
+      ! `y` must be a vector, not an environment.
 

--- a/tests/testthat/test-na-if.R
+++ b/tests/testthat/test-na-if.R
@@ -10,8 +10,26 @@ test_that("`y` can be a vector the same length as `x` (matching SQL NULLIF)", {
   expect_identical(na_if(x, y), c(NA, NA, 0))
 })
 
-test_that("comparison is done with equality, so missings don't match", {
-  expect_identical(na_if(NaN, NaN), NaN)
+test_that("`NA` replacing itself is a no-op", {
+  expect_identical(na_if(NA, NA), NA)
+})
+
+test_that("missing values are allowed to equal each other, so `NaN`s can be standardized", {
+  expect_identical(na_if(NaN, NaN), NA_real_)
+})
+
+test_that("missing values equal each other in partially incomplete data frame rows", {
+  x <- tibble(
+    x = c(2, 1, NA, 1),
+    y = c(1, NA, NA, NA),
+    z = c(3, NaN, NA, NaN)
+  )
+
+  y <- tibble(x = 1, y = NA, z = NaN)
+
+  expect <- vec_assign(x, i = c(2, 4), value = NA)
+
+  expect_identical(na_if(x, y), expect)
 })
 
 test_that("works when there are missings in either input", {

--- a/tests/testthat/test-na-if.R
+++ b/tests/testthat/test-na-if.R
@@ -1,15 +1,69 @@
 test_that("scalar y replaces all matching x", {
   x <- c(0, 1, 0)
-  expect_equal(na_if(x, 0), c(NA, 1, NA))
-  expect_equal(na_if(x, 1), c(0, NA, 0))
+  expect_identical(na_if(x, 0), c(NA, 1, NA))
+  expect_identical(na_if(x, 1), c(0, NA, 0))
 })
 
+test_that("`y` can be a vector the same length as `x` (matching SQL NULLIF)", {
+  x <- c(0, 1, 0)
+  y <- c(0, 1, 2)
+  expect_identical(na_if(x, y), c(NA, NA, 0))
+})
 
-# Errors ------------------------------------------------------------------
+test_that("comparison is done with equality, so missings don't match", {
+  expect_identical(na_if(NaN, NaN), NaN)
+})
 
-test_that("na_if() gives meaningful errors", {
-  expect_snapshot({
-    (expect_error(na_if(1:3, 1:2)))
-    (expect_error(na_if(1, 1:2)))
+test_that("works when there are missings in either input", {
+  expect_identical(na_if(c(1, NA, 2), 1), c(NA, NA, 2))
+  expect_identical(na_if(c(1, NA, 2), c(1, NA, NA)), c(NA, NA, 2))
+})
+
+test_that("works with data frames", {
+  x <- tibble(a = c(1, 99, 99, 99), b = c("x", "NA", "bar", "NA"))
+  y <- tibble(a = 99, b = "NA")
+
+  expect_identical(
+    na_if(x, y),
+    x[c(1, NA, 3, NA),]
+  )
+})
+
+test_that("works with rcrd types", {
+  x <- new_rcrd(list(a = c(1, 99, 99, 99), b = c("x", "NA", "bar", "NA")))
+  y <- new_rcrd(list(a = 99, b = "NA"))
+
+  expect_identical(
+    na_if(x, y),
+    x[c(1, NA, 3, NA)]
+  )
+})
+
+test_that("is type stable on `x`", {
+  expect_identical(na_if(0L, 0), NA_integer_)
+
+  expect_snapshot(error = TRUE, {
+    na_if(0L, 1.5)
+  })
+})
+
+test_that("is size stable on `x`", {
+  expect_snapshot(error = TRUE, {
+    na_if(1, integer())
+  })
+  expect_snapshot(error = TRUE, {
+    na_if(1, c(1, 2))
+  })
+  expect_snapshot(error = TRUE, {
+    na_if(c(1, 2, 3), c(1, 2))
+  })
+})
+
+test_that("requires vector types for `x` and `y`", {
+  expect_snapshot(error = TRUE, {
+    na_if(environment(), 1)
+  })
+  expect_snapshot(error = TRUE, {
+    na_if(1, environment())
   })
 })


### PR DESCRIPTION
We talked about making `na_if()` work in a match-like way, like `na_if(x, c("bad", "NA"))`, but I no longer think we should do that. While that might be more useful, I think:
- It would break existing code where people are currently supplying vector `y` values and expect `==` to be used, which does seem to come up on a quick GitHub scan
- It would no longer match `NULLIF()` from SQL, which it is advertised as mimicking. The Microsoft SQL docs state that `NULLIF(e1, e2)` should be treated as a "searched CASE expression", meaning that the following should be exactly equivalent

  ```
  NULLIF(e1, e2)

  CASE  
    WHEN e1 = e2 THEN NULL  
    ELSE e1  
  END 
  ```

  https://docs.microsoft.com/en-us/sql/t-sql/language-elements/nullif-transact-sql?view=sql-server-ver16#remarks

If people want a match-like `na_if()`, we could add `replace_match(x, c("bad", "NA") ~ NA)` as part of #6328 

---

Other notes on what changes from this update:
- Now casts `y` to the type of `x`, with the intention of making it very clear that this is type stable on `x`
- Now uses `vec_equal()` for comparison
- Now uses `vec_assign()` for assignment

`"9c7db457-e0e3-4d62-8d92-1a8af03dae11"`