### PR TITLE
Remove `tbl_sql` methods for `count()` and `tally()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # dplyr (development version)
 
+* dplyr no longer provides `count()` and `tally()` methods for `tbl_sql`.
+  These methods have been accidentally overriding the `tbl_lazy` methods that
+  dbplyr provides, which has resulted in issues with the grouping structure of
+  the output (#6338, tidyverse/dbplyr#940).
+
 * `relocate()` now retains the last name change when a single column is renamed
   multiple times while it is being moved. This better matches the behavior of
   `rename()` (#6209, with help from @eutwt).

--- a/R/count-tally.R
+++ b/R/count-tally.R
@@ -76,13 +76,10 @@ count.data.frame <- function(x, ..., wt = NULL, sort = FALSE, name = NULL, .drop
   out <- tally(out, wt = !!enquo(wt), sort = sort, name = name)
 
   # Ensure grouping is transient
-  if (is.data.frame(x)) {
-    out <- dplyr_reconstruct(out, x)
-  }
+  out <- dplyr_reconstruct(out, x)
+
   out
 }
-
-count.tbl_sql <- count.data.frame
 
 #' @export
 #' @rdname count
@@ -104,8 +101,6 @@ tally.data.frame <- function(x, wt = NULL, sort = FALSE, name = NULL) {
     out
   }
 }
-
-tally.tbl_sql <- tally.data.frame
 
 #' @export
 #' @rdname count

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -10,12 +10,6 @@
 
   .Call(dplyr_init_library, ns_dplyr, ns_env("vctrs"), ns_env("rlang"))
 
-  has_dbplyr <- is_installed("dbplyr")
-  if (!has_dbplyr || !exists("count.tbl_sql", ns_env("dbplyr"))) {
-    s3_register("dplyr::count", "tbl_sql")
-    s3_register("dplyr::tally", "tbl_sql")
-  }
-
   # TODO: For `arrange()`, `group_by()`, and `with_order()` until vctrs changes
   # `vec_order()` to the new ordering algorithm and officially exports
   # `vec_order_base()`, at which point we should use `vec_order()` and


### PR DESCRIPTION
Closes #6338 
Closes https://github.com/tidyverse/dbplyr/issues/940

See https://github.com/tidyverse/dplyr/issues/6338#issuecomment-1189423451 for the full diagnosis

@mgirlich could you please confirm that this is working as you expect? I think I've gotten it right, but you know more about dbplyr. You might want to add a test that is similar to the one here on the dbplyr side as well.


`"c5253d35-98ae-4a66-a3b7-78e93d321fd3"`