### PR TITLE
Retain only the last duplicate when a column is renamed multiple times in `relocate()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # dplyr (development version)
 
+* `relocate()` now retains the last name change when a single column is renamed
+  multiple times while it is being moved. This better matches the behavior of
+  `rename()` (#6209, with help from @eutwt).
+
 * `na_if()` has been rewritten to utilize vctrs. This comes with the following
   improvements (#6329):
 

--- a/man/relocate.Rd
+++ b/man/relocate.Rd
@@ -22,7 +22,8 @@ An object of the same type as \code{.data}. The output has the following
 properties:
 \itemize{
 \item Rows are not affected.
-\item The same columns appear in the output, but (usually) in a different place.
+\item The same columns appear in the output, but (usually) in a different place
+and possibly renamed.
 \item Data frame attributes are preserved.
 \item Groups are not affected.
 }

--- a/tests/testthat/test-relocate.R
+++ b/tests/testthat/test-relocate.R
@@ -70,3 +70,24 @@ test_that("relocate() can rename (#5569)", {
     tibble(a = 1, b = 1, c = 1, ffff = "a", d = "a", e = "a")
   )
 })
+
+test_that("`relocate()` retains the last duplicate when renaming while moving (#6209)", {
+  # To enforce the invariant that `ncol(.data) == ncol(relocate(.data, ...))`.
+  # Also matches `rename()` behavior.
+
+  df <- tibble(x = 1)
+
+  expect_named(relocate(df, a = x, b = x), "b")
+  expect_identical(
+    relocate(df, a = x, b = x),
+    rename(df, a = x, b = x)
+  )
+
+  df <- tibble(x = 1, y = 2)
+
+  expect_named(relocate(df, a = x, b = y, c = x), c("b", "c"))
+  expect_identical(
+    relocate(df, a = x, b = y, c = x),
+    select(rename(df, a = x, b = y, c = x), b, c)
+  )
+})


### PR DESCRIPTION
Closes #6301 
Closes #6209 

Alternative approach vs #6301. I actually don't think we should error here. I think we should take the _last_ name change when a column is renamed multiple times while it is being moved.

CRAN behavior takes the _first_ change, which I feel is wrong:

``` r
library(dplyr)

df <- tibble(a = 1)

relocate(df, x = a, y = a)
#> # A tibble: 1 × 1
#>       x
#>   <dbl>
#> 1     1
```

This PR takes the _last_ name change, which is more consistent with `rename()`:

``` r
library(dplyr)

df <- tibble(a = 1)

relocate(df, x = a, y = a)
#> # A tibble: 1 × 1
#>       y
#>   <dbl>
#> 1     1

rename(df, x = a, y = a)
#> # A tibble: 1 × 1
#>       y
#>   <dbl>
#> 1     1
```

I think this generally makes a little more sense too. We could error here, but I feel like this is a little more forgiving and better matches the spirit of dplyr while still being consistent with existing functions like `rename()`.