### PR TITLE
Prevent mask methods from being mentioned in error calls

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dplyr (development version)
 
+* Fixed an issue with latest rlang that caused internal tools (such as
+  `mask$eval_all_summarise()`) to be mentioned in error messages (#6308).
+
 * `distinct()` now retains attributes of bare data frames (#6318).
 
 * dplyr no longer provides `count()` and `tally()` methods for `tbl_sql`.

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -54,15 +54,21 @@ DataMask <- R6Class("DataMask",
     },
 
     eval_all_summarise = function(quo) {
-      .Call(`dplyr_mask_eval_all_summarise`, quo, private)
+      # Wrap in a function called `eval()` so that rlang ignores the
+      # call in error messages. This only concerns errors that occur
+      # directly in `quo`.
+      eval <- function() .Call(`dplyr_mask_eval_all_summarise`, quo, private)
+      eval()
     },
 
     eval_all_mutate = function(quo) {
-      .Call(`dplyr_mask_eval_all_mutate`, quo, private)
+      eval <- function() .Call(`dplyr_mask_eval_all_mutate`, quo, private)
+      eval()
     },
 
     eval_all_filter = function(quos, env_filter) {
-      .Call(`dplyr_mask_eval_all_filter`, quos, private, nrow(private$data), env_filter)
+      eval <- function() .Call(`dplyr_mask_eval_all_filter`, quos, private, nrow(private$data), env_filter)
+      eval()
     },
 
     pick = function(vars) {

--- a/tests/testthat/_snaps/arrange.md
+++ b/tests/testthat/_snaps/arrange.md
@@ -15,7 +15,7 @@
       Error in `arrange()`:
       ! Problem with the implicit `transmute()` step.
       x Problem while computing `..1 = y`.
-      Caused by error in `mask$eval_all_mutate()`:
+      Caused by error:
       ! object 'y' not found
     Code
       (expect_error(tibble(x = 1) %>% arrange(rep(x, 2))))

--- a/tests/testthat/_snaps/distinct.md
+++ b/tests/testthat/_snaps/distinct.md
@@ -31,6 +31,6 @@
       ! Problem adding computed columns.
       Caused by error in `mutate()`:
       ! Problem while computing `y = a + 1`.
-      Caused by error in `mask$eval_all_mutate()`:
+      Caused by error:
       ! object 'a' not found
 

--- a/tests/testthat/_snaps/filter.md
+++ b/tests/testthat/_snaps/filter.md
@@ -99,7 +99,7 @@
       <error/rlang_error>
       Error in `filter()`:
       ! Problem while computing `..1 = _x`.
-      Caused by error in `mask$eval_all_filter()`:
+      Caused by error:
       ! object '_x' not found
     Code
       (expect_error(mtcars %>% group_by(cyl) %>% filter(`_x`)))
@@ -108,7 +108,7 @@
       Error in `filter()`:
       ! Problem while computing `..1 = _x`.
       i The error occurred in group 1: cyl = 4.
-      Caused by error in `mask$eval_all_filter()`:
+      Caused by error:
       ! object '_x' not found
     Code
       (expect_error(filter(mtcars, x = 1)))
@@ -148,7 +148,7 @@
       <error/rlang_error>
       Error in `filter()`:
       ! Problem while computing `..1 = stop("{")`.
-      Caused by error in `mask$eval_all_filter()`:
+      Caused by error:
       ! {
     Code
       data.frame(x = 1, y = 1) %>% filter(across(everything(), ~ .x > 0))

--- a/tests/testthat/_snaps/group-by.md
+++ b/tests/testthat/_snaps/group-by.md
@@ -46,6 +46,6 @@
       ! Problem adding computed columns.
       Caused by error in `mutate()`:
       ! Problem while computing `z = a + 1`.
-      Caused by error in `mask$eval_all_mutate()`:
+      Caused by error:
       ! object 'a' not found
 

--- a/tests/testthat/_snaps/mutate.md
+++ b/tests/testthat/_snaps/mutate.md
@@ -7,7 +7,7 @@
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
       ! Problem while computing `a = sum(y)`.
-      Caused by error in `mask$eval_all_mutate()`:
+      Caused by error:
       ! object 'y' not found
     Code
       (expect_error(tbl %>% group_by(x) %>% mutate(y = NULL, a = sum(y))))
@@ -16,7 +16,7 @@
       Error in `mutate()`:
       ! Problem while computing `a = sum(y)`.
       i The error occurred in group 1: x = 1.
-      Caused by error in `mask$eval_all_mutate()`:
+      Caused by error:
       ! object 'y' not found
     Code
       (expect_error(tibble(x = 1) %>% mutate(y = mean)))
@@ -153,6 +153,6 @@
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
       ! Problem while computing `..1 = stop("{")`.
-      Caused by error in `mask$eval_all_mutate()`:
+      Caused by error:
       ! {
 

--- a/tests/testthat/_snaps/summarise.md
+++ b/tests/testthat/_snaps/summarise.md
@@ -167,7 +167,7 @@
       <error/rlang_error>
       Error in `summarise()`:
       ! Problem while computing `..1 = stop("{")`.
-      Caused by error in `mask$eval_all_summarise()`:
+      Caused by error:
       ! {
     Code
       (expect_error(tibble(a = 1, b = "{value:1, unit:a}") %>% group_by(b) %>%
@@ -177,6 +177,6 @@
       Error in `summarise()`:
       ! Problem while computing `a = stop("!")`.
       i The error occurred in group 1: b = "{value:1, unit:a}".
-      Caused by error in `mask$eval_all_summarise()`:
+      Caused by error:
       ! !
 


### PR DESCRIPTION
Closes #6308.

This was a bit tricky because the `call` for these top-level errors is created by R itself, before calling `.handleSimpleError()`. To fix these, I wrapped the evaluation routine in a function called `eval()` which rlang ignores by default.