### PR TITLE
Prefer `dplyr_col_select()` over `[` to retain attributes in `distinct()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr (development version)
 
+* `distinct()` now retains attributes of bare data frames (#6318).
+
 * dplyr no longer provides `count()` and `tally()` methods for `tbl_sql`.
   These methods have been accidentally overriding the `tbl_lazy` methods that
   dbplyr provides, which has resulted in issues with the grouping structure of

--- a/R/distinct.R
+++ b/R/distinct.R
@@ -134,7 +134,6 @@ distinct.data.frame <- function(.data, ..., .keep_all = FALSE) {
   loc <- vec_unique_loc(cols)
 
   out <- dplyr_col_select(out, prep$keep)
-
   dplyr_row_slice(out, loc)
 }
 

--- a/R/distinct.R
+++ b/R/distinct.R
@@ -128,11 +128,14 @@ distinct.data.frame <- function(.data, ..., .keep_all = FALSE) {
     caller_env = caller_env()
   )
 
-  # out <- as_tibble(prep$data)
   out <- prep$data
-  loc <- vec_unique_loc(as_tibble(out)[prep$vars])
 
-  dplyr_row_slice(out[prep$keep], loc)
+  cols <- dplyr_col_select(out, prep$vars)
+  loc <- vec_unique_loc(cols)
+
+  out <- dplyr_col_select(out, prep$keep)
+
+  dplyr_row_slice(out, loc)
 }
 
 

--- a/tests/testthat/test-distinct.R
+++ b/tests/testthat/test-distinct.R
@@ -156,6 +156,16 @@ test_that("distinct() propagates caller env", {
   expect_caller_env(distinct(mtcars, sig_caller_env()))
 })
 
+test_that("distinct() preserves attributes on bare data frames (#6318)", {
+  df <- vctrs::data_frame(x = c(1, 1))
+  attr(df, "foo") <- "bar"
+
+  out <- distinct(df, x)
+  expect_identical(attr(out, "foo"), "bar")
+
+  out <- distinct(df, y = x + 1L)
+  expect_identical(attr(out, "foo"), "bar")
+})
 
 # Errors ------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #6318 