### PR TITLE
Mark mutate() args + row_* as no longer experimental

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # dplyr (development version)
 
+* The `.keep`, `.before`, and `.after` arguments to `mutate()` 
+  are no longer experimental.
+  
+* The `rows_` family of functions are no longer experimental.
+
 * `slice()` helpers again produce output equivalent to `slice(.data, 0)` when
   the `n` or `prop` argument is 0, fixing a bug introduced in the previous
   version (@eutwt, #6184).

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 * The `.keep`, `.before`, and `.after` arguments to `mutate()` 
   are no longer experimental.
   
-* The `rows_` family of functions are no longer experimental.
+* The `rows_*()` family of functions are no longer experimental.
 
 * `slice()` helpers again produce output equivalent to `slice(.data, 0)` when
   the `n` or `prop` argument is 0, fixing a bug introduced in the previous

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -118,14 +118,12 @@
 #' # see `vignette("window-functions")` for more details
 #'
 #' # By default, new columns are placed on the far right.
-#' # Experimental: you can override with `.before` or `.after`
 #' df <- tibble(x = 1, y = 2)
 #' df %>% mutate(z = x + y)
 #' df %>% mutate(z = x + y, .before = 1)
 #' df %>% mutate(z = x + y, .after = x)
 #'
 #' # By default, mutate() keeps all columns from the input data.
-#' # Experimental: You can override with `.keep`
 #' df <- tibble(x = 1, y = 2, a = "a", b = "b")
 #' df %>% mutate(z = x + y, .keep = "all") # the default
 #' df %>% mutate(z = x + y, .keep = "used")
@@ -157,7 +155,7 @@ mutate <- function(.data, ...) {
 }
 
 #' @rdname mutate
-#' @param .keep `r lifecycle::badge("experimental")`
+#' @param .keep
 #'   Control which columns from `.data` are retained in the output. Grouping
 #'   columns and columns created by `...` are always kept.
 #'
@@ -170,7 +168,7 @@ mutate <- function(.data, ...) {
 #'     the columns used to generate them.
 #'   * `"none"` doesn't retain any extra columns from `.data`. Only the grouping
 #'     variables and columns created by `...` are kept.
-#' @param .before,.after `r lifecycle::badge("experimental")`
+#' @param .before,.after
 #'   <[`tidy-select`][dplyr_tidy_select]> Optionally, control where new columns
 #'   should appear (the default is to add to the right hand side). See
 #'   [relocate()] for more details.

--- a/R/rows.R
+++ b/R/rows.R
@@ -1,7 +1,6 @@
 #' Manipulate individual rows
 #'
 #' @description
-#' `r lifecycle::badge("experimental")`
 #'
 #' These functions provide a framework for modifying rows in a table using a
 #' second table of data. The two tables are matched `by` a set of key variables
@@ -114,7 +113,6 @@ rows_insert <- function(x,
                         conflict = c("error", "ignore"),
                         copy = FALSE,
                         in_place = FALSE) {
-  lifecycle::signal_stage("experimental", "rows_insert()")
   UseMethod("rows_insert")
 }
 
@@ -155,7 +153,6 @@ rows_append <- function(x,
                         ...,
                         copy = FALSE,
                         in_place = FALSE) {
-  lifecycle::signal_stage("experimental", "rows_append()")
   UseMethod("rows_append")
 }
 
@@ -185,7 +182,6 @@ rows_update <- function(x,
                         unmatched = c("error", "ignore"),
                         copy = FALSE,
                         in_place = FALSE) {
-  lifecycle::signal_stage("experimental", "rows_update()")
   UseMethod("rows_update", x)
 }
 
@@ -250,7 +246,6 @@ rows_patch <- function(x,
                        unmatched = c("error", "ignore"),
                        copy = FALSE,
                        in_place = FALSE) {
-  lifecycle::signal_stage("experimental", "rows_patch()")
   UseMethod("rows_patch", x)
 }
 
@@ -321,7 +316,6 @@ rows_upsert <- function(x,
                         ...,
                         copy = FALSE,
                         in_place = FALSE) {
-  lifecycle::signal_stage("experimental", "rows_upsert()")
   UseMethod("rows_upsert", x)
 }
 
@@ -387,7 +381,6 @@ rows_delete <- function(x,
                         unmatched = c("error", "ignore"),
                         copy = FALSE,
                         in_place = FALSE) {
-  lifecycle::signal_stage("experimental", "rows_delete()")
   UseMethod("rows_delete", x)
 }
 

--- a/man/mutate.Rd
+++ b/man/mutate.Rd
@@ -35,8 +35,7 @@ if ungrouped).
 \item A data frame or tibble, to create multiple columns in the output.
 }}
 
-\item{.keep}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-Control which columns from \code{.data} are retained in the output. Grouping
+\item{.keep}{Control which columns from \code{.data} are retained in the output. Grouping
 columns and columns created by \code{...} are always kept.
 \itemize{
 \item \code{"all"} retains all columns from \code{.data}. This is the default.
@@ -50,8 +49,7 @@ the columns used to generate them.
 variables and columns created by \code{...} are kept.
 }}
 
-\item{.before, .after}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-<\code{\link[=dplyr_tidy_select]{tidy-select}}> Optionally, control where new columns
+\item{.before, .after}{<\code{\link[=dplyr_tidy_select]{tidy-select}}> Optionally, control where new columns
 should appear (the default is to add to the right hand side). See
 \code{\link[=relocate]{relocate()}} for more details.}
 }
@@ -169,14 +167,12 @@ starwars \%>\%
 # see `vignette("window-functions")` for more details
 
 # By default, new columns are placed on the far right.
-# Experimental: you can override with `.before` or `.after`
 df <- tibble(x = 1, y = 2)
 df \%>\% mutate(z = x + y)
 df \%>\% mutate(z = x + y, .before = 1)
 df \%>\% mutate(z = x + y, .after = x)
 
 # By default, mutate() keeps all columns from the input data.
-# Experimental: You can override with `.keep`
 df <- tibble(x = 1, y = 2, a = "a", b = "b")
 df \%>\% mutate(z = x + y, .keep = "all") # the default
 df \%>\% mutate(z = x + y, .keep = "used")

--- a/man/rows.Rd
+++ b/man/rows.Rd
@@ -119,8 +119,6 @@ updated.
 If \code{in_place = TRUE}, the result will be returned invisibly.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-
 These functions provide a framework for modifying rows in a table using a
 second table of data. The two tables are matched \code{by} a set of key variables
 whose values typically uniquely identify each row. The functions are inspired


### PR DESCRIPTION
I think these are unquestionably useful. Other experimental functions that I left as is are the `dplyr_*` generics, `group_map()`/`group_walk()`/`group_nest()`/`group_split()`/`group_trim()`, `with_groups()`, and `nest_by()`. I don't see any reason that these would go away, but it feels like we still want to reserve the right to play around with them still.

Fixes #6110