### PR TITLE
Silently cap `slice_sample()` slice size at `n()` when `replace = FALSE`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # dplyr (development version)
 
+* `slice_sample()` returns a data frame or group with the same number of rows as 
+  the input when `replace = FALSE` and `n` is larger than the number of rows or 
+  `prop` is larger than 1. This reverts a change made in 1.0.8, returning to the 
+  behavior of 1.0.7 (#6185)
+
 * `slice()` helpers again produce output equivalent to `slice(.data, 0)` when
   the `n` or `prop` argument is 0, fixing a bug introduced in the previous
   version (@eutwt, #6184).

--- a/R/slice.R
+++ b/R/slice.R
@@ -452,17 +452,7 @@ get_slice_size <- function(n, prop, allow_negative = TRUE, error_call = caller_e
 
 sample_int <- function(n, size, replace = FALSE, wt = NULL, call = caller_env()) {
   if (!replace && n < size) {
-    header <- paste0(
-      "Can't sample without replacement using a size that is larger than ",
-      "the number of rows in the data."
-    )
-    message <- c(
-      header,
-      i = glue("{size} rows were requested in the sample."),
-      i = glue("{n} rows are present in the data."),
-      i = "Set `replace = TRUE` to sample with replacement."
-    )
-    abort(message, call = call)
+    size <- n
   }
 
   if (size == 0L) {

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -12,52 +12,6 @@
       <error/rlang_error>
       Error in `slice_sample()`:
       ! `prop` must be positive.
-    Code
-      (expect_error(df %>% slice_sample(n = 4, replace = FALSE)))
-    Output
-      <error/rlang_error>
-      Error in `slice_sample()`:
-      ! Problem while computing indices.
-      Caused by error:
-      ! Can't sample without replacement using a size that is larger than the number of rows in the data.
-      i 4 rows were requested in the sample.
-      i 1 rows are present in the data.
-      i Set `replace = TRUE` to sample with replacement.
-    Code
-      (expect_error(gdf %>% slice_sample(n = 4, replace = FALSE)))
-    Output
-      <error/rlang_error>
-      Error in `slice_sample()`:
-      ! Problem while computing indices.
-      i The error occurred in group 1: a = 1.
-      Caused by error:
-      ! Can't sample without replacement using a size that is larger than the number of rows in the data.
-      i 4 rows were requested in the sample.
-      i 1 rows are present in the data.
-      i Set `replace = TRUE` to sample with replacement.
-    Code
-      (expect_error(df %>% slice_sample(prop = 4, replace = FALSE)))
-    Output
-      <error/rlang_error>
-      Error in `slice_sample()`:
-      ! Problem while computing indices.
-      Caused by error:
-      ! Can't sample without replacement using a size that is larger than the number of rows in the data.
-      i 4 rows were requested in the sample.
-      i 1 rows are present in the data.
-      i Set `replace = TRUE` to sample with replacement.
-    Code
-      (expect_error(gdf %>% slice_sample(prop = 4, replace = FALSE)))
-    Output
-      <error/rlang_error>
-      Error in `slice_sample()`:
-      ! Problem while computing indices.
-      i The error occurred in group 1: a = 1.
-      Caused by error:
-      ! Can't sample without replacement using a size that is larger than the number of rows in the data.
-      i 4 rows were requested in the sample.
-      i 1 rows are present in the data.
-      i Set `replace = TRUE` to sample with replacement.
 
 # slice() gives meaningfull errors
 

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -210,34 +210,37 @@ test_that("slice_sample() handles n= and prop=", {
     (expect_error(
       df %>% slice_sample(prop = -1)
     ))
-
-    (expect_error(
-      df %>% slice_sample(n = 4, replace = FALSE)
-    ))
-    (expect_error(
-      gdf %>% slice_sample(n = 4, replace = FALSE)
-    ))
-
-    (expect_error(
-      df %>% slice_sample(prop = 4, replace = FALSE)
-    ))
-    (expect_error(
-      gdf %>% slice_sample(prop = 4, replace = FALSE)
-    ))
   })
 })
 
 test_that("functions silently truncate results", {
   df <- data.frame(x = 1:5)
 
+  # positive n
+  expect_equal(df %>% slice_sample(n = 6) %>% nrow(), 5)
   expect_equal(df %>% slice_head(n = 6) %>% nrow(), 5)
   expect_equal(df %>% slice_tail(n = 6) %>% nrow(), 5)
   expect_equal(df %>% slice_min(x, n = 6) %>% nrow(), 5)
   expect_equal(df %>% slice_max(x, n = 6) %>% nrow(), 5)
+
+  # positive prop
+  expect_equal(df %>% slice_sample(prop = 2) %>% nrow(), 5)
+  expect_equal(df %>% slice_head(prop = 2) %>% nrow(), 5)
+  expect_equal(df %>% slice_tail(prop = 2) %>% nrow(), 5)
+  expect_equal(df %>% slice_min(x, prop = 2) %>% nrow(), 5)
+  expect_equal(df %>% slice_max(x, prop = 2) %>% nrow(), 5)
+
+  # negative n
   expect_equal(df %>% slice_head(n = -6) %>% nrow(), 0)
   expect_equal(df %>% slice_tail(n = -6) %>% nrow(), 0)
   expect_equal(df %>% slice_min(x, n = -6) %>% nrow(), 0)
   expect_equal(df %>% slice_max(x, n = -6) %>% nrow(), 0)
+
+  # negative prop
+  expect_equal(df %>% slice_head(prop = -2) %>% nrow(), 0)
+  expect_equal(df %>% slice_tail(prop = -2) %>% nrow(), 0)
+  expect_equal(df %>% slice_min(x, prop = -2) %>% nrow(), 0)
+  expect_equal(df %>% slice_max(x, prop = -2) %>% nrow(), 0)
 })
 
 test_that("proportion computed correctly", {


### PR DESCRIPTION
closes #6185 

This PR silently caps slice size at `n()` for `slice_sample(..., replace = FALSE)` e.g. 
``` r
data.frame(a = 1) %>% 
  slice_sample(n = 2)
#>   a
#> 1 1
```
The timeline on this, as I understand it:

- In #5962, when adding support for negative `n` and `prop` in slice functions, I moved calculation of "slice size" to one function for all slice helpers. This function (silently) bounded all sizes between `0` and `n()`. I didn't realize, though, that  `slice_sample(..., replace = TRUE)`, allowed users to produce groups with more than `n()` rows, and so in doing this I changed that behavior.
- In revdeps before releasing 1.0.8 it [was found](https://github.com/Nowosad/motif/issues/66) that this change broke a package, and so #6172 reverted to the old behavior for `slice_sample(..., replace = TRUE)` and size > `n()`. The PR also made two other changes
  - For `slice_sample(..., replace = FALSE)`,  supplying a slice size is larger than `n()` is not allowed (causes error)
  - For `slice_sample()` in general, supplying negative `n` or `prop` is not allowed (causes error)
- Issue #6185 was opened requesting that the first of the two "additional" changes above be reverted

