### PR TITLE
Add `na.rm` argument to `slice_min()` and `slice_max()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # dplyr (development version)
 
+* The default output of `slice_min()` and `slice_max()` no longer excludes
+  rows where the `order_by` variable has a missing value. A new argument `na.rm` 
+  is added, defaulting to `FALSE` and allowing rows with a missing value to be 
+  excluded by setting `na.rm = TRUE` (#6177).
+
 * `arrange()` now correctly ignores `NULL` inputs (#6193).
 
 * `*_join()` now error if you supply them with additional arguments that

--- a/man/slice.Rd
+++ b/man/slice.Rd
@@ -15,9 +15,9 @@ slice_head(.data, ..., n, prop)
 
 slice_tail(.data, ..., n, prop)
 
-slice_min(.data, order_by, ..., n, prop, with_ties = TRUE)
+slice_min(.data, order_by, ..., n, prop, with_ties = TRUE, na.rm = FALSE)
 
-slice_max(.data, order_by, ..., n, prop, with_ties = TRUE)
+slice_max(.data, order_by, ..., n, prop, with_ties = TRUE, na.rm = FALSE)
 
 slice_sample(.data, ..., n, prop, weight_by = NULL, replace = FALSE)
 }
@@ -56,6 +56,9 @@ absolute value of \code{prop*nrow(.data)} is rounded down.}
 \item{with_ties}{Should ties be kept together? The default, \code{TRUE},
 may return more rows than you request. Use \code{FALSE} to ignore ties,
 and return the first \code{n} rows.}
+
+\item{na.rm}{Should rows where the \code{order_by} variable is missing be
+removed from the output?}
 
 \item{weight_by}{Sampling weights. This must evaluate to a vector of
 non-negative numbers the same length as the input. Weights are

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -312,8 +312,10 @@ test_that("min and max ignore NA's with na.rm = TRUE (#4826, #6177)", {
 
   expect_equal(df %>% slice_min(x, n = 2, na.rm = TRUE) %>% pull(id), c(3, 1, 4))
   expect_equal(df %>% slice_min(y, n = 2, na.rm = TRUE) %>% nrow(), 0)
+  expect_equal(df %>% slice_min(y, n = 2, with_ties = FALSE, na.rm = TRUE) %>% nrow(), 0)
   expect_equal(df %>% slice_max(x, n = 2, na.rm = TRUE) %>% pull(id), c(1, 4))
   expect_equal(df %>% slice_max(y, n = 2, na.rm = TRUE) %>% nrow(), 0)
+  expect_equal(df %>% slice_max(y, n = 2, with_ties = FALSE, na.rm = TRUE) %>% nrow(), 0)
 })
 
 test_that("min and max show NAs when na.rm = FALSE (#6177)", {
@@ -321,12 +323,10 @@ test_that("min and max show NAs when na.rm = FALSE (#6177)", {
 
   expect_equal(df %>% slice_min(x, n = 2) %>% pull(id), c(3, 1, 4))
   expect_equal(df %>% slice_min(x, n = 4) %>% pull(id), c(3, 1, 4, 2, 5))
-  expect_equal(df %>% slice_min(x, n = 4, with_ties = FALSE) %>% pull(id),
-               c(3, 1, 4, 2))
+  expect_equal(df %>% slice_min(x, n = 4, with_ties = FALSE) %>% pull(id), c(3, 1, 4, 2))
   expect_equal(df %>% slice_max(x, n = 2) %>% pull(id), c(1, 4))
   expect_equal(df %>% slice_max(x, n = 4) %>% pull(id), c(1, 4, 3, 2, 5))
-  expect_equal(df %>% slice_max(x, n = 4, with_ties = FALSE) %>% pull(id),
-               c(1, 4, 3, 2))
+  expect_equal(df %>% slice_max(x, n = 4, with_ties = FALSE) %>% pull(id), c(1, 4, 3, 2))
 })
 
 test_that("arguments to sample are passed along", {

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -307,13 +307,26 @@ test_that("min and max reorder results", {
   expect_equal(df %>% slice_max(x, n = 2, with_ties = FALSE) %>% pull(id), c(2, 1))
 })
 
-test_that("min and max ignore NA's (#4826)", {
+test_that("min and max ignore NA's with na.rm = TRUE (#4826, #6177)", {
   df <- data.frame(id = 1:4, x = c(2, NA, 1, 2), y = c(NA, NA, NA, NA))
 
+  expect_equal(df %>% slice_min(x, n = 2, na.rm = TRUE) %>% pull(id), c(3, 1, 4))
+  expect_equal(df %>% slice_min(y, n = 2, na.rm = TRUE) %>% nrow(), 0)
+  expect_equal(df %>% slice_max(x, n = 2, na.rm = TRUE) %>% pull(id), c(1, 4))
+  expect_equal(df %>% slice_max(y, n = 2, na.rm = TRUE) %>% nrow(), 0)
+})
+
+test_that("min and max show NAs when na.rm = FALSE (#6177)", {
+  df <- data.frame(id = 1:5, x = c(2, NA, 1, 2, NA), y = rep(NA, 5))
+
   expect_equal(df %>% slice_min(x, n = 2) %>% pull(id), c(3, 1, 4))
-  expect_equal(df %>% slice_min(y, n = 2) %>% nrow(), 0)
+  expect_equal(df %>% slice_min(x, n = 4) %>% pull(id), c(3, 1, 4, 2, 5))
+  expect_equal(df %>% slice_min(x, n = 4, with_ties = FALSE) %>% pull(id),
+               c(3, 1, 4, 2))
   expect_equal(df %>% slice_max(x, n = 2) %>% pull(id), c(1, 4))
-  expect_equal(df %>% slice_max(y, n = 2) %>% nrow(), 0)
+  expect_equal(df %>% slice_max(x, n = 4) %>% pull(id), c(1, 4, 3, 2, 5))
+  expect_equal(df %>% slice_max(x, n = 4, with_ties = FALSE) %>% pull(id),
+               c(1, 4, 3, 2))
 })
 
 test_that("arguments to sample are passed along", {


### PR DESCRIPTION
closes #6177

PR behavior below. For this example all the results are the same with `slice_max` instead of `slice_min` (`NA` always last).

This is the behavior I'd want, but it seems possible there could be a decent chunk of code out there relying on a default of na.rm = TRUE. 

``` r
library(dplyr, warn.conflicts = FALSE)

df <- tibble(x = c(1, NA, NA))
df %>% slice_min(x, n = 2)
#> # A tibble: 3 × 1
#>       x
#>   <dbl>
#> 1     1
#> 2    NA
#> 3    NA
df %>% slice_min(x, n = 2, with_ties = FALSE)
#> # A tibble: 2 × 1
#>       x
#>   <dbl>
#> 1     1
#> 2    NA
df %>% slice_min(x, n = 2, na.rm = TRUE)
#> # A tibble: 1 × 1
#>       x
#>   <dbl>
#> 1     1
```

<sup>Created on 2022-08-01 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
