### PR TITLE
Use `$pick()` when `across(.fns = NULL)` is specified

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dplyr (development version)
 
+* `across()` used without functions inside a rowwise-data frame no longer
+   generates an invalid data frame (#6264).
+
 * New `consecutive_id()` for creating groups based on contiguous runs of the
   same values, like `data.table::rleid()` (#1534).
 

--- a/R/across.R
+++ b/R/across.R
@@ -170,11 +170,9 @@ across <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
   names <- setup$names
 
   mask <- peek_mask()
-  data <- mask$current_cols(vars)
 
   if (is.null(fns)) {
-    nrow <- length(mask$current_rows())
-    data <- new_data_frame(data, n = nrow, class = c("tbl_df", "tbl"))
+    data <- mask$pick(vars)
 
     if (is.null(names)) {
       return(data)
@@ -182,6 +180,8 @@ across <- function(.cols = everything(), .fns = NULL, ..., .names = NULL) {
       return(set_names(data, names))
     }
   }
+
+  data <- mask$current_cols(vars)
 
   n_cols <- length(data)
   n_fns <- length(fns)

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -823,6 +823,20 @@ test_that("expand_if_across() expands lambdas", {
   )
 })
 
+test_that("rowwise() preserves list-cols iff no `.fns` (#5951, #6264)", {
+  rf <- rowwise(tibble(x = list(1:2, 3:5)))
+
+  # Need to unchop so works like mutate(rf, x = length(x))
+  out <- mutate(rf, across(everything(), length))
+  expect_equal(out$x, c(2, 3))
+
+  # Need to preserve to create valid data frame
+  out <- mutate(rf, across = list(across(everything())))
+  expect_equal(out$across, list(
+    tibble(x = list(1:2)),
+    tibble(x = list(3:5))
+  ))
+})
 
 # c_across ----------------------------------------------------------------
 

--- a/tests/testthat/test-mutate.r
+++ b/tests/testthat/test-mutate.r
@@ -551,14 +551,6 @@ test_that("mutate() propagates caller env", {
   expect_caller_env(mutate(mtcars, sig_caller_env()))
 })
 
-test_that("rowwise() + mutate(across()) correctly handles list columns (#5951)", {
-  tib <- tibble(a=list(1:2,3:4),c=list(NULL,NULL)) %>% rowwise()
-  expect_identical(
-    mutate(tib, sum = across(everything(),sum)),
-    mutate(tib, sum = across(where(is.list),sum))
-  )
-})
-
 test_that("mutate() fails on named empty arguments (#5925)", {
   expect_error(
     mutate(tibble(), bogus = )


### PR DESCRIPTION
Closes #6380 (alternative)
Closes #6264

@hadley I think I like this approach more?

- It seems a lot simpler to me
- It avoids a new argument to `current_cols()` (which I think shouldn't ever alter the cols if possible)
- It matches the spirit of what an official `pick()` function would do. It would be semantically the same as `across(.fns = NULL)`, so it is nice to see that we internally use `$pick()` for the `across(.fns = NULL)` code path.

I think this further supports the need for `pick()`. It would allow us to "purify" `across()` a bit more with rowwise data frames. Once we deprecate `.fns = NULL`, `across()` would _always_ work directly on list column elements VS `pick()` which would _always_ preserve the full list-column as-is