### PR TITLE
Make `dplyr_col_select()` purely about selection

### DIFF
--- a/R/generics.R
+++ b/R/generics.R
@@ -212,7 +212,7 @@ dplyr_reconstruct.rowwise_df <- function(data, template) {
   rowwise_df(data, group_vars)
 }
 
-dplyr_col_select <- function(.data, loc, names = NULL, error_call = caller_env()) {
+dplyr_col_select <- function(.data, loc, error_call = caller_env()) {
   loc <- vec_as_location(loc, n = ncol(.data), names = names(.data))
 
   out <- .data[loc]
@@ -242,10 +242,6 @@ dplyr_col_select <- function(.data, loc, names = NULL, error_call = caller_env()
   # We require `[` methods to keep extra attributes for all data frame subclasses.
   if (identical(class(.data), "data.frame") || identical(class(.data), c("data.table", "data.frame"))) {
     out <- dplyr_reconstruct(out, .data)
-  }
-
-  if (!is.null(names)) {
-    names(out) <- names
   }
 
   out

--- a/R/relocate.R
+++ b/R/relocate.R
@@ -61,7 +61,10 @@ relocate.data.frame <- function(.data, ..., .before = NULL, .after = NULL) {
     after_arg = ".after"
   )
 
-  dplyr_col_select(.data, loc, names = names(loc))
+  out <- dplyr_col_select(.data, loc)
+  out <- set_names(out, names(loc))
+
+  out
 }
 
 eval_relocate <- function(expr,

--- a/R/select.R
+++ b/R/select.R
@@ -71,7 +71,10 @@ select.data.frame <- function(.data, ...) {
   )
   loc <- ensure_group_vars(loc, .data, notify = TRUE)
 
-  dplyr_col_select(.data, loc, names(loc))
+  out <- dplyr_col_select(.data, loc)
+  out <- set_names(out, names(loc))
+
+  out
 }
 
 


### PR DESCRIPTION
It has bugged me that "col select" also handles renaming, since most of the time it isn't used that way. It isn't hard to separate this renaming bit out, so I did that here