### PR TITLE
Clarify tests/docs for negative n/prop

### DIFF
--- a/R/slice.R
+++ b/R/slice.R
@@ -35,13 +35,14 @@
 #'   proportion of rows to select. If neither are supplied, `n = 1` will be
 #'   used.
 #'
-#'   If a negative value of `n` or `prop` is provided, the specified number or
-#'   proportion of rows will be removed.
+#'   A negative value of `n` or `prop` will count backwards from the group
+#'   size. For example, `n = -2` with a group of 5 rows will select 5 - 2 = 3
+#'   rows; `prop = -0.25` with 8 rows will select 8 * (1 - 0.25) = 6 rows.
 #'
 #'   If `n` is greater than the number of rows in the group (or `prop > 1`),
-#'   the result will be silently truncated to the group size. If the
-#'   `prop`ortion of a group size does not yield an integer number of rows, the
-#'   absolute value of `prop*nrow(.data)` is rounded down.
+#'   the result will be silently truncated to the group size; `n < 0` or
+#'   `prop < 0 ` then the result will contain zero rows. If `prop * group_size`
+#'   is not an integer, it is rounded towards zero.
 #' @return
 #' An object of the same type as `.data`. The output has the following
 #' properties:

--- a/R/slice.R
+++ b/R/slice.R
@@ -33,16 +33,14 @@
 #'
 #' @param n,prop Provide either `n`, the number of rows, or `prop`, the
 #'   proportion of rows to select. If neither are supplied, `n = 1` will be
-#'   used.
+#'   used. If `n` is greater than the number of rows in the group
+#'   (or `prop > 1`), the result will be silently truncated to the group size.
+#'   `prop` will be rounded towards zero to generate an integer number of
+#'   rows.
 #'
-#'   A negative value of `n` or `prop` will count backwards from the group
+#'   A negative value of `n` or `prop` will be subtracted from the group
 #'   size. For example, `n = -2` with a group of 5 rows will select 5 - 2 = 3
 #'   rows; `prop = -0.25` with 8 rows will select 8 * (1 - 0.25) = 6 rows.
-#'
-#'   If `n` is greater than the number of rows in the group (or `prop > 1`),
-#'   the result will be silently truncated to the group size; `n < 0` or
-#'   `prop < 0 ` then the result will contain zero rows. If `prop * group_size`
-#'   is not an integer, it is rounded towards zero.
 #' @return
 #' An object of the same type as `.data`. The output has the following
 #' properties:

--- a/man/slice.Rd
+++ b/man/slice.Rd
@@ -43,13 +43,14 @@ is recalculated based on the resulting data, otherwise the grouping is kept as i
 proportion of rows to select. If neither are supplied, \code{n = 1} will be
 used.
 
-If a negative value of \code{n} or \code{prop} is provided, the specified number or
-proportion of rows will be removed.
+A negative value of \code{n} or \code{prop} will count backwards from the group
+size. For example, \code{n = -2} with a group of 5 rows will select 5 - 2 = 3
+rows; \code{prop = -0.25} with 8 rows will select 8 * (1 - 0.25) = 6 rows.
 
 If \code{n} is greater than the number of rows in the group (or \code{prop > 1}),
-the result will be silently truncated to the group size. If the
-\code{prop}ortion of a group size does not yield an integer number of rows, the
-absolute value of \code{prop*nrow(.data)} is rounded down.}
+the result will be silently truncated to the group size; \code{n < 0} or
+\code{prop < 0 } then the result will contain zero rows. If \code{prop * group_size}
+is not an integer, it is rounded towards zero.}
 
 \item{order_by}{Variable or function of variables to order by.
 To order by multiple variables, wrap them in a data frame or

--- a/man/slice.Rd
+++ b/man/slice.Rd
@@ -41,16 +41,14 @@ is recalculated based on the resulting data, otherwise the grouping is kept as i
 
 \item{n, prop}{Provide either \code{n}, the number of rows, or \code{prop}, the
 proportion of rows to select. If neither are supplied, \code{n = 1} will be
-used.
+used. If \code{n} is greater than the number of rows in the group
+(or \code{prop > 1}), the result will be silently truncated to the group size.
+\code{prop} will be rounded towards zero to generate an integer number of
+rows.
 
-A negative value of \code{n} or \code{prop} will count backwards from the group
+A negative value of \code{n} or \code{prop} will be subtracted from the group
 size. For example, \code{n = -2} with a group of 5 rows will select 5 - 2 = 3
-rows; \code{prop = -0.25} with 8 rows will select 8 * (1 - 0.25) = 6 rows.
-
-If \code{n} is greater than the number of rows in the group (or \code{prop > 1}),
-the result will be silently truncated to the group size; \code{n < 0} or
-\code{prop < 0 } then the result will contain zero rows. If \code{prop * group_size}
-is not an integer, it is rounded towards zero.}
+rows; \code{prop = -0.25} with 8 rows will select 8 * (1 - 0.25) = 6 rows.}
 
 \item{order_by}{Variable or function of variables to order by.
 To order by multiple variables, wrap them in a data frame or

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -255,6 +255,16 @@ test_that("min and max ignore NA's when requested (#4826)", {
   expect_equal(slice_max(df, tibble(a, b), n = 3, na_rm = TRUE)$id, 1)
 })
 
+test_that("slice_min/max() count from back with negative n/prop", {
+  df <- tibble(id = 1:4, x = c(2, 3, 1, 4))
+  expect_equal(slice_min(df, x, n = -1), slice_min(df, x, n = 3))
+  expect_equal(slice_max(df, x, n = -1), slice_max(df, x, n = 3))
+
+  # and can be larger that group size
+  expect_equal(slice_min(df, x, n = -10), df[0, ])
+  expect_equal(slice_max(df, x, n = -10), df[0, ])
+})
+
 test_that("slice_min/max() can order by multiple variables (#6176)", {
   df <- tibble(id = 1:4, x = 1, y = c(1, 4, 2, 3))
   expect_equal(slice_min(df, tibble(x, y), n = 1)$id, 1)
@@ -334,6 +344,16 @@ test_that("slice_head/slice_tail keep positive values", {
 
   expect_equal(slice_tail(gf, n = 1)$id, c(1, 3, 6))
   expect_equal(slice_tail(gf, n = 2)$id, c(1, 2, 3, 5, 6))
+})
+
+test_that("slice_head/tail() count from back with negative n/prop", {
+  df <- tibble(id = 1:4, x = c(2, 3, 1, 4))
+  expect_equal(slice_head(df, n = -1), slice_head(df, n = 3))
+  expect_equal(slice_tail(df, n = -1), slice_tail(df, n = 3))
+
+  # and can be larger that group size
+  expect_equal(slice_head(df, n = -10), df[0, ])
+  expect_equal(slice_tail(df, n = -10), df[0, ])
 })
 
 test_that("slice_head/slice_tail drop from opposite end when n/prop negative", {

--- a/tests/testthat/test-slice.r
+++ b/tests/testthat/test-slice.r
@@ -260,7 +260,7 @@ test_that("slice_min/max() count from back with negative n/prop", {
   expect_equal(slice_min(df, x, n = -1), slice_min(df, x, n = 3))
   expect_equal(slice_max(df, x, n = -1), slice_max(df, x, n = 3))
 
-  # and can be larger that group size
+  # and can be larger than group size
   expect_equal(slice_min(df, x, n = -10), df[0, ])
   expect_equal(slice_max(df, x, n = -10), df[0, ])
 })
@@ -351,7 +351,7 @@ test_that("slice_head/tail() count from back with negative n/prop", {
   expect_equal(slice_head(df, n = -1), slice_head(df, n = 3))
   expect_equal(slice_tail(df, n = -1), slice_tail(df, n = 3))
 
-  # and can be larger that group size
+  # and can be larger than group size
   expect_equal(slice_head(df, n = -10), df[0, ])
   expect_equal(slice_tail(df, n = -10), df[0, ])
 })


### PR DESCRIPTION
I think this does a better job of conveying how negative values work. The previous explanation made me think that `bind_rows(slice_head(df, n = 5), slice_head(df, n = -5))` would yield `df`.