### PR TITLE
WIP: Add dots to many generics

### DIFF
--- a/R/colwise.R
+++ b/R/colwise.R
@@ -249,12 +249,12 @@ tbl_if_syms <- function(.tbl, .p, .env, ..., .include_group_vars = FALSE, error_
 #'
 #' @export
 #' @keywords internal
-tbl_ptype <- function(.data) {
+tbl_ptype <- function(.data, ...) {
   UseMethod("tbl_ptype")
 }
 
 #' @export
-tbl_ptype.default <- function(.data) {
+tbl_ptype.default <- function(.data, ...) {
   if (inherits(.data, "tbl_lazy")) {
     # TODO: remove once moved to dplyr
     inform("Applying predicate on the first 100 rows")

--- a/R/count-tally.R
+++ b/R/count-tally.R
@@ -84,12 +84,12 @@ count.data.frame <- function(x, ..., wt = NULL, sort = FALSE, name = NULL, .drop
 
 #' @export
 #' @rdname count
-tally <- function(x, wt = NULL, sort = FALSE, name = NULL) {
+tally <- function(x, ..., wt = NULL, sort = FALSE, name = NULL) {
   UseMethod("tally")
 }
 
 #' @export
-tally.data.frame <- function(x, wt = NULL, sort = FALSE, name = NULL) {
+tally.data.frame <- function(x, ..., wt = NULL, sort = FALSE, name = NULL) {
   n <- tally_n(x, {{ wt }})
   name <- check_name(name, group_vars(x))
 

--- a/R/generics.R
+++ b/R/generics.R
@@ -128,12 +128,12 @@ dplyr_row_slice.rowwise_df <- function(data, i, ..., preserve = FALSE) {
 #' @rdname dplyr_extending
 #' @param cols A named list used modify columns. A `NULL` value should remove
 #'   an existing column.
-dplyr_col_modify <- function(data, cols) {
+dplyr_col_modify <- function(data, cols, ...) {
   UseMethod("dplyr_col_modify")
 }
 
 #' @export
-dplyr_col_modify.data.frame <- function(data, cols) {
+dplyr_col_modify.data.frame <- function(data, cols, ...) {
   # Must be implemented from first principles to avoiding edge cases in
   # [.data.frame and [.tibble (2.1.3 and earlier).
 
@@ -159,7 +159,7 @@ dplyr_col_modify.data.frame <- function(data, cols) {
 }
 
 #' @export
-dplyr_col_modify.grouped_df <- function(data, cols) {
+dplyr_col_modify.grouped_df <- function(data, cols, ...) {
   out <- dplyr_col_modify(as_tibble(data), cols)
 
   if (any(names(cols) %in% group_vars(data))) {
@@ -171,7 +171,7 @@ dplyr_col_modify.grouped_df <- function(data, cols) {
 }
 
 #' @export
-dplyr_col_modify.rowwise_df <- function(data, cols) {
+dplyr_col_modify.rowwise_df <- function(data, cols, ...) {
   out <- dplyr_col_modify(as_tibble(data), cols)
   rowwise_df(out, group_vars(data))
 }

--- a/R/generics.R
+++ b/R/generics.R
@@ -179,19 +179,19 @@ dplyr_col_modify.rowwise_df <- function(data, cols, ...) {
 #' @param template Template to use for restoring attributes
 #' @export
 #' @rdname dplyr_extending
-dplyr_reconstruct <- function(data, template) {
+dplyr_reconstruct <- function(data, template, ...) {
   # Strip attributes before dispatch to make it easier to implement
   # methods and prevent unexpected leaking of irrelevant attributes.
   data <- dplyr_new_data_frame(data)
   return(dplyr_reconstruct_dispatch(data, template))
   UseMethod("dplyr_reconstruct", template)
 }
-dplyr_reconstruct_dispatch <- function(data, template) {
+dplyr_reconstruct_dispatch <- function(data, template, ...) {
   UseMethod("dplyr_reconstruct", template)
 }
 
 #' @export
-dplyr_reconstruct.data.frame <- function(data, template) {
+dplyr_reconstruct.data.frame <- function(data, template, ...) {
   attrs <- attributes(template)
   attrs$names <- names(data)
   attrs$row.names <- .row_names_info(data, type = 0L)
@@ -201,13 +201,13 @@ dplyr_reconstruct.data.frame <- function(data, template) {
 }
 
 #' @export
-dplyr_reconstruct.grouped_df <- function(data, template) {
+dplyr_reconstruct.grouped_df <- function(data, template, ...) {
   group_vars <- group_intersect(template, data)
   grouped_df(data, group_vars, drop = group_by_drop_default(template))
 }
 
 #' @export
-dplyr_reconstruct.rowwise_df <- function(data, template) {
+dplyr_reconstruct.rowwise_df <- function(data, template, ...) {
   group_vars <- group_intersect(template, data)
   rowwise_df(data, group_vars)
 }

--- a/R/group-by.r
+++ b/R/group-by.r
@@ -310,17 +310,17 @@ quo_is_variable_reference <- function(quo) {
 #'
 #' @keywords internal
 #' @export
-group_by_drop_default <- function(.tbl) {
+group_by_drop_default <- function(.tbl, ...) {
   UseMethod("group_by_drop_default")
 }
 
 #' @export
-group_by_drop_default.default <- function(.tbl) {
+group_by_drop_default.default <- function(.tbl, ...) {
   TRUE
 }
 
 #' @export
-group_by_drop_default.grouped_df <- function(.tbl) {
+group_by_drop_default.grouped_df <- function(.tbl, ...) {
   tryCatch({
     !identical(attr(group_data(.tbl), ".drop"), FALSE)
   }, error = function(e){

--- a/R/group_data.R
+++ b/R/group_data.R
@@ -159,8 +159,8 @@ group_size.data.frame <- function(x, ...) {
 
 #' @export
 #' @rdname group_data
-n_groups <- function(x) UseMethod("n_groups")
+n_groups <- function(x, ...) UseMethod("n_groups")
 #' @export
-n_groups.data.frame <- function(x) {
+n_groups.data.frame <- function(x, ...) {
   nrow(group_data(x))
 }

--- a/R/group_data.R
+++ b/R/group_data.R
@@ -45,28 +45,28 @@
 #' group_data(gf)
 #' group_indices(gf)
 #' @export
-group_data <- function(.data) {
+group_data <- function(.data, ...) {
   UseMethod("group_data")
 }
 
 #' @export
-group_data.data.frame <- function(.data) {
+group_data.data.frame <- function(.data, ...) {
   rows <- new_list_of(list(seq_len(nrow(.data))), ptype = integer())
   new_data_frame(list(.rows = rows), n = 1L)
 }
 
 #' @export
-group_data.tbl_df <- function(.data) {
+group_data.tbl_df <- function(.data, ...) {
   as_tibble(NextMethod())
 }
 
 #' @export
-group_data.rowwise_df <- function(.data) {
+group_data.rowwise_df <- function(.data, ...) {
   attr(.data, "groups")
 }
 
 #' @export
-group_data.grouped_df <- function(.data) {
+group_data.grouped_df <- function(.data, ...) {
   error_call <- current_env()
   withCallingHandlers(
     validate_grouped_df(.data),

--- a/R/group_data.R
+++ b/R/group_data.R
@@ -141,11 +141,11 @@ group_vars.data.frame <- function(x, ...) {
 
 #' @export
 #' @rdname group_data
-groups <- function(x) {
+groups <- function(x, ...) {
   UseMethod("groups")
 }
 #' @export
-groups.data.frame <- function(x) {
+groups.data.frame <- function(x, ...) {
   syms(group_vars(x))
 }
 

--- a/R/group_data.R
+++ b/R/group_data.R
@@ -131,11 +131,11 @@ group_indices.data.frame <- function(.data, ...) {
 
 #' @export
 #' @rdname group_data
-group_vars <- function(x) {
+group_vars <- function(x, ...) {
   UseMethod("group_vars")
 }
 #' @export
-group_vars.data.frame <- function(x) {
+group_vars.data.frame <- function(x, ...) {
   setdiff(names(group_data(x)), ".rows")
 }
 

--- a/R/group_data.R
+++ b/R/group_data.R
@@ -151,9 +151,9 @@ groups.data.frame <- function(x, ...) {
 
 #' @export
 #' @rdname group_data
-group_size <- function(x) UseMethod("group_size")
+group_size <- function(x, ...) UseMethod("group_size")
 #' @export
-group_size.data.frame <- function(x) {
+group_size.data.frame <- function(x, ...) {
   lengths(group_rows(x))
 }
 

--- a/R/group_trim.R
+++ b/R/group_trim.R
@@ -18,18 +18,18 @@
 #'   group_by(Species) %>%
 #'   filter(Species == "setosa", .preserve = TRUE) %>%
 #'   group_trim()
-group_trim <- function(.tbl, .drop = group_by_drop_default(.tbl)) {
+group_trim <- function(.tbl, ..., .drop = group_by_drop_default(.tbl)) {
   lifecycle::signal_stage("experimental", "group_trim()")
   UseMethod("group_trim")
 }
 
 #' @export
-group_trim.data.frame <- function(.tbl, .drop = group_by_drop_default(.tbl)) {
+group_trim.data.frame <- function(.tbl, ..., .drop = group_by_drop_default(.tbl)) {
   .tbl
 }
 
 #' @export
-group_trim.grouped_df <- function(.tbl, .drop = group_by_drop_default(.tbl)) {
+group_trim.grouped_df <- function(.tbl, ..., .drop = group_by_drop_default(.tbl)) {
   vars <- group_vars(.tbl)
   ungrouped <- ungroup(.tbl)
 

--- a/R/join-by.R
+++ b/R/join-by.R
@@ -284,12 +284,12 @@ flat_map_chr <- function(x, fn) {
 # ------------------------------------------------------------------------------
 
 # Internal generic
-as_join_by <- function(x, error_call = caller_env()) {
+as_join_by <- function(x, ..., error_call = caller_env()) {
   UseMethod("as_join_by")
 }
 
 #' @export
-as_join_by.default <- function(x, error_call = caller_env()) {
+as_join_by.default <- function(x, ..., error_call = caller_env()) {
   message <- glue(paste0(
     "`by` must be a (named) character vector, list, `join_by()` result, ",
     "or NULL, not {obj_type_friendly(x)}."
@@ -298,12 +298,12 @@ as_join_by.default <- function(x, error_call = caller_env()) {
 }
 
 #' @export
-as_join_by.dplyr_join_by <- function(x, error_call = caller_env()) {
+as_join_by.dplyr_join_by <- function(x, ..., error_call = caller_env()) {
   x
 }
 
 #' @export
-as_join_by.character <- function(x, error_call = caller_env()) {
+as_join_by.character <- function(x, ..., error_call = caller_env()) {
   x_names <- names(x) %||% x
   y_names <- unname(x)
 
@@ -314,7 +314,7 @@ as_join_by.character <- function(x, error_call = caller_env()) {
 }
 
 #' @export
-as_join_by.list <- function(x, error_call = caller_env()) {
+as_join_by.list <- function(x, ..., error_call = caller_env()) {
   # TODO: check lengths
   x_names <- x[["x"]]
   y_names <- x[["y"]]

--- a/R/join-common-by.R
+++ b/R/join-common-by.R
@@ -2,10 +2,10 @@
 #'
 #' @export
 #' @keywords internal
-common_by <- function(by = NULL, x, y) UseMethod("common_by", by)
+common_by <- function(by = NULL, x, y, ...) UseMethod("common_by", by)
 
 #' @export
-common_by.character <- function(by, x, y) {
+common_by.character <- function(by, x, y, ...) {
   by <- common_by_from_vector(by)
   common_by.list(by, x, y)
 }
@@ -22,7 +22,7 @@ common_by_from_vector <- function(by) {
 }
 
 #' @export
-common_by.list <- function(by, x, y) {
+common_by.list <- function(by, x, y, ...) {
   x_vars <- tbl_vars(x)
   if (!all(by$x %in% x_vars)) {
     msg <- glue("`by` can't contain join column {missing} which is missing from LHS.",
@@ -43,7 +43,7 @@ common_by.list <- function(by, x, y) {
 }
 
 #' @export
-common_by.NULL <- function(by, x, y) {
+common_by.NULL <- function(by, x, y, ...) {
   by <- intersect(tbl_vars(x), tbl_vars(y))
   by <- by[!is.na(by)]
   if (length(by) == 0) {
@@ -69,7 +69,7 @@ auto_by_msg <- function(by) {
 }
 
 #' @export
-common_by.default <- function(by, x, y) {
+common_by.default <- function(by, x, y, ...) {
   msg <- glue("`by` must be a (named) character vector, list, or NULL for natural joins (not recommended in production code), not {obj_type_friendly(by)}.")
   abort(msg)
 }

--- a/R/tbl.r
+++ b/R/tbl.r
@@ -32,7 +32,7 @@ make_tbl <- function(subclass, ...) {
 #' @export
 is.tbl <- function(x) inherits(x, "tbl")
 
-tbl_vars_dispatch <- function(x) {
+tbl_vars_dispatch <- function(x, ...) {
   UseMethod("tbl_vars")
 }
 
@@ -56,7 +56,7 @@ new_sel_vars <- function(vars, group_vars) {
 #' @seealso [group_vars()] for a function that returns grouping
 #'   variables.
 #' @keywords internal
-tbl_vars <- function(x) {
+tbl_vars <- function(x, ...) {
   return(new_sel_vars(tbl_vars_dispatch(x), group_vars(x)))
 
   # For roxygen and static analysis
@@ -64,7 +64,7 @@ tbl_vars <- function(x) {
 }
 
 #' @export
-tbl_vars.data.frame <- function(x) {
+tbl_vars.data.frame <- function(x, ...) {
   names(x)
 }
 


### PR DESCRIPTION
From painful experience with pillar, it seems advisable to *always* add dots to all generics, even if there is no use for them today. Once a generic is available and used by other packages, I have found it to be *impossible* to add dots to a generic without temporarily CRAN-breaking all downstream packages that implement methods for the generic.

Is there a downside to always adding dots? Will R7 make this easier?

Action advice:

- Add dots at least to all new methods
- Consider `tally()`
- Add dots to methods that aren't used by other CRAN packages yet

Omitting database generics due to #4663.