### PR TITLE
WIP: New .multi argument to summarize()

### DIFF
--- a/man/summarise.Rd
+++ b/man/summarise.Rd
@@ -5,9 +5,9 @@
 \alias{summarize}
 \title{Summarise each group to fewer rows}
 \usage{
-summarise(.data, ..., .groups = NULL)
+summarise(.data, ..., .groups = NULL, .multi = c("allow", "fail", "require"))
 
-summarize(.data, ..., .groups = NULL)
+summarize(.data, ..., .groups = NULL, .multi = c("allow", "fail", "require"))
 }
 \arguments{
 \item{.data}{A data frame, data frame extension (e.g. a tibble), or a
@@ -43,6 +43,18 @@ based on the number of rows of the results:
 In addition, a message informs you of that choice, unless the result is ungrouped,
 the option "dplyr.summarise.inform" is set to \code{FALSE},
 or when \code{summarise()} is called from a function in a package.}
+
+\item{.multi}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} Support multiple resulting rows per group
+
+As of dplyr 1.0.0, if one summary function returns a vector of size != 1,
+multiple rows are created for each group.
+This feature is currently supported only for data frames.
+While useful occasionally, it may lead to accidental duplication or loss of output rows.
+Specifying \code{.multi = "fail"} leads to an error if any summary function
+has returned a vector of size != 1.
+With \code{.multi = "require"}, an error is raised if the size of all summaries is 1.
+The default, \code{.multi = "allow"}, means no checking and is kept for compatibility
+with earlier versions of dplyr.}
 }
 \value{
 An object \emph{usually} of the same type as \code{.data}.


### PR DESCRIPTION
``` r
library(conflicted)
library(dplyr)

my_custom_summary_function <- function(n) {
  # Should return a scalar, but I accidentally return a vector
  rep(n, n)
}

tibble(n = 2:0) %>%
  group_by(n) %>%
  summarize(out = my_custom_summary_function(n), .groups = "drop", .multi = "fail")
#> Error in `summarize()`:
#> ! A summary function returned a vector of size != 1, use `.multi =
#>   "require"` or `.multi = "allow"`.

tibble(n = 2:0) %>%
  group_by(n) %>%
  summarize(out = my_custom_summary_function(n), .groups = "drop", .multi = "require")
#> # A tibble: 3 × 2
#>       n   out
#>   <int> <int>
#> 1     1     1
#> 2     2     2
#> 3     2     2

tibble(n = 2:0) %>%
  group_by(n) %>%
  summarize(out = n, .groups = "drop", .multi = "require")
#> Error in `summarize()`:
#> ! All summary functions returned a vector of size one, use `.multi =
#>   "fail"` or `.multi = "allow"`.
```

<sup>Created on 2022-08-19 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Happy to discuss argument name and values. The error message can be made much prettier, I'll also add tests.

There seems to be no mention of multi-row `summarize()` in the vignettes.

Closes #6382.