### PR TITLE
Eliminate `mask$full_data()` and `private$data`

### DIFF
--- a/R/conditions.R
+++ b/R/conditions.R
@@ -43,8 +43,7 @@ cnd_bullet_cur_group_label <- function(what = "error") {
 }
 
 cnd_bullet_rowwise_unlist <- function() {
-  data <- peek_mask()$full_data()
-  if (inherits(data, "rowwise_df")) {
+  if (peek_mask()$is_rowwise_df()) {
     glue_data(peek_error_context(), "Did you mean: `{error_name} = list({error_expression})` ?")
   }
 }
@@ -108,7 +107,7 @@ cnd_bullet_header <- function(what) {
 
 cnd_bullet_combine_details <- function(x, arg) {
   group <- as.integer(sub("^..", "", arg))
-  keys <- group_keys(peek_mask()$full_data())[group, ]
+  keys <- peek_mask()$get_keys()[group, ]
   details <- group_labels_details(keys)
   glue("Result type for group {group} ({details}): <{vec_ptype_full(x)}>.")
 }

--- a/R/context.R
+++ b/R/context.R
@@ -98,10 +98,9 @@ group_labels_details <- function(keys) {
 
 cur_group_label <- function() {
   mask <- peek_mask()
-  data <- mask$full_data()
-  if(is_grouped_df(data) && nrow(data) > 0) {
+  if(mask$is_grouped_df() && mask$get_size() > 0) {
     glue("group {id}: {label}", id = cur_group_id(), label = group_labels_details(cur_group()))
-  } else if (inherits(data, "rowwise_df") && nrow(data) > 0) {
+  } else if (mask$is_rowwise_df() && mask$get_size() > 0) {
     paste0("row ", cur_group_id())
   } else {
     ""

--- a/R/rowwise.r
+++ b/R/rowwise.r
@@ -88,6 +88,10 @@ rowwise_df <- function(data, group_vars) {
   new_rowwise_df(data, group_data)
 }
 
+is_rowwise_df <- function(x) {
+  inherits(x, "rowwise_df")
+}
+
 #' @rdname new_grouped_df
 #' @export
 new_rowwise_df <- function(data, group_data = NULL, ..., class = character()) {


### PR DESCRIPTION
Working on `mutate(.when =)` (#6313) showed that having `$full_data()` was a bit dangerous because the original data might now always reflect the real state of the data mask, i.e. with `.when` the real data was the original data sliced to where `.when` was `TRUE`.

Removing `$full_data()` actually makes it very easy to remove `private$data` too, which seems like a nice simplification