### PR TITLE
Ensure that `rows` is type stable

### DIFF
--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -2,9 +2,9 @@ DataMask <- R6Class("DataMask",
   public = list(
     initialize = function(data, caller, verb, error_call) {
       rows <- group_rows(data)
-      # workaround for when there are 0 groups
       if (length(rows) == 0) {
-        rows <- list(integer())
+        # Specially handle case of zero groups
+        rows <- new_list_of(list(integer()), ptype = integer())
       }
       private$rows <- rows
 


### PR DESCRIPTION
It should always be a `list_of<integer>`. This doesn't have any practical effect here, but I think it is better practice

This is another thing noticed in #6313 