### PR TITLE
Fix ownership of errors thrown by internal dplyr steps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # dplyr (development version)
 
-* Evaluation errors in `group_by()` and `distinct()` have been
-  simplified (#6139).
+* Error messages in `group_by()`, `distinct()`, `tally()`, and `count()` are now
+  more relevant (#6139).
 
 * `slice_sample()` now accepts negative `n` and `prop` values (#6402).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dplyr (development version)
 
+* Evaluation errors in `group_by()` and `distinct()` have been
+  simplified (#6139).
+
 * `slice_sample()` now accepts negative `n` and `prop` values (#6402).
 
 * `slice_*()` now requires `n` to be an integer.

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -16,12 +16,16 @@ dplyr_error_call <- function(call) {
   if (is_missing(call)) {
     call <- caller_env()
   }
-  if (is_environment(call)) {
+
+  while (is_environment(call)) {
     caller <- eval_bare(quote(base::parent.frame()), call)
     caller_call <- caller[[".__dplyr_error_call__."]]
-    if (!is_null(caller_call)) {
-      call <- caller_call
+
+    if (is_null(caller_call)) {
+      break
     }
+
+    call <- caller_call
   }
 
   call

--- a/R/count-tally.R
+++ b/R/count-tally.R
@@ -114,36 +114,50 @@ add_count <- function(x, ..., wt = NULL, sort = FALSE, name = NULL, .drop = depr
 
 #' @export
 add_count.default <- function(x, ..., wt = NULL, sort = FALSE, name = NULL, .drop = deprecated()) {
-  if (!missing(.drop)) {
-    lifecycle::deprecate_warn("1.0.0", "add_count(.drop = )", always = TRUE)
-  }
-
-  dplyr_local_error_call()
-
-  if (!missing(...)) {
-    out <- group_by(x, ..., .add = TRUE)
-  } else {
-    out <- x
-  }
-  add_tally(out, wt = !!enquo(wt), sort = sort, name = name)
+  add_count_impl(
+    x,
+    ...,
+    wt = {{ wt }},
+    sort = sort,
+    name = name,
+    .drop = .drop
+  )
 }
 
 
 #' @export
 add_count.data.frame <- function(x, ..., wt = NULL, sort = FALSE, name = NULL, .drop = deprecated()) {
-  if (!missing(.drop)) {
+  out <- add_count_impl(
+    x,
+    ...,
+    wt = {{ wt }},
+    sort = sort,
+    name = name,
+    .drop = .drop
+  )
+  dplyr_reconstruct(out, x)
+}
+
+add_count_impl <- function(x,
+                           ...,
+                           wt = NULL,
+                           sort = FALSE,
+                           name = NULL,
+                           .drop = deprecated(),
+                           error_call = caller_env()) {
+  if (!is_missing(.drop)) {
     lifecycle::deprecate_warn("1.0.0", "add_count(.drop = )", always = TRUE)
   }
 
-  dplyr_local_error_call()
+  dplyr_local_error_call(error_call)
 
   if (!missing(...)) {
     out <- group_by(x, ..., .add = TRUE)
   } else {
     out <- x
   }
-  out <- add_tally(out, wt = !!enquo(wt), sort = sort, name = name)
-  dplyr_reconstruct(out, x)
+
+  add_tally(out, wt = {{ wt }}, sort = sort, name = name)
 }
 
 #' @rdname count

--- a/R/count-tally.R
+++ b/R/count-tally.R
@@ -68,6 +68,8 @@ count <- function(x, ..., wt = NULL, sort = FALSE, name = NULL) {
 
 #' @export
 count.data.frame <- function(x, ..., wt = NULL, sort = FALSE, name = NULL, .drop = group_by_drop_default(x)) {
+  dplyr_local_error_call()
+
   if (!missing(...)) {
     out <- group_by(x, ..., .add = TRUE, .drop = .drop)
   } else {
@@ -116,6 +118,8 @@ add_count.default <- function(x, ..., wt = NULL, sort = FALSE, name = NULL, .dro
     lifecycle::deprecate_warn("1.0.0", "add_count(.drop = )", always = TRUE)
   }
 
+  dplyr_local_error_call()
+
   if (!missing(...)) {
     out <- group_by(x, ..., .add = TRUE)
   } else {
@@ -130,6 +134,8 @@ add_count.data.frame <- function(x, ..., wt = NULL, sort = FALSE, name = NULL, .
   if (!missing(.drop)) {
     lifecycle::deprecate_warn("1.0.0", "add_count(.drop = )", always = TRUE)
   }
+
+  dplyr_local_error_call()
 
   if (!missing(...)) {
     out <- group_by(x, ..., .add = TRUE)

--- a/R/count-tally.R
+++ b/R/count-tally.R
@@ -167,6 +167,8 @@ add_count_impl <- function(x,
 add_tally <- function(x, wt = NULL, sort = FALSE, name = NULL) {
   name <- check_name(name, tbl_vars(x))
 
+  dplyr_local_error_call()
+
   n <- tally_n(x, {{ wt }})
   out <- mutate(x, !!name := !!n)
 

--- a/R/count-tally.R
+++ b/R/count-tally.R
@@ -94,6 +94,8 @@ tally <- function(x, wt = NULL, sort = FALSE, name = NULL) {
 tally.data.frame <- function(x, wt = NULL, sort = FALSE, name = NULL) {
   name <- check_name(name, group_vars(x))
 
+  dplyr_local_error_call()
+
   n <- tally_n(x, {{ wt }})
 
   local_options(dplyr.summarise.inform = FALSE)

--- a/R/group-by.r
+++ b/R/group-by.r
@@ -243,14 +243,11 @@ add_computed_columns <- function(.data,
   if (any(needs_mutate)) {
     # TODO: use less of a hack
     if (inherits(.data, "data.frame")) {
-      cols <- withCallingHandlers(
-        mutate_cols(
-          ungroup(.data), dplyr_quosures(!!!vars), caller_env = caller_env,
-          error_call = call("mutate") # this is a pretend `mutate()`
-        ),
-        error = function(e) {
-          abort("Problem adding computed columns.", parent = e, call = error_call)
-        }
+      cols <- mutate_cols(
+        ungroup(.data),
+        dplyr_quosures(!!!vars),
+        caller_env = caller_env,
+        error_call = error_call
       )
 
       out <- dplyr_col_modify(.data, cols)

--- a/R/group-by.r
+++ b/R/group-by.r
@@ -137,7 +137,13 @@ group_by <- function(.data, ..., .add = FALSE, .drop = group_by_drop_default(.da
 
 #' @export
 group_by.data.frame <- function(.data, ..., .add = FALSE, .drop = group_by_drop_default(.data)) {
-  groups <- group_by_prepare(.data, ..., .add = .add, caller_env = caller_env())
+  groups <- group_by_prepare(
+    .data,
+    ...,
+    .add = .add,
+    caller_env = caller_env(),
+    error_call = current_env()
+  )
   grouped_df(groups$data, groups$group_names, .drop)
 }
 
@@ -191,6 +197,7 @@ group_by_prepare <- function(.data,
                              .dots = deprecated(),
                              add = deprecated(),
                              error_call = caller_env()) {
+  error_call <- dplyr_error_call(error_call)
 
   if (!missing(add)) {
     lifecycle::deprecate_warn("1.0.0", "group_by(add = )", "group_by(.add = )", always = TRUE)

--- a/tests/testthat/_snaps/count-tally.md
+++ b/tests/testthat/_snaps/count-tally.md
@@ -80,4 +80,23 @@
       ! Problem while computing `new = 1 + ""`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
+    Code
+      (expect_error(add_count(mtcars, wt = 1 + "")))
+    Output
+      <error/dplyr:::mutate_error>
+      Error in `add_count()`:
+      ! Problem while computing `n = sum(1 + "", na.rm = TRUE)`.
+      Caused by error in `1 + ""`:
+      ! non-numeric argument to binary operator
+
+# add_tally() owns errors (#6139)
+
+    Code
+      (expect_error(add_tally(mtcars, wt = 1 + "")))
+    Output
+      <error/dplyr:::mutate_error>
+      Error in `add_tally()`:
+      ! Problem while computing `n = sum(1 + "", na.rm = TRUE)`.
+      Caused by error in `1 + ""`:
+      ! non-numeric argument to binary operator
 

--- a/tests/testthat/_snaps/count-tally.md
+++ b/tests/testthat/_snaps/count-tally.md
@@ -40,3 +40,25 @@
       3 3  1
       4 4  1
 
+# count() owns error messages (#6139)
+
+    Code
+      (expect_error(count(mtcars, new = 1 + "")))
+    Output
+      <error/dplyr:::mutate_error>
+      Error in `count()`:
+      ! Problem while computing `new = 1 + ""`.
+      Caused by error in `1 + ""`:
+      ! non-numeric argument to binary operator
+
+# add_count() owns error messages (#6139)
+
+    Code
+      (expect_error(add_count(mtcars, new = 1 + "")))
+    Output
+      <error/dplyr:::mutate_error>
+      Error in `add_count()`:
+      ! Problem while computing `new = 1 + ""`.
+      Caused by error in `1 + ""`:
+      ! non-numeric argument to binary operator
+

--- a/tests/testthat/_snaps/count-tally.md
+++ b/tests/testthat/_snaps/count-tally.md
@@ -50,6 +50,14 @@
       ! Problem while computing `new = 1 + ""`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
+    Code
+      (expect_error(count(mtcars, wt = 1 + "")))
+    Output
+      <error/rlang_error>
+      Error in `count()`:
+      ! Problem while computing `n = sum(1 + "", na.rm = TRUE)`.
+      Caused by error in `1 + ""`:
+      ! non-numeric argument to binary operator
 
 # tally() owns errors (#6139)
 

--- a/tests/testthat/_snaps/count-tally.md
+++ b/tests/testthat/_snaps/count-tally.md
@@ -40,7 +40,7 @@
       3 3  1
       4 4  1
 
-# count() owns error messages (#6139)
+# count() owns errors (#6139)
 
     Code
       (expect_error(count(mtcars, new = 1 + "")))
@@ -51,7 +51,18 @@
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
 
-# add_count() owns error messages (#6139)
+# tally() owns errors (#6139)
+
+    Code
+      (expect_error(tally(mtcars, wt = 1 + "")))
+    Output
+      <error/rlang_error>
+      Error in `tally()`:
+      ! Problem while computing `n = sum(1 + "", na.rm = TRUE)`.
+      Caused by error in `1 + ""`:
+      ! non-numeric argument to binary operator
+
+# add_count() owns errors (#6139)
 
     Code
       (expect_error(add_count(mtcars, new = 1 + "")))

--- a/tests/testthat/_snaps/distinct.md
+++ b/tests/testthat/_snaps/distinct.md
@@ -26,10 +26,8 @@
     Code
       (expect_error(df %>% distinct(y = a + 1)))
     Output
-      <error/rlang_error>
+      <error/dplyr:::mutate_error>
       Error in `distinct()`:
-      ! Problem adding computed columns.
-      Caused by error in `mutate()`:
       ! Problem while computing `y = a + 1`.
       Caused by error:
       ! object 'a' not found

--- a/tests/testthat/_snaps/group-by.md
+++ b/tests/testthat/_snaps/group-by.md
@@ -41,10 +41,8 @@
     Code
       (expect_error(df %>% group_by(z = a + 1)))
     Output
-      <error/rlang_error>
+      <error/dplyr:::mutate_error>
       Error in `group_by()`:
-      ! Problem adding computed columns.
-      Caused by error in `mutate()`:
       ! Problem while computing `z = a + 1`.
       Caused by error:
       ! object 'a' not found

--- a/tests/testthat/test-count-tally.r
+++ b/tests/testthat/test-count-tally.r
@@ -108,6 +108,12 @@ test_that("wt = n() is deprecated", {
   expect_warning(count(df, wt = n()), "`wt = n()`", fixed = TRUE)
 })
 
+test_that("count() owns errors (#6139)", {
+  expect_snapshot({
+    (expect_error(count(mtcars, new = 1 + "")))
+  })
+})
+
 # tally -------------------------------------------------------------------
 
 test_that("tally can sort output", {
@@ -143,6 +149,12 @@ test_that(".drop is deprecated",  {
 
   df <- tibble(f = factor("b", levels = c("a", "b", "c")))
   expect_warning(out <- add_count(df, f, .drop = FALSE), "deprecated")
+})
+
+test_that("add_count() owns errors (#6139)", {
+  expect_snapshot({
+    (expect_error(add_count(mtcars, new = 1 + "")))
+  })
 })
 
 # add_tally ---------------------------------------------------------------

--- a/tests/testthat/test-count-tally.r
+++ b/tests/testthat/test-count-tally.r
@@ -161,6 +161,7 @@ test_that(".drop is deprecated",  {
 test_that("add_count() owns errors (#6139)", {
   expect_snapshot({
     (expect_error(add_count(mtcars, new = 1 + "")))
+    (expect_error(add_count(mtcars, wt = 1 + "")))
   })
 })
 
@@ -187,4 +188,10 @@ test_that("add_tally can be given a weighting variable", {
 test_that("can override output column", {
   df <- data.frame(g = c(1, 1, 2, 2, 2), x = c(3, 2, 5, 5, 5))
   expect_named(add_tally(df, name = "xxx"), c("g", "x", "xxx"))
+})
+
+test_that("add_tally() owns errors (#6139)", {
+  expect_snapshot({
+    (expect_error(add_tally(mtcars, wt = 1 + "")))
+  })
 })

--- a/tests/testthat/test-count-tally.r
+++ b/tests/testthat/test-count-tally.r
@@ -111,6 +111,7 @@ test_that("wt = n() is deprecated", {
 test_that("count() owns errors (#6139)", {
   expect_snapshot({
     (expect_error(count(mtcars, new = 1 + "")))
+    (expect_error(count(mtcars, wt = 1 + "")))
   })
 })
 

--- a/tests/testthat/test-count-tally.r
+++ b/tests/testthat/test-count-tally.r
@@ -134,6 +134,12 @@ test_that("tally() drops last group (#5199) ", {
   expect_equal(group_vars(res), "x")
 })
 
+test_that("tally() owns errors (#6139)", {
+  expect_snapshot({
+    (expect_error(tally(mtcars, wt = 1 + "")))
+  })
+})
+
 # add_count ---------------------------------------------------------------
 
 test_that("ouput preserves grouping", {


### PR DESCRIPTION
Closes #6139.

Also makes `dplyr_error_call()` recursive so that, for example, `mutate()` errors transferred to `add_tally()` can be transferred to `add_count()`.