### PR TITLE
Mention `join_by()` when `by` argument is omitted in joins

### DIFF
--- a/R/join-by.R
+++ b/R/join-by.R
@@ -352,17 +352,13 @@ join_by_common <- function(x_names,
   if (length(by) == 0) {
     message <- c(
       "`by` must be supplied when `x` and `y` have no common variables.",
-      i = "Use `by = character()` to perform a cross-join."
+      i = "Use `by = join_by()` to perform a cross-join."
     )
     abort(message, call = error_call)
   }
 
-  by_quoted <- encodeString(by, quote = '"')
-  if (length(by_quoted) == 1L) {
-    by_code <- by_quoted
-  } else {
-    by_code <- paste0("c(", paste(by_quoted, collapse = ", "), ")")
-  }
+  by_quoted <- tick_if_needed(by)
+  by_code <- paste0("join_by(", paste(by_quoted, collapse = ", "), ")")
   inform(paste0("Joining, by = ", by_code))
 
   finalise_equi_join_by(by, by)

--- a/R/join-by.R
+++ b/R/join-by.R
@@ -357,9 +357,9 @@ join_by_common <- function(x_names,
     abort(message, call = error_call)
   }
 
-  by_quoted <- tick_if_needed(by)
-  by_code <- paste0("join_by(", paste(by_quoted, collapse = ", "), ")")
-  inform(paste0("Joining, by = ", by_code))
+  by_names <- tick_if_needed(by)
+  by_names <- glue_collapse(by_names, sep = ", ")
+  inform(glue("Joining with `by = join_by({by_names})`"))
 
   finalise_equi_join_by(by, by)
 }

--- a/tests/testthat/_snaps/join-by.md
+++ b/tests/testthat/_snaps/join-by.md
@@ -349,6 +349,13 @@
 ---
 
     Code
+      by <- join_by_common(c("_x", "foo bar"), c("_x", "foo bar"))
+    Message
+      Joining with `by = join_by(`_x`, `foo bar`)`
+
+---
+
+    Code
       join_by_common(c("x", "y"), c("w", "z"))
     Condition
       Error:

--- a/tests/testthat/_snaps/join-by.md
+++ b/tests/testthat/_snaps/join-by.md
@@ -344,7 +344,7 @@
     Code
       by <- join_by_common(c("x", "y"), c("x", "y"))
     Message
-      Joining, by = c("x", "y")
+      Joining, by = join_by(x, y)
 
 ---
 
@@ -353,5 +353,5 @@
     Condition
       Error:
       ! `by` must be supplied when `x` and `y` have no common variables.
-      i Use `by = character()` to perform a cross-join.
+      i Use `by = join_by()` to perform a cross-join.
 

--- a/tests/testthat/_snaps/join-by.md
+++ b/tests/testthat/_snaps/join-by.md
@@ -344,7 +344,7 @@
     Code
       by <- join_by_common(c("x", "y"), c("x", "y"))
     Message
-      Joining, by = join_by(x, y)
+      Joining with `by = join_by(x, y)`
 
 ---
 

--- a/tests/testthat/_snaps/join.md
+++ b/tests/testthat/_snaps/join.md
@@ -44,21 +44,21 @@
     Code
       out <- left_join(df1, df2)
     Message
-      Joining, by = "x"
+      Joining, by = join_by(x)
 
 # filtering joins compute common columns
 
     Code
       out <- semi_join(df1, df2)
     Message
-      Joining, by = "x"
+      Joining, by = join_by(x)
 
 # error if passed additional arguments
 
     Code
       inner_join(df1, df2, on = "a")
     Message
-      Joining, by = "a"
+      Joining, by = join_by(a)
     Condition
       Error in `inner_join()`:
       ! Arguments in `...` must be used.
@@ -67,7 +67,7 @@
     Code
       left_join(df1, df2, on = "a")
     Message
-      Joining, by = "a"
+      Joining, by = join_by(a)
     Condition
       Error in `left_join()`:
       ! Arguments in `...` must be used.
@@ -76,7 +76,7 @@
     Code
       right_join(df1, df2, on = "a")
     Message
-      Joining, by = "a"
+      Joining, by = join_by(a)
     Condition
       Error in `right_join()`:
       ! Arguments in `...` must be used.
@@ -85,7 +85,7 @@
     Code
       full_join(df1, df2, on = "a")
     Message
-      Joining, by = "a"
+      Joining, by = join_by(a)
     Condition
       Error in `full_join()`:
       ! Arguments in `...` must be used.
@@ -94,7 +94,7 @@
     Code
       nest_join(df1, df2, on = "a")
     Message
-      Joining, by = "a"
+      Joining, by = join_by(a)
     Condition
       Error in `nest_join()`:
       ! Arguments in `...` must be used.
@@ -103,7 +103,7 @@
     Code
       anti_join(df1, df2, on = "a")
     Message
-      Joining, by = "a"
+      Joining, by = join_by(a)
     Condition
       Error in `anti_join()`:
       ! Arguments in `...` must be used.
@@ -112,7 +112,7 @@
     Code
       semi_join(df1, df2, on = "a")
     Message
-      Joining, by = "a"
+      Joining, by = join_by(a)
     Condition
       Error in `semi_join()`:
       ! Arguments in `...` must be used.
@@ -124,7 +124,7 @@
     Code
       out <- nest_join(df1, df2)
     Message
-      Joining, by = "x"
+      Joining, by = join_by(x)
 
 # validates inputs
 

--- a/tests/testthat/_snaps/join.md
+++ b/tests/testthat/_snaps/join.md
@@ -44,21 +44,21 @@
     Code
       out <- left_join(df1, df2)
     Message
-      Joining, by = join_by(x)
+      Joining with `by = join_by(x)`
 
 # filtering joins compute common columns
 
     Code
       out <- semi_join(df1, df2)
     Message
-      Joining, by = join_by(x)
+      Joining with `by = join_by(x)`
 
 # error if passed additional arguments
 
     Code
       inner_join(df1, df2, on = "a")
     Message
-      Joining, by = join_by(a)
+      Joining with `by = join_by(a)`
     Condition
       Error in `inner_join()`:
       ! Arguments in `...` must be used.
@@ -67,7 +67,7 @@
     Code
       left_join(df1, df2, on = "a")
     Message
-      Joining, by = join_by(a)
+      Joining with `by = join_by(a)`
     Condition
       Error in `left_join()`:
       ! Arguments in `...` must be used.
@@ -76,7 +76,7 @@
     Code
       right_join(df1, df2, on = "a")
     Message
-      Joining, by = join_by(a)
+      Joining with `by = join_by(a)`
     Condition
       Error in `right_join()`:
       ! Arguments in `...` must be used.
@@ -85,7 +85,7 @@
     Code
       full_join(df1, df2, on = "a")
     Message
-      Joining, by = join_by(a)
+      Joining with `by = join_by(a)`
     Condition
       Error in `full_join()`:
       ! Arguments in `...` must be used.
@@ -94,7 +94,7 @@
     Code
       nest_join(df1, df2, on = "a")
     Message
-      Joining, by = join_by(a)
+      Joining with `by = join_by(a)`
     Condition
       Error in `nest_join()`:
       ! Arguments in `...` must be used.
@@ -103,7 +103,7 @@
     Code
       anti_join(df1, df2, on = "a")
     Message
-      Joining, by = join_by(a)
+      Joining with `by = join_by(a)`
     Condition
       Error in `anti_join()`:
       ! Arguments in `...` must be used.
@@ -112,7 +112,7 @@
     Code
       semi_join(df1, df2, on = "a")
     Message
-      Joining, by = join_by(a)
+      Joining with `by = join_by(a)`
     Condition
       Error in `semi_join()`:
       ! Arguments in `...` must be used.
@@ -124,7 +124,7 @@
     Code
       out <- nest_join(df1, df2)
     Message
-      Joining, by = join_by(x)
+      Joining with `by = join_by(x)`
 
 # validates inputs
 

--- a/tests/testthat/test-join-by.R
+++ b/tests/testthat/test-join-by.R
@@ -249,6 +249,9 @@ test_that("join_by_common() emits useful information", {
   # Common by message
   expect_snapshot(by <- join_by_common(c("x", "y"), c("x", "y")))
 
+  # Works with names that need backticks
+  expect_snapshot(by <- join_by_common(c("_x", "foo bar"), c("_x", "foo bar")))
+
   # No common variables error
   expect_snapshot(error = TRUE, join_by_common(c("x", "y"), c("w", "z")))
 })


### PR DESCRIPTION
We already have `tick_if_needed()` .

Closes #6448.