### PR TITLE
Switch to radix ordering in more places

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # dplyr (development version)
 
+* `nth()`, `first()`, `last()`, and `with_order()` now sort character `order_by`
+  vectors in the C locale. Using character vectors for `order_by` is rare, so we
+  expect this to have little practical impact (#6451).
+
 * `slice()`ing with a 1-column matrix is now deprecated.
 
 * `row_number()`, `min_rank()`, `dense_rank()`, `ntile()`, `cume_dist()`, and

--- a/R/nth-value.R
+++ b/R/nth-value.R
@@ -115,7 +115,7 @@ nth <- function(x, n, order_by = NULL, default = NULL, na_rm = FALSE) {
   }
 
   if (!is.null(order_by)) {
-    order <- vec_order_base(order_by)
+    order <- vec_order_radix(order_by)
     n <- order[[n]]
   }
 

--- a/R/order-by.R
+++ b/R/order-by.R
@@ -63,11 +63,11 @@ order_by <- function(order_by, call) {
 with_order <- function(order_by, fun, x, ...) {
   vec_assert(order_by, size = vec_size(x), arg = "order_by")
 
-  o <- vec_order_base(order_by)
+  o <- vec_order_radix(order_by)
   x <- vec_slice(x, o)
 
   out <- fun(x, ...)
 
-  o <- vec_order_base(o)
+  o <- vec_order_radix(o)
   vec_slice(out, o)
 }


### PR DESCRIPTION
- `nth(order_by =)`
- `with_order()`

This means that `vec_order_base()` is now only used in the `dplyr.legacy_locale` code path of `group_by()`. And I might be able to remove that in another PR by using `dplyr_order_legacy()`, which is used in the `arrange()` legacy path. I'll take a look.

I did not feel like this needs a news bullet, because it is highly unlikely to affect much code, and we don't provide a way to opt out of this.