### PR TITLE
Use `dplyr_order_legacy()` and remove `vec_order_base()`

### DIFF
--- a/R/arrange.R
+++ b/R/arrange.R
@@ -187,7 +187,7 @@ sort_key_generator <- function(locale) {
 
 # ------------------------------------------------------------------------------
 
-dplyr_order_legacy <- function(data, direction) {
+dplyr_order_legacy <- function(data, direction = "asc") {
   if (ncol(data) == 0L) {
     # Work around `order(!!!list())` returning `NULL`
     return(seq_len(nrow(data)))
@@ -225,6 +225,14 @@ dplyr_proxy_order_legacy <- function(x, direction) {
     out <- vec_match(x, sorted_unique)
 
     return(out)
+  }
+
+  if (!is_character(x) && !is_logical(x) && !is_integer(x) && !is_double(x) && !is_complex(x)) {
+    abort("Invalid type returned by `vec_proxy_order()`.", .internal = TRUE)
+  }
+
+  if (is.object(x)) {
+    x <- unstructure(x)
   }
 
   if (direction == "desc") {

--- a/R/grouped-df.r
+++ b/R/grouped-df.r
@@ -299,9 +299,9 @@ dplyr_locate_sorted_groups <- function(x) {
   out$loc <- new_list_of(out$loc, ptype = integer())
 
   if (dplyr_legacy_locale()) {
-    # Temporary legacy support for respecting the system locale
+    # Temporary legacy support for respecting the system locale.
     # Matches legacy `arrange()` ordering.
-    out <- vec_slice(out, vec_order_base(out$key))
+    out <- vec_slice(out, dplyr_order_legacy(out$key))
   }
 
   out

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -10,13 +10,12 @@
 
   .Call(dplyr_init_library, ns_dplyr, ns_env("vctrs"), ns_env("rlang"))
 
-  # TODO: For `arrange()`, `group_by()`, and `with_order()` until vctrs changes
-  # `vec_order()` to the new ordering algorithm and officially exports
-  # `vec_order_base()`, at which point we should use `vec_order()` and
-  # `vec_order_base()` directly and remove this.
+  # TODO: For `arrange()`, `group_by()`, `with_order()`, and `nth()` until vctrs
+  # changes `vec_order()` to the new ordering algorithm, at which point we
+  # should switch from `vec_order_radix()` to `vec_order()` so vctrs can remove
+  # it.
   env_bind(
     .env = ns_dplyr,
-    vec_order_base = import_vctrs("vec_order_base"),
     vec_order_radix = import_vctrs("vec_order_radix")
   )
 


### PR DESCRIPTION
We already have `dplyr_order_legacy()` for `arrange()`, which is slightly different from `vec_order_base()` because it allows you to use a vectorized `direction` argument.

Since `arrange()` already needed a custom version of `vec_order_base()`, we might as well adapt it to be usable by the legacy path of `group_by()` as well.

That means:
- Both `arrange()` and `group_by()` use the exact same legacy ordering helper
- We don't need to import `vctrs:::vec_order_base()`, which simplifies things a bit and means we definitely don't need it in vctrs anymore

So now we just have to worry about managing `vec_order_radix()`