### PR TITLE
Remove `preceding()` and `following()` in favor of `closest()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -301,10 +301,10 @@
       `join_by(sale_date >= commercial_date)` to find every commercial that
       aired before a particular sale.
       
-    * Rolling joins: For "rolling" the preceding value forward or the following
-      value backwards when there isn't an exact match, specified by using one of
-      the rolling helpers: `preceding()` or `following()`. For example,
-      `join_by(preceding(sale_date, commercial_date))` to find only the most
+    * Rolling joins: For "rolling" the closest match forward or backwards when
+      there isn't an exact match, specified by using the rolling helper,
+      `closest()`. For example,
+      `join_by(closest(sale_date >= commercial_date))` to find only the most
       recent commercial that aired before a particular sale.
       
     * Overlap joins: For detecting overlaps between sets of columns, specified

--- a/man/join_by.Rd
+++ b/man/join_by.Rd
@@ -12,7 +12,7 @@ join_by(...)
 Each expression should consist of either a join condition or a join helper:
 \itemize{
 \item Join conditions: \code{==}, \code{>=}, \code{>}, \code{<=}, or \code{<}.
-\item Rolling helpers: \code{preceding()} or \code{following()}.
+\item Rolling helper: \code{closest()}.
 \item Overlap helpers: \code{between()}, \code{within()}, or \code{overlaps()}.
 }
 
@@ -35,7 +35,7 @@ using a small domain specific language. The result can be supplied as the
 \code{by} argument to any of the join functions (such as \code{\link[=left_join]{left_join()}}).
 }
 \section{Join types}{
-\code{join_by()} supports four types of join, as described below:
+\code{join_by()} supports four types of joins, as described below:
 \itemize{
 \item Equi joins
 \item Non-equi joins
@@ -64,46 +64,24 @@ join specifications!
 
 \subsection{Rolling joins}{
 
-Rolling joins are a variant of a non-equi join that limit the results
-returned from the non-equi join condition. They are useful for "rolling"
-the preceding value forward or the following value backwards when there
-isn't an exact match. There are two helpers that \code{join_by()} recognizes
-to assist with constructing rolling joins.
+Rolling joins are a variant of non-equi joins that limit the results returned
+from a non-equi join condition. They are useful for "rolling" the closest
+match forward/backwards when there isn't an exact match. To construct a
+rolling join, wrap an inequality with \code{closest()}.
 \itemize{
-\item \code{preceding(x, y, ..., inclusive = TRUE)}
+\item \code{closest(expr)}
 
-For each value in \code{x}, this finds the value in \code{y} that is directly
-preceding it. If \code{inclusive = TRUE}, an exact match is allowed to count as
-the preceding value.
+\code{expr} must be a binary inequality involving one of: \code{>}, \code{>=}, \code{<},
+or \code{<=}.
 
-Technically, this finds all matches using the binary condition \code{x >= y},
-then filters those matches to only include the one corresponding to the
-maximum value of \code{y} (i.e. the preceding match). If \code{inclusive = FALSE},
-\code{>=} is replaced with \code{>}.
-
-Dots are for future extensions and must be empty.
-\item \code{following(x, y, ..., inclusive = TRUE)}
-
-For each value in \code{x}, this finds the value in \code{y} that is directly
-following it. If \code{inclusive = TRUE}, an exact match is allowed to count as
-the following value.
-
-Technically, this finds all matches using the binary condition \code{x <= y},
-then filters those matches to only include the one corresponding to the
-minimum value of \code{y} (i.e. the following match). If \code{inclusive = FALSE},
-\code{<=} is replaced with \code{<}.
-
-Dots are for future extensions and must be empty.
+For example, \code{closest(x >= y)} is interpreted as: For each value in \code{x},
+find the closest value in \code{y} that is less than or equal to that \code{x} value.
 }
 
-Unlike other join helpers, the \code{x} argument must reference the left-hand
-table (\code{x}) and the \code{y} argument must reference the right-hand table (\code{y}).
-Attempting something like \code{preceding(y$a, x$b)} is not defined and will
-result in an error.
-
-Rolling joins can't be constructed directly from binary conditions, but are
-approximately equivalent to applying the binary condition mentioned above
-followed by a \code{filter()} for only the maximum or minimum \code{y} value.
+\code{closest()} will always use the left-hand table (\code{x}) as the primary table,
+and the right-hand table (\code{y}) as the one to find the closest match in,
+regardless of how the binary condition is specified. For example,
+\code{closest(y$a >= x$b)} will always be interpreted as \code{closest(x$b <= y$a)}.
 }
 
 \subsection{Overlap joins}{
@@ -166,22 +144,21 @@ by <- join_by(id, sale_date >= promo_date)
 left_join(sales, promos, by)
 
 # For each `sale_date` within a particular `id`,
-# find only the preceding `promo_date` that occurred directly
-# before that sale
-by <- join_by(id, preceding(sale_date, promo_date))
+# find only the closest `promo_date` that occurred before that sale
+by <- join_by(id, closest(sale_date >= promo_date))
 left_join(sales, promos, by)
 
-# If you want to disallow exact matching in rolling joins,
-# set `inclusive = FALSE`. Note that the promo on `2019-01-05` is no longer
-# considered the preceding match for the sale on the same date.
-by <- join_by(id, preceding(sale_date, promo_date, inclusive = FALSE))
+# If you want to disallow exact matching in rolling joins, use `>` rather
+# than `>=`. Note that the promo on `2019-01-05` is no longer considered the
+# closest match for the sale on the same date.
+by <- join_by(id, closest(sale_date > promo_date))
 left_join(sales, promos, by)
 
 # Same as before, but also require that the promo had to occur at most 1
 # day before the sale was made. We'll use a full join to see that id 2's
 # promo on `2019-01-02` is no longer matched to the sale on `2019-01-04`.
 sales <- mutate(sales, sale_date_lower = sale_date - 1)
-by <- join_by(id, preceding(sale_date, promo_date), sale_date_lower <= promo_date)
+by <- join_by(id, closest(sale_date >= promo_date), sale_date_lower <= promo_date)
 full_join(sales, promos, by)
 
 # ---------------------------------------------------------------------------

--- a/tests/testthat/_snaps/join-by.md
+++ b/tests/testthat/_snaps/join-by.md
@@ -45,12 +45,12 @@
 ---
 
     Code
-      join_by(a == a, preceding(b, c), following(d, e, inclusive = FALSE))
+      join_by(a == a, closest(b >= c), closest(d < e))
     Output
       Join By:
       - a == a
-      - preceding(b, c)
-      - following(d, e, inclusive = FALSE)
+      - closest(b >= c)
+      - closest(d < e)
 
 # has informative error messages
 
@@ -76,7 +76,7 @@
       join_by(foo(x > y))
     Condition
       Error in `join_by()`:
-      ! Join by expressions must use one of: `==`, `>=`, `>`, `<=`, `<`, `preceding()`, `following()`, `between()`, `overlaps()`, or `within()`.
+      ! Join by expressions must use one of: `==`, `>=`, `>`, `<=`, `<`, `closest()`, `between()`, `overlaps()`, or `within()`.
       i Expression 1 is `foo(x > y)`.
 
 ---
@@ -85,7 +85,7 @@
       join_by(x == y, x^y)
     Condition
       Error in `join_by()`:
-      ! Join by expressions must use one of: `==`, `>=`, `>`, `<=`, `<`, `preceding()`, `following()`, `between()`, `overlaps()`, or `within()`.
+      ! Join by expressions must use one of: `==`, `>=`, `>`, `<=`, `<`, `closest()`, `between()`, `overlaps()`, or `within()`.
       i Expression 2 is `x^y`.
 
 ---
@@ -199,6 +199,15 @@
 ---
 
     Code
+      join_by(closest(x$a >= x$b))
+    Condition
+      Error in `join_by()`:
+      ! The left and right-hand sides of a binary expression must reference different tables.
+      i Expression 1 contains `x$a >= x$b`.
+
+---
+
+    Code
       join_by(between(a, x$a, y$b))
     Condition
       Error in `join_by()`:
@@ -262,29 +271,11 @@
 ---
 
     Code
-      join_by(preceding(x))
+      join_by(closest())
     Condition
       Error:
-      ! Expressions using `preceding()` can't contain missing arguments.
-      x Argument `y` is missing.
-
----
-
-    Code
-      join_by(preceding(y = x))
-    Condition
-      Error:
-      ! Expressions using `preceding()` can't contain missing arguments.
-      x Argument `x` is missing.
-
----
-
-    Code
-      join_by(following(x))
-    Condition
-      Error:
-      ! Expressions using `following()` can't contain missing arguments.
-      x Argument `y` is missing.
+      ! Expressions using `closest()` can't contain missing arguments.
+      x Argument `expr` is missing.
 
 ---
 
@@ -298,38 +289,46 @@
 ---
 
     Code
-      join_by(preceding(x, y, TRUE))
+      join_by(closest(a >= b, 1))
     Condition
-      Error:
-      ! `...` must be empty.
-      i Non-empty dots were detected inside `preceding()`.
+      Error in `closest()`:
+      ! unused argument (1)
 
 ---
 
     Code
-      join_by(following(x, y, TRUE))
-    Condition
-      Error:
-      ! `...` must be empty.
-      i Non-empty dots were detected inside `following()`.
-
----
-
-    Code
-      join_by(preceding(y$a, b))
+      join_by(closest(a == b))
     Condition
       Error in `join_by()`:
-      ! The first argument to `preceding()` must reference the `x` table.
-      i Expression 1 contains `preceding(y$a, b)`.
+      ! The expression used in `closest()` can't use `==`.
+      i Expression 1 is `closest(a == b)`.
 
 ---
 
     Code
-      join_by(preceding(a, x$b))
+      join_by(closest(x))
     Condition
       Error in `join_by()`:
-      ! The second argument to `preceding()` must reference the `y` table.
-      i Expression 1 contains `preceding(a, x$b)`.
+      ! The first argument of `closest()` must be an expression.
+      i Expression 1 is `closest(x)`.
+
+---
+
+    Code
+      join_by(closest(1))
+    Condition
+      Error in `join_by()`:
+      ! The first argument of `closest()` must be an expression.
+      i Expression 1 is `closest(1)`.
+
+---
+
+    Code
+      join_by(closest(x + y))
+    Condition
+      Error in `join_by()`:
+      ! The expression used in `closest()` must use one of: `>=`, `>`, `<=`, or `<`.
+      i Expression 1 is `closest(x + y)`.
 
 # as_join_by() emits useful errors
 

--- a/tests/testthat/test-join-by.R
+++ b/tests/testthat/test-join-by.R
@@ -19,29 +19,29 @@ test_that("works with non-equi conditions", {
   expect_identical(by$condition, c("==", ">", ">=", "<", "<="))
 })
 
-test_that("works with rolling conditions", {
-  by <- join_by(x == y, preceding(a, b))
+test_that("works with `closest()`", {
+  by <- join_by(x == y, closest(a >= b))
 
   expect_identical(by$x, c("x", "a"))
   expect_identical(by$y, c("y", "b"))
   expect_identical(by$filter, c("none", "max"))
   expect_identical(by$condition, c("==", ">="))
 
-  by <- join_by(x == y, preceding(a, b, inclusive = FALSE))
+  by <- join_by(x == y, closest(a > b))
 
   expect_identical(by$x, c("x", "a"))
   expect_identical(by$y, c("y", "b"))
   expect_identical(by$filter, c("none", "max"))
   expect_identical(by$condition, c("==", ">"))
 
-  by <- join_by(x == y, following(a, b))
+  by <- join_by(x == y, closest(a <= b))
 
   expect_identical(by$x, c("x", "a"))
   expect_identical(by$y, c("y", "b"))
   expect_identical(by$filter, c("none", "min"))
   expect_identical(by$condition, c("==", "<="))
 
-  by <- join_by(x == y, following(a, b, inclusive = FALSE))
+  by <- join_by(x == y, closest(a < b))
 
   expect_identical(by$x, c("x", "a"))
   expect_identical(by$y, c("y", "b"))
@@ -56,8 +56,8 @@ test_that("works with single arguments", {
 })
 
 test_that("works with character strings", {
-  by1 <- join_by("a", "b" == "c", preceding("d", "e"))
-  by2 <- join_by(a, b  == c, preceding(d, e))
+  by1 <- join_by("a", "b" == "c", closest("d" >= "e"))
+  by2 <- join_by(a, b  == c, closest(d >= e))
 
   expect_identical(by1$condition, by2$condition)
   expect_identical(by1$filter, by2$filter)
@@ -78,6 +78,14 @@ test_that("works with explicit referencing", {
 test_that("join condition is correctly reversed with explicit referencing", {
   by <- join_by(y$a == x$a, y$a >= x$a, y$a > x$a, y$a <= x$a, y$a < x$a)
   expect_identical(by$condition, c("==", "<=", "<", ">=", ">"))
+})
+
+test_that("`closest()` works with explicit referencing", {
+  by <- join_by(closest(y$a <= x$b), closest(y$a > x$b))
+  expect_identical(by$x, c("b", "b"))
+  expect_identical(by$y, c("a", "a"))
+  expect_identical(by$filter, c("max", "min"))
+  expect_identical(by$condition, c(">=", "<"))
 })
 
 test_that("between conditions expand correctly", {
@@ -114,7 +122,7 @@ test_that("overlaps / within conditions expand correctly", {
   expect_identical(by$condition, c("<=", ">="))
 })
 
-test_that("between / overlaps / within / preceding / following can use named arguments", {
+test_that("between / overlaps / within / closest can use named arguments", {
   by <- join_by(between(a, y_upper = b, y_lower = c))
   expect_identical(by$x, c("a", "a"))
   expect_identical(by$y, c("c", "b"))
@@ -139,11 +147,7 @@ test_that("between / overlaps / within / preceding / following can use named arg
   expect_identical(by$y, c("a", "b"))
   expect_identical(by$condition, c("<=", ">="))
 
-  by <- join_by(preceding(y = b, x = a))
-  expect_identical(by$x, "a")
-  expect_identical(by$y, "b")
-
-  by <- join_by(following(y = b, x = a))
+  by <- join_by(closest(expr = a > b))
   expect_identical(by$x, "a")
   expect_identical(by$y, "b")
 })
@@ -161,7 +165,7 @@ test_that("has an informative print method", {
   expect_snapshot(join_by("a", "b"))
   expect_snapshot(join_by(a == a, b >= c))
   expect_snapshot(join_by(a == a, b >= "c"))
-  expect_snapshot(join_by(a == a, preceding(b, c), following(d, e, inclusive = FALSE)))
+  expect_snapshot(join_by(a == a, closest(b >= c), closest(d < e)))
 })
 
 test_that("has informative error messages", {
@@ -171,7 +175,7 @@ test_that("has informative error messages", {
   # Empty expression
   expect_snapshot(error = TRUE, join_by(NULL))
 
-  # Improper rolling specification
+  # Improper helper specification
   expect_snapshot(error = TRUE, join_by(foo(x > y)))
 
   # Improper separator
@@ -202,6 +206,7 @@ test_that("has informative error messages", {
   expect_snapshot(error = TRUE, join_by(between(x$a, x$a, x$b)))
   expect_snapshot(error = TRUE, join_by(within(x$a, x$b, x$a, x$b)))
   expect_snapshot(error = TRUE, join_by(overlaps(a, b, x$a, x$b)))
+  expect_snapshot(error = TRUE, join_by(closest(x$a >= x$b)))
 
   # Referencing different tables in lower/upper bound pairs
   expect_snapshot(error = TRUE, join_by(between(a, x$a, y$b)))
@@ -213,18 +218,21 @@ test_that("has informative error messages", {
   expect_snapshot(error = TRUE, join_by(between(x)))
   expect_snapshot(error = TRUE, join_by(within(x)))
   expect_snapshot(error = TRUE, join_by(overlaps(x)))
-  expect_snapshot(error = TRUE, join_by(preceding(x)))
-  expect_snapshot(error = TRUE, join_by(preceding(y = x)))
-  expect_snapshot(error = TRUE, join_by(following(x)))
+  expect_snapshot(error = TRUE, join_by(closest()))
   expect_snapshot(error = TRUE, join_by(`$`(x) > y))
 
-  # Arguments supplied in empty dots
-  expect_snapshot(error = TRUE, join_by(preceding(x, y, TRUE)))
-  expect_snapshot(error = TRUE, join_by(following(x, y, TRUE)))
+  # Too many arguments
+  expect_snapshot(error = TRUE, join_by(closest(a >= b, 1)))
 
-  # Referencing wrong table in `preceding()` or `following()`
-  expect_snapshot(error = TRUE, join_by(preceding(y$a, b)))
-  expect_snapshot(error = TRUE, join_by(preceding(a, x$b)))
+  # `==` in `closest()`
+  expect_snapshot(error = TRUE, join_by(closest(a == b)))
+
+  # Non-expression in `closest()`
+  expect_snapshot(error = TRUE, join_by(closest(x)))
+  expect_snapshot(error = TRUE, join_by(closest(1)))
+
+  # Invalid expression in `closest()`
+  expect_snapshot(error = TRUE, join_by(closest(x + y)))
 })
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Closes #6439 

I think this is much nicer. It was easier to talk about in the docs, and the progression from

```r
join_by(id, sale_date >= promo_date)
```

to

```r
join_by(id, closest(sale_date >= promo_date))
```

in the examples is now much easier to understand