### PR TITLE
Update summarise.R

### DIFF
--- a/R/summarise.R
+++ b/R/summarise.R
@@ -153,14 +153,14 @@ summarise.grouped_df <- function(.data, ..., .groups = NULL) {
     if (n > 1) {
       if (verbose) {
         new_groups <- glue_collapse(paste0("'", group_vars[-n], "'"), sep = ", ")
-        summarise_inform("has grouped output by {new_groups}")
+        summarise_inform("has grouped its output by {new_groups}")
       }
       out <- grouped_df(out, group_vars[-n], group_by_drop_default(.data))
     }
   } else if (identical(.groups, "keep")) {
     if (verbose) {
       new_groups <- glue_collapse(paste0("'", group_vars, "'"), sep = ", ")
-      summarise_inform("has grouped output by {new_groups}")
+      summarise_inform("has grouped its output by {new_groups}")
     }
     out <- grouped_df(out, group_vars, group_by_drop_default(.data))
   } else if (identical(.groups, "rowwise")) {
@@ -186,7 +186,7 @@ summarise.rowwise_df <- function(.data, ..., .groups = NULL) {
   if (is.null(.groups) || identical(.groups, "keep")) {
     if (verbose && length(group_vars)) {
       new_groups <- glue_collapse(paste0("'", group_vars, "'"), sep = ", ")
-      summarise_inform("has grouped output by {new_groups}")
+      summarise_inform("has grouped its output by {new_groups}")
     }
     out <- grouped_df(out, group_vars)
   } else if (identical(.groups, "rowwise")) {
@@ -407,6 +407,6 @@ summarise_verbose <- function(.groups, .env) {
 
 summarise_inform <- function(..., .env = parent.frame()) {
   inform(paste0(
-    "`summarise()` ", glue(..., .envir = .env), '. You can override using the `.groups` argument.'
+    "`summarise()` ", glue(..., .envir = .env), '. You can specify the grouping coming out of summarise() using its `.groups` argument.'
   ))
 }


### PR DESCRIPTION
When the informing message first popped up (and then for the next what, year? until today anyway) I interpreted it to mean that summarise() had ignored the grouping set up by group_by(), and had instead chosen to work with the reported new grouping.  It was not clear (enough to me) that it had grouped /its/ output, ready for any following functions, by the reported grouping.  I'm proposing a slightly more verbose message, which might also be slightly more informative (although I concede that verbosity and informance are imperfectly correlated, and possibly even negatively correlated. Not "informance", informativity). Anyway, see what you think, run it past your test panels, workshop it, mull it over and make your call.