### PR TITLE
Use original `y` name in join common type error message

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dplyr (development version)
 
+* Joins now reference the correct column in `y` when a type error is thrown
+  while joining on two columns with different names (#6465).
+
 * Warnings are now enriched with contextualised information in `summarise()` and
   `filter()` just like they have been in `mutate()` and `arrange()`.
 

--- a/R/join-cols.R
+++ b/R/join-cols.R
@@ -16,7 +16,7 @@ join_cols <- function(x_names,
   suffix <- standardise_join_suffix(suffix, error_call = error_call)
 
   x_by <- set_names(match(by$x, x_names), by$x)
-  y_by <- set_names(match(by$y, y_names), by$x)
+  y_by <- set_names(match(by$y, y_names), by$y)
 
   x_loc <- seq_along(x_names)
   names(x_loc) <- x_names

--- a/R/join-cols.R
+++ b/R/join-cols.R
@@ -164,3 +164,42 @@ add_suffixes <- function(x, y, suffix) {
   }
   out
 }
+
+join_cast_common <- function(x, y, vars, error_call = caller_env()) {
+  # Explicit `x/y_arg = ""` to avoid auto naming in `cnd$x_arg`
+  ptype <- try_fetch(
+    vec_ptype2(x, y, x_arg = "", y_arg = "", call = error_call),
+    vctrs_error_incompatible_type = function(cnd) {
+      rethrow_error_join_incompatible_type(cnd, vars, error_call)
+    }
+  )
+
+  vec_cast_common(x = x, y = y, .to = ptype, .call = error_call)
+}
+
+rethrow_error_join_incompatible_type <- function(cnd, vars, call) {
+  x_name <- cnd$x_arg
+  y_name <- cnd$y_arg
+
+  # Remap `y_name` to actual name from `y`. Useful for `join_by(a == b)`
+  # where the name from `x` is used when determining the common type and will
+  # be in the error `cnd`, but we need to tell the user about the name in `y`.
+  loc <- match(y_name, names(vars$x$key))
+  y_name <- names(vars$y$key)[[loc]]
+
+  x_name <- paste0("x$", x_name)
+  y_name <- paste0("y$", y_name)
+
+  x_type <- vec_ptype_full(cnd$x)
+  y_type <- vec_ptype_full(cnd$y)
+
+  stop_join(
+    message = c(
+      glue("Can't join `{x_name}` with `{y_name}` due to incompatible types."),
+      i = glue("`{x_name}` is a <{x_type}>."),
+      i = glue("`{y_name}` is a <{y_type}>.")
+    ),
+    class = "dplyr_error_join_incompatible_type",
+    call = call
+  )
+}

--- a/R/join-rows.R
+++ b/R/join-rows.R
@@ -74,7 +74,7 @@ dplyr_locate_matches <- function(needles,
       nan_distinct = TRUE
     ),
     vctrs_error_incompatible_type = function(cnd) {
-      rethrow_error_join_incompatible_type(cnd, error_call)
+      abort("`join_cast_common()` should have handled this.", .internal = TRUE)
     },
     vctrs_error_matches_nothing = function(cnd) {
       rethrow_error_join_matches_nothing(cnd, error_call)
@@ -91,24 +91,6 @@ dplyr_locate_matches <- function(needles,
     vctrs_warning_matches_multiple = function(cnd) {
       rethrow_warning_join_matches_multiple(cnd, error_call)
     }
-  )
-}
-
-rethrow_error_join_incompatible_type <- function(cnd, call) {
-  x_name <- cnd$x_arg
-  y_name <- cnd$y_arg
-
-  x_type <- vec_ptype_full(cnd$x)
-  y_type <- vec_ptype_full(cnd$y)
-
-  stop_join(
-    message = c(
-      glue("Can't join `{x_name}` with `{y_name}` because of incompatible types."),
-      i = glue("`{x_name}` is of type <{x_type}>."),
-      i = glue("`{y_name}` is of type <{y_type}>.")
-    ),
-    class = "dplyr_error_join_incompatible_type",
-    call = call
   )
 }
 

--- a/R/join.R
+++ b/R/join.R
@@ -508,6 +508,10 @@ nest_join.data.frame <- function(x,
   x_key <- set_names(x_in[vars$x$key], names(vars$x$key))
   y_key <- set_names(y_in[vars$y$key], names(vars$x$key))
 
+  args <- join_cast_common(x_key, y_key, vars)
+  x_key <- args$x
+  y_key <- args$y
+
   condition <- by$condition
   filter <- by$filter
   cross <- by$cross
@@ -535,7 +539,7 @@ nest_join.data.frame <- function(x,
   out <- set_names(x_in[vars$x$out], names(vars$x$out))
 
   # Modify all columns in one step so that we only need to re-group once
-  new_cols <- vec_cast(out[names(x_key)], vec_ptype2(x_key, y_key))
+  new_cols <- vec_cast(out[names(x_key)], x_key)
 
   y_out <- set_names(y_in[vars$y$out], names(vars$y$out))
   y_out <- map(y_loc, vec_slice, x = y_out)
@@ -589,6 +593,10 @@ join_mutate <- function(x,
   x_key <- set_names(x_in[vars$x$key], names(vars$x$key))
   y_key <- set_names(y_in[vars$y$key], names(vars$x$key))
 
+  args <- join_cast_common(x_key, y_key, vars, error_call = error_call)
+  x_key <- args$x
+  y_key <- args$y
+
   condition <- by$condition
   filter <- by$filter
   cross <- by$cross
@@ -622,26 +630,22 @@ join_mutate <- function(x,
       merge <- by$x
     }
 
+    # Keys have already been cast to the common type
     x_merge <- x_key[merge]
-    y_merge <- y_key[merge]
 
-    key_type <- vec_ptype_common(x_merge, y_merge, .call = error_call)
-
-    out[names(x_merge)] <- vec_cast(
-      x = out[names(x_merge)],
-      to = key_type,
+    out[merge] <- vec_cast(
+      x = out[merge],
+      to = x_merge,
       call = error_call
     )
 
     if ((type == "right" || type == "full") && anyNA(x_slicer)) {
+      y_merge <- y_key[merge]
+
       new_rows <- which(is.na(x_slicer))
       y_replacer <- y_slicer[new_rows]
 
-      out[new_rows, names(y_merge)] <- vec_cast(
-        x = vec_slice(y_merge, y_replacer),
-        to = key_type,
-        call = error_call
-      )
+      out[new_rows, merge] <- vec_slice(y_merge, y_replacer)
     }
   }
 
@@ -675,6 +679,10 @@ join_filter <- function(x,
 
   x_key <- set_names(x_in[vars$x$key], names(vars$x$key))
   y_key <- set_names(y_in[vars$y$key], names(vars$x$key))
+
+  args <- join_cast_common(x_key, y_key, vars, error_call = error_call)
+  x_key <- args$x
+  y_key <- args$y
 
   condition <- by$condition
   filter <- by$filter

--- a/R/join.R
+++ b/R/join.R
@@ -506,7 +506,7 @@ nest_join.data.frame <- function(x,
   y_in <- as_tibble(y, .name_repair = "minimal")
 
   x_key <- set_names(x_in[vars$x$key], names(vars$x$key))
-  y_key <- set_names(y_in[vars$y$key], names(vars$y$key))
+  y_key <- set_names(y_in[vars$y$key], names(vars$x$key))
 
   condition <- by$condition
   filter <- by$filter
@@ -587,7 +587,7 @@ join_mutate <- function(x,
   y_in <- as_tibble(y, .name_repair = "minimal")
 
   x_key <- set_names(x_in[vars$x$key], names(vars$x$key))
-  y_key <- set_names(y_in[vars$y$key], names(vars$y$key))
+  y_key <- set_names(y_in[vars$y$key], names(vars$x$key))
 
   condition <- by$condition
   filter <- by$filter
@@ -674,7 +674,7 @@ join_filter <- function(x,
   y_in <- as_tibble(y, .name_repair = "minimal")
 
   x_key <- set_names(x_in[vars$x$key], names(vars$x$key))
-  y_key <- set_names(y_in[vars$y$key], names(vars$y$key))
+  y_key <- set_names(y_in[vars$y$key], names(vars$x$key))
 
   condition <- by$condition
   filter <- by$filter

--- a/tests/testthat/_snaps/join-cols.md
+++ b/tests/testthat/_snaps/join-cols.md
@@ -112,3 +112,14 @@
       Error:
       ! `suffix` can't be NA.
 
+# references original column in `y` when there are type errors (#6465)
+
+    Code
+      (expect_error(join_cast_common(x_key, y_key, vars)))
+    Output
+      <error/dplyr_error_join_incompatible_type>
+      Error:
+      ! Can't join `x$a` with `y$b` due to incompatible types.
+      i `x$a` is a <double>.
+      i `y$b` is a <character>.
+

--- a/tests/testthat/_snaps/join-rows.md
+++ b/tests/testthat/_snaps/join-rows.md
@@ -18,16 +18,15 @@
       i Row 1 of `x` matches multiple rows.
       i If multiple matches are expected, set `multiple = "all"` to silence this warning.
 
-# join_rows() gives meaningful error message on incompatible types
+# join_rows() expects incompatible type errors to have been handled by join_cast_common()
 
     Code
       (expect_error(join_rows(data.frame(x = 1), data.frame(x = factor("a")))))
     Output
-      <error/dplyr_error_join_incompatible_type>
+      <error/rlang_error>
       Error:
-      ! Can't join `x$x` with `y$x` because of incompatible types.
-      i `x$x` is of type <double>.
-      i `y$x` is of type <factor<4d52a>>.
+      ! `join_cast_common()` should have handled this.
+      i This is an internal error in the dplyr package, please report it to the package authors.
 
 # join_rows() gives meaningful error/warning message on multiple matches
 

--- a/tests/testthat/_snaps/join-rows.md
+++ b/tests/testthat/_snaps/join-rows.md
@@ -26,7 +26,8 @@
       <error/rlang_error>
       Error:
       ! `join_cast_common()` should have handled this.
-      i This is an internal error in the dplyr package, please report it to the package authors.
+      i This is an internal error that was detected in the dplyr package.
+        Please report it at <https://github.com/tidyverse/dplyr/issues> with a reprex (<https://https://tidyverse.org/help/>) and the full backtrace.
 
 # join_rows() gives meaningful error/warning message on multiple matches
 

--- a/tests/testthat/_snaps/join.md
+++ b/tests/testthat/_snaps/join.md
@@ -53,6 +53,28 @@
     Message
       Joining with `by = join_by(x)`
 
+# mutating joins reference original column in `y` when there are type errors (#6465)
+
+    Code
+      (expect_error(left_join(x, y, by = join_by(a == b))))
+    Output
+      <error/dplyr_error_join_incompatible_type>
+      Error in `left_join()`:
+      ! Can't join `x$a` with `y$b` due to incompatible types.
+      i `x$a` is a <double>.
+      i `y$b` is a <character>.
+
+# filtering joins reference original column in `y` when there are type errors (#6465)
+
+    Code
+      (expect_error(semi_join(x, y, by = join_by(a == b))))
+    Output
+      <error/dplyr_error_join_incompatible_type>
+      Error in `semi_join()`:
+      ! Can't join `x$a` with `y$b` due to incompatible types.
+      i `x$a` is a <double>.
+      i `y$b` is a <character>.
+
 # error if passed additional arguments
 
     Code
@@ -125,6 +147,17 @@
       out <- nest_join(df1, df2)
     Message
       Joining with `by = join_by(x)`
+
+# nest_join references original column in `y` when there are type errors (#6465)
+
+    Code
+      (expect_error(nest_join(x, y, by = join_by(a == b))))
+    Output
+      <error/dplyr_error_join_incompatible_type>
+      Error in `nest_join()`:
+      ! Can't join `x$a` with `y$b` due to incompatible types.
+      i `x$a` is a <double>.
+      i `y$b` is a <character>.
 
 # validates inputs
 

--- a/tests/testthat/test-join-cols.R
+++ b/tests/testthat/test-join-cols.R
@@ -9,17 +9,17 @@ test_that("key vars are found", {
 
   vars <- join_cols(c("x", "y"), c("a", "x", "z"), by = join_by(y == z))
   expect_equal(vars$x$key, c(y = 2L))
-  expect_equal(vars$y$key, c(y = 3L))
+  expect_equal(vars$y$key, c(z = 3L))
 
   vars <- join_cols(c("x", "y"), c("a", "x", "z"), by = join_by(y >= z))
   expect_equal(vars$x$key, c(y = 2L))
-  expect_equal(vars$y$key, c(y = 3L))
+  expect_equal(vars$y$key, c(z = 3L))
 })
 
 test_that("y key matches order and names of x key", {
   vars <- join_cols(c("x", "y", "z"), c("c", "b", "a"), by = join_by(x == a, y == b))
   expect_equal(vars$x$key, c(x = 1L, y = 2L))
-  expect_equal(vars$y$key, c(x = 3L, y = 2L))
+  expect_equal(vars$y$key, c(a = 3L, b = 2L))
 })
 
 test_that("duplicate column names are given suffixes", {
@@ -90,7 +90,7 @@ test_that("can duplicate key between non-equi conditions", {
   expect_identical(vars$x$key, c(x = 1L, x = 1L))
   expect_identical(vars$x$out, c(x = 1L))
 
-  expect_identical(vars$y$key, c(x = 1L, x = 2L))
+  expect_identical(vars$y$key, c(xl = 1L, xu = 2L))
   expect_identical(vars$y$out, c(xl = 1L, xu = 2L))
 
   expect_identical(

--- a/tests/testthat/test-join-cols.R
+++ b/tests/testthat/test-join-cols.R
@@ -129,3 +129,32 @@ test_that("emits useful messages", {
   expect_snapshot(error = TRUE, join_cols(xy, xy, by = join_by(x), suffix = "x"))
   expect_snapshot(error = TRUE, join_cols(xy, xy, by = join_by(x), suffix = c("", NA)))
 })
+
+# ------------------------------------------------------------------------------
+# join_cast_common()
+
+test_that("takes common type", {
+  x <- tibble(a = 1, b = 2L)
+  y <- tibble(a = 1L, b = 3)
+
+  vars <- join_cols(names(x), names(y), by = join_by(a, b))
+
+  out <- join_cast_common(x, y, vars)
+
+  expect_identical(out$x, tibble(a = 1, b = 2))
+  expect_identical(out$y, tibble(a = 1, b = 3))
+})
+
+test_that("references original column in `y` when there are type errors (#6465)", {
+  x <- tibble(a = 1)
+  y <- tibble(b = "1")
+
+  x_key <- x
+  y_key <- set_names(y, names(x))
+
+  vars <- join_cols(names(x), names(y), by = join_by(a == b))
+
+  expect_snapshot({
+    (expect_error(join_cast_common(x_key, y_key, vars)))
+  })
+})

--- a/tests/testthat/test-join-rows.R
+++ b/tests/testthat/test-join-rows.R
@@ -139,7 +139,7 @@ test_that("join_rows() doesn't error on unmatched rows if they won't be dropped"
   expect_identical(out$y, c(1L, NA, 2L))
 })
 
-test_that("join_rows() gives meaningful error message on incompatible types", {
+test_that("join_rows() expects incompatible type errors to have been handled by join_cast_common()", {
   expect_snapshot({
     (expect_error(
       join_rows(data.frame(x = 1), data.frame(x = factor("a")))

--- a/tests/testthat/test-join.R
+++ b/tests/testthat/test-join.R
@@ -226,6 +226,24 @@ test_that("filtering joins compute common columns", {
   expect_snapshot(out <- semi_join(df1, df2))
 })
 
+test_that("mutating joins reference original column in `y` when there are type errors (#6465)", {
+  x <- tibble(a = 1)
+  y <- tibble(b = "1")
+
+  expect_snapshot({
+    (expect_error(left_join(x, y, by = join_by(a == b))))
+  })
+})
+
+test_that("filtering joins reference original column in `y` when there are type errors (#6465)", {
+  x <- tibble(a = 1)
+  y <- tibble(b = "1")
+
+  expect_snapshot({
+    (expect_error(semi_join(x, y, by = join_by(a == b))))
+  })
+})
+
 test_that("error if passed additional arguments", {
   df1 <- data.frame(a = 1:3)
   df2 <- data.frame(a = 1)
@@ -276,6 +294,15 @@ test_that("nest_join computes common columns", {
   df1 <- tibble(x = c(1, 2), y = c(2, 3))
   df2 <- tibble(x = c(1, 3), z = c(2, 3))
   expect_snapshot(out <- nest_join(df1, df2))
+})
+
+test_that("nest_join references original column in `y` when there are type errors (#6465)", {
+  x <- tibble(a = 1)
+  y <- tibble(b = "1")
+
+  expect_snapshot({
+    (expect_error(nest_join(x, y, by = join_by(a == b))))
+  })
 })
 
 test_that("nest_join handles multiple matches in x (#3642)", {


### PR DESCRIPTION
Closes https://github.com/tidyverse/dplyr/issues/6465

This was slightly more work than expected. I ended up making the common cast operation more explicit, as currently it is implicit in the `vec_locate_matches()` call.

Pulling it out into `join_cast_common()` felt better than trying to pass `vars` through to `join_rows()`, which otherwise wouldn't need to know anything about `vars`. Casting early also allowed me to remove some code that was recomputing the common type again.

