### PR TITLE
Deprecate usage of 1 column matrices in `filter()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr (development version)
 
+* Using 1 column matrices in `filter()` is now deprecated (#6091).
+
 * Warnings emitted inside `mutate()` and variants are now collected and stashed
   away. Run the new `last_dplyr_warnings()` function to see the warnings emitted
   within dplyr verbs during the last top-level command.

--- a/R/filter.R
+++ b/R/filter.R
@@ -183,6 +183,9 @@ filter_eval <- function(dots, mask, error_call = caller_env()) {
       abort(bullets, call = error_call, parent = skip_internal_condition(e))
 
     },
+    `dplyr:::signal_filter_one_column_matrix` = function(e) {
+      warn_filter_one_column_matrix(call = error_call)
+    },
     `dplyr:::signal_filter_across` = function(e) {
       warn_filter_across(call = error_call)
     },
@@ -226,6 +229,15 @@ filter_bullets.default <- function(cnd, ...) {
   c(
     x = glue("Input `..{index}` must be of size {or_1(expected_size)}, not size {size}."),
     i = cnd_bullet_cur_group_label()
+  )
+}
+
+warn_filter_one_column_matrix <- function(call) {
+  lifecycle::deprecate_warn(
+    when = "1.1.0",
+    what = I("Using one column matrices in `filter()`"),
+    with = I("one dimensional logical vectors"),
+    env = call
   )
 }
 

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -34,6 +34,10 @@ void signal_filter(const char* cls) {
   UNPROTECT(2);
 }
 static
+void signal_filter_one_column_matrix() {
+  signal_filter("dplyr:::signal_filter_one_column_matrix");
+}
+static
 void signal_filter_across() {
   signal_filter("dplyr:::signal_filter_across");
 }
@@ -91,8 +95,7 @@ bool filter_is_valid_lgl(SEXP x, bool first) {
     // 1 column matrix. We allow these with a warning that this will be
     // deprecated in the future.
     if (first) {
-      // TODO: Warn on 1 column matrices
-      // dplyr::signal_filter_one_column_matrix();
+      dplyr::signal_filter_one_column_matrix();
     }
     UNPROTECT(1);
     return true;

--- a/tests/testthat/_snaps/filter.md
+++ b/tests/testthat/_snaps/filter.md
@@ -1,3 +1,21 @@
+# filter() allows matrices with 1 column with a deprecation warning (#6091)
+
+    Code
+      out <- filter(df, matrix(c(TRUE, FALSE), nrow = 2))
+    Condition
+      Warning:
+      Using one column matrices in `filter()` was deprecated in dplyr 1.1.0.
+      Please use one dimensional logical vectors instead.
+
+---
+
+    Code
+      out <- filter(gdf, matrix(c(TRUE, FALSE), nrow = 2))
+    Condition
+      Warning:
+      Using one column matrices in `filter()` was deprecated in dplyr 1.1.0.
+      Please use one dimensional logical vectors instead.
+
 # filter() disallows matrices with >1 column
 
     Code

--- a/tests/testthat/test-filter.R
+++ b/tests/testthat/test-filter.R
@@ -381,11 +381,20 @@ test_that("filter() allows 1 dimension arrays", {
   expect_identical(filter(df, x), df[c(1, 3),])
 })
 
-test_that("filter() allowing matrices with 1 column", {
-  out <- expect_warning(
-    filter(data.frame(x = 1:2), matrix(c(TRUE, FALSE), nrow = 2)), NA
-  )
-  expect_identical(out, data.frame(x = 1L))
+test_that("filter() allows matrices with 1 column with a deprecation warning (#6091)", {
+  df <- tibble(x = 1:2)
+  expect_snapshot({
+    out <- filter(df, matrix(c(TRUE, FALSE), nrow = 2))
+  })
+  expect_identical(out, tibble(x = 1L))
+
+  # Only warns once when grouped
+  df <- tibble(x = c(1, 1, 2, 2))
+  gdf <- group_by(df, x)
+  expect_snapshot({
+    out <- filter(gdf, matrix(c(TRUE, FALSE), nrow = 2))
+  })
+  expect_identical(out, group_by(tibble(x = c(1, 2)), x))
 })
 
 test_that("filter() disallows matrices with >1 column", {

--- a/tests/testthat/test-filter.R
+++ b/tests/testthat/test-filter.R
@@ -112,7 +112,7 @@ test_that("$ does not end call traversing. #502", {
   # Do some aggregation
   trial_outcomes <- d %>%
     group_by(Subject, TrialNo) %>%
-    summarise(MeanOutcome = mean(Outcome))
+    summarise(MeanOutcome = mean(Outcome), .groups = "drop")
 
   left <- filter(trial_outcomes, MeanOutcome < analysis_opts$min_outcome)
   right <- filter(trial_outcomes, analysis_opts$min_outcome > MeanOutcome)


### PR DESCRIPTION
Closes #6091 

Went with `deprecate_warn()` rather than `deprecate_soft()` because filtering by a 1 column matrix should be sufficiently rare enough that we can skip a step in the deprecation process.