### PR TITLE
Simplify contextual errors with "i" bullets

### DIFF
--- a/R/conditions.R
+++ b/R/conditions.R
@@ -152,7 +152,7 @@ cnd_bullet_header <- function(what) {
   if (is_string(what, "recycle")) {
     glue("Can't {what} `{error_name}{sep}{error_expression}`.")
   } else {
-    c("i" = glue("In `{error_name}{sep}{error_expression}`."))
+    c("i" = glue("In argument `{error_name}{sep}{error_expression}`."))
   }
 }
 

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -149,7 +149,11 @@ cnd_bullet_header <- function(what) {
     sep <- ""
   }
 
-  glue("Can't {what} `{error_name}{sep}{error_expression}`.")
+  if (is_string(what, "recycle")) {
+    glue("Can't {what} `{error_name}{sep}{error_expression}`.")
+  } else {
+    c("i" = glue("In `{error_name}{sep}{error_expression}`."))
+  }
 }
 
 cnd_bullet_combine_details <- function(x, arg) {

--- a/tests/testthat/_snaps/across.md
+++ b/tests/testthat/_snaps/across.md
@@ -4,7 +4,7 @@
       mutate(df, across(x:y, fn, .unpack = "{outer}"))
     Condition
       Error in `mutate()`:
-      ! Can't compute `..1 = across(x:y, fn, .unpack = "{outer}")`.
+      i In `..1 = across(x:y, fn, .unpack = "{outer}")`.
       Caused by error in `across()`:
       ! Names must be unique.
       x These names are duplicated:
@@ -17,7 +17,7 @@
       summarise(df, across(x, mean, .unpack = 1))
     Condition
       Error in `summarise()`:
-      ! Can't compute `..1 = across(x, mean, .unpack = 1)`.
+      i In `..1 = across(x, mean, .unpack = 1)`.
       Caused by error in `across()`:
       ! `.unpack` must be `TRUE`, `FALSE`, or a single string, not a number.
 
@@ -27,7 +27,7 @@
       summarise(df, across(x, mean, .unpack = c("x", "y")))
     Condition
       Error in `summarise()`:
-      ! Can't compute `..1 = across(x, mean, .unpack = c("x", "y"))`.
+      i In `..1 = across(x, mean, .unpack = c("x", "y"))`.
       Caused by error in `across()`:
       ! `.unpack` must be `TRUE`, `FALSE`, or a single string, not a character vector.
 
@@ -37,7 +37,7 @@
       summarise(df, across(x, mean, .unpack = NA))
     Condition
       Error in `summarise()`:
-      ! Can't compute `..1 = across(x, mean, .unpack = NA)`.
+      i In `..1 = across(x, mean, .unpack = NA)`.
       Caused by error in `across()`:
       ! `.unpack` must be `TRUE`, `FALSE`, or a single string, not `NA`.
 
@@ -48,7 +48,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      ! Can't compute `..1 = across(where(is.numeric), 42)`.
+      i In `..1 = across(where(is.numeric), 42)`.
       Caused by error in `across()`:
       ! `.fns` must be NULL, a function, a formula, or a list of functions/formulas.
     Code
@@ -56,7 +56,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      ! Can't compute `..1 = across(y, mean)`.
+      i In `..1 = across(y, mean)`.
       Caused by error in `across()`:
       ! Can't subset columns that don't exist.
       x Column `y` doesn't exist.
@@ -65,7 +65,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      ! Can't compute `res = across(where(is.numeric), 42)`.
+      i In `res = across(where(is.numeric), 42)`.
       Caused by error in `across()`:
       ! `.fns` must be NULL, a function, a formula, or a list of functions/formulas.
     Code
@@ -73,7 +73,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      ! Can't compute `z = across(y, mean)`.
+      i In `z = across(y, mean)`.
       Caused by error in `across()`:
       ! Can't subset columns that don't exist.
       x Column `y` doesn't exist.
@@ -83,7 +83,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      ! Can't compute `res = sum(if_any(where(is.numeric), 42))`.
+      i In `res = sum(if_any(where(is.numeric), 42))`.
       Caused by error in `if_any()`:
       ! `.fns` must be NULL, a function, a formula, or a list of functions/formulas.
     Code
@@ -91,7 +91,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      ! Can't compute `res = sum(if_all(~mean(.x)))`.
+      i In `res = sum(if_all(~mean(.x)))`.
       Caused by error in `if_all()`:
       ! Must supply a column selection.
       i You most likely meant: `if_all(everything(), ~mean(.x))`.
@@ -102,7 +102,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      ! Can't compute `res = sum(if_any(~mean(.x)))`.
+      i In `res = sum(if_any(~mean(.x)))`.
       Caused by error in `if_any()`:
       ! Must supply a column selection.
       i You most likely meant: `if_any(everything(), ~mean(.x))`.
@@ -133,7 +133,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      ! Can't compute `..1 = across(everything(), error_fn)`.
+      i In `..1 = across(everything(), error_fn)`.
       Caused by error in `across()`:
       ! Can't compute column `y`.
       Caused by error in `error_fn()`:
@@ -144,7 +144,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      ! Can't compute `..1 = across(everything(), error_fn)`.
+      i In `..1 = across(everything(), error_fn)`.
       Caused by error in `across()`:
       ! Can't compute column `y`.
       Caused by error in `error_fn()`:
@@ -155,7 +155,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      ! Can't compute `..1 = force(across(everything(), error_fn))`.
+      i In `..1 = force(across(everything(), error_fn))`.
       Caused by error in `across()`:
       ! Can't compute column `y`.
       Caused by error in `error_fn()`:
@@ -166,7 +166,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      ! Can't compute `..1 = force(across(everything(), error_fn))`.
+      i In `..1 = force(across(everything(), error_fn))`.
       Caused by error in `across()`:
       ! Can't compute column `y`.
       Caused by error in `error_fn()`:
@@ -177,7 +177,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      ! Can't compute `..1 = across(everything(), list(f = mean, f = mean))`.
+      i In `..1 = across(everything(), list(f = mean, f = mean))`.
       Caused by error in `across()`:
       ! Names must be unique.
       x These names are duplicated:
@@ -190,7 +190,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      ! Can't expand `..1 = if_any(~.x > 5)`.
+      i In `..1 = if_any(~.x > 5)`.
       Caused by error in `if_any()`:
       ! Must supply a column selection.
       i You most likely meant: `if_any(everything(), ~.x > 5)`.
@@ -201,7 +201,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      ! Can't expand `..1 = if_all(~.x > 5)`.
+      i In `..1 = if_all(~.x > 5)`.
       Caused by error in `if_all()`:
       ! Must supply a column selection.
       i You most likely meant: `if_all(everything(), ~.x > 5)`.
@@ -212,7 +212,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      ! Can't compute `..1 = !if_any(~.x > 5)`.
+      i In `..1 = !if_any(~.x > 5)`.
       Caused by error in `if_any()`:
       ! Must supply a column selection.
       i You most likely meant: `if_any(everything(), ~.x > 5)`.
@@ -223,7 +223,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      ! Can't compute `..1 = !if_all(~.x > 5)`.
+      i In `..1 = !if_all(~.x > 5)`.
       Caused by error in `if_all()`:
       ! Must supply a column selection.
       i You most likely meant: `if_all(everything(), ~.x > 5)`.

--- a/tests/testthat/_snaps/across.md
+++ b/tests/testthat/_snaps/across.md
@@ -4,7 +4,7 @@
       mutate(df, across(x:y, fn, .unpack = "{outer}"))
     Condition
       Error in `mutate()`:
-      i In `..1 = across(x:y, fn, .unpack = "{outer}")`.
+      i In argument `..1 = across(x:y, fn, .unpack = "{outer}")`.
       Caused by error in `across()`:
       ! Names must be unique.
       x These names are duplicated:
@@ -17,7 +17,7 @@
       summarise(df, across(x, mean, .unpack = 1))
     Condition
       Error in `summarise()`:
-      i In `..1 = across(x, mean, .unpack = 1)`.
+      i In argument `..1 = across(x, mean, .unpack = 1)`.
       Caused by error in `across()`:
       ! `.unpack` must be `TRUE`, `FALSE`, or a single string, not a number.
 
@@ -27,7 +27,7 @@
       summarise(df, across(x, mean, .unpack = c("x", "y")))
     Condition
       Error in `summarise()`:
-      i In `..1 = across(x, mean, .unpack = c("x", "y"))`.
+      i In argument `..1 = across(x, mean, .unpack = c("x", "y"))`.
       Caused by error in `across()`:
       ! `.unpack` must be `TRUE`, `FALSE`, or a single string, not a character vector.
 
@@ -37,7 +37,7 @@
       summarise(df, across(x, mean, .unpack = NA))
     Condition
       Error in `summarise()`:
-      i In `..1 = across(x, mean, .unpack = NA)`.
+      i In argument `..1 = across(x, mean, .unpack = NA)`.
       Caused by error in `across()`:
       ! `.unpack` must be `TRUE`, `FALSE`, or a single string, not `NA`.
 
@@ -48,7 +48,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      i In `..1 = across(where(is.numeric), 42)`.
+      i In argument `..1 = across(where(is.numeric), 42)`.
       Caused by error in `across()`:
       ! `.fns` must be NULL, a function, a formula, or a list of functions/formulas.
     Code
@@ -56,7 +56,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      i In `..1 = across(y, mean)`.
+      i In argument `..1 = across(y, mean)`.
       Caused by error in `across()`:
       ! Can't subset columns that don't exist.
       x Column `y` doesn't exist.
@@ -65,7 +65,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      i In `res = across(where(is.numeric), 42)`.
+      i In argument `res = across(where(is.numeric), 42)`.
       Caused by error in `across()`:
       ! `.fns` must be NULL, a function, a formula, or a list of functions/formulas.
     Code
@@ -73,7 +73,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      i In `z = across(y, mean)`.
+      i In argument `z = across(y, mean)`.
       Caused by error in `across()`:
       ! Can't subset columns that don't exist.
       x Column `y` doesn't exist.
@@ -83,7 +83,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      i In `res = sum(if_any(where(is.numeric), 42))`.
+      i In argument `res = sum(if_any(where(is.numeric), 42))`.
       Caused by error in `if_any()`:
       ! `.fns` must be NULL, a function, a formula, or a list of functions/formulas.
     Code
@@ -91,7 +91,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      i In `res = sum(if_all(~mean(.x)))`.
+      i In argument `res = sum(if_all(~mean(.x)))`.
       Caused by error in `if_all()`:
       ! Must supply a column selection.
       i You most likely meant: `if_all(everything(), ~mean(.x))`.
@@ -102,7 +102,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      i In `res = sum(if_any(~mean(.x)))`.
+      i In argument `res = sum(if_any(~mean(.x)))`.
       Caused by error in `if_any()`:
       ! Must supply a column selection.
       i You most likely meant: `if_any(everything(), ~mean(.x))`.
@@ -133,7 +133,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      i In `..1 = across(everything(), error_fn)`.
+      i In argument `..1 = across(everything(), error_fn)`.
       Caused by error in `across()`:
       ! Can't compute column `y`.
       Caused by error in `error_fn()`:
@@ -144,7 +144,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      i In `..1 = across(everything(), error_fn)`.
+      i In argument `..1 = across(everything(), error_fn)`.
       Caused by error in `across()`:
       ! Can't compute column `y`.
       Caused by error in `error_fn()`:
@@ -155,7 +155,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      i In `..1 = force(across(everything(), error_fn))`.
+      i In argument `..1 = force(across(everything(), error_fn))`.
       Caused by error in `across()`:
       ! Can't compute column `y`.
       Caused by error in `error_fn()`:
@@ -166,7 +166,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      i In `..1 = force(across(everything(), error_fn))`.
+      i In argument `..1 = force(across(everything(), error_fn))`.
       Caused by error in `across()`:
       ! Can't compute column `y`.
       Caused by error in `error_fn()`:
@@ -177,7 +177,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      i In `..1 = across(everything(), list(f = mean, f = mean))`.
+      i In argument `..1 = across(everything(), list(f = mean, f = mean))`.
       Caused by error in `across()`:
       ! Names must be unique.
       x These names are duplicated:
@@ -190,7 +190,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      i In `..1 = if_any(~.x > 5)`.
+      i In argument `..1 = if_any(~.x > 5)`.
       Caused by error in `if_any()`:
       ! Must supply a column selection.
       i You most likely meant: `if_any(everything(), ~.x > 5)`.
@@ -201,7 +201,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      i In `..1 = if_all(~.x > 5)`.
+      i In argument `..1 = if_all(~.x > 5)`.
       Caused by error in `if_all()`:
       ! Must supply a column selection.
       i You most likely meant: `if_all(everything(), ~.x > 5)`.
@@ -212,7 +212,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      i In `..1 = !if_any(~.x > 5)`.
+      i In argument `..1 = !if_any(~.x > 5)`.
       Caused by error in `if_any()`:
       ! Must supply a column selection.
       i You most likely meant: `if_any(everything(), ~.x > 5)`.
@@ -223,7 +223,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      i In `..1 = !if_all(~.x > 5)`.
+      i In argument `..1 = !if_all(~.x > 5)`.
       Caused by error in `if_all()`:
       ! Must supply a column selection.
       i You most likely meant: `if_all(everything(), ~.x > 5)`.

--- a/tests/testthat/_snaps/arrange.md
+++ b/tests/testthat/_snaps/arrange.md
@@ -11,7 +11,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `arrange()`:
-      i In `..1 = y`.
+      i In argument `..1 = y`.
       Caused by error:
       ! object 'y' not found
     Code
@@ -19,7 +19,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `arrange()`:
-      i In `..1 = rep(x, 2)`.
+      i In argument `..1 = rep(x, 2)`.
       Caused by error:
       ! `..1` must be size 1, not 2.
 

--- a/tests/testthat/_snaps/arrange.md
+++ b/tests/testthat/_snaps/arrange.md
@@ -11,7 +11,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `arrange()`:
-      ! Can't compute `..1 = y`.
+      i In `..1 = y`.
       Caused by error:
       ! object 'y' not found
     Code
@@ -19,7 +19,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `arrange()`:
-      ! Can't compute `..1 = rep(x, 2)`.
+      i In `..1 = rep(x, 2)`.
       Caused by error:
       ! `..1` must be size 1, not 2.
 

--- a/tests/testthat/_snaps/colwise-mutate.md
+++ b/tests/testthat/_snaps/colwise-mutate.md
@@ -29,7 +29,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      i In `mpg = .Primitive("length")(mpg, 0, 0)`.
+      i In argument `mpg = .Primitive("length")(mpg, 0, 0)`.
       Caused by error:
       ! 3 arguments passed to 'length' which requires 1
     Code
@@ -37,7 +37,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      i In `mpg = (function (x, ...) ...`.
+      i In argument `mpg = (function (x, ...) ...`.
       Caused by error in `mean.default()`:
       ! formal argument "na.rm" matched by multiple actual arguments
 

--- a/tests/testthat/_snaps/colwise-mutate.md
+++ b/tests/testthat/_snaps/colwise-mutate.md
@@ -29,7 +29,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      ! Can't compute `mpg = .Primitive("length")(mpg, 0, 0)`.
+      i In `mpg = .Primitive("length")(mpg, 0, 0)`.
       Caused by error:
       ! 3 arguments passed to 'length' which requires 1
     Code
@@ -37,7 +37,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      ! Can't compute `mpg = (function (x, ...) ...`.
+      i In `mpg = (function (x, ...) ...`.
       Caused by error in `mean.default()`:
       ! formal argument "na.rm" matched by multiple actual arguments
 

--- a/tests/testthat/_snaps/conditions.md
+++ b/tests/testthat/_snaps/conditions.md
@@ -4,28 +4,28 @@
       mutate(mtcars, invisible(999 + ""))
     Condition
       Error in `mutate()`:
-      i In `..1`.
+      i In argument `..1`.
       Caused by error in `999 + ""`:
       ! non-numeric argument to binary operator
     Code
       summarise(mtcars, invisible(999 + ""))
     Condition
       Error in `summarise()`:
-      i In `..1`.
+      i In argument `..1`.
       Caused by error in `999 + ""`:
       ! non-numeric argument to binary operator
     Code
       filter(mtcars, invisible(999 + ""))
     Condition
       Error in `filter()`:
-      i In `..1`.
+      i In argument `..1`.
       Caused by error in `999 + ""`:
       ! non-numeric argument to binary operator
     Code
       arrange(mtcars, invisible(999 + ""))
     Condition
       Error in `arrange()`:
-      i In `..1`.
+      i In argument `..1`.
       Caused by error in `999 + ""`:
       ! non-numeric argument to binary operator
     Code
@@ -39,21 +39,21 @@
       slice(mtcars, invisible(999 + ""))
     Condition
       Error in `slice()`:
-      i In `..1`.
+      i In argument `..1`.
       Caused by error in `999 + ""`:
       ! non-numeric argument to binary operator
     Code
       mutate(mtcars, var = invisible(999 + ""))
     Condition
       Error in `mutate()`:
-      i In `var`.
+      i In argument `var`.
       Caused by error in `999 + ""`:
       ! non-numeric argument to binary operator
     Code
       summarise(mtcars, var = invisible(999 + ""))
     Condition
       Error in `summarise()`:
-      i In `var`.
+      i In argument `var`.
       Caused by error in `999 + ""`:
       ! non-numeric argument to binary operator
     Code
@@ -67,7 +67,7 @@
       arrange(mtcars, var = invisible(999 + ""))
     Condition
       Error in `arrange()`:
-      i In `..1`.
+      i In argument `..1`.
       Caused by error in `999 + ""`:
       ! non-numeric argument to binary operator
     Code
@@ -81,7 +81,7 @@
       slice(mtcars, var = invisible(999 + ""))
     Condition
       Error in `slice()`:
-      i In `var`.
+      i In argument `var`.
       Caused by error in `999 + ""`:
       ! non-numeric argument to binary operator
 
@@ -91,28 +91,28 @@
       mutate(mtcars, 1 + "")
     Condition
       Error in `foo()`:
-      i In `..1 = 1 + ""`.
+      i In argument `..1 = 1 + ""`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
     Code
       transmute(mtcars, 1 + "")
     Condition
       Error in `foo()`:
-      i In `..1 = 1 + ""`.
+      i In argument `..1 = 1 + ""`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
     Code
       summarise(mtcars, 1 + "")
     Condition
       Error in `foo()`:
-      i In `..1 = 1 + ""`.
+      i In argument `..1 = 1 + ""`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
     Code
       summarise(group_by(mtcars, cyl), 1 + "")
     Condition
       Error in `foo()`:
-      i In `..1 = 1 + ""`.
+      i In argument `..1 = 1 + ""`.
       i In group 1: `cyl = 4`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
@@ -120,14 +120,14 @@
       filter(mtcars, 1 + "")
     Condition
       Error in `foo()`:
-      i In `..1 = 1 + ""`.
+      i In argument `..1 = 1 + ""`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
     Code
       arrange(mtcars, 1 + "")
     Condition
       Error in `foo()`:
-      i In `..1 = 1 + ""`.
+      i In argument `..1 = 1 + ""`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
     Code
@@ -141,7 +141,7 @@
       slice(mtcars, 1 + "")
     Condition
       Error in `foo()`:
-      i In `..1 = 1 + ""`.
+      i In argument `..1 = 1 + ""`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
 
@@ -151,14 +151,14 @@
       my_verb(mtcars, 1 + "", am)
     Condition
       Error in `my_verb()`:
-      i In `.result = (1 + "") * am`.
+      i In argument `.result = (1 + "") * am`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
     Code
       my_verb(mtcars, cyl, c(am, vs))
     Condition
       Error in `my_verb()`:
-      i In `.result = cyl * c(am, vs)`.
+      i In argument `.result = cyl * c(am, vs)`.
       Caused by error:
       ! `.result` must be size 32 or 1, not 64.
 

--- a/tests/testthat/_snaps/conditions.md
+++ b/tests/testthat/_snaps/conditions.md
@@ -4,28 +4,28 @@
       mutate(mtcars, invisible(999 + ""))
     Condition
       Error in `mutate()`:
-      ! Can't compute `..1`.
+      i In `..1`.
       Caused by error in `999 + ""`:
       ! non-numeric argument to binary operator
     Code
       summarise(mtcars, invisible(999 + ""))
     Condition
       Error in `summarise()`:
-      ! Can't compute `..1`.
+      i In `..1`.
       Caused by error in `999 + ""`:
       ! non-numeric argument to binary operator
     Code
       filter(mtcars, invisible(999 + ""))
     Condition
       Error in `filter()`:
-      ! Can't compute `..1`.
+      i In `..1`.
       Caused by error in `999 + ""`:
       ! non-numeric argument to binary operator
     Code
       arrange(mtcars, invisible(999 + ""))
     Condition
       Error in `arrange()`:
-      ! Can't compute `..1`.
+      i In `..1`.
       Caused by error in `999 + ""`:
       ! non-numeric argument to binary operator
     Code
@@ -39,21 +39,21 @@
       slice(mtcars, invisible(999 + ""))
     Condition
       Error in `slice()`:
-      ! Can't compute `..1`.
+      i In `..1`.
       Caused by error in `999 + ""`:
       ! non-numeric argument to binary operator
     Code
       mutate(mtcars, var = invisible(999 + ""))
     Condition
       Error in `mutate()`:
-      ! Can't compute `var`.
+      i In `var`.
       Caused by error in `999 + ""`:
       ! non-numeric argument to binary operator
     Code
       summarise(mtcars, var = invisible(999 + ""))
     Condition
       Error in `summarise()`:
-      ! Can't compute `var`.
+      i In `var`.
       Caused by error in `999 + ""`:
       ! non-numeric argument to binary operator
     Code
@@ -67,7 +67,7 @@
       arrange(mtcars, var = invisible(999 + ""))
     Condition
       Error in `arrange()`:
-      ! Can't compute `..1`.
+      i In `..1`.
       Caused by error in `999 + ""`:
       ! non-numeric argument to binary operator
     Code
@@ -81,7 +81,7 @@
       slice(mtcars, var = invisible(999 + ""))
     Condition
       Error in `slice()`:
-      ! Can't compute `var`.
+      i In `var`.
       Caused by error in `999 + ""`:
       ! non-numeric argument to binary operator
 
@@ -91,28 +91,28 @@
       mutate(mtcars, 1 + "")
     Condition
       Error in `foo()`:
-      ! Can't compute `..1 = 1 + ""`.
+      i In `..1 = 1 + ""`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
     Code
       transmute(mtcars, 1 + "")
     Condition
       Error in `foo()`:
-      ! Can't compute `..1 = 1 + ""`.
+      i In `..1 = 1 + ""`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
     Code
       summarise(mtcars, 1 + "")
     Condition
       Error in `foo()`:
-      ! Can't compute `..1 = 1 + ""`.
+      i In `..1 = 1 + ""`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
     Code
       summarise(group_by(mtcars, cyl), 1 + "")
     Condition
       Error in `foo()`:
-      ! Can't compute `..1 = 1 + ""`.
+      i In `..1 = 1 + ""`.
       i In group 1: `cyl = 4`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
@@ -120,14 +120,14 @@
       filter(mtcars, 1 + "")
     Condition
       Error in `foo()`:
-      ! Can't compute `..1 = 1 + ""`.
+      i In `..1 = 1 + ""`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
     Code
       arrange(mtcars, 1 + "")
     Condition
       Error in `foo()`:
-      ! Can't compute `..1 = 1 + ""`.
+      i In `..1 = 1 + ""`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
     Code
@@ -141,7 +141,7 @@
       slice(mtcars, 1 + "")
     Condition
       Error in `foo()`:
-      ! Can't compute `..1 = 1 + ""`.
+      i In `..1 = 1 + ""`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
 
@@ -151,14 +151,14 @@
       my_verb(mtcars, 1 + "", am)
     Condition
       Error in `my_verb()`:
-      ! Can't compute `.result = (1 + "") * am`.
+      i In `.result = (1 + "") * am`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
     Code
       my_verb(mtcars, cyl, c(am, vs))
     Condition
       Error in `my_verb()`:
-      ! Can't compute `.result = cyl * c(am, vs)`.
+      i In `.result = cyl * c(am, vs)`.
       Caused by error:
       ! `.result` must be size 32 or 1, not 64.
 

--- a/tests/testthat/_snaps/count-tally.md
+++ b/tests/testthat/_snaps/count-tally.md
@@ -47,7 +47,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `count()`:
-      ! Can't compute `new = 1 + ""`.
+      i In `new = 1 + ""`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
     Code
@@ -55,7 +55,7 @@
     Output
       <error/rlang_error>
       Error in `count()`:
-      ! Can't compute `n = sum(1 + "", na.rm = TRUE)`.
+      i In `n = sum(1 + "", na.rm = TRUE)`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
 
@@ -66,7 +66,7 @@
     Output
       <error/rlang_error>
       Error in `tally()`:
-      ! Can't compute `n = sum(1 + "", na.rm = TRUE)`.
+      i In `n = sum(1 + "", na.rm = TRUE)`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
 
@@ -77,7 +77,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `add_count()`:
-      ! Can't compute `new = 1 + ""`.
+      i In `new = 1 + ""`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
     Code
@@ -85,7 +85,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `add_count()`:
-      ! Can't compute `n = sum(1 + "", na.rm = TRUE)`.
+      i In `n = sum(1 + "", na.rm = TRUE)`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
 
@@ -96,7 +96,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `add_tally()`:
-      ! Can't compute `n = sum(1 + "", na.rm = TRUE)`.
+      i In `n = sum(1 + "", na.rm = TRUE)`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
 

--- a/tests/testthat/_snaps/count-tally.md
+++ b/tests/testthat/_snaps/count-tally.md
@@ -47,7 +47,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `count()`:
-      i In `new = 1 + ""`.
+      i In argument `new = 1 + ""`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
     Code
@@ -55,7 +55,7 @@
     Output
       <error/rlang_error>
       Error in `count()`:
-      i In `n = sum(1 + "", na.rm = TRUE)`.
+      i In argument `n = sum(1 + "", na.rm = TRUE)`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
 
@@ -66,7 +66,7 @@
     Output
       <error/rlang_error>
       Error in `tally()`:
-      i In `n = sum(1 + "", na.rm = TRUE)`.
+      i In argument `n = sum(1 + "", na.rm = TRUE)`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
 
@@ -77,7 +77,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `add_count()`:
-      i In `new = 1 + ""`.
+      i In argument `new = 1 + ""`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
     Code
@@ -85,7 +85,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `add_count()`:
-      i In `n = sum(1 + "", na.rm = TRUE)`.
+      i In argument `n = sum(1 + "", na.rm = TRUE)`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
 
@@ -96,7 +96,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `add_tally()`:
-      i In `n = sum(1 + "", na.rm = TRUE)`.
+      i In argument `n = sum(1 + "", na.rm = TRUE)`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
 

--- a/tests/testthat/_snaps/distinct.md
+++ b/tests/testthat/_snaps/distinct.md
@@ -28,7 +28,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `distinct()`:
-      ! Can't compute `y = a + 1`.
+      i In `y = a + 1`.
       Caused by error:
       ! object 'a' not found
 

--- a/tests/testthat/_snaps/distinct.md
+++ b/tests/testthat/_snaps/distinct.md
@@ -28,7 +28,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `distinct()`:
-      i In `y = a + 1`.
+      i In argument `y = a + 1`.
       Caused by error:
       ! object 'a' not found
 

--- a/tests/testthat/_snaps/filter.md
+++ b/tests/testthat/_snaps/filter.md
@@ -23,7 +23,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      i In `..1 = matrix(TRUE, nrow = 3, ncol = 2)`.
+      i In argument `..1 = matrix(TRUE, nrow = 3, ncol = 2)`.
       Caused by error:
       ! `..1` must be a logical vector, not a logical matrix.
 
@@ -34,7 +34,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      i In `..1 = array(TRUE, dim = c(3, 1, 1))`.
+      i In argument `..1 = array(TRUE, dim = c(3, 1, 1))`.
       Caused by error:
       ! `..1` must be a logical vector, not a logical array.
 
@@ -45,7 +45,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      i In `..1 = 1:n()`.
+      i In argument `..1 = 1:n()`.
       i In group 1: `Species = setosa`.
       Caused by error:
       ! `..1` must be a logical vector, not an integer vector.
@@ -54,7 +54,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      i In `..1 = 1:n()`.
+      i In argument `..1 = 1:n()`.
       Caused by error:
       ! `..1` must be a logical vector, not an integer vector.
     Code
@@ -63,7 +63,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      i In `..1 = matrix(c(TRUE, FALSE, TRUE, FALSE), nrow = 2)`.
+      i In argument `..1 = matrix(c(TRUE, FALSE, TRUE, FALSE), nrow = 2)`.
       Caused by error:
       ! `..1` must be a logical vector, not a logical matrix.
     Code
@@ -71,7 +71,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      i In `..1 = c(TRUE, FALSE)`.
+      i In argument `..1 = c(TRUE, FALSE)`.
       i In group 1: `Species = setosa`.
       Caused by error:
       ! `..1` must be of size 50 or 1, not size 2.
@@ -80,7 +80,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      i In `..1 = c(TRUE, FALSE)`.
+      i In argument `..1 = c(TRUE, FALSE)`.
       i In row 1.
       Caused by error:
       ! `..1` must be of size 1, not size 2.
@@ -89,7 +89,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      i In `..1 = c(TRUE, FALSE)`.
+      i In argument `..1 = c(TRUE, FALSE)`.
       Caused by error:
       ! `..1` must be of size 150 or 1, not size 2.
     Code
@@ -98,7 +98,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      i In `..1 = data.frame(c(TRUE, FALSE))`.
+      i In argument `..1 = data.frame(c(TRUE, FALSE))`.
       i In group 1: `Species = setosa`.
       Caused by error:
       ! `..1` must be of size 50 or 1, not size 2.
@@ -107,7 +107,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      i In `..1 = data.frame(c(TRUE, FALSE))`.
+      i In argument `..1 = data.frame(c(TRUE, FALSE))`.
       i In row 1.
       Caused by error:
       ! `..1` must be of size 1, not size 2.
@@ -116,7 +116,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      i In `..1 = data.frame(c(TRUE, FALSE))`.
+      i In argument `..1 = data.frame(c(TRUE, FALSE))`.
       Caused by error:
       ! `..1` must be of size 150 or 1, not size 2.
     Code
@@ -124,7 +124,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      i In `..1 = c(TRUE, TRUE)`.
+      i In argument `..1 = c(TRUE, TRUE)`.
       Caused by error:
       ! `..1` must be of size 1, not size 2.
     Code
@@ -137,7 +137,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      i In `..1 = data.frame(Sepal.Length > 3, 1:n())`.
+      i In argument `..1 = data.frame(Sepal.Length > 3, 1:n())`.
       i In group 1: `Species = setosa`.
       Caused by error:
       ! `..1$X1.n..` must be a logical vector, not an integer vector.
@@ -150,7 +150,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      i In `..1 = data.frame(Sepal.Length > 3, 1:n())`.
+      i In argument `..1 = data.frame(Sepal.Length > 3, 1:n())`.
       Caused by error:
       ! `..1$X1.n..` must be a logical vector, not an integer vector.
     Code
@@ -158,7 +158,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      i In `..1 = _x`.
+      i In argument `..1 = _x`.
       Caused by error:
       ! object '_x' not found
     Code
@@ -166,7 +166,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      i In `..1 = _x`.
+      i In argument `..1 = _x`.
       i In group 1: `cyl = 4`.
       Caused by error:
       ! object '_x' not found
@@ -207,7 +207,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      i In `..1 = stop("{")`.
+      i In argument `..1 = stop("{")`.
       Caused by error:
       ! {
     Code

--- a/tests/testthat/_snaps/filter.md
+++ b/tests/testthat/_snaps/filter.md
@@ -23,7 +23,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      ! Can't compute `..1 = matrix(TRUE, nrow = 3, ncol = 2)`.
+      i In `..1 = matrix(TRUE, nrow = 3, ncol = 2)`.
       Caused by error:
       ! `..1` must be a logical vector, not a logical matrix.
 
@@ -34,7 +34,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      ! Can't compute `..1 = array(TRUE, dim = c(3, 1, 1))`.
+      i In `..1 = array(TRUE, dim = c(3, 1, 1))`.
       Caused by error:
       ! `..1` must be a logical vector, not a logical array.
 
@@ -45,7 +45,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      ! Can't compute `..1 = 1:n()`.
+      i In `..1 = 1:n()`.
       i In group 1: `Species = setosa`.
       Caused by error:
       ! `..1` must be a logical vector, not an integer vector.
@@ -54,7 +54,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      ! Can't compute `..1 = 1:n()`.
+      i In `..1 = 1:n()`.
       Caused by error:
       ! `..1` must be a logical vector, not an integer vector.
     Code
@@ -63,7 +63,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      ! Can't compute `..1 = matrix(c(TRUE, FALSE, TRUE, FALSE), nrow = 2)`.
+      i In `..1 = matrix(c(TRUE, FALSE, TRUE, FALSE), nrow = 2)`.
       Caused by error:
       ! `..1` must be a logical vector, not a logical matrix.
     Code
@@ -71,7 +71,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      ! Can't compute `..1 = c(TRUE, FALSE)`.
+      i In `..1 = c(TRUE, FALSE)`.
       i In group 1: `Species = setosa`.
       Caused by error:
       ! `..1` must be of size 50 or 1, not size 2.
@@ -80,7 +80,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      ! Can't compute `..1 = c(TRUE, FALSE)`.
+      i In `..1 = c(TRUE, FALSE)`.
       i In row 1.
       Caused by error:
       ! `..1` must be of size 1, not size 2.
@@ -89,7 +89,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      ! Can't compute `..1 = c(TRUE, FALSE)`.
+      i In `..1 = c(TRUE, FALSE)`.
       Caused by error:
       ! `..1` must be of size 150 or 1, not size 2.
     Code
@@ -98,7 +98,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      ! Can't compute `..1 = data.frame(c(TRUE, FALSE))`.
+      i In `..1 = data.frame(c(TRUE, FALSE))`.
       i In group 1: `Species = setosa`.
       Caused by error:
       ! `..1` must be of size 50 or 1, not size 2.
@@ -107,7 +107,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      ! Can't compute `..1 = data.frame(c(TRUE, FALSE))`.
+      i In `..1 = data.frame(c(TRUE, FALSE))`.
       i In row 1.
       Caused by error:
       ! `..1` must be of size 1, not size 2.
@@ -116,7 +116,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      ! Can't compute `..1 = data.frame(c(TRUE, FALSE))`.
+      i In `..1 = data.frame(c(TRUE, FALSE))`.
       Caused by error:
       ! `..1` must be of size 150 or 1, not size 2.
     Code
@@ -124,7 +124,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      ! Can't compute `..1 = c(TRUE, TRUE)`.
+      i In `..1 = c(TRUE, TRUE)`.
       Caused by error:
       ! `..1` must be of size 1, not size 2.
     Code
@@ -137,7 +137,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      ! Can't compute `..1 = data.frame(Sepal.Length > 3, 1:n())`.
+      i In `..1 = data.frame(Sepal.Length > 3, 1:n())`.
       i In group 1: `Species = setosa`.
       Caused by error:
       ! `..1$X1.n..` must be a logical vector, not an integer vector.
@@ -150,7 +150,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      ! Can't compute `..1 = data.frame(Sepal.Length > 3, 1:n())`.
+      i In `..1 = data.frame(Sepal.Length > 3, 1:n())`.
       Caused by error:
       ! `..1$X1.n..` must be a logical vector, not an integer vector.
     Code
@@ -158,7 +158,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      ! Can't compute `..1 = _x`.
+      i In `..1 = _x`.
       Caused by error:
       ! object '_x' not found
     Code
@@ -166,7 +166,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      ! Can't compute `..1 = _x`.
+      i In `..1 = _x`.
       i In group 1: `cyl = 4`.
       Caused by error:
       ! object '_x' not found
@@ -207,7 +207,7 @@
     Output
       <error/rlang_error>
       Error in `filter()`:
-      ! Can't compute `..1 = stop("{")`.
+      i In `..1 = stop("{")`.
       Caused by error:
       ! {
     Code

--- a/tests/testthat/_snaps/group-by.md
+++ b/tests/testthat/_snaps/group-by.md
@@ -43,7 +43,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `group_by()`:
-      ! Can't compute `z = a + 1`.
+      i In `z = a + 1`.
       Caused by error:
       ! object 'a' not found
 

--- a/tests/testthat/_snaps/group-by.md
+++ b/tests/testthat/_snaps/group-by.md
@@ -43,7 +43,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `group_by()`:
-      i In `z = a + 1`.
+      i In argument `z = a + 1`.
       Caused by error:
       ! object 'a' not found
 

--- a/tests/testthat/_snaps/mutate.md
+++ b/tests/testthat/_snaps/mutate.md
@@ -5,7 +5,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      i In `z = <int>`.
+      i In argument `z = <int>`.
       Caused by error:
       ! Inlined constant `z` must be size 10 or 1, not 5.
     Code
@@ -13,7 +13,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      i In `z = <int>`.
+      i In argument `z = <int>`.
       Caused by error:
       ! Inlined constant `z` must be size 10 or 1, not 5.
     Code
@@ -21,7 +21,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      i In `z = <int>`.
+      i In argument `z = <int>`.
       Caused by error:
       ! Inlined constant `z` must be size 10 or 1, not 5.
 
@@ -32,7 +32,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      i In `y = .env$y`.
+      i In argument `y = .env$y`.
       i In group 1: `g = 1`.
       Caused by error:
       ! `y` must be size 5 or 1, not 10.
@@ -41,7 +41,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      i In `y = .env$y`.
+      i In argument `y = .env$y`.
       i In row 1.
       Caused by error:
       ! `y` must be size 1, not 10.
@@ -53,7 +53,7 @@
       mutate(df, y = x)
     Condition
       Error in `mutate()`:
-      i In `y = x`.
+      i In argument `y = x`.
       i In row 2.
       Caused by error:
       ! `y` must be size 1, not 2.
@@ -82,7 +82,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      i In `a = sum(y)`.
+      i In argument `a = sum(y)`.
       Caused by error:
       ! object 'y' not found
     Code
@@ -90,7 +90,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      i In `a = sum(y)`.
+      i In argument `a = sum(y)`.
       i In group 1: `x = 1`.
       Caused by error:
       ! object 'y' not found
@@ -99,7 +99,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      i In `y = mean`.
+      i In argument `y = mean`.
       Caused by error:
       ! `y` must be a vector, not a function.
     Code
@@ -108,7 +108,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      i In `out = env(a = 1)`.
+      i In argument `out = env(a = 1)`.
       Caused by error:
       ! `out` must be a vector, not an environment.
     Code
@@ -116,7 +116,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      i In `out = env(a = 1)`.
+      i In argument `out = env(a = 1)`.
       i In group 1: `g = 1`.
       Caused by error:
       ! `out` must be a vector, not an environment.
@@ -125,7 +125,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      i In `out = rnorm`.
+      i In argument `out = rnorm`.
       i In row 1.
       Caused by error:
       ! `out` must be a vector, not a function.
@@ -136,7 +136,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      i In `val = ifelse(x < 3, "foo", 2)`.
+      i In argument `val = ifelse(x < 3, "foo", 2)`.
       Caused by error:
       ! `val` must return compatible vectors across groups.
       i Result of type <character> for group 1: `x = 1`.
@@ -147,7 +147,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      i In `..1 = if (a == 1) NULL else "foo"`.
+      i In argument `..1 = if (a == 1) NULL else "foo"`.
       Caused by error:
       ! `..1` must return compatible vectors across groups.
       x Can't combine NULL and non NULL results.
@@ -156,7 +156,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      i In `int = 1:5`.
+      i In argument `int = 1:5`.
       Caused by error:
       ! `int` must be size 4 or 1, not 5.
     Code
@@ -165,7 +165,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      i In `int = 1:5`.
+      i In argument `int = 1:5`.
       i In group 1: `x = 2`.
       Caused by error:
       ! `int` must be size 2 or 1, not 5.
@@ -174,7 +174,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      i In `int = 1:5`.
+      i In argument `int = 1:5`.
       i In group 1: `x = 2`.
       Caused by error:
       ! `int` must be size 1, not 5.
@@ -184,7 +184,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      i In `int = 1:5`.
+      i In argument `int = 1:5`.
       i In row 1.
       Caused by error:
       ! `int` must be size 1, not 5.
@@ -194,7 +194,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      i In `y2 = y`.
+      i In argument `y2 = y`.
       i In row 1.
       Caused by error:
       ! `y2` must be size 1, not 3.
@@ -204,7 +204,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      i In `y = 1:2`.
+      i In argument `y = 1:2`.
       Caused by error:
       ! `y` must be size 10 or 1, not 2.
     Code
@@ -212,7 +212,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      i In `c = .data$b`.
+      i In argument `c = .data$b`.
       Caused by error in `.data$b`:
       ! Column `b` not found in `.data`.
     Code
@@ -220,7 +220,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      i In `c = .data$b`.
+      i In argument `c = .data$b`.
       i In group 1: `a = 1`.
       Caused by error in `.data$b`:
       ! Column `b` not found in `.data`.
@@ -239,7 +239,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      i In `..1 = stop("{")`.
+      i In argument `..1 = stop("{")`.
       Caused by error:
       ! {
 

--- a/tests/testthat/_snaps/mutate.md
+++ b/tests/testthat/_snaps/mutate.md
@@ -5,7 +5,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      ! Can't compute `z = <int>`.
+      i In `z = <int>`.
       Caused by error:
       ! Inlined constant `z` must be size 10 or 1, not 5.
     Code
@@ -13,7 +13,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      ! Can't compute `z = <int>`.
+      i In `z = <int>`.
       Caused by error:
       ! Inlined constant `z` must be size 10 or 1, not 5.
     Code
@@ -21,7 +21,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      ! Can't compute `z = <int>`.
+      i In `z = <int>`.
       Caused by error:
       ! Inlined constant `z` must be size 10 or 1, not 5.
 
@@ -32,7 +32,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      ! Can't compute `y = .env$y`.
+      i In `y = .env$y`.
       i In group 1: `g = 1`.
       Caused by error:
       ! `y` must be size 5 or 1, not 10.
@@ -41,7 +41,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      ! Can't compute `y = .env$y`.
+      i In `y = .env$y`.
       i In row 1.
       Caused by error:
       ! `y` must be size 1, not 10.
@@ -53,7 +53,7 @@
       mutate(df, y = x)
     Condition
       Error in `mutate()`:
-      ! Can't compute `y = x`.
+      i In `y = x`.
       i In row 2.
       Caused by error:
       ! `y` must be size 1, not 2.
@@ -82,7 +82,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      ! Can't compute `a = sum(y)`.
+      i In `a = sum(y)`.
       Caused by error:
       ! object 'y' not found
     Code
@@ -90,7 +90,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      ! Can't compute `a = sum(y)`.
+      i In `a = sum(y)`.
       i In group 1: `x = 1`.
       Caused by error:
       ! object 'y' not found
@@ -99,7 +99,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      ! Can't compute `y = mean`.
+      i In `y = mean`.
       Caused by error:
       ! `y` must be a vector, not a function.
     Code
@@ -108,7 +108,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      ! Can't compute `out = env(a = 1)`.
+      i In `out = env(a = 1)`.
       Caused by error:
       ! `out` must be a vector, not an environment.
     Code
@@ -116,7 +116,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      ! Can't compute `out = env(a = 1)`.
+      i In `out = env(a = 1)`.
       i In group 1: `g = 1`.
       Caused by error:
       ! `out` must be a vector, not an environment.
@@ -125,7 +125,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      ! Can't compute `out = rnorm`.
+      i In `out = rnorm`.
       i In row 1.
       Caused by error:
       ! `out` must be a vector, not a function.
@@ -136,7 +136,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      ! Can't compute `val = ifelse(x < 3, "foo", 2)`.
+      i In `val = ifelse(x < 3, "foo", 2)`.
       Caused by error:
       ! `val` must return compatible vectors across groups.
       i Result of type <character> for group 1: `x = 1`.
@@ -147,7 +147,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      ! Can't compute `..1 = if (a == 1) NULL else "foo"`.
+      i In `..1 = if (a == 1) NULL else "foo"`.
       Caused by error:
       ! `..1` must return compatible vectors across groups.
       x Can't combine NULL and non NULL results.
@@ -156,7 +156,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      ! Can't compute `int = 1:5`.
+      i In `int = 1:5`.
       Caused by error:
       ! `int` must be size 4 or 1, not 5.
     Code
@@ -165,7 +165,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      ! Can't compute `int = 1:5`.
+      i In `int = 1:5`.
       i In group 1: `x = 2`.
       Caused by error:
       ! `int` must be size 2 or 1, not 5.
@@ -174,7 +174,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      ! Can't compute `int = 1:5`.
+      i In `int = 1:5`.
       i In group 1: `x = 2`.
       Caused by error:
       ! `int` must be size 1, not 5.
@@ -184,7 +184,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      ! Can't compute `int = 1:5`.
+      i In `int = 1:5`.
       i In row 1.
       Caused by error:
       ! `int` must be size 1, not 5.
@@ -194,7 +194,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      ! Can't compute `y2 = y`.
+      i In `y2 = y`.
       i In row 1.
       Caused by error:
       ! `y2` must be size 1, not 3.
@@ -204,7 +204,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      ! Can't compute `y = 1:2`.
+      i In `y = 1:2`.
       Caused by error:
       ! `y` must be size 10 or 1, not 2.
     Code
@@ -212,7 +212,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      ! Can't compute `c = .data$b`.
+      i In `c = .data$b`.
       Caused by error in `.data$b`:
       ! Column `b` not found in `.data`.
     Code
@@ -220,7 +220,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      ! Can't compute `c = .data$b`.
+      i In `c = .data$b`.
       i In group 1: `a = 1`.
       Caused by error in `.data$b`:
       ! Column `b` not found in `.data`.
@@ -239,7 +239,7 @@
     Output
       <error/dplyr:::mutate_error>
       Error in `mutate()`:
-      ! Can't compute `..1 = stop("{")`.
+      i In `..1 = stop("{")`.
       Caused by error:
       ! {
 

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -24,7 +24,7 @@
       slice(tibble(), "a")
     Condition
       Error in `slice()`:
-      ! Can't process `..1 = "a"`.
+      i In `..1 = "a"`.
       Caused by error:
       ! Must subset elements with a valid subscript vector.
       x Subscript `"a"` has the wrong type `character`.
@@ -36,14 +36,14 @@
       slice(df, 1 + "")
     Condition
       Error in `slice()`:
-      ! Can't compute `..1 = 1 + ""`.
+      i In `..1 = 1 + ""`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
     Code
       slice(group_by(df, x), 1 + "")
     Condition
       Error in `slice()`:
-      ! Can't compute `..1 = 1 + ""`.
+      i In `..1 = 1 + ""`.
       i In group 1: `x = 1`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -24,7 +24,7 @@
       slice(tibble(), "a")
     Condition
       Error in `slice()`:
-      i In `..1 = "a"`.
+      i In argument `..1 = "a"`.
       Caused by error:
       ! Must subset elements with a valid subscript vector.
       x Subscript `"a"` has the wrong type `character`.
@@ -36,14 +36,14 @@
       slice(df, 1 + "")
     Condition
       Error in `slice()`:
-      i In `..1 = 1 + ""`.
+      i In argument `..1 = 1 + ""`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
     Code
       slice(group_by(df, x), 1 + "")
     Condition
       Error in `slice()`:
-      i In `..1 = 1 + ""`.
+      i In argument `..1 = 1 + ""`.
       i In group 1: `x = 1`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator

--- a/tests/testthat/_snaps/summarise.md
+++ b/tests/testthat/_snaps/summarise.md
@@ -44,7 +44,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      ! Can't compute `a = rlang::env(a = 1)`.
+      i In `a = rlang::env(a = 1)`.
       Caused by error:
       ! `a` must be a vector, not an environment.
     Code
@@ -53,7 +53,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      ! Can't compute `a = rlang::env(a = 1)`.
+      i In `a = rlang::env(a = 1)`.
       i In group 1: `x = 1`, `y = 1`.
       Caused by error:
       ! `a` must be a vector, not an environment.
@@ -63,7 +63,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      ! Can't compute `a = lm(y ~ x)`.
+      i In `a = lm(y ~ x)`.
       i In row 1.
       Caused by error:
       ! `a` must be a vector, not a <lm> object.
@@ -74,7 +74,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      ! Can't compute `a = a[[1]]`.
+      i In `a = a[[1]]`.
       Caused by error:
       ! `a` must return compatible vectors across groups.
       i Result of type <double> for group 1: `id = 1`.
@@ -85,7 +85,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      ! Can't compute `a = a[[1]]`.
+      i In `a = a[[1]]`.
       Caused by error:
       ! `a` must return compatible vectors across groups.
     Code
@@ -124,7 +124,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      ! Can't compute `x = if (g == 1) 42`.
+      i In `x = if (g == 1) 42`.
       Caused by error:
       ! `x` must return compatible vectors across groups.
       x Can't combine NULL and non NULL results.
@@ -133,7 +133,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      ! Can't compute `a = mean(not_there)`.
+      i In `a = mean(not_there)`.
       Caused by error in `mean()`:
       ! object 'not_there' not found
     Code
@@ -141,7 +141,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      ! Can't compute `a = mean(not_there)`.
+      i In `a = mean(not_there)`.
       i In group 1: `cyl = 4`.
       Caused by error in `mean()`:
       ! object 'not_there' not found
@@ -150,7 +150,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      ! Can't compute `c = .data$b`.
+      i In `c = .data$b`.
       Caused by error in `.data$b`:
       ! Column `b` not found in `.data`.
     Code
@@ -158,7 +158,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      ! Can't compute `c = .data$b`.
+      i In `c = .data$b`.
       i In group 1: `a = 1`.
       Caused by error in `.data$b`:
       ! Column `b` not found in `.data`.
@@ -173,7 +173,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      ! Can't compute `..1 = stop("{")`.
+      i In `..1 = stop("{")`.
       Caused by error:
       ! {
     Code
@@ -182,7 +182,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      ! Can't compute `a = stop("!")`.
+      i In `a = stop("!")`.
       i In group 1: `b = "{value:1, unit:a}"`.
       Caused by error:
       ! !

--- a/tests/testthat/_snaps/summarise.md
+++ b/tests/testthat/_snaps/summarise.md
@@ -44,7 +44,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      i In `a = rlang::env(a = 1)`.
+      i In argument `a = rlang::env(a = 1)`.
       Caused by error:
       ! `a` must be a vector, not an environment.
     Code
@@ -53,7 +53,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      i In `a = rlang::env(a = 1)`.
+      i In argument `a = rlang::env(a = 1)`.
       i In group 1: `x = 1`, `y = 1`.
       Caused by error:
       ! `a` must be a vector, not an environment.
@@ -63,7 +63,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      i In `a = lm(y ~ x)`.
+      i In argument `a = lm(y ~ x)`.
       i In row 1.
       Caused by error:
       ! `a` must be a vector, not a <lm> object.
@@ -74,7 +74,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      i In `a = a[[1]]`.
+      i In argument `a = a[[1]]`.
       Caused by error:
       ! `a` must return compatible vectors across groups.
       i Result of type <double> for group 1: `id = 1`.
@@ -85,7 +85,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      i In `a = a[[1]]`.
+      i In argument `a = a[[1]]`.
       Caused by error:
       ! `a` must return compatible vectors across groups.
     Code
@@ -124,7 +124,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      i In `x = if (g == 1) 42`.
+      i In argument `x = if (g == 1) 42`.
       Caused by error:
       ! `x` must return compatible vectors across groups.
       x Can't combine NULL and non NULL results.
@@ -133,7 +133,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      i In `a = mean(not_there)`.
+      i In argument `a = mean(not_there)`.
       Caused by error in `mean()`:
       ! object 'not_there' not found
     Code
@@ -141,7 +141,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      i In `a = mean(not_there)`.
+      i In argument `a = mean(not_there)`.
       i In group 1: `cyl = 4`.
       Caused by error in `mean()`:
       ! object 'not_there' not found
@@ -150,7 +150,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      i In `c = .data$b`.
+      i In argument `c = .data$b`.
       Caused by error in `.data$b`:
       ! Column `b` not found in `.data`.
     Code
@@ -158,7 +158,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      i In `c = .data$b`.
+      i In argument `c = .data$b`.
       i In group 1: `a = 1`.
       Caused by error in `.data$b`:
       ! Column `b` not found in `.data`.
@@ -173,7 +173,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      i In `..1 = stop("{")`.
+      i In argument `..1 = stop("{")`.
       Caused by error:
       ! {
     Code
@@ -182,7 +182,7 @@
     Output
       <error/rlang_error>
       Error in `summarise()`:
-      i In `a = stop("!")`.
+      i In argument `a = stop("!")`.
       i In group 1: `b = "{value:1, unit:a}"`.
       Caused by error:
       ! !


### PR DESCRIPTION
I realised that:

- The "compute" and "process" verbs don't bring any information.
- Having `!` bullets in contextual errors that only display contextual information without reformulating the causal error in a higher level way is distracting.

This PR simplifies contextual errors by using "i" bullets starting with "In argument", as in #6477.

I kept `!` bullets for recycling errors though because "Can't recycle" is informative.