### PR TITLE
Update to latest vctrs features

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,7 @@ Imports:
     tibble (>= 2.1.3),
     tidyselect (>= 1.1.2.9000),
     utils,
-    vctrs (>= 0.4.1.9000),
+    vctrs (>= 0.4.1.9001),
     pillar (>= 1.5.1)
 Suggests: 
     bench,

--- a/R/bind-cols.R
+++ b/R/bind-cols.R
@@ -34,7 +34,7 @@ bind_cols <- function(..., .name_repair = c("unique", "universal", "check_unique
   # Strip names off of data frame components so that vec_cbind() unpacks them
   names2(dots)[map_lgl(dots, is.data.frame)] <- ""
 
-  out <- vec_cbind(!!!dots, .name_repair = .name_repair, .call = current_env())
+  out <- vec_cbind(!!!dots, .name_repair = .name_repair, .error_call = current_env())
   if (!any(map_lgl(dots, is.data.frame))) {
     out <- as_tibble(out)
   }

--- a/R/bind-rows.R
+++ b/R/bind-rows.R
@@ -71,7 +71,7 @@ bind_rows <- function(..., .id = NULL) {
     names(dots) <- NULL
   }
 
-  out <- vec_rbind(!!!dots, .names_to = .id, .call = current_env())
+  out <- vec_rbind(!!!dots, .names_to = .id, .error_call = current_env())
 
   # Override vctrs coercion rules and instead derive class from first input
   if (is.data.frame(first)) {

--- a/R/coalesce.R
+++ b/R/coalesce.R
@@ -64,7 +64,7 @@ coalesce <- function(..., .ptype = NULL, .size = NULL) {
   args <- set_names(args, names)
 
   conditions <- map(args, ~{
-    !vec_equal_na(.x)
+    !vec_detect_missing(.x)
   })
 
   vec_case_when(

--- a/R/nth-value.R
+++ b/R/nth-value.R
@@ -95,7 +95,7 @@ nth <- function(x, n, order_by = NULL, default = NULL, na_rm = FALSE) {
   check_bool(na_rm)
 
   if (na_rm) {
-    not_missing <- !vec_equal_na(x)
+    not_missing <- !vec_detect_missing(x)
 
     x <- vec_slice(x, not_missing)
     size <- vec_size(x)

--- a/R/rank.R
+++ b/R/rank.R
@@ -107,7 +107,7 @@ ntile <- function(x = row_number(), n) {
   if (!missing(x)) {
     x <- row_number(x)
   }
-  len <- vec_size(x) - sum(vec_equal_na(x))
+  len <- vec_size(x) - sum(vec_detect_missing(x))
 
   check_number(n)
   n <- vec_cast(n, integer())


### PR DESCRIPTION
- `.error_call` not `.call`
- `vec_detect_missing()` not `vec_equal_na()`