### PR TITLE
Take the common type in `between()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -288,12 +288,8 @@
 * `between()` has been rewritten to utilize vctrs. This means that it is no
   longer restricted to just numeric and date-time vectors. Additionally, `left`
   and `right` are no longer required to be scalars, they can now also be vectors
-  with the same length as `x`. Finally, `left` and `right` are now cast to the
-  type of `x` before the comparison is made. This last change means that you
-  can no longer make comparisons like `between(<int>, 0, 2.5)`, as `2.5` can't
-  be cast to integer without losing information. We recommend that you convert
-  the `<int>` vector to double before calling `between()` if you require this
-  (#6183, #6260).
+  with the same length as `x`. Finally, `x`, `left`, and `right` are now cast to
+  their common type before the comparison is made (#6183, #6260, #6478).
 
 * Joins have undergone a complete overhaul. The purpose of this overhaul is to
   enable more flexible join operations, while also providing tools to perform

--- a/R/funs.R
+++ b/R/funs.R
@@ -3,9 +3,13 @@
 #' This is a shortcut for `x >= left & x <= right`, implemented for local
 #' vectors and translated to the appropriate SQL for remote tables.
 #'
+#' @details
+#' `x`, `left`, and `right` are all cast to their common type before the
+#' comparison is made.
+#'
 #' @param x A vector
 #' @param left,right Boundary values. Both `left` and `right` are recycled to
-#'   the size of `x` and are cast to the type of `x`.
+#'   the size of `x`.
 #' @export
 #' @examples
 #' between(1:12, 7, 9)
@@ -16,11 +20,17 @@
 #' # On a tibble using `filter()`
 #' filter(starwars, between(height, 100, 150))
 between <- function(x, left, right) {
-  args <- list(left = left, right = right)
-  args <- vec_cast_common(!!!args, .to = x)
+  args <- list(x = x, left = left, right = right)
+
+  # Common type of all inputs
+  args <- vec_cast_common(!!!args)
+  x <- args$x
+  args$x <- NULL
+
+  # But recycle to size of `x`
   args <- vec_recycle_common(!!!args, .size = vec_size(x))
-  left <- args[[1L]]
-  right <- args[[2L]]
+  left <- args$left
+  right <- args$right
 
   left <- vec_compare(x, left)
   left <- left >= 0L

--- a/R/funs.R
+++ b/R/funs.R
@@ -10,6 +10,10 @@
 #' @param x A vector
 #' @param left,right Boundary values. Both `left` and `right` are recycled to
 #'   the size of `x`.
+#'
+#' @returns
+#' A logical vector the same size as `x`.
+#'
 #' @export
 #' @examples
 #' between(1:12, 7, 9)

--- a/man/between.Rd
+++ b/man/between.Rd
@@ -12,6 +12,9 @@ between(x, left, right)
 \item{left, right}{Boundary values. Both \code{left} and \code{right} are recycled to
 the size of \code{x}.}
 }
+\value{
+A logical vector the same size as \code{x}.
+}
 \description{
 This is a shortcut for \code{x >= left & x <= right}, implemented for local
 vectors and translated to the appropriate SQL for remote tables.

--- a/man/between.Rd
+++ b/man/between.Rd
@@ -10,11 +10,15 @@ between(x, left, right)
 \item{x}{A vector}
 
 \item{left, right}{Boundary values. Both \code{left} and \code{right} are recycled to
-the size of \code{x} and are cast to the type of \code{x}.}
+the size of \code{x}.}
 }
 \description{
 This is a shortcut for \code{x >= left & x <= right}, implemented for local
 vectors and translated to the appropriate SQL for remote tables.
+}
+\details{
+\code{x}, \code{left}, and \code{right} are all cast to their common type before the
+comparison is made.
 }
 \examples{
 between(1:12, 7, 9)

--- a/tests/testthat/_snaps/funs.md
+++ b/tests/testthat/_snaps/funs.md
@@ -1,20 +1,26 @@
-# casts `left` and `right` to the type of `x`
+# takes the common type between all inputs (#6478)
 
     Code
-      between(1L, 1.5, 2L)
+      between("1", 2, 3)
     Condition
       Error in `between()`:
-      ! Can't convert from `left` <double> to <integer> due to loss of precision.
-      * Locations: 1
+      ! Can't combine `x` <character> and `left` <double>.
 
 ---
 
     Code
-      between(1L, 1L, 2.5)
+      between(1, "2", 3)
     Condition
       Error in `between()`:
-      ! Can't convert from `right` <double> to <integer> due to loss of precision.
-      * Locations: 1
+      ! Can't combine `x` <double> and `left` <character>.
+
+---
+
+    Code
+      between(1, 2, "3")
+    Condition
+      Error in `between()`:
+      ! Can't combine `x` <double> and `right` <character>.
 
 # recycles `left` and `right` to the size of `x`
 

--- a/tests/testthat/test-funs.R
+++ b/tests/testthat/test-funs.R
@@ -50,12 +50,18 @@ test_that("works with rcrds", {
   expect_identical(between(x, left, right), c(TRUE, FALSE, TRUE))
 })
 
-test_that("casts `left` and `right` to the type of `x`", {
+test_that("takes the common type between all inputs (#6478)", {
+  expect_identical(between(1L, 1.5, 2L), FALSE)
+  expect_identical(between(1L, 0.5, 2.5), TRUE)
+
   expect_snapshot(error = TRUE, {
-    between(1L, 1.5, 2L)
+    between("1", 2, 3)
   })
   expect_snapshot(error = TRUE, {
-    between(1L, 1L, 2.5)
+    between(1, "2", 3)
+  })
+  expect_snapshot(error = TRUE, {
+    between(1, 2, "3")
   })
 })
 


### PR DESCRIPTION
Closes #6478

- Casting to the type of `x` feels slightly too strict. If this was `clamp(x, left, right)` then it would be obvious that we should cast to the type of `x`, but this is slightly more ambiguous because it returns a logical vector. 
- We document this as a shortcut for `x >= lower & x <= upper`, which does imply common type
- Practical usage can reasonably do something like `between(1:5, .5, 3.5)` when users don't want to worry about boundary values (I don't love this argument, but it is a real life occurrence that I am willing to bend for)
- We still retain the _size_ of `x`, even though we take the common type