### PR TITLE
Update to latest lifecycle

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Imports:
     cli (>= 3.4.0),
     generics,
     glue (>= 1.3.2),
-    lifecycle (>= 1.0.2),
+    lifecycle (>= 1.0.2.9000),
     magrittr (>= 1.5),
     methods,
     R6,
@@ -66,6 +66,7 @@ Suggests:
     tidyr, 
     withr
 Remotes: 
+    r-lib/lifecycle,
     r-lib/tidyselect,
     r-lib/vctrs
 VignetteBuilder: 

--- a/R/across.R
+++ b/R/across.R
@@ -208,14 +208,14 @@ across <- function(.cols = everything(),
   )
 
   if (!missing(...)) {
-    details <- paste_line(
+    details <- c(
       "Supply arguments directly to `.fns` through a lambda instead.",
       "",
-      "  # Previously",
-      "  across(a:b, mean, na.rm = TRUE)",
+      " " = "# Previously",
+      " " = "across(a:b, mean, na.rm = TRUE)",
       "",
-      "  # Now",
-      "  across(a:b, ~mean(.x, na.rm = TRUE))"
+      " " = "# Now",
+      " " = "across(a:b, ~mean(.x, na.rm = TRUE))"
     )
     lifecycle::deprecate_warn(
       when = "1.1.0",

--- a/R/colwise-funs.R
+++ b/R/colwise-funs.R
@@ -1,6 +1,12 @@
-
-as_fun_list <- function(.funs, .env, ..., .caller, .caller_arg = "...", error_call = caller_env()) {
+as_fun_list <- function(.funs,
+                        .env,
+                        ...,
+                        .caller,
+                        .caller_arg = "...",
+                        error_call = caller_env(),
+                        .user_env = caller_env(2)) {
   args <- list2(...)
+  force(.user_env)
 
   if (is_fun_list(.funs)) {
     if (!is_empty(args)) {
@@ -26,14 +32,15 @@ as_fun_list <- function(.funs, .env, ..., .caller, .caller_arg = "...", error_ca
       if (is_quosure(.x)) {
         what <- paste0(
           "dplyr::", .caller, "(", .caller_arg, " = ",
-          "'can\\'t contain quosures.')"
+          "'can\\'t contain quosures')"
         )
 
         lifecycle::deprecate_warn(
           "0.8.3", what,
           details = "Please use a one-sided formula, a function, or a function name.",
           always = TRUE,
-          env = .env
+          env = .env,
+          user_env = .user_env
         )
         .x <- new_formula(NULL, quo_squash(.x), quo_get_env(.x))
       }

--- a/R/colwise-mutate.R
+++ b/R/colwise-mutate.R
@@ -307,17 +307,17 @@ manip_all <- function(.tbl, .funs, .quo, .env, ..., .include_group_vars = FALSE,
   } else {
     syms <- syms(tbl_nongroup_vars(.tbl))
   }
-  funs <- as_fun_list(.funs, .env, ..., .caller = .caller, error_call = error_call)
+  funs <- as_fun_list(.funs, .env, ..., .caller = .caller, error_call = error_call, .user_env = caller_env(2))
   manip_apply_syms(funs, syms, .tbl)
 }
 manip_if <- function(.tbl, .predicate, .funs, .quo, .env, ..., .include_group_vars = FALSE, .caller, error_call = caller_env()) {
   vars <- tbl_if_syms(.tbl, .predicate, .env, .include_group_vars = .include_group_vars, error_call = error_call)
-  funs <- as_fun_list(.funs, .env, ..., .caller = .caller, error_call = error_call)
+  funs <- as_fun_list(.funs, .env, ..., .caller = .caller, error_call = error_call, .user_env = caller_env(2))
   manip_apply_syms(funs, vars, .tbl)
 }
 manip_at <- function(.tbl, .vars, .funs, .quo, .env, ..., .include_group_vars = FALSE, .caller, error_call = caller_env()) {
   syms <- tbl_at_syms(.tbl, .vars, .include_group_vars = .include_group_vars, error_call = error_call)
-  funs <- as_fun_list(.funs, .env, ..., .caller = .caller, error_call = error_call)
+  funs <- as_fun_list(.funs, .env, ..., .caller = .caller, error_call = error_call, .user_env = caller_env(2))
   manip_apply_syms(funs, syms, .tbl)
 }
 

--- a/R/defunct.R
+++ b/R/defunct.R
@@ -38,17 +38,17 @@ NULL
 #' @export
 #' @rdname defunct
 funs <- function(..., .args = list()) {
-  lifecycle::deprecate_stop("0.8.0", "funs()", details = paste_line(
-    "Please use a list of either functions or lambdas: ",
+  lifecycle::deprecate_stop("0.8.0", "funs()", details = c(
+    "Please use a list of either functions or lambdas:",
     "",
-    "  # Simple named list: ",
-    "  list(mean = mean, median = median)",
+    " " = "# Simple named list:",
+    " " = "list(mean = mean, median = median)",
     "",
-    "  # Auto named with `tibble::lst()`: ",
-    "  tibble::lst(mean, median)",
+    " " = "# Auto named with `tibble::lst()`:",
+    " " = "tibble::lst(mean, median)",
     "",
-    "  # Using lambdas",
-    "  list(~ mean(., trim = .2), ~ median(., na.rm = TRUE))"
+    " " = "# Using lambdas",
+    " " = "list(~ mean(., trim = .2), ~ median(., na.rm = TRUE))"
   ))
 }
 

--- a/tests/testthat/_snaps/colwise-mutate.md
+++ b/tests/testthat/_snaps/colwise-mutate.md
@@ -6,6 +6,23 @@
       `mutate_if()` ignored the following grouping variables:
       * Column `Species`
 
+# colwise verbs soft deprecate quosures (#4330)
+
+    Code
+      (expect_warning(mutate_at(mtcars, vars(mpg), quo(mean(.)))))
+    Output
+      <warning/lifecycle_warning_deprecated>
+      Warning:
+      The `...` argument of `mutate_at()` can't contain quosures as of dplyr 0.8.3.
+      Please use a one-sided formula, a function, or a function name.
+    Code
+      (expect_warning(summarise_at(mtcars, vars(mpg), quo(mean(.)))))
+    Output
+      <warning/lifecycle_warning_deprecated>
+      Warning:
+      The `...` argument of `summarise_at()` can't contain quosures as of dplyr 0.8.3.
+      Please use a one-sided formula, a function, or a function name.
+
 # colwise mutate gives meaningful error messages
 
     Code

--- a/tests/testthat/_snaps/defunct.md
+++ b/tests/testthat/_snaps/defunct.md
@@ -17,12 +17,12 @@
     Condition
       Error:
       ! `funs()` was deprecated in dplyr 0.8.0 and is now defunct.
-      Please use a list of either functions or lambdas: 
+      Please use a list of either functions or lambdas:
       
-        # Simple named list: 
+        # Simple named list:
         list(mean = mean, median = median)
       
-        # Auto named with `tibble::lst()`: 
+        # Auto named with `tibble::lst()`:
         tibble::lst(mean, median)
       
         # Using lambdas

--- a/tests/testthat/test-colwise-mutate.R
+++ b/tests/testthat/test-colwise-mutate.R
@@ -291,7 +291,7 @@ test_that("colwise mutate handle named chr vectors", {
   expect_identical(res, tibble(x = 1:10, y = 5.5))
 })
 
-test_that("colwise verbs soft deprecate quosures (#4330)", {
+test_that("colwise verbs deprecate quosures (#4330)", {
   expect_snapshot({
     (expect_warning(mutate_at(mtcars, vars(mpg), quo(mean(.)))))
     (expect_warning(summarise_at(mtcars, vars(mpg), quo(mean(.)))))

--- a/tests/testthat/test-colwise-mutate.R
+++ b/tests/testthat/test-colwise-mutate.R
@@ -292,10 +292,11 @@ test_that("colwise mutate handle named chr vectors", {
 })
 
 test_that("colwise verbs soft deprecate quosures (#4330)", {
-  expect_warning(mutate_at(mtcars, vars(mpg), quo(mean(.))), "quosure")
-  expect_warning(summarise_at(mtcars, vars(mpg), quo(mean(.))), "quosure")
+  expect_snapshot({
+    (expect_warning(mutate_at(mtcars, vars(mpg), quo(mean(.)))))
+    (expect_warning(summarise_at(mtcars, vars(mpg), quo(mean(.)))))
+  })
 })
-
 
 test_that("rlang lambda inherit from the data mask (#3843)", {
   res <- iris %>%


### PR DESCRIPTION
- Pass bullets instead of formatted strings. This is compatible with both CRAN and dev lifecycle.

- Pass `user_env` to `deprecate_warn()` to differentiate between direct and indirect calls. This requires dev lifecycle.