### PR TITLE
Evaluate each expression in `arrange()` separately

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dplyr (development version)
 
+* `arrange()` now works correctly when `across()` calls are used as the 2nd
+  (or more) ordering expression (#6495).
+
 * Joins now reference the correct column in `y` when a type error is thrown
   while joining on two columns with different names (#6465).
 

--- a/tests/testthat/test-arrange.R
+++ b/tests/testthat/test-arrange.R
@@ -97,8 +97,11 @@ test_that("arrange works with two columns when the first has a data frame proxy 
 test_that("arrange ignores NULLs (#6193)", {
   df <- tibble(x = 1:2)
   y <- NULL
-  out <- arrange(df, y, desc(x))
 
+  out <- arrange(df, y, desc(x))
+  expect_equal(out$x, 2:1)
+
+  out <- arrange(df, y, desc(x), y)
   expect_equal(out$x, 2:1)
 })
 
@@ -226,6 +229,16 @@ test_that("arrange() works with across() cols that return multiple columns (#649
     arrange(df, across(c(a, b)), across(c(c, d))),
     df[c(3, 2, 1),]
   )
+})
+
+test_that("arrange() evaluates each across() call on the original data (#6495)", {
+  df <- tibble(x = 2:1)
+
+  out <- arrange(df, TRUE, across(everything()))
+  expect_identical(out, df[c(2, 1),])
+
+  out <- arrange(df, NULL, across(everything()))
+  expect_identical(out, df[c(2, 1),])
 })
 
 test_that("arrange() with empty dots still calls dplyr_row_slice()", {


### PR DESCRIPTION
Closes #6495 

I've ended up with an approach that just evaluates each expression provided to `arrange()` in its own `mutate()` call. I don't expect the performance here to matter because it is always on ungrouped data frames and the `mutate()` call itself has a fairly small amount of overhead.

This means that each `across()` call will be evaluated on the original data, preventing `everything()` from accessing dummy columns added after evaluating earlier expressions.

I'm actually still using `..1`, `..2`, etc as the column names here, because they need to be called _something_ and that something ends up as part of the error message, so this seemed like the best option.