### PR TITLE
Use `enquos()` + `quo_squash()` in `join_by()`

### DIFF
--- a/R/join-by.R
+++ b/R/join-by.R
@@ -354,18 +354,18 @@ join_by_common <- function(x_names,
 # these functions don't have an `error_call` argument.
 
 parse_join_by_expr <- function(expr, i, error_call) {
-  if (length(expr) == 0L) {
-    message <- c(
-      "Join by expressions can't be empty.",
-      x = glue("Expression {i} is empty.")
-    )
-    abort(message, call = error_call)
-  }
-
   if (is_missing(expr)) {
     message <- c(
       "Join by expressions can't be missing.",
       x = glue("Expression {i} is missing.")
+    )
+    abort(message, call = error_call)
+  }
+
+  if (length(expr) == 0L) {
+    message <- c(
+      "Join by expressions can't be empty.",
+      x = glue("Expression {i} is empty.")
     )
     abort(message, call = error_call)
   }

--- a/R/join-by.R
+++ b/R/join-by.R
@@ -189,10 +189,10 @@
 #' by <- join_by(chromosome, overlaps(x$start, x$end, y$start, y$end))
 #' full_join(segments, reference, by)
 join_by <- function(...) {
-  # `join_by()` captures pure expressions, but we want to allow `{{ }}`. Since
-  # embracing doesn't work with `enexprs()`, the second best option is to use
-  # `enquos()` and immediately squash all quosures to recursively extract the
-  # expressions.
+  # `join_by()` works off pure expressions with no evaluation in the user's
+  # environment, but we want to allow `{{ }}` to make it easier to program with.
+  # The best way to do this is to capture quosures with `enquos()`, and then
+  # immediately squash them recursively into expressions with `quo_squash()`.
   exprs <- enquos(..., .named = NULL)
   exprs <- map(exprs, quo_squash)
 

--- a/tests/testthat/_snaps/join-by.md
+++ b/tests/testthat/_snaps/join-by.md
@@ -1,3 +1,21 @@
+# nicely catches missing arguments when wrapped
+
+    Code
+      fn(a)
+    Condition
+      Error in `join_by()`:
+      ! Join by expressions can't be missing.
+      x Expression 2 is missing.
+
+---
+
+    Code
+      fn(a)
+    Condition
+      Error:
+      ! Expressions using `==` can't contain missing arguments.
+      x Argument `y` is missing.
+
 # has an informative print method
 
     Code


### PR DESCRIPTION
Closes #6469 

To allow `{{ }}`, since `enexprs()` doesn't allow that.

I spent quite a bit of time yesterday re-convincing myself that this is the best way to handle this, and I think it is. 