### PR TITLE
Disallow `keep = FALSE` with non-equi conditions

### DIFF
--- a/R/join-cols.R
+++ b/R/join-cols.R
@@ -9,7 +9,7 @@ join_cols <- function(x_names,
 
   if (is_false(keep) && any(by$condition != "==")) {
     abort(
-      "Can't set `keep = FALSE` when using a non-equi, rolling, or overlap join.",
+      "Can't set `keep = FALSE` when using an inequality, rolling, or overlap join.",
       call = error_call
     )
   }

--- a/R/join-cols.R
+++ b/R/join-cols.R
@@ -7,11 +7,18 @@ join_cols <- function(x_names,
                       error_call = caller_env()) {
   check_dots_empty0(...)
 
+  if (is_false(keep) && any(by$condition != "==")) {
+    abort(
+      "Can't set `keep = FALSE` when using a non-equi, rolling, or overlap join.",
+      call = error_call
+    )
+  }
+
   check_duplicate_vars(x_names, "x", error_call = error_call)
   check_duplicate_vars(y_names, "y", error_call = error_call)
 
-  check_join_vars(by$x, x_names, by$condition, keep, "x", error_call = error_call)
-  check_join_vars(by$y, y_names, by$condition, keep, "y", error_call = error_call)
+  check_join_vars(by$x, x_names, by$condition, "x", error_call = error_call)
+  check_join_vars(by$y, y_names, by$condition, "y", error_call = error_call)
 
   suffix <- standardise_join_suffix(suffix, error_call = error_call)
 
@@ -65,7 +72,6 @@ join_cols <- function(x_names,
 check_join_vars <- function(vars,
                             names,
                             condition,
-                            keep,
                             input,
                             ...,
                             error_call = caller_env()) {
@@ -85,11 +91,12 @@ check_join_vars <- function(vars,
     abort(bullets, call = error_call)
   }
 
-  if (!is_false(keep)) {
-    # Non-equi columns are allowed to be duplicated when `keep = TRUE/NULL`
-    non_equi <- condition != "=="
-    vars <- c(vars[!non_equi], unique(vars[non_equi]))
-  }
+  # Columns are allowed to appear in more than one non-equi condition
+  # (but not in a mix of non-equi and equi conditions).
+  # When non-equi conditions are present, `keep` can't be `FALSE` so we don't
+  # have to worry about merging into the same key column multiple times (#6499).
+  non_equi <- condition != "=="
+  vars <- c(vars[!non_equi], unique(vars[non_equi]))
 
   dup <- duplicated(vars)
   if (any(dup)) {

--- a/R/join.R
+++ b/R/join.R
@@ -102,10 +102,11 @@
 #'   output?
 #'   - If `NULL`, the default, joins on equality retain only the keys from `x`,
 #'     while joins on inequality retain the keys from both inputs.
-#'   - If `TRUE`, keys from both inputs are retained.
+#'   - If `TRUE`, all keys from both inputs are retained.
 #'   - If `FALSE`, only keys from `x` are retained. For right and full joins,
 #'     the data in key columns corresponding to rows that only exist in `y` are
-#'     merged into the key columns from `x`.
+#'     merged into the key columns from `x`. Can't be used when joining on
+#'     inequality conditions.
 #' @param ... Other parameters passed onto methods.
 #' @param na_matches Should two `NA` or two `NaN` values match?
 #'   - `"na"`, the default, treats two `NA` or two `NaN` values as equal, like
@@ -627,6 +628,7 @@ join_mutate <- function(x,
     if (is_null(keep)) {
       merge <- by$x[by$condition == "=="]
     } else if (is_false(keep)) {
+      # Won't ever contain non-equi conditions
       merge <- by$x
     }
 

--- a/man/mutate-joins.Rd
+++ b/man/mutate-joins.Rd
@@ -151,10 +151,11 @@ output?
 \itemize{
 \item If \code{NULL}, the default, joins on equality retain only the keys from \code{x},
 while joins on inequality retain the keys from both inputs.
-\item If \code{TRUE}, keys from both inputs are retained.
+\item If \code{TRUE}, all keys from both inputs are retained.
 \item If \code{FALSE}, only keys from \code{x} are retained. For right and full joins,
 the data in key columns corresponding to rows that only exist in \code{y} are
-merged into the key columns from \code{x}.
+merged into the key columns from \code{x}. Can't be used when joining on
+inequality conditions.
 }}
 
 \item{na_matches}{Should two \code{NA} or two \code{NaN} values match?

--- a/tests/testthat/_snaps/join-cols.md
+++ b/tests/testthat/_snaps/join-cols.md
@@ -1,20 +1,35 @@
-# can duplicate key between non-equi conditions
+# can't mix non-equi conditions with `keep = FALSE` (#6499)
 
     Code
-      join_cols("x", c("xl", "xu"), by = join_by(x > xl, x < xu), keep = FALSE)
+      join_cols(c("x", "y"), c("x", "z"), by = join_by(x, y > z), keep = FALSE)
     Condition
       Error:
-      ! Join columns in `x` must be unique.
-      x Problem with `x`.
+      ! Can't set `keep = FALSE` when using a non-equi, rolling, or overlap join.
 
 ---
 
     Code
-      join_cols(c("xl", "xu"), "x", by = join_by(xl < x, xu > x), keep = FALSE)
+      join_cols(c("xl", "xu"), c("yl", "yu"), by = join_by(xl >= yl, xu < yu), keep = FALSE)
     Condition
       Error:
-      ! Join columns in `y` must be unique.
-      x Problem with `x`.
+      ! Can't set `keep = FALSE` when using a non-equi, rolling, or overlap join.
+
+---
+
+    Code
+      join_cols("x", c("yl", "yu"), by = join_by(between(x, yl, yu)), keep = FALSE)
+    Condition
+      Error:
+      ! Can't set `keep = FALSE` when using a non-equi, rolling, or overlap join.
+
+---
+
+    Code
+      join_cols(c("xl", "xu"), c("yl", "yu"), by = join_by(overlaps(xl, xu, yl, yu)),
+      keep = FALSE)
+    Condition
+      Error:
+      ! Can't set `keep = FALSE` when using a non-equi, rolling, or overlap join.
 
 # can't duplicate key between equi condition and non-equi condition
 

--- a/tests/testthat/_snaps/join-cols.md
+++ b/tests/testthat/_snaps/join-cols.md
@@ -4,7 +4,7 @@
       join_cols(c("x", "y"), c("x", "z"), by = join_by(x, y > z), keep = FALSE)
     Condition
       Error:
-      ! Can't set `keep = FALSE` when using a non-equi, rolling, or overlap join.
+      ! Can't set `keep = FALSE` when using an inequality, rolling, or overlap join.
 
 ---
 
@@ -12,7 +12,7 @@
       join_cols(c("xl", "xu"), c("yl", "yu"), by = join_by(xl >= yl, xu < yu), keep = FALSE)
     Condition
       Error:
-      ! Can't set `keep = FALSE` when using a non-equi, rolling, or overlap join.
+      ! Can't set `keep = FALSE` when using an inequality, rolling, or overlap join.
 
 ---
 
@@ -20,7 +20,7 @@
       join_cols("x", c("yl", "yu"), by = join_by(between(x, yl, yu)), keep = FALSE)
     Condition
       Error:
-      ! Can't set `keep = FALSE` when using a non-equi, rolling, or overlap join.
+      ! Can't set `keep = FALSE` when using an inequality, rolling, or overlap join.
 
 ---
 
@@ -29,7 +29,7 @@
       keep = FALSE)
     Condition
       Error:
-      ! Can't set `keep = FALSE` when using a non-equi, rolling, or overlap join.
+      ! Can't set `keep = FALSE` when using an inequality, rolling, or overlap join.
 
 # can't duplicate key between equi condition and non-equi condition
 

--- a/tests/testthat/_snaps/join.md
+++ b/tests/testthat/_snaps/join.md
@@ -1,3 +1,19 @@
+# can't use `keep = FALSE` with non-equi conditions (#6499)
+
+    Code
+      left_join(df1, df2, join_by(overlaps(xl, xu, yl, yu)), keep = FALSE)
+    Condition
+      Error in `left_join()`:
+      ! Can't set `keep = FALSE` when using a non-equi, rolling, or overlap join.
+
+---
+
+    Code
+      full_join(df1, df2, join_by(overlaps(xl, xu, yl, yu)), keep = FALSE)
+    Condition
+      Error in `full_join()`:
+      ! Can't set `keep = FALSE` when using a non-equi, rolling, or overlap join.
+
 # join_mutate() validates arguments
 
     Code

--- a/tests/testthat/_snaps/join.md
+++ b/tests/testthat/_snaps/join.md
@@ -4,7 +4,7 @@
       left_join(df1, df2, join_by(overlaps(xl, xu, yl, yu)), keep = FALSE)
     Condition
       Error in `left_join()`:
-      ! Can't set `keep = FALSE` when using a non-equi, rolling, or overlap join.
+      ! Can't set `keep = FALSE` when using an inequality, rolling, or overlap join.
 
 ---
 
@@ -12,7 +12,7 @@
       full_join(df1, df2, join_by(overlaps(xl, xu, yl, yu)), keep = FALSE)
     Condition
       Error in `full_join()`:
-      ! Can't set `keep = FALSE` when using a non-equi, rolling, or overlap join.
+      ! Can't set `keep = FALSE` when using an inequality, rolling, or overlap join.
 
 # join_mutate() validates arguments
 

--- a/tests/testthat/test-join.R
+++ b/tests/testthat/test-join.R
@@ -79,10 +79,6 @@ test_that("keys of non-equi conditions are not coerced if `keep = NULL`", {
   expect_type(out$id, "character")
   expect_type(out$col1, "double")
   expect_type(out$col2, "integer")
-
-  # But they are if `keep = FALSE`
-  out <- inner_join(bar, foo, by = join_by(id, col2 <= col1), keep = FALSE)
-  expect_type(out$col2, "double")
 })
 
 test_that("when keep = TRUE, left_join() preserves both sets of keys", {
@@ -149,20 +145,22 @@ test_that("when keep = TRUE, inner_join() preserves both sets of keys (#5581)", 
   expect_equal(out$a.y, c(3))
 })
 
-test_that("can use `keep = FALSE` with non-equi conditions that don't have duplicate keys (#6499)", {
+test_that("can't use `keep = FALSE` with non-equi conditions (#6499)", {
   df1 <- tibble(xl = c(1, 3), xu = c(4, 7))
   df2 <- tibble(yl = c(2, 5, 8), yu = c(6, 8, 9))
 
-  out <- left_join(df1, df2, join_by(overlaps(xl, xu, yl, yu)), keep = FALSE)
-  expect_identical(out, tibble(xl = c(1, 3, 3), xu = c(4, 7, 7)))
+  expect_snapshot(error = TRUE, {
+    left_join(df1, df2, join_by(overlaps(xl, xu, yl, yu)), keep = FALSE)
+  })
 
-  # The key merging is a bit strange here, due to the fact that the underlying
-  # binary conditions are: `xl <= yu, xu >= yl`. It results in an `xl/xu` column
-  # that no longer has the `xl <= xu` invariant anymore.
-  # TODO: Consider making `keep = FALSE` an error when non-equi keys are
-  # present (#6499).
-  out <- full_join(df1, df2, join_by(overlaps(xl, xu, yl, yu)), keep = FALSE)
-  expect_identical(out, tibble(xl = c(1, 3, 3, 9), xu = c(4, 7, 7, 8)))
+  # Would never make sense here.
+  # Based on how the binary conditions are generated we'd merge:
+  # - `yu` into `xl`
+  # - `yl` into `xu`
+  # Which results in `xl` and `xu` columns that don't maintain `xl <= xu`.
+  expect_snapshot(error = TRUE, {
+    full_join(df1, df2, join_by(overlaps(xl, xu, yl, yu)), keep = FALSE)
+  })
 })
 
 test_that("joins matches NAs by default (#892, #2033)", {


### PR DESCRIPTION
Closes #6499 

See https://github.com/tidyverse/dplyr/issues/6499#issuecomment-1276346314 for rationale and good examples of why we shouldn't allow `keep = FALSE` with non-equi joins. Those examples have been turned into snapshot tests that now error informatively.