### PR TITLE
Add `between(bounds =)` and `overlaps(bounds =)`

### DIFF
--- a/R/join-by.R
+++ b/R/join-by.R
@@ -58,10 +58,18 @@
 #' `join_by()` recognizes to assist with constructing overlap joins, all of
 #' which can be constructed from simpler binary expressions.
 #'
-#' - `between(x, y_lower, y_upper)`
+#' - `between(x, y_lower, y_upper, ..., bounds = "[]")`
 #'
 #'   For each value in `x`, this finds everywhere that value falls between
-#'   `[y_lower, y_upper]`. Equivalent to `x >= y_lower, x <= y_upper`.
+#'   `[y_lower, y_upper]`. Equivalent to `x >= y_lower, x <= y_upper` by
+#'   default.
+#'
+#'   `bounds` can be one of \code{"[]"}, \code{"[)"}, \code{"(]"}, or
+#'   \code{"()"} to alter the inclusiveness of the lower and upper bounds. This
+#'   changes whether `>=` or `>` and `<=` or `<` are used to build the binary
+#'   conditions shown above.
+#'
+#'   Dots are for future extensions and must be empty.
 #'
 #' - `within(x_lower, x_upper, y_lower, y_upper)`
 #'
@@ -69,14 +77,25 @@
 #'   falls completely within `[y_lower, y_upper]`. Equivalent to `x_lower >=
 #'   y_lower, x_upper <= y_upper`.
 #'
-#' - `overlaps(x_lower, x_upper, y_lower, y_upper)`
+#'   The binary conditions used to build `within()` are the same regardless of
+#'   the inclusiveness of the supplied ranges.
+#'
+#' - `overlaps(x_lower, x_upper, y_lower, y_upper, ..., closed = TRUE)`
 #'
 #'   For each range in `[x_lower, x_upper]`, this finds everywhere that range
 #'   overlaps `[y_lower, y_upper]` in any capacity. Equivalent to `x_lower <=
-#'   y_upper, x_upper >= y_lower`.
+#'   y_upper, x_upper >= y_lower` by default.
 #'
-#' These conditions assume that the ranges are well-formed, i.e.
-#' `x_lower <= x_upper`.
+#'   `closed` controls whether or not the ranges are treated as fully closed
+#'   intervals, like \code{"[]"}. If `FALSE`, the binary conditions `x_lower <
+#'   y_upper, x_upper > y_lower` are used, which work for \code{"[)"},
+#'   \code{"(]"}, and \code{"()"}.
+#'
+#'   Dots are for future extensions and must be empty.
+#'
+#' These conditions assume that the ranges are well-formed and non-empty, i.e.
+#' `x_lower <= x_upper` when bounds are treated as \code{"[]"}, and
+#' `x_lower < x_upper` otherwise.
 #'
 #' # Column referencing
 #'
@@ -163,7 +182,7 @@
 #' reference <- tibble(
 #'   reference_id = 1:4,
 #'   chromosome = c("chr1", "chr1", "chr2", "chr2"),
-#'   start = c(100, 200, 300, 400),
+#'   start = c(100, 200, 300, 415),
 #'   end = c(150, 250, 399, 450)
 #' )
 #' reference
@@ -187,6 +206,13 @@
 #'
 #' # Find every time a segment overlaps a reference in any way.
 #' by <- join_by(chromosome, overlaps(x$start, x$end, y$start, y$end))
+#' full_join(segments, reference, by)
+#'
+#' # It is common to have right-open ranges with bounds like `[)`, which would
+#' # mean an end value of `415` would no longer overlap a start value of `415`.
+#' # Setting `closed = FALSE` allows you to compute overlaps with those kinds
+#' # of ranges.
+#' by <- join_by(chromosome, overlaps(x$start, x$end, y$start, y$end, closed = FALSE))
 #' full_join(segments, reference, by)
 join_by <- function(...) {
   # `join_by()` works off pure expressions with no evaluation in the user's
@@ -394,9 +420,8 @@ parse_join_by_expr <- function(expr, i, error_call) {
     "<" = parse_join_by_binary(expr, i, error_call),
 
     "between" = parse_join_by_between(expr, i, error_call),
-
-    "overlaps" =,
-    "within" = parse_join_by_containment(expr, i, error_call),
+    "within" = parse_join_by_within(expr, i, error_call),
+    "overlaps" = parse_join_by_overlaps(expr, i, error_call),
 
     "closest" = parse_join_by_closest(expr, i, error_call),
 
@@ -676,6 +701,8 @@ parse_join_by_between <- function(expr, i, error_call) {
   rhs_lower <- parse_join_by_name(args$rhs_lower, i, "y", error_call)
   rhs_upper <- parse_join_by_name(args$rhs_upper, i, "y", error_call)
 
+  bounds <- args$bounds
+
   if (rhs_lower$side != rhs_upper$side) {
     message <- c(
       "Expressions containing `between()` must reference the same table for the lower and upper bounds.",
@@ -695,11 +722,23 @@ parse_join_by_between <- function(expr, i, error_call) {
   if (lhs$side == "x") {
     x <- c(lhs$name, lhs$name)
     y <- c(rhs_lower$name, rhs_upper$name)
-    condition <- c(">=", "<=")
+    condition <- switch(
+      bounds,
+      "[]" = c(">=", "<="),
+      "[)" = c(">=", "<"),
+      "(]" = c(">", "<="),
+      "()" = c(">", "<")
+    )
   } else {
     x <- c(rhs_lower$name, rhs_upper$name)
     y <- c(lhs$name, lhs$name)
-    condition <- c("<=", ">=")
+    condition <- switch(
+      bounds,
+      "[]" = c("<=", ">="),
+      "[)" = c("<=", ">"),
+      "(]" = c("<", ">="),
+      "()" = c("<", ">")
+    )
   }
 
   filter <- c("none", "none")
@@ -719,8 +758,10 @@ eval_join_by_between <- function(expr, error_call) {
 
   eval_tidy(expr, env = env)
 }
-binding_join_by_between <- function(x, y_lower, y_upper) {
+binding_join_by_between <- function(x, y_lower, y_upper, ..., bounds = "[]") {
   error_call <- caller_env()
+
+  check_join_by_dots_empty(..., fn = "between", call = error_call)
 
   x <- enexpr(x)
   y_lower <- enexpr(y_lower)
@@ -730,13 +771,18 @@ binding_join_by_between <- function(x, y_lower, y_upper) {
   check_missing_arg(y_lower, "y_lower", "between", error_call)
   check_missing_arg(y_upper, "y_upper", "between", error_call)
 
-  list(lhs = x, rhs_lower = y_lower, rhs_upper = y_upper)
+  bounds <- arg_match0(
+    bounds,
+    values = c("[]", "[)", "(]", "()"),
+    arg_nm = "bounds",
+    error_call = error_call
+  )
+
+  list(lhs = x, rhs_lower = y_lower, rhs_upper = y_upper, bounds = bounds)
 }
 
-parse_join_by_containment <- function(expr, i, error_call) {
-  args <- eval_join_by_containment(expr, error_call)
-
-  type <- args$type
+parse_join_by_within <- function(expr, i, error_call) {
+  args <- eval_join_by_within(expr, error_call)
 
   lhs_lower <- parse_join_by_name(args$lhs_lower, i, "x", error_call)
   lhs_upper <- parse_join_by_name(args$lhs_upper, i, "x", error_call)
@@ -746,7 +792,7 @@ parse_join_by_containment <- function(expr, i, error_call) {
   if (lhs_lower$side != lhs_upper$side) {
     message <- c(
       paste0(
-        "Expressions containing `overlaps()` or `within()` must reference ",
+        "Expressions containing `within()` must reference ",
         "the same table for the left-hand side lower and upper bounds."
       ),
       i = glue("Expression {i} is {err_expr(expr)}.")
@@ -757,7 +803,7 @@ parse_join_by_containment <- function(expr, i, error_call) {
   if (rhs_lower$side != rhs_upper$side) {
     message <- c(
       paste0(
-        "Expressions containing `overlaps()` or `within()` must reference ",
+        "Expressions containing `within()` must reference ",
         "the same table for the right-hand side lower and upper bounds."
       ),
       i = glue("Expression {i} is {err_expr(expr)}.")
@@ -767,34 +813,20 @@ parse_join_by_containment <- function(expr, i, error_call) {
 
   if (lhs_lower$side == rhs_lower$side) {
     message <- c(
-      "Expressions containing `overlaps()` or `within()` can't all reference the same table.",
+      "Expressions containing `within()` can't all reference the same table.",
       i = glue("Expression {i} is {err_expr(expr)}.")
     )
     abort(message, call = error_call)
   }
 
-  if (type == "overlaps") {
-    if (lhs_lower$side == "x") {
-      x <- c(lhs_lower$name, lhs_upper$name)
-      y <- c(rhs_upper$name, rhs_lower$name)
-      condition <- c("<=", ">=")
-    } else {
-      x <- c(rhs_upper$name, rhs_lower$name)
-      y <- c(lhs_lower$name, lhs_upper$name)
-      condition <- c(">=", "<=")
-    }
-  } else if (type == "within") {
-    if (lhs_lower$side == "x") {
-      x <- c(lhs_lower$name, lhs_upper$name)
-      y <- c(rhs_lower$name, rhs_upper$name)
-      condition <- c(">=", "<=")
-    } else {
-      x <- c(rhs_lower$name, rhs_upper$name)
-      y <- c(lhs_lower$name, lhs_upper$name)
-      condition <- c("<=", ">=")
-    }
+  if (lhs_lower$side == "x") {
+    x <- c(lhs_lower$name, lhs_upper$name)
+    y <- c(rhs_lower$name, rhs_upper$name)
+    condition <- c(">=", "<=")
   } else {
-    abort("Unknown containment `type`.", .internal = TRUE)
+    x <- c(rhs_lower$name, rhs_upper$name)
+    y <- c(lhs_lower$name, lhs_upper$name)
+    condition <- c("<=", ">=")
   }
 
   filter <- c("none", "none")
@@ -806,61 +838,159 @@ parse_join_by_containment <- function(expr, i, error_call) {
     filter = filter
   )
 }
-eval_join_by_containment <- function(expr, error_call) {
+eval_join_by_within <- function(expr, error_call) {
   env <- new_environment()
   local_error_call(error_call, frame = env)
 
-  env_bind(
-    env,
-    within = binding_join_by_within,
-    overlaps = binding_join_by_overlaps
-  )
+  env_poke(env, "within", binding_join_by_within)
 
   eval_tidy(expr, env = env)
 }
-binding_join_by_containment <- function(type,
-                                        error_call,
-                                        x_lower,
-                                        x_upper,
-                                        y_lower,
-                                        y_upper) {
+binding_join_by_within <- function(x_lower,
+                                   x_upper,
+                                   y_lower,
+                                   y_upper) {
+  error_call <- caller_env()
+
   x_lower <- enexpr(x_lower)
   x_upper <- enexpr(x_upper)
   y_lower <- enexpr(y_lower)
   y_upper <- enexpr(y_upper)
 
-  check_missing_arg(x_lower, "x_lower", type, error_call)
-  check_missing_arg(x_upper, "x_upper", type, error_call)
-  check_missing_arg(y_lower, "y_lower", type, error_call)
-  check_missing_arg(y_upper, "y_upper", type, error_call)
+  check_missing_arg(x_lower, "x_lower", "within", error_call)
+  check_missing_arg(x_upper, "x_upper", "within", error_call)
+  check_missing_arg(y_lower, "y_lower", "within", error_call)
+  check_missing_arg(y_upper, "y_upper", "within", error_call)
 
   list(
-    type = type,
     lhs_lower = x_lower,
     lhs_upper = x_upper,
     rhs_lower = y_lower,
     rhs_upper = y_upper
   )
 }
-binding_join_by_within <- function(x_lower, x_upper, y_lower, y_upper) {
-  binding_join_by_containment(
-    type = "within",
-    error_call = caller_env(),
-    x_lower = !!enexpr(x_lower),
-    x_upper = !!enexpr(x_upper),
-    y_lower = !!enexpr(y_lower),
-    y_upper = !!enexpr(y_upper)
+
+parse_join_by_overlaps <- function(expr, i, error_call) {
+  args <- eval_join_by_overlaps(expr, error_call)
+
+  lhs_lower <- parse_join_by_name(args$lhs_lower, i, "x", error_call)
+  lhs_upper <- parse_join_by_name(args$lhs_upper, i, "x", error_call)
+  rhs_lower <- parse_join_by_name(args$rhs_lower, i, "y", error_call)
+  rhs_upper <- parse_join_by_name(args$rhs_upper, i, "y", error_call)
+
+  closed <- args$closed
+
+  if (lhs_lower$side != lhs_upper$side) {
+    message <- c(
+      paste0(
+        "Expressions containing `overlaps()` must reference ",
+        "the same table for the left-hand side lower and upper bounds."
+      ),
+      i = glue("Expression {i} is {err_expr(expr)}.")
+    )
+    abort(message, call = error_call)
+  }
+
+  if (rhs_lower$side != rhs_upper$side) {
+    message <- c(
+      paste0(
+        "Expressions containing `overlaps()` must reference ",
+        "the same table for the right-hand side lower and upper bounds."
+      ),
+      i = glue("Expression {i} is {err_expr(expr)}.")
+    )
+    abort(message, call = error_call)
+  }
+
+  if (lhs_lower$side == rhs_lower$side) {
+    message <- c(
+      "Expressions containing `overlaps()` can't all reference the same table.",
+      i = glue("Expression {i} is {err_expr(expr)}.")
+    )
+    abort(message, call = error_call)
+  }
+
+  if (lhs_lower$side == "x") {
+    x <- c(lhs_lower$name, lhs_upper$name)
+    y <- c(rhs_upper$name, rhs_lower$name)
+
+    if (closed) {
+      condition <- c("<=", ">=")
+    } else {
+      condition <- c("<", ">")
+    }
+  } else {
+    x <- c(rhs_upper$name, rhs_lower$name)
+    y <- c(lhs_lower$name, lhs_upper$name)
+
+    if (closed) {
+      condition <- c(">=", "<=")
+    } else {
+      condition <- c(">", "<")
+    }
+  }
+
+  filter <- c("none", "none")
+
+  list(
+    x = x,
+    y = y,
+    condition = condition,
+    filter = filter
   )
 }
-binding_join_by_overlaps <- function(x_lower, x_upper, y_lower, y_upper) {
-  binding_join_by_containment(
-    type = "overlaps",
-    error_call = caller_env(),
-    x_lower = !!enexpr(x_lower),
-    x_upper = !!enexpr(x_upper),
-    y_lower = !!enexpr(y_lower),
-    y_upper = !!enexpr(y_upper)
+eval_join_by_overlaps <- function(expr, error_call) {
+  env <- new_environment()
+  local_error_call(error_call, frame = env)
+
+  env_poke(env, "overlaps", binding_join_by_overlaps)
+
+  eval_tidy(expr, env = env)
+}
+binding_join_by_overlaps <- function(x_lower,
+                                     x_upper,
+                                     y_lower,
+                                     y_upper,
+                                     ...,
+                                     closed = TRUE) {
+  error_call <- caller_env()
+
+  check_join_by_dots_empty(..., fn = "overlaps", call = error_call)
+
+  x_lower <- enexpr(x_lower)
+  x_upper <- enexpr(x_upper)
+  y_lower <- enexpr(y_lower)
+  y_upper <- enexpr(y_upper)
+
+  check_missing_arg(x_lower, "x_lower", "overlaps", error_call)
+  check_missing_arg(x_upper, "x_upper", "overlaps", error_call)
+  check_missing_arg(y_lower, "y_lower", "overlaps", error_call)
+  check_missing_arg(y_upper, "y_upper", "overlaps", error_call)
+
+  check_bool(closed, call = error_call)
+
+  list(
+    lhs_lower = x_lower,
+    lhs_upper = x_upper,
+    rhs_lower = y_lower,
+    rhs_upper = y_upper,
+    closed = closed
   )
+}
+
+check_join_by_dots_empty <- function(..., fn, call) {
+  if (dots_n(...) == 0L) {
+    return()
+  }
+
+  fn <- glue::backtick(glue("{fn}()"))
+
+  message <- c(
+    "`...` must be empty.",
+    i = glue("Non-empty dots were detected inside {fn}.")
+  )
+
+  abort(message, call = call)
 }
 
 check_missing_arg <- function(arg,

--- a/man/join_by.Rd
+++ b/man/join_by.Rd
@@ -111,14 +111,15 @@ falls completely within \verb{[y_lower, y_upper]}. Equivalent to \verb{x_lower >
 
 The binary conditions used to build \code{within()} are the same regardless of
 the inclusiveness of the supplied ranges.
-\item \code{overlaps(x_lower, x_upper, y_lower, y_upper, ..., closed = TRUE)}
+\item \code{overlaps(x_lower, x_upper, y_lower, y_upper, ..., bounds = "[]")}
 
 For each range in \verb{[x_lower, x_upper]}, this finds everywhere that range
 overlaps \verb{[y_lower, y_upper]} in any capacity. Equivalent to \verb{x_lower <= y_upper, x_upper >= y_lower} by default.
 
-\code{closed} controls whether or not the ranges are treated as fully closed
-intervals, like \code{"[]"}. If \code{FALSE}, the binary conditions \verb{x_lower < y_upper, x_upper > y_lower} are used, which work for \code{"[)"},
-\code{"(]"}, and \code{"()"}.
+\code{bounds} can be one of \code{"[]"}, \code{"[)"}, \code{"(]"}, or
+\code{"()"} to alter the inclusiveness of the lower and upper bounds.
+\code{"[]"} uses \code{<=} and \code{>=}, but the 3 other options use \code{<} and \code{>}
+and generate the exact same binary conditions.
 
 Dots are for future extensions and must be empty.
 }
@@ -220,8 +221,7 @@ full_join(segments, reference, by)
 
 # It is common to have right-open ranges with bounds like `[)`, which would
 # mean an end value of `415` would no longer overlap a start value of `415`.
-# Setting `closed = FALSE` allows you to compute overlaps with those kinds
-# of ranges.
-by <- join_by(chromosome, overlaps(x$start, x$end, y$start, y$end, closed = FALSE))
+# Setting `bounds` allows you to compute overlaps with those kinds of ranges.
+by <- join_by(chromosome, overlaps(x$start, x$end, y$start, y$end, bounds = "[)"))
 full_join(segments, reference, by)
 }

--- a/man/join_by.Rd
+++ b/man/join_by.Rd
@@ -92,22 +92,40 @@ two columns from the right-hand table. There are three helpers that
 \code{join_by()} recognizes to assist with constructing overlap joins, all of
 which can be constructed from simpler binary expressions.
 \itemize{
-\item \code{between(x, y_lower, y_upper)}
+\item \code{between(x, y_lower, y_upper, ..., bounds = "[]")}
 
 For each value in \code{x}, this finds everywhere that value falls between
-\verb{[y_lower, y_upper]}. Equivalent to \verb{x >= y_lower, x <= y_upper}.
+\verb{[y_lower, y_upper]}. Equivalent to \verb{x >= y_lower, x <= y_upper} by
+default.
+
+\code{bounds} can be one of \code{"[]"}, \code{"[)"}, \code{"(]"}, or
+\code{"()"} to alter the inclusiveness of the lower and upper bounds. This
+changes whether \code{>=} or \code{>} and \code{<=} or \code{<} are used to build the binary
+conditions shown above.
+
+Dots are for future extensions and must be empty.
 \item \code{within(x_lower, x_upper, y_lower, y_upper)}
 
 For each range in \verb{[x_lower, x_upper]}, this finds everywhere that range
 falls completely within \verb{[y_lower, y_upper]}. Equivalent to \verb{x_lower >= y_lower, x_upper <= y_upper}.
-\item \code{overlaps(x_lower, x_upper, y_lower, y_upper)}
+
+The binary conditions used to build \code{within()} are the same regardless of
+the inclusiveness of the supplied ranges.
+\item \code{overlaps(x_lower, x_upper, y_lower, y_upper, ..., closed = TRUE)}
 
 For each range in \verb{[x_lower, x_upper]}, this finds everywhere that range
-overlaps \verb{[y_lower, y_upper]} in any capacity. Equivalent to \verb{x_lower <= y_upper, x_upper >= y_lower}.
+overlaps \verb{[y_lower, y_upper]} in any capacity. Equivalent to \verb{x_lower <= y_upper, x_upper >= y_lower} by default.
+
+\code{closed} controls whether or not the ranges are treated as fully closed
+intervals, like \code{"[]"}. If \code{FALSE}, the binary conditions \verb{x_lower < y_upper, x_upper > y_lower} are used, which work for \code{"[)"},
+\code{"(]"}, and \code{"()"}.
+
+Dots are for future extensions and must be empty.
 }
 
-These conditions assume that the ranges are well-formed, i.e.
-\code{x_lower <= x_upper}.
+These conditions assume that the ranges are well-formed and non-empty, i.e.
+\code{x_lower <= x_upper} when bounds are treated as \code{"[]"}, and
+\code{x_lower < x_upper} otherwise.
 }
 }
 
@@ -174,7 +192,7 @@ segments
 reference <- tibble(
   reference_id = 1:4,
   chromosome = c("chr1", "chr1", "chr2", "chr2"),
-  start = c(100, 200, 300, 400),
+  start = c(100, 200, 300, 415),
   end = c(150, 250, 399, 450)
 )
 reference
@@ -198,5 +216,12 @@ inner_join(segments, reference, by)
 
 # Find every time a segment overlaps a reference in any way.
 by <- join_by(chromosome, overlaps(x$start, x$end, y$start, y$end))
+full_join(segments, reference, by)
+
+# It is common to have right-open ranges with bounds like `[)`, which would
+# mean an end value of `415` would no longer overlap a start value of `415`.
+# Setting `closed = FALSE` allows you to compute overlaps with those kinds
+# of ranges.
+by <- join_by(chromosome, overlaps(x$start, x$end, y$start, y$end, closed = FALSE))
 full_join(segments, reference, by)
 }

--- a/tests/testthat/_snaps/join-by.md
+++ b/tests/testthat/_snaps/join-by.md
@@ -367,18 +367,18 @@
 ---
 
     Code
-      join_by(overlaps(x, y, lower, upper, closed = 1))
+      join_by(overlaps(x, y, lower, upper, bounds = 1))
     Condition
       Error:
-      ! `closed` must be `TRUE` or `FALSE`, not a number.
+      ! `bounds` must be a string or character vector.
 
 ---
 
     Code
-      join_by(overlaps(x, y, lower, upper, closed = NA))
+      join_by(overlaps(x, y, lower, upper, bounds = "a"))
     Condition
       Error:
-      ! `closed` must be `TRUE` or `FALSE`, not `NA`.
+      ! `bounds` must be one of "[]", "[)", "(]", or "()", not "a".
 
 ---
 

--- a/tests/testthat/_snaps/join-by.md
+++ b/tests/testthat/_snaps/join-by.md
@@ -202,7 +202,7 @@
       join_by(within(x$a, x$b, x$a, x$b))
     Condition
       Error in `join_by()`:
-      ! Expressions containing `overlaps()` or `within()` can't all reference the same table.
+      ! Expressions containing `within()` can't all reference the same table.
       i Expression 1 is `within(x$a, x$b, x$a, x$b)`.
 
 ---
@@ -211,7 +211,7 @@
       join_by(overlaps(a, b, x$a, x$b))
     Condition
       Error in `join_by()`:
-      ! Expressions containing `overlaps()` or `within()` can't all reference the same table.
+      ! Expressions containing `overlaps()` can't all reference the same table.
       i Expression 1 is `overlaps(a, b, x$a, x$b)`.
 
 ---
@@ -238,7 +238,7 @@
       join_by(within(x$a, y$b, y$a, y$b))
     Condition
       Error in `join_by()`:
-      ! Expressions containing `overlaps()` or `within()` must reference the same table for the left-hand side lower and upper bounds.
+      ! Expressions containing `within()` must reference the same table for the left-hand side lower and upper bounds.
       i Expression 1 is `within(x$a, y$b, y$a, y$b)`.
 
 ---
@@ -247,7 +247,7 @@
       join_by(overlaps(x$a, x$b, y$a, x$b))
     Condition
       Error in `join_by()`:
-      ! Expressions containing `overlaps()` or `within()` must reference the same table for the right-hand side lower and upper bounds.
+      ! Expressions containing `overlaps()` must reference the same table for the right-hand side lower and upper bounds.
       i Expression 1 is `overlaps(x$a, x$b, y$a, x$b)`.
 
 ---
@@ -347,6 +347,56 @@
       Error in `join_by()`:
       ! The expression used in `closest()` must use one of: `>=`, `>`, `<=`, or `<`.
       i Expression 1 is `closest(x + y)`.
+
+---
+
+    Code
+      join_by(between(x, lower, upper, bounds = 1))
+    Condition
+      Error:
+      ! `bounds` must be a string or character vector.
+
+---
+
+    Code
+      join_by(between(x, lower, upper, bounds = "a"))
+    Condition
+      Error:
+      ! `bounds` must be one of "[]", "[)", "(]", or "()", not "a".
+
+---
+
+    Code
+      join_by(overlaps(x, y, lower, upper, closed = 1))
+    Condition
+      Error:
+      ! `closed` must be `TRUE` or `FALSE`, not a number.
+
+---
+
+    Code
+      join_by(overlaps(x, y, lower, upper, closed = NA))
+    Condition
+      Error:
+      ! `closed` must be `TRUE` or `FALSE`, not `NA`.
+
+---
+
+    Code
+      join_by(between(x, lower, upper, foo = 1))
+    Condition
+      Error:
+      ! `...` must be empty.
+      i Non-empty dots were detected inside `between()`.
+
+---
+
+    Code
+      join_by(overlaps(x, y, lower, upper, foo = 1))
+    Condition
+      Error:
+      ! `...` must be empty.
+      i Non-empty dots were detected inside `overlaps()`.
 
 # as_join_by() emits useful errors
 

--- a/tests/testthat/test-join-by.R
+++ b/tests/testthat/test-join-by.R
@@ -92,25 +92,31 @@ test_that("between conditions expand correctly", {
   by <- join_by(between(a, b, c))
   expect_identical(by$x, c("a", "a"))
   expect_identical(by$y, c("b", "c"))
-  expect_identical(by$condition, c(">=", "<="))
 
   by <- join_by(between(y$a, x$b, x$c))
   expect_identical(by$x, c("b", "c"))
   expect_identical(by$y, c("a", "a"))
+
+  by <- join_by(between(a, b, c, bounds = "[]"))
+  expect_identical(by$condition, c(">=", "<="))
+  by <- join_by(between(a, b, c, bounds = "[)"))
+  expect_identical(by$condition, c(">=", "<"))
+  by <- join_by(between(a, b, c, bounds = "(]"))
+  expect_identical(by$condition, c(">", "<="))
+  by <- join_by(between(a, b, c, bounds = "()"))
+  expect_identical(by$condition, c(">", "<"))
+
+  by <- join_by(between(y$a, x$b, x$c, bounds = "[]"))
   expect_identical(by$condition, c("<=", ">="))
+  by <- join_by(between(y$a, x$b, x$c, bounds = "[)"))
+  expect_identical(by$condition, c("<=", ">"))
+  by <- join_by(between(y$a, x$b, x$c, bounds = "(]"))
+  expect_identical(by$condition, c("<", ">="))
+  by <- join_by(between(y$a, x$b, x$c, bounds = "()"))
+  expect_identical(by$condition, c("<", ">"))
 })
 
-test_that("overlaps / within conditions expand correctly", {
-  by <- join_by(overlaps(a, b, c, d))
-  expect_identical(by$x, c("a", "b"))
-  expect_identical(by$y, c("d", "c"))
-  expect_identical(by$condition, c("<=", ">="))
-
-  by <- join_by(overlaps(y$a, y$b, x$b, x$c))
-  expect_identical(by$x, c("c", "b"))
-  expect_identical(by$y, c("a", "b"))
-  expect_identical(by$condition, c(">=", "<="))
-
+test_that("within conditions expand correctly", {
   by <- join_by(within(a, b, c, d))
   expect_identical(by$x, c("a", "b"))
   expect_identical(by$y, c("c", "d"))
@@ -120,6 +126,26 @@ test_that("overlaps / within conditions expand correctly", {
   expect_identical(by$x, c("b", "c"))
   expect_identical(by$y, c("a", "b"))
   expect_identical(by$condition, c("<=", ">="))
+})
+
+test_that("overlaps conditions expand correctly", {
+  by <- join_by(overlaps(a, b, c, d))
+  expect_identical(by$x, c("a", "b"))
+  expect_identical(by$y, c("d", "c"))
+
+  by <- join_by(overlaps(y$a, y$b, x$b, x$c))
+  expect_identical(by$x, c("c", "b"))
+  expect_identical(by$y, c("a", "b"))
+
+  by <- join_by(overlaps(a, b, c, d, closed = TRUE))
+  expect_identical(by$condition, c("<=", ">="))
+  by <- join_by(overlaps(a, b, c, d, closed = FALSE))
+  expect_identical(by$condition, c("<", ">"))
+
+  by <- join_by(overlaps(y$a, y$b, x$b, x$c, closed = TRUE))
+  expect_identical(by$condition, c(">=", "<="))
+  by <- join_by(overlaps(y$a, y$b, x$b, x$c, closed = FALSE))
+  expect_identical(by$condition, c(">", "<"))
 })
 
 test_that("between / overlaps / within / closest can use named arguments", {
@@ -283,6 +309,18 @@ test_that("has informative error messages", {
 
   # Invalid expression in `closest()`
   expect_snapshot(error = TRUE, join_by(closest(x + y)))
+
+  # Invalid `bounds` in `between()`
+  expect_snapshot(error = TRUE, join_by(between(x, lower, upper, bounds = 1)))
+  expect_snapshot(error = TRUE, join_by(between(x, lower, upper, bounds = "a")))
+
+  # Invalid `closed` in `overlaps()`
+  expect_snapshot(error = TRUE, join_by(overlaps(x, y, lower, upper, closed = 1)))
+  expect_snapshot(error = TRUE, join_by(overlaps(x, y, lower, upper, closed = NA)))
+
+  # Non-empty dots in `between()` and `overlaps()`
+  expect_snapshot(error = TRUE, join_by(between(x, lower, upper, foo = 1)))
+  expect_snapshot(error = TRUE, join_by(overlaps(x, y, lower, upper, foo = 1)))
 })
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-join-by.R
+++ b/tests/testthat/test-join-by.R
@@ -137,14 +137,22 @@ test_that("overlaps conditions expand correctly", {
   expect_identical(by$x, c("c", "b"))
   expect_identical(by$y, c("a", "b"))
 
-  by <- join_by(overlaps(a, b, c, d, closed = TRUE))
+  by <- join_by(overlaps(a, b, c, d, bounds = "[]"))
   expect_identical(by$condition, c("<=", ">="))
-  by <- join_by(overlaps(a, b, c, d, closed = FALSE))
+  by <- join_by(overlaps(a, b, c, d, bounds = "[)"))
+  expect_identical(by$condition, c("<", ">"))
+  by <- join_by(overlaps(a, b, c, d, bounds = "(]"))
+  expect_identical(by$condition, c("<", ">"))
+  by <- join_by(overlaps(a, b, c, d, bounds = "()"))
   expect_identical(by$condition, c("<", ">"))
 
-  by <- join_by(overlaps(y$a, y$b, x$b, x$c, closed = TRUE))
+  by <- join_by(overlaps(y$a, y$b, x$b, x$c, bounds = "[]"))
   expect_identical(by$condition, c(">=", "<="))
-  by <- join_by(overlaps(y$a, y$b, x$b, x$c, closed = FALSE))
+  by <- join_by(overlaps(y$a, y$b, x$b, x$c, bounds = "[)"))
+  expect_identical(by$condition, c(">", "<"))
+  by <- join_by(overlaps(y$a, y$b, x$b, x$c, bounds = "(]"))
+  expect_identical(by$condition, c(">", "<"))
+  by <- join_by(overlaps(y$a, y$b, x$b, x$c, bounds = "()"))
   expect_identical(by$condition, c(">", "<"))
 })
 
@@ -310,13 +318,11 @@ test_that("has informative error messages", {
   # Invalid expression in `closest()`
   expect_snapshot(error = TRUE, join_by(closest(x + y)))
 
-  # Invalid `bounds` in `between()`
+  # Invalid `bounds` in `between()` and `overlaps()`
   expect_snapshot(error = TRUE, join_by(between(x, lower, upper, bounds = 1)))
   expect_snapshot(error = TRUE, join_by(between(x, lower, upper, bounds = "a")))
-
-  # Invalid `closed` in `overlaps()`
-  expect_snapshot(error = TRUE, join_by(overlaps(x, y, lower, upper, closed = 1)))
-  expect_snapshot(error = TRUE, join_by(overlaps(x, y, lower, upper, closed = NA)))
+  expect_snapshot(error = TRUE, join_by(overlaps(x, y, lower, upper, bounds = 1)))
+  expect_snapshot(error = TRUE, join_by(overlaps(x, y, lower, upper, bounds = "a")))
 
   # Non-empty dots in `between()` and `overlaps()`
   expect_snapshot(error = TRUE, join_by(between(x, lower, upper, foo = 1)))

--- a/tests/testthat/test-join.R
+++ b/tests/testthat/test-join.R
@@ -228,15 +228,25 @@ test_that("joins using `between(bounds =)` work as expected (#6488)", {
   expect_identical(out$upper, c(NA, NA, 4, NA, NA))
 })
 
-test_that("joins using `overlaps(closed =)` work as expected (#6488)", {
+test_that("joins using `overlaps(bounds =)` work as expected (#6488)", {
   df1 <- tibble(x_lower = c(1, 1, 3, 4), x_upper = c(2, 3, 4, 5))
   df2 <- tibble(y_lower = 2, y_upper = 4)
 
-  out <- full_join(df1, df2, by = join_by(overlaps(x_lower, x_upper, y_lower, y_upper, closed = TRUE)))
-  expect_identical(out, vec_cbind(df1, vec_c(df2, df2, df2, df2)))
+  expect_closed <- vec_cbind(df1, vec_c(df2, df2, df2, df2))
 
-  out <- full_join(df1, df2, by = join_by(overlaps(x_lower, x_upper, y_lower, y_upper, closed = FALSE)))
-  expect_identical(out, vec_cbind(df1, vec_c(NA, df2, df2, NA)))
+  out <- full_join(df1, df2, by = join_by(overlaps(x_lower, x_upper, y_lower, y_upper, bounds = "[]")))
+  expect_identical(out, expect_closed)
+
+  # `[)`, `(]`, and `()` all generate the same binary conditions but are useful
+  # for consistency with `between(bounds =)`
+  expect_open <- vec_cbind(df1, vec_c(NA, df2, df2, NA))
+
+  out <- full_join(df1, df2, by = join_by(overlaps(x_lower, x_upper, y_lower, y_upper, bounds = "[)")))
+  expect_identical(out, expect_open)
+  out <- full_join(df1, df2, by = join_by(overlaps(x_lower, x_upper, y_lower, y_upper, bounds = "(]")))
+  expect_identical(out, expect_open)
+  out <- full_join(df1, df2, by = join_by(overlaps(x_lower, x_upper, y_lower, y_upper, bounds = "()")))
+  expect_identical(out, expect_open)
 })
 
 test_that("join_mutate() validates arguments", {

--- a/tests/testthat/test-join.R
+++ b/tests/testthat/test-join.R
@@ -207,6 +207,38 @@ test_that("joins don't match NA when na_matches = 'never' (#2033)", {
   )
 })
 
+test_that("joins using `between(bounds =)` work as expected (#6488)", {
+  df1 <- tibble(x = 1:5)
+  df2 <- tibble(lower = 2, upper = 4)
+
+  out <- full_join(df1, df2, by = join_by(between(x, lower, upper, bounds = "[]")))
+  expect_identical(out$lower, c(NA, 2, 2, 2, NA))
+  expect_identical(out$upper, c(NA, 4, 4, 4, NA))
+
+  out <- full_join(df1, df2, by = join_by(between(x, lower, upper, bounds = "[)")))
+  expect_identical(out$lower, c(NA, 2, 2, NA, NA))
+  expect_identical(out$upper, c(NA, 4, 4, NA, NA))
+
+  out <- full_join(df1, df2, by = join_by(between(x, lower, upper, bounds = "(]")))
+  expect_identical(out$lower, c(NA, NA, 2, 2, NA))
+  expect_identical(out$upper, c(NA, NA, 4, 4, NA))
+
+  out <- full_join(df1, df2, by = join_by(between(x, lower, upper, bounds = "()")))
+  expect_identical(out$lower, c(NA, NA, 2, NA, NA))
+  expect_identical(out$upper, c(NA, NA, 4, NA, NA))
+})
+
+test_that("joins using `overlaps(closed =)` work as expected (#6488)", {
+  df1 <- tibble(x_lower = c(1, 1, 3, 4), x_upper = c(2, 3, 4, 5))
+  df2 <- tibble(y_lower = 2, y_upper = 4)
+
+  out <- full_join(df1, df2, by = join_by(overlaps(x_lower, x_upper, y_lower, y_upper, closed = TRUE)))
+  expect_identical(out, vec_cbind(df1, vec_c(df2, df2, df2, df2)))
+
+  out <- full_join(df1, df2, by = join_by(overlaps(x_lower, x_upper, y_lower, y_upper, closed = FALSE)))
+  expect_identical(out, vec_cbind(df1, vec_c(NA, df2, df2, NA)))
+})
+
 test_that("join_mutate() validates arguments", {
   df <- tibble(x = 1)
 


### PR DESCRIPTION
Closes #6488 

Highlights of my analysis in #6488:

- Kept `[]` default in `between()` and `overlaps()` for compatibility with `dplyr::between()` and how I think these are most likely to be used

- `between()` gains `bounds = "[]"` because `[]`, `[)`, and `()` all have their uses (and `(]` is then for completeness)

- `overlaps()` gains `closed = TRUE` because `xl <= yu, xu >= yl` covers `[]` and `xl < yu, xu > yl` covers the other 3 partially/fully open range cases.

- The binary conditions for `within()` are the same regardless of the inclusiveness of the range boundaries, so it doesn't gain any new arguments.

This would allow me to talk about `between(bounds = "[)")` and `overlaps(closed = FALSE)` in ivs, which would align with `iv_locate_between()` and `iv_locate_overlaps()`.

And R4DS could use `between(bounds = "[)")` which makes generation of `start` and `end` simpler and less error prone. Plus I find it a little easier to read row-by-row (i.e. `end` of row `i` is the same as the `start` of row `i+1`)

``` r
employees <- tibble(
  name = wakefield::name(100),
  birthday = lubridate::ymd("2022-01-01") + (sample(365, 100, replace = TRUE) - 1)
)

parties <- tibble(
  q = 1:4,
  party = lubridate::ymd(c("2022-01-10", "2022-04-04", "2022-07-11", "2022-10-03"))
)

# Use lag/lead/diff techniques to generate `start` and `end`
# (this one is a little complicated from the specifics of the R4DS example)
parties <- parties %>%
  mutate(
    start = replace(party, 1L, as.Date("2022-01-01")),
    end = lead(start, default = as.Date("2022-12-31"))
  )
parties
#> # A tibble: 4 × 4
#>       q party      start      end       
#>   <int> <date>     <date>     <date>    
#> 1     1 2022-01-10 2022-01-01 2022-04-04
#> 2     2 2022-04-04 2022-04-04 2022-07-11
#> 3     3 2022-07-11 2022-07-11 2022-10-03
#> 4     4 2022-10-03 2022-10-03 2022-12-31

employees |> 
  inner_join(
    parties, 
    join_by(between(birthday, start, end, bounds = "[)")), 
    unmatched = "error"
  )
#> # A tibble: 100 × 6
#>    name       birthday       q party      start      end       
#>    <variable> <date>     <int> <date>     <date>     <date>    
#>  1 Optimus    2022-09-09     3 2022-07-11 2022-07-11 2022-10-03
#>  2 Brij       2022-12-13     4 2022-10-03 2022-10-03 2022-12-31
#>  3 Kaytin     2022-03-11     1 2022-01-10 2022-01-01 2022-04-04
#>  4 Turki      2022-03-27     1 2022-01-10 2022-01-01 2022-04-04
#>  5 Panfilo    2022-11-19     4 2022-10-03 2022-10-03 2022-12-31
#>  6 Catori     2022-02-22     1 2022-01-10 2022-01-01 2022-04-04
#>  7 Jeselle    2022-01-22     1 2022-01-10 2022-01-01 2022-04-04
#>  8 Donte      2022-09-13     3 2022-07-11 2022-07-11 2022-10-03
#>  9 Tishonda   2022-07-07     2 2022-04-04 2022-04-04 2022-07-11
#> 10 Darlien    2022-05-07     2 2022-04-04 2022-04-04 2022-07-11
#> # … with 90 more rows
```