### PR TITLE
Use `df_list()` in `n_distinct()` and `consecutive_id()`

### DIFF
--- a/R/consecutive-id.R
+++ b/R/consecutive-id.R
@@ -17,7 +17,14 @@
 #' df %>% group_by(id = consecutive_id(x, y), x, y) %>% summarise(n = n())
 consecutive_id <- function(...) {
   check_dots_unnamed()
-  data <- vctrs::data_frame(..., .name_repair = "minimal")
+
+  data <- df_list(
+    ...,
+    .unpack = FALSE,
+    .name_repair = "minimal",
+    .error_call = current_env()
+  )
+  data <- new_data_frame(data)
 
   out <- vec_identify_runs(data)
   attr(out, "n") <- NULL

--- a/R/n-distinct.R
+++ b/R/n-distinct.R
@@ -31,7 +31,14 @@
 #' n_distinct(data.frame(x, y))
 n_distinct <- function(..., na.rm = FALSE) {
   check_dots_unnamed()
-  data <- vctrs::data_frame(..., .name_repair = "minimal")
+
+  data <- df_list(
+    ...,
+    .unpack = FALSE,
+    .name_repair = "minimal",
+    .error_call = current_env()
+  )
+  data <- new_data_frame(data)
 
   if (isTRUE(na.rm)) {
     # Drop observation if *any* missing

--- a/tests/testthat/_snaps/consecutive-id.md
+++ b/tests/testthat/_snaps/consecutive-id.md
@@ -1,3 +1,11 @@
+# follows recycling rules
+
+    Code
+      consecutive_id(1:3, 1:4)
+    Condition
+      Error in `consecutive_id()`:
+      ! Can't recycle `..1` (size 3) to match `..2` (size 4).
+
 # generates useful errors
 
     Code
@@ -10,6 +18,6 @@
     Code
       consecutive_id(mean)
     Condition
-      Error in `vctrs::data_frame()`:
+      Error in `consecutive_id()`:
       ! `..1` must be a vector, not a function.
 

--- a/tests/testthat/_snaps/n-distinct.md
+++ b/tests/testthat/_snaps/n-distinct.md
@@ -10,6 +10,6 @@
     Code
       n_distinct(mean)
     Condition
-      Error in `vctrs::data_frame()`:
+      Error in `n_distinct()`:
       ! `..1` must be a vector, not a function.
 

--- a/tests/testthat/test-consecutive-id.R
+++ b/tests/testthat/test-consecutive-id.R
@@ -10,6 +10,10 @@ test_that("handles data frames", {
 test_that("follows recycling rules", {
   expect_equal(consecutive_id(double(), 1), integer())
   expect_equal(consecutive_id(1:2, 1), 1:2)
+
+  expect_snapshot(error = TRUE, {
+    consecutive_id(1:3, 1:4)
+  })
 })
 
 test_that("generates useful errors", {


### PR DESCRIPTION
Follow up to https://github.com/tidyverse/dplyr/pull/6381

- Better error calls with `.error_call`
- Setting `.unpack = FALSE` which at this point is for theoretical reasons, because we solved the only practical issue that could arise in `n_distinct(na.rm = TRUE)` in https://github.com/tidyverse/dplyr/pull/6381#discussion_r941352917