### PR TITLE
Quietly deprecate optional `.cols` and `.fns` cases

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,18 @@
 # dplyr (development version)
 
 * `.cols` and `.fns` are now required arguments in `across()`, `c_across()`,
-  `if_any()`, and `if_all()`. We now recommend that you use `pick()` instead of
-  `across(.fns = NULL)` to select a subset of columns without applying any
-  transformation. Relying on the previously optional arguments is not yet
-  formally soft-deprecated, but will be in the next minor release of dplyr, so
-  we encourage you to explicitly supply `.cols` and `.fns` in all calls to these
-  functions going forward (#6523).
+  `if_any()`, and `if_all()`. In general, we now recommend that you use `pick()`
+  instead of empty calls to `across()` (i.e. with no arguments) or
+  `across(c(x, y))` (i.e. with no `.fns`) to select a subset of columns without
+  applying any transformation (#6523).
+  
+  * Relying on the previous default of `.cols = everything()` is deprecated.
+    We have skipped the soft-deprecation stage in this case, because indirect
+    usage of `across()` and friends in this way is rare.
+  
+  * Relying on the previous default of `.fns = NULL` is not yet formally
+    soft-deprecated, because there was no good alternative until now, but is
+    discouraged and will be soft-deprecated in the next minor release.
 
 * `cur_data()` and `cur_data_all()` are now soft-deprecated in favor of
   `pick()` (#6204).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # dplyr (development version)
 
+* `.cols` and `.fns` are now required arguments in `across()`, `c_across()`,
+  `if_any()`, and `if_all()`. We now recommend that you use `pick()` instead of
+  `across(.fns = NULL)` to select a subset of columns without applying any
+  transformation. Relying on the previously optional arguments is not yet
+  formally soft-deprecated, but will be in the next minor release of dplyr, so
+  we encourage you to explicitly supply `.cols` and `.fns` in all calls to these
+  functions going forward (#6523).
+
 * `cur_data()` and `cur_data_all()` are now soft-deprecated in favor of
   `pick()` (#6204).
 

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -66,7 +66,8 @@ needs_group_context <- function(cnd) {
     "dplyr:::mutate_mixed_null",
     "dplyr:::mutate_constant_recycle_error",
     "dplyr:::summarise_mixed_null",
-    "dplyr:::error_pick_tidyselect"
+    "dplyr:::error_pick_tidyselect",
+    "dplyr:::warning_across_missing_cols_deprecated"
   ))
 }
 
@@ -368,11 +369,15 @@ signal_warnings <- function(state, error_call) {
 }
 
 new_dplyr_warning <- function(data) {
-  label <- cur_group_label(
-    data$type,
-    data$group_data$id,
-    data$group_data$group
-  )
+  if (data$needs_group_context) {
+    label <- cur_group_label(
+      data$type,
+      data$group_data$id,
+      data$group_data$group
+    )
+  } else {
+    label <- ""
+  }
 
   msg <- c(
     "i" = glue::glue("In argument `{data$name} = {data$expr}`."),

--- a/R/context.R
+++ b/R/context.R
@@ -109,12 +109,21 @@ stop_mask_type <- function(type) {
 }
 
 cnd_data <- function(cnd, ctxt, mask_type, call) {
+  needs_group_context <- needs_group_context(cnd)
+
+  if (needs_group_context) {
+    group_data <- cur_group_data(mask_type)
+  } else {
+    group_data <- NULL
+  }
+
   list(
     cnd = cnd,
     name = ctxt$error_name,
     expr = ctxt$error_expression,
     type = mask_type,
-    group_data = cur_group_data(mask_type),
+    needs_group_context = needs_group_context,
+    group_data = group_data,
     call = call
   )
 }

--- a/man/across.Rd
+++ b/man/across.Rd
@@ -6,11 +6,11 @@
 \alias{if_all}
 \title{Apply a function (or functions) across multiple columns}
 \usage{
-across(.cols = everything(), .fns = NULL, ..., .names = NULL, .unpack = FALSE)
+across(.cols, .fns, ..., .names = NULL, .unpack = FALSE)
 
-if_any(.cols = everything(), .fns = NULL, ..., .names = NULL)
+if_any(.cols, .fns, ..., .names = NULL)
 
-if_all(.cols = everything(), .fns = NULL, ..., .names = NULL)
+if_all(.cols, .fns, ..., .names = NULL)
 }
 \arguments{
 \item{.cols}{<\code{\link[=dplyr_tidy_select]{tidy-select}}> Columns to transform.
@@ -26,9 +26,6 @@ Possible values are:
 \verb{list(mean = mean, n_miss = ~ sum(is.na(.x))}. Each function is applied
 to each column, and the output is named by combining the function name
 and the column name using the glue specification in \code{.names}.
-\item \code{NULL}: the default, returns the selected columns in a data frame
-without applying a transformation. This is useful for when you want to
-use a function that takes a data frame.
 }
 
 Within these functions you can use \code{\link[=cur_column]{cur_column()}} and \code{\link[=cur_group]{cur_group()}}
@@ -82,6 +79,9 @@ predicate function to a selection of columns and combine the
 results into a single logical vector: \code{if_any()} is \code{TRUE} when
 the predicate is \code{TRUE} for \emph{any} of the selected columns, \code{if_all()}
 is \code{TRUE} when the predicate is \code{TRUE} for \emph{all} selected columns.
+
+If you just need to select columns without applying a transformation to each
+of them, then you probably want to use \code{\link[=pick]{pick()}} instead.
 
 \code{across()} supersedes the family of "scoped variants" like
 \code{summarise_at()}, \code{summarise_if()}, and \code{summarise_all()}.

--- a/man/c_across.Rd
+++ b/man/c_across.Rd
@@ -4,7 +4,7 @@
 \alias{c_across}
 \title{Combine values from multiple columns}
 \usage{
-c_across(cols = everything())
+c_across(cols)
 }
 \arguments{
 \item{cols}{<\code{\link[=dplyr_tidy_select]{tidy-select}}> Columns to transform.
@@ -27,7 +27,7 @@ df \%>\%
   mutate(
     sum = sum(c_across(w:z)),
     sd = sd(c_across(w:z))
- )
+  )
 }
 \seealso{
 \code{\link[=across]{across()}} for a function that returns a tibble.

--- a/tests/testthat/_snaps/across.md
+++ b/tests/testthat/_snaps/across.md
@@ -50,7 +50,7 @@
       Error in `summarise()`:
       i In argument: `..1 = across(where(is.numeric), 42)`.
       Caused by error in `across()`:
-      ! `.fns` must be NULL, a function, a formula, or a list of functions/formulas.
+      ! `.fns` must be a function, a formula, or a list of functions/formulas.
     Code
       (expect_error(tibble(x = 1) %>% summarise(across(y, mean))))
     Output
@@ -67,7 +67,7 @@
       Error in `summarise()`:
       i In argument: `res = across(where(is.numeric), 42)`.
       Caused by error in `across()`:
-      ! `.fns` must be NULL, a function, a formula, or a list of functions/formulas.
+      ! `.fns` must be a function, a formula, or a list of functions/formulas.
     Code
       (expect_error(tibble(x = 1) %>% summarise(z = across(y, mean))))
     Output
@@ -85,7 +85,7 @@
       Error in `summarise()`:
       i In argument: `res = sum(if_any(where(is.numeric), 42))`.
       Caused by error in `if_any()`:
-      ! `.fns` must be NULL, a function, a formula, or a list of functions/formulas.
+      ! `.fns` must be a function, a formula, or a list of functions/formulas.
     Code
       (expect_error(tibble(x = 1) %>% summarise(res = sum(if_all(~ mean(.x))))))
     Output

--- a/tests/testthat/_snaps/across.md
+++ b/tests/testthat/_snaps/across.md
@@ -230,6 +230,161 @@
       i The first argument `.cols` selects a set of columns.
       i The second argument `.fns` operates on each selected columns.
 
+# across() applies old `.cols = everything()` default with a warning
+
+    Code
+      out <- mutate(df, z = across())
+    Condition
+      Warning:
+      There was 1 warning in `mutate()`.
+      i In argument `z = across()`.
+      Caused by warning:
+      ! Using `across()` without supplying `.cols` was deprecated in dplyr 1.1.0.
+      i Please supply `.cols` instead.
+
+---
+
+    Code
+      out <- mutate(gdf, z = across())
+    Condition
+      Warning:
+      There were 2 warnings in `mutate()`.
+      The first warning was:
+      i In argument `z = across()`.
+      Caused by warning:
+      ! Using `across()` without supplying `.cols` was deprecated in dplyr 1.1.0.
+      i Please supply `.cols` instead.
+      i Run `dplyr::last_dplyr_warnings()` to see the 1 remaining warning.
+
+---
+
+    Code
+      out <- mutate(df, z = (across()))
+    Condition
+      Warning:
+      There was 1 warning in `mutate()`.
+      i In argument `z = (across())`.
+      Caused by warning:
+      ! Using `across()` without supplying `.cols` was deprecated in dplyr 1.1.0.
+      i Please supply `.cols` instead.
+
+---
+
+    Code
+      out <- mutate(gdf, z = (across()))
+    Condition
+      Warning:
+      There were 2 warnings in `mutate()`.
+      The first warning was:
+      i In argument `z = (across())`.
+      Caused by warning:
+      ! Using `across()` without supplying `.cols` was deprecated in dplyr 1.1.0.
+      i Please supply `.cols` instead.
+      i Run `dplyr::last_dplyr_warnings()` to see the 1 remaining warning.
+
+# if_any() and if_all() apply old `.cols = everything()` default with a warning
+
+    Code
+      out <- filter(df, if_any())
+    Condition
+      Warning:
+      Using `if_any()` without supplying `.cols` was deprecated in dplyr 1.1.0.
+      i Please supply `.cols` instead.
+
+---
+
+    Code
+      out <- filter(gdf, if_any())
+    Condition
+      Warning:
+      Using `if_any()` without supplying `.cols` was deprecated in dplyr 1.1.0.
+      i Please supply `.cols` instead.
+
+---
+
+    Code
+      out <- filter(df, if_all())
+    Condition
+      Warning:
+      Using `if_all()` without supplying `.cols` was deprecated in dplyr 1.1.0.
+      i Please supply `.cols` instead.
+
+---
+
+    Code
+      out <- filter(gdf, if_all())
+    Condition
+      Warning:
+      Using `if_all()` without supplying `.cols` was deprecated in dplyr 1.1.0.
+      i Please supply `.cols` instead.
+
+---
+
+    Code
+      out <- filter(df, (if_any()))
+    Condition
+      Warning:
+      There was 1 warning in `filter()`.
+      i In argument `..1 = (if_any())`.
+      Caused by warning:
+      ! Using `if_any()` without supplying `.cols` was deprecated in dplyr 1.1.0.
+      i Please supply `.cols` instead.
+
+---
+
+    Code
+      out <- filter(gdf, (if_any()))
+    Condition
+      Warning:
+      There were 2 warnings in `filter()`.
+      The first warning was:
+      i In argument `..1 = (if_any())`.
+      Caused by warning:
+      ! Using `if_any()` without supplying `.cols` was deprecated in dplyr 1.1.0.
+      i Please supply `.cols` instead.
+      i Run `dplyr::last_dplyr_warnings()` to see the 1 remaining warning.
+
+---
+
+    Code
+      out <- filter(df, (if_all()))
+    Condition
+      Warning:
+      There was 1 warning in `filter()`.
+      i In argument `..1 = (if_all())`.
+      Caused by warning:
+      ! Using `if_all()` without supplying `.cols` was deprecated in dplyr 1.1.0.
+      i Please supply `.cols` instead.
+
+---
+
+    Code
+      out <- filter(gdf, (if_all()))
+    Condition
+      Warning:
+      There were 2 warnings in `filter()`.
+      The first warning was:
+      i In argument `..1 = (if_all())`.
+      Caused by warning:
+      ! Using `if_all()` without supplying `.cols` was deprecated in dplyr 1.1.0.
+      i Please supply `.cols` instead.
+      i Run `dplyr::last_dplyr_warnings()` to see the 1 remaining warning.
+
+# c_across() applies old `cols = everything()` default with a warning
+
+    Code
+      out <- mutate(df, z = sum(c_across()))
+    Condition
+      Warning:
+      There were 2 warnings in `mutate()`.
+      The first warning was:
+      i In argument `z = sum(c_across())`.
+      i In row 1.
+      Caused by warning:
+      ! Using `c_across()` without supplying `cols` was deprecated in dplyr 1.1.0.
+      i Please supply `cols` instead.
+      i Run `dplyr::last_dplyr_warnings()` to see the 1 remaining warning.
+
 # across(...) is deprecated
 
     Code

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -968,38 +968,92 @@ test_that("selects and combines columns", {
   expect_equal(out$z, list(1:4))
 })
 
-# cols/fns deprecation ----------------------------------------------------
+# cols deprecation --------------------------------------------------------
 
-test_that("across() with no arguments applies old `.cols = everything()` and `.fns = NULL` defaults", {
-  df <- tibble(x = 1, y = 2)
+test_that("across() applies old `.cols = everything()` default with a warning", {
+  local_options(lifecycle_verbosity = "warning")
+
+  df <- tibble(g = c(1, 2), x = c(1, 2), y = c(3, 4))
+  gdf <- group_by(df, g)
 
   # Expansion path
-  out <- mutate(df, z = across())
+  expect_snapshot(out <- mutate(df, z = across()))
   expect_identical(out$z, df)
+  expect_snapshot(out <- mutate(gdf, z = across()))
+  expect_identical(out$z, df[c("x", "y")])
 
   # Evaluation path
-  out <- mutate(df, z = (across()))
+  expect_snapshot(out <- mutate(df, z = (across())))
   expect_identical(out$z, df)
+  expect_snapshot(out <- mutate(gdf, z = (across())))
+  expect_identical(out$z, df[c("x", "y")])
 })
 
-test_that("if_any() and if_all() with no arguments applies old `.cols = everything()` and `.fns = NULL` defaults", {
+test_that("if_any() and if_all() apply old `.cols = everything()` default with a warning", {
+  local_options(lifecycle_verbosity = "warning")
+
   df <- tibble(x = c(TRUE, FALSE, TRUE), y = c(FALSE, FALSE, TRUE))
+  gdf <- mutate(df, g = c(1, 1, 2), .before = 1)
+  gdf <- group_by(gdf, g)
 
   # Expansion path
-  expect_identical(filter(df, if_any()), df[c(1, 3),])
-  expect_identical(filter(df, if_all()), df[3,])
+  expect_snapshot(out <- filter(df, if_any()))
+  expect_identical(out, df[c(1, 3),])
+  expect_snapshot(out <- filter(gdf, if_any()))
+  expect_identical(out, gdf[c(1, 3),])
+
+  expect_snapshot(out <- filter(df, if_all()))
+  expect_identical(out, df[3,])
+  expect_snapshot(out <- filter(gdf, if_all()))
+  expect_identical(out, gdf[3,])
 
   # Evaluation path
-  expect_identical(filter(df, (if_any())), df[c(1, 3),])
-  expect_identical(filter(df, (if_all())), df[3,])
+  expect_snapshot(out <- filter(df, (if_any())))
+  expect_identical(out, df[c(1, 3),])
+  expect_snapshot(out <- filter(gdf, (if_any())))
+  expect_identical(out, gdf[c(1, 3),])
+
+  expect_snapshot(out <- filter(df, (if_all())))
+  expect_identical(out, df[3,])
+  expect_snapshot(out <- filter(gdf, (if_all())))
+  expect_identical(out, gdf[3,])
 })
 
-test_that("c_across() with no arguments applies old `cols = everything()` default", {
+test_that("c_across() applies old `cols = everything()` default with a warning", {
+  local_options(lifecycle_verbosity = "warning")
+
   df <- tibble(x = c(1, 3), y = c(2, 4))
   df <- rowwise(df)
 
-  out <- mutate(df, z = sum(c_across()))
+  # Will see 2 warnings because verbosity option forces it to warn every time
+  expect_snapshot(out <- mutate(df, z = sum(c_across())))
   expect_identical(out$z, c(3, 7))
+})
+
+# fns deprecation ---------------------------------------------------------
+
+test_that("across() applies old `.fns = NULL` default", {
+  df <- tibble(x = 1, y = 2)
+
+  # Expansion path
+  out <- mutate(df, z = across(everything()))
+  expect_identical(out$z, df)
+
+  # Evaluation path
+  out <- mutate(df, z = (across(everything())))
+  expect_identical(out$z, df)
+})
+
+test_that("if_any() and if_all() apply old `.fns = NULL` default", {
+  df <- tibble(x = c(TRUE, FALSE, TRUE), y = c(FALSE, FALSE, TRUE))
+
+  # Expansion path
+  expect_identical(filter(df, if_any(everything())), df[c(1, 3),])
+  expect_identical(filter(df, if_all(everything())), df[3,])
+
+  # Evaluation path
+  expect_identical(filter(df, (if_any(everything()))), df[c(1, 3),])
+  expect_identical(filter(df, (if_all(everything()))), df[3,])
 })
 
 # dots --------------------------------------------------------------------

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -968,6 +968,40 @@ test_that("selects and combines columns", {
   expect_equal(out$z, list(1:4))
 })
 
+# cols/fns deprecation ----------------------------------------------------
+
+test_that("across() with no arguments applies old `.cols = everything()` and `.fns = NULL` defaults", {
+  df <- tibble(x = 1, y = 2)
+
+  # Expansion path
+  out <- mutate(df, z = across())
+  expect_identical(out$z, df)
+
+  # Evaluation path
+  out <- mutate(df, z = (across()))
+  expect_identical(out$z, df)
+})
+
+test_that("if_any() and if_all() with no arguments applies old `.cols = everything()` and `.fns = NULL` defaults", {
+  df <- tibble(x = c(TRUE, FALSE, TRUE), y = c(FALSE, FALSE, TRUE))
+
+  # Expansion path
+  expect_identical(filter(df, if_any()), df[c(1, 3),])
+  expect_identical(filter(df, if_all()), df[3,])
+
+  # Evaluation path
+  expect_identical(filter(df, (if_any())), df[c(1, 3),])
+  expect_identical(filter(df, (if_all())), df[3,])
+})
+
+test_that("c_across() with no arguments applies old `cols = everything()` default", {
+  df <- tibble(x = c(1, 3), y = c(2, 4))
+  df <- rowwise(df)
+
+  out <- mutate(df, z = sum(c_across()))
+  expect_identical(out$z, c(3, 7))
+})
+
 # dots --------------------------------------------------------------------
 
 test_that("across(...) is deprecated", {


### PR DESCRIPTION
Follow up to #6492 

`.cols` and `.fns` are now required for `across()`, `c_across()`, `if_all()`, and `if_any()`.

We recommend in the NEWS that you use `pick()` instead of `across(.fns = NULL)`, which was the most common case of how people relied on these defaults

~This deprecation is currently hidden, all calls to these functions that rely on the previous defaults still work with no messages or warnings. I think that is definitely the right thing to do for `.fns = NULL`, because people would often do `across(c(x, y))` to mimic what `pick()` now does, and previously there was no other option. But I wonder if we could go ahead and soft deprecate the `.cols` case?~ The deprecation is hidden for `.fns = NULL`, but we now use `deprecate_warn()` for missing `.cols`

