### PR TITLE
Only throw the `multiple` warning on "direct" calls to join functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,7 +52,7 @@ Suggests:
     RPostgreSQL,
     RSQLite,
     stringi (>= 1.7.6),
-    testthat (>= 3.1.1),
+    testthat (>= 3.1.5),
     tidyr,
     withr
 VignetteBuilder: 

--- a/R/join-rows.R
+++ b/R/join-rows.R
@@ -8,7 +8,8 @@ join_rows <- function(x_key,
                       cross = FALSE,
                       multiple = NULL,
                       unmatched = "drop",
-                      error_call = caller_env()) {
+                      error_call = caller_env(),
+                      user_env = caller_env()) {
   check_dots_empty0(...)
 
   type <- arg_match(type, error_call = error_call)
@@ -26,7 +27,7 @@ join_rows <- function(x_key,
   incomplete <- standardise_join_incomplete(type, na_matches, unmatched)
   no_match <- standardise_join_no_match(type, unmatched)
   remaining <- standardise_join_remaining(type, unmatched)
-  multiple <- standardise_multiple(multiple, condition, filter, cross)
+  multiple <- standardise_multiple(multiple, condition, filter, cross, user_env)
 
   matches <- dplyr_locate_matches(
     needles = x_key,
@@ -222,7 +223,7 @@ standardise_join_remaining <- function(type, unmatched) {
   }
 }
 
-standardise_multiple <- function(multiple, condition, filter, cross) {
+standardise_multiple <- function(multiple, condition, filter, cross, user_env) {
   if (!is_null(multiple)) {
     # User supplied value always wins
     return(multiple)
@@ -236,11 +237,50 @@ standardise_multiple <- function(multiple, condition, filter, cross) {
   # "warning" for equi and rolling joins where multiple matches are surprising.
   # "all" for non-equi joins where multiple matches are expected.
   non_equi <- (condition != "==") & (filter == "none")
-
   if (any(non_equi)) {
-    "all"
-  } else {
+    return("all")
+  }
+
+  if (is_direct(user_env)) {
+    # Direct calls result in a warning when there are multiple matches,
+    # because they are likely surprising and the caller will be able to set
+    # the `multiple` argument. Indirect calls don't warn, because the caller
+    # is unlikely to have access to `multiple` to silence it.
     "warning"
+  } else {
+    "all"
   }
 }
 
+# `lifecycle:::is_direct()`
+is_direct <- function(env) {
+  env_inherits_global(env) || from_testthat(env)
+}
+env_inherits_global <- function(env) {
+  # `topenv(emptyenv())` returns the global env. Return `FALSE` in
+  # that case to allow passing the empty env when the
+  # soft-deprecation should not be promoted to deprecation based on
+  # the caller environment.
+  if (is_reference(env, empty_env())) {
+    return(FALSE)
+  }
+
+  is_reference(topenv(env), global_env())
+}
+# TRUE if we are in unit tests and the package being tested is the
+# same as the package that called
+from_testthat <- function(env) {
+  tested_package <- Sys.getenv("TESTTHAT_PKG")
+  if (!nzchar(tested_package)) {
+    return(FALSE)
+  }
+
+  top <- topenv(env)
+  if (!is_namespace(top)) {
+    return(FALSE)
+  }
+
+  # Test for environment names rather than reference/contents because
+  # testthat clones the namespace
+  identical(ns_env_name(top), tested_package)
+}

--- a/R/join-rows.R
+++ b/R/join-rows.R
@@ -252,6 +252,7 @@ standardise_multiple <- function(multiple, condition, filter, cross, user_env) {
   }
 }
 
+# TODO: Use upstream function when exported from rlang
 # `lifecycle:::is_direct()`
 is_direct <- function(env) {
   env_inherits_global(env) || from_testthat(env)

--- a/R/join.R
+++ b/R/join.R
@@ -221,7 +221,8 @@ inner_join.data.frame <- function(x,
     na_matches = na_matches,
     keep = keep,
     multiple = multiple,
-    unmatched = unmatched
+    unmatched = unmatched,
+    user_env = caller_env()
   )
 }
 
@@ -260,7 +261,8 @@ left_join.data.frame <- function(x,
     na_matches = na_matches,
     keep = keep,
     multiple = multiple,
-    unmatched = unmatched
+    unmatched = unmatched,
+    user_env = caller_env()
   )
 }
 
@@ -299,7 +301,8 @@ right_join.data.frame <- function(x,
     na_matches = na_matches,
     keep = keep,
     multiple = multiple,
-    unmatched = unmatched
+    unmatched = unmatched,
+    user_env = caller_env()
   )
 }
 
@@ -338,7 +341,8 @@ full_join.data.frame <- function(x,
     keep = keep,
     multiple = multiple,
     # All keys from both inputs are retained. Erroring never makes sense.
-    unmatched = "drop"
+    unmatched = "drop",
+    user_env = caller_env()
   )
 }
 
@@ -394,7 +398,7 @@ semi_join <- function(x, y, by = NULL, copy = FALSE, ...) {
 #' @rdname filter-joins
 semi_join.data.frame <- function(x, y, by = NULL, copy = FALSE, ..., na_matches = c("na", "never")) {
   y <- auto_copy(x, y, copy = copy)
-  join_filter(x, y, by = by, type = "semi", na_matches = na_matches)
+  join_filter(x, y, by = by, type = "semi", na_matches = na_matches, user_env = caller_env())
 }
 
 #' @export
@@ -408,7 +412,7 @@ anti_join <- function(x, y, by = NULL, copy = FALSE, ...) {
 #' @rdname filter-joins
 anti_join.data.frame <- function(x, y, by = NULL, copy = FALSE, ..., na_matches = c("na", "never")) {
   y <- auto_copy(x, y, copy = copy)
-  join_filter(x, y, by = by, type = "anti", na_matches = na_matches)
+  join_filter(x, y, by = by, type = "anti", na_matches = na_matches, user_env = caller_env())
 }
 
 #' Nest join
@@ -532,7 +536,8 @@ nest_join.data.frame <- function(x,
     filter = filter,
     cross = cross,
     multiple = multiple,
-    unmatched = unmatched
+    unmatched = unmatched,
+    user_env = caller_env()
   )
 
   y_loc <- vec_split(rows$y, rows$x)$val
@@ -563,7 +568,8 @@ join_mutate <- function(x,
                         keep = NULL,
                         multiple = NULL,
                         unmatched = "drop",
-                        error_call = caller_env()) {
+                        error_call = caller_env(),
+                        user_env = caller_env()) {
   check_dots_empty0(...)
 
   na_matches <- check_na_matches(na_matches, error_call = error_call)
@@ -612,7 +618,8 @@ join_mutate <- function(x,
     cross = cross,
     multiple = multiple,
     unmatched = unmatched,
-    error_call = error_call
+    error_call = error_call,
+    user_env = user_env
   )
 
   x_slicer <- rows$x
@@ -660,7 +667,8 @@ join_filter <- function(x,
                         type,
                         ...,
                         na_matches = c("na", "never"),
-                        error_call = caller_env()) {
+                        error_call = caller_env(),
+                        user_env = caller_env()) {
   check_dots_empty0(...)
 
   na_matches <- check_na_matches(na_matches, error_call = error_call)
@@ -707,7 +715,8 @@ join_filter <- function(x,
     cross = cross,
     multiple = multiple,
     unmatched = unmatched,
-    error_call = error_call
+    error_call = error_call,
+    user_env = user_env
   )
 
   if (type == "semi") {

--- a/tests/testthat/_snaps/join.md
+++ b/tests/testthat/_snaps/join.md
@@ -55,6 +55,16 @@
       Error:
       ! `na_matches` must be one of "na" or "never", not "foo".
 
+# mutating joins trigger multiple match warning
+
+    Code
+      out <- left_join(df1, df2, join_by(x))
+    Condition
+      Warning in `left_join()`:
+      Each row in `x` is expected to match at most 1 row in `y`.
+      i Row 1 of `x` matches multiple rows.
+      i If multiple matches are expected, set `multiple = "all"` to silence this warning.
+
 # mutating joins compute common columns
 
     Code


### PR DESCRIPTION
This uses the same code as `lifecycle::deprecate_soft()`, which means that the following two cases _do_ still get the warning:
- dplyr users that directly call the join functions will see the warning
- Package authors that directly call join functions in their package code will see the warning in their tests

But users or package authors who _indirectly_ call a join function through some other package will not see the join warning, because they likely won't have access to `multiple` to silence it (there are probably some exceptions to this, like packages that write S3 methods for the join functions and would expose `multiple` in their method, but I'm willing to live with accidental silence there).

For example, pretty much any package author or user who called `tidyr::complete()` was probably getting a multiple match warning because it called `full_join()` and often produced multiple matches on purpose. It will no longer produce warnings in those cases, but when we run the tidyr tests ourselves we should still see the warnings.