### PR TITLE
Recycle 0-column data frames in `summarise()` when they are named

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr (development version)
 
+* `summarise()` now correctly recycles named 0-column data frames (#6509).
+
 * `.cols` and `.fns` are now required arguments in `across()`, `c_across()`,
   `if_any()`, and `if_all()`. In general, we now recommend that you use `pick()`
   instead of empty calls to `across()` (i.e. with no arguments) or

--- a/src/dplyr.h
+++ b/src/dplyr.h
@@ -105,7 +105,7 @@ SEXP dplyr_mask_eval_all(SEXP quo, SEXP env_private);
 SEXP dplyr_mask_eval_all_summarise(SEXP quo, SEXP env_private);
 SEXP dplyr_mask_eval_all_mutate(SEXP quo, SEXP env_private);
 SEXP dplyr_mask_eval_all_filter(SEXP quos, SEXP env_private, SEXP s_n, SEXP env_filter);
-SEXP dplyr_summarise_recycle_chunks(SEXP chunks, SEXP rows, SEXP ptypes, SEXP results);
+SEXP dplyr_summarise_recycle_chunks_in_place(SEXP list_of_chunks, SEXP list_of_result);
 SEXP dplyr_group_indices(SEXP data, SEXP rows);
 SEXP dplyr_group_keys(SEXP group_data);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -106,7 +106,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"dplyr_mask_eval_all_mutate", (DL_FUNC)& dplyr_mask_eval_all_mutate, 2},
   {"dplyr_mask_eval_all_filter", (DL_FUNC)& dplyr_mask_eval_all_filter, 4},
 
-  {"dplyr_summarise_recycle_chunks", (DL_FUNC)& dplyr_summarise_recycle_chunks, 4},
+  {"dplyr_summarise_recycle_chunks_in_place", (DL_FUNC)& dplyr_summarise_recycle_chunks_in_place, 2},
 
   {"dplyr_group_indices", (DL_FUNC)& dplyr_group_indices, 2},
   {"dplyr_group_keys", (DL_FUNC)& dplyr_group_keys, 1},

--- a/src/summarise.cpp
+++ b/src/summarise.cpp
@@ -56,101 +56,104 @@ SEXP dplyr_mask_eval_all_summarise(SEXP quo, SEXP env_private) {
   return chunks;
 }
 
-bool is_useful_chunk(SEXP ptype) {
-  return !Rf_inherits(ptype, "data.frame") || XLENGTH(ptype) > 0;
-}
+SEXP dplyr_summarise_recycle_chunks_in_place(SEXP list_of_chunks, SEXP list_of_result) {
+  // - `list_of_chunks` will be modified in place by recycling each chunk
+  //   to its common size as necessary.
+  // - `list_of_result` will be modified in place if any chunks that originally
+  //   created the result element were recycled, because the result won't be
+  //   the right size anymore.
+  // - Returns an integer vector of the common sizes.
 
-SEXP dplyr_summarise_recycle_chunks(SEXP chunks, SEXP rows, SEXP ptypes, SEXP results) {
-  R_len_t n_chunks = LENGTH(chunks);
-  R_len_t n_groups = LENGTH(rows);
-
-  SEXP res = PROTECT(Rf_allocVector(VECSXP, 3));
-  Rf_namesgets(res, dplyr::vectors::names_summarise_recycle_chunks);
-  SET_VECTOR_ELT(res, 0, chunks);
-  SET_VECTOR_ELT(res, 2, results);
-
-  SEXP useful = PROTECT(Rf_allocVector(LGLSXP, n_chunks));
-  int* p_useful = LOGICAL(useful);
-  int n_useful = 0;
-  const SEXP* p_ptypes = VECTOR_PTR_RO(ptypes);
-  for (R_len_t j = 0; j < n_chunks; j++) {
-    n_useful += p_useful[j] = is_useful_chunk(p_ptypes[j]);
+  if (TYPEOF(list_of_chunks) != VECSXP) {
+    Rf_errorcall(R_NilValue, "Internal error: `list_of_chunks` must be a list.");
+  }
+  if (TYPEOF(list_of_result) != VECSXP) {
+    Rf_errorcall(R_NilValue, "Internal error: `list_of_result` must be a list.");
   }
 
-  // early exit if there are no useful chunks, this includes
-  // when there are no chunks at all
-  if (n_useful == 0) {
-    SET_VECTOR_ELT(res, 1, Rf_ScalarInteger(1));
-    UNPROTECT(2);
-    return res;
+  const R_xlen_t n_list_of_chunks = Rf_xlength(list_of_chunks);
+  const SEXP* v_list_of_chunks = VECTOR_PTR_RO(list_of_chunks);
+
+  if (n_list_of_chunks == 0) {
+    // At least one set of chunks is required to proceed
+    return dplyr::vectors::empty_int_vector;
   }
 
-  bool all_one = true;
-  int k = 1;
-  SEXP sizes = PROTECT(Rf_allocVector(INTSXP, n_groups));
-  int* p_sizes = INTEGER(sizes);
-  const SEXP* p_chunks = VECTOR_PTR_RO(chunks);
-  for (R_xlen_t i = 0; i < n_groups; i++, ++p_sizes) {
-    R_len_t n_i = 1;
+  SEXP first_chunks = v_list_of_chunks[0];
+  const SEXP* v_first_chunks = VECTOR_PTR_RO(first_chunks);
+  const R_xlen_t n_chunks = Rf_xlength(first_chunks);
 
-    R_len_t j = 0;
-    for (; j < n_chunks; j++) {
-      // skip useless chunks before looking for chunk size
-      for (; j < n_chunks && !p_useful[j]; j++);
-      if (j == n_chunks) break;
+  SEXP sizes = PROTECT(Rf_allocVector(INTSXP, n_chunks));
+  int* v_sizes = INTEGER(sizes);
 
-      R_len_t n_i_j = vctrs::short_vec_size(VECTOR_ELT(p_chunks[j], i));
+  // Initialize `sizes` with first set of chunks
+  for (R_xlen_t i = 0; i < n_chunks; ++i) {
+    v_sizes[i] = vctrs::short_vec_size(v_first_chunks[i]);
+  }
 
-      if (n_i != n_i_j) {
-        if (n_i == 1) {
-          n_i = n_i_j;
-        } else if (n_i_j != 1) {
-          dplyr::stop_summarise_incompatible_size(i, j, n_i, n_i_j);
-        }
+  bool any_need_recycling = false;
+
+  // Find common size across sets of chunks
+  for (R_xlen_t i = 1; i < n_list_of_chunks; ++i) {
+    SEXP chunks = v_list_of_chunks[i];
+    const SEXP* v_chunks = VECTOR_PTR_RO(chunks);
+
+    for (R_xlen_t j = 0; j < n_chunks; ++j) {
+      SEXP chunk = v_chunks[j];
+
+      const R_xlen_t out_size = v_sizes[j];
+      const R_xlen_t elt_size = vctrs::short_vec_size(chunk);
+
+      if (out_size == elt_size) {
+        // v_sizes[j] is correct
+      } else if (out_size == 1) {
+        v_sizes[j] = elt_size;
+        any_need_recycling = true;
+      } else if (elt_size == 1) {
+        // v_sizes[j] is correct
+        any_need_recycling = true;
+      } else {
+        dplyr::stop_summarise_incompatible_size(j, i, out_size, elt_size);
+      }
+    }
+  }
+
+  if (!any_need_recycling) {
+    UNPROTECT(1);
+    return sizes;
+  }
+
+  // Actually recycle across chunks
+  for (R_xlen_t i = 0; i < n_list_of_chunks; ++i) {
+    SEXP chunks = v_list_of_chunks[i];
+    const SEXP* v_chunks = VECTOR_PTR_RO(chunks);
+
+    bool reset_result = false;
+
+    for (R_xlen_t j = 0; j < n_chunks; ++j) {
+      SEXP chunk = v_chunks[j];
+
+      const R_xlen_t out_size = v_sizes[j];
+      const R_xlen_t elt_size = vctrs::short_vec_size(chunk);
+
+      if (out_size != elt_size) {
+        // Recycle and modify `chunks` in place!
+        chunk = vctrs::short_vec_recycle(chunk, out_size);
+        SET_VECTOR_ELT(chunks, j, chunk);
+        reset_result = true;
       }
     }
 
-    k = k + n_i;
-    *p_sizes = n_i;
-    if (n_i != 1) {
-      all_one = false;
+    if (reset_result) {
+      // `list_of_result[[i]]` was created from `list_of_chunks[[i]]`,
+      // but the chunks have been recycled so now the result is out of date.
+      // It will be regenerated on the R side from the new chunks.
+      SET_VECTOR_ELT(list_of_result, i, R_NilValue);
     }
   }
 
-  if (all_one) {
-    SET_VECTOR_ELT(res, 1, Rf_ScalarInteger(1));
-  } else {
-    // perform recycling
-    for (int j = 0; j < n_chunks; j++){
-      // skip useless chunks before recycling
-      for (; j < n_chunks && !p_useful[j]; j++);
-      if (j == n_chunks) break;
-
-      SEXP chunks_j = p_chunks[j];
-      int* p_sizes = INTEGER(sizes);
-      bool reset_result_j = false;
-      for (int i = 0; i < n_groups; i++, ++p_sizes) {
-        SEXP chunks_j_i = VECTOR_ELT(chunks_j, i);
-        if (*p_sizes != vctrs::short_vec_size(chunks_j_i)) {
-          reset_result_j = true;
-          SET_VECTOR_ELT(chunks_j, i,
-            vctrs::short_vec_recycle(chunks_j_i, *p_sizes)
-          );
-        }
-      }
-
-      // results[[j]] will be regenerated from !!!chunks[[j]]
-      // as it's been recycled
-      if (reset_result_j) {
-        SET_VECTOR_ELT(results, j, R_NilValue);
-      }
-    }
-    SET_VECTOR_ELT(res, 0, chunks);
-    SET_VECTOR_ELT(res, 1, sizes);
-  }
-
-  UNPROTECT(3);
-  return res;
+  UNPROTECT(1);
+  return sizes;
 }
 
 SEXP dplyr_extract_chunks(SEXP df_list, SEXP df_ptype) {

--- a/tests/testthat/test-pick.R
+++ b/tests/testthat/test-pick.R
@@ -362,16 +362,14 @@ test_that("can `pick()` inside `summarize()`", {
   expect_identical(out$count, expect_count)
 })
 
-test_that("recycles correctly with no inputs", {
-  skip("Until #6509 is fixed")
-
+test_that("recycles correctly with empty selection", {
   df <- tibble(x = 1:5)
 
-  out <- summarise(df, sum = sum(x), y = pick())
+  out <- summarise(df, sum = sum(x), y = pick(starts_with("foo")))
   expect_identical(out$sum, integer())
   expect_identical(out$y, new_tibble(list(), nrow = 0L))
 
-  out <- summarise(df, sum = sum(x), y = pick_wrapper())
+  out <- summarise(df, sum = sum(x), y = pick_wrapper(starts_with("foo")))
   expect_identical(out$sum, integer())
   expect_identical(out$y, new_tibble(list(), nrow = 0L))
 })


### PR DESCRIPTION
Closes https://github.com/tidyverse/dplyr/issues/6509

``` r
df <- tibble(x = 1:3)

# Now correctly recycles rather than erroring
summarise(df, sum = sum(x), empty = tibble())
#> # A tibble: 0 × 2
#> # … with 2 variables: sum <int>, empty <tibble[,0]>

summarise(df, sum = sum(x), empty = new_tibble(list(), nrow = 3))
#> # A tibble: 3 × 2
#>     sum empty       
#>   <int> <tibble[,0]>
#> 1     6             
#> 2     6             
#> 3     6
```

This reverts most of https://github.com/tidyverse/dplyr/pull/5088, but the tests that were added there still pass. This is because _unnamed_ data frames are actually already handled on the R side these days. They get auto-spliced ahead of time into their individual columns, which effectively makes 0-column data frames disappear.

https://github.com/tidyverse/dplyr/blob/02ef1d7c2de2bd70252a124004b2fe7c1ee9f5d8/R/summarise.R#L256-L270

So we don't need the complicated C code that was trying to exclude "useless" data frames that have 0 columns from the size computation. Those data frames actually do matter when they are named, because they will result in a df-col in the result and need to be considered during recycling.

I had a tough time trying to work through the C code for the recycling helper, so I've rewritten it. I think it is much easier to read now, and I think it should be faster because it uses more linear access of the lists.

The C function used to return `1L` if all of the chunks were size 1, but I've tried to make it more type stable by always returning the `sizes` vector. We just do `all(sizes == 1L)` on the R side now, which I'm not expecting to have any performance impact.

I've also tried to make it clearer that the function modifies its input by reference, which took me awhile to figure out. I do think it makes sense to do that though, for performance.