### PR TITLE
Fix `c_across()` quosure environment and disallow renaming

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # dplyr (development version)
 
+* `c_across()` now evaluates `all_of()` correctly and no longer allows you to
+  accidentally select grouping variables (#6522).
+
+* `c_across()` now throws a more informative error if you try to rename during
+  column selection (#6522).
+
 * `n_distinct()` now errors if you don't give it any input (#6535).
 
 * `group_walk()` gains an explict `.keep` argument (#6530).

--- a/R/across.R
+++ b/R/across.R
@@ -487,9 +487,14 @@ c_across_setup <- function(cols, mask, error_call = caller_env()) {
 
   data <- mask$get_current_data(groups = FALSE)
 
-  vars <- tidyselect::eval_select(cols, data, error_call = error_call)
-  value <- names(vars)
+  vars <- tidyselect::eval_select(
+    expr = cols,
+    data = data,
+    allow_rename = FALSE,
+    error_call = error_call
+  )
 
+  value <- names(vars)
   value
 }
 

--- a/R/across.R
+++ b/R/across.R
@@ -478,7 +478,7 @@ quo_set_env_to_data_mask_top <- function(quo) {
   quo_set_env(quo, env)
 }
 
-c_across_setup <- function(cols, mask) {
+c_across_setup <- function(cols, mask, error_call = caller_env()) {
   cols <- enquo(cols)
 
   # `c_across()` is evaluated in a data mask so we need to remove the
@@ -487,7 +487,7 @@ c_across_setup <- function(cols, mask) {
 
   data <- mask$get_current_data(groups = FALSE)
 
-  vars <- tidyselect::eval_select(cols, data)
+  vars <- tidyselect::eval_select(cols, data, error_call = error_call)
   value <- names(vars)
 
   value

--- a/R/across.R
+++ b/R/across.R
@@ -480,9 +480,14 @@ quo_set_env_to_data_mask_top <- function(quo) {
 
 c_across_setup <- function(cols, mask) {
   cols <- enquo(cols)
+
+  # `c_across()` is evaluated in a data mask so we need to remove the
+  # mask layer from the quosure environments (same as `across()`) (#5460, #6522)
+  cols <- quo_set_env_to_data_mask_top(cols)
+
   data <- mask$get_current_data(groups = FALSE)
 
-  vars <- tidyselect::eval_select(expr(!!cols), data)
+  vars <- tidyselect::eval_select(cols, data)
   value <- names(vars)
 
   value

--- a/tests/testthat/_snaps/across.md
+++ b/tests/testthat/_snaps/across.md
@@ -238,7 +238,7 @@
       Error in `mutate()`:
       i In argument: `y = c_across(g)`.
       i In group 1: `g = 1`.
-      Caused by error in `c_across_setup()`:
+      Caused by error in `c_across()`:
       ! Can't subset columns that don't exist.
       x Column `g` doesn't exist.
 
@@ -249,7 +249,7 @@
     Condition
       Error in `mutate()`:
       i In argument: `z = c_across(all_of(y))`.
-      Caused by error in `c_across_setup()`:
+      Caused by error in `c_across()`:
       ! Problem while evaluating `all_of(y)`.
       Caused by error in `as_indices_impl()`:
       ! object 'y' not found

--- a/tests/testthat/_snaps/across.md
+++ b/tests/testthat/_snaps/across.md
@@ -230,6 +230,42 @@
       i The first argument `.cols` selects a set of columns.
       i The second argument `.fns` operates on each selected columns.
 
+# can't explicitly select grouping columns (#6522)
+
+    Code
+      mutate(gdf, y = c_across(g))
+    Condition
+      Warning:
+      There was 1 warning in `mutate()`.
+      i In argument `y = c_across(g)`.
+      i In group 1: `g = 1`.
+      Caused by warning:
+      ! Using an external vector in selections was deprecated in tidyselect 1.1.0.
+      i Please use `all_of()` or `any_of()` instead.
+        # Was:
+        data %>% select(g)
+      
+        # Now:
+        data %>% select(all_of(g))
+      
+      See <https://tidyselect.r-lib.org/reference/faq-external-vector.html>.
+    Output
+      # A tibble: 1 x 3
+      # Groups:   g [1]
+            g     x     y
+        <dbl> <dbl> <dbl>
+      1     1     2     2
+
+# `all_of()` is evaluated in the correct environment (#6522)
+
+    Code
+      mutate(df, z = c_across(all_of(y)))
+    Output
+      # A tibble: 1 x 3
+            x     y     z
+        <dbl> <dbl> <dbl>
+      1     1     2     2
+
 # across() applies old `.cols = everything()` default with a warning
 
     Code

--- a/tests/testthat/_snaps/across.md
+++ b/tests/testthat/_snaps/across.md
@@ -230,6 +230,16 @@
       i The first argument `.cols` selects a set of columns.
       i The second argument `.fns` operates on each selected columns.
 
+# can't rename during selection (#6522)
+
+    Code
+      mutate(df, z = c_across(c(y = x)))
+    Condition
+      Error in `mutate()`:
+      i In argument: `z = c_across(c(y = x))`.
+      Caused by error in `env_get_list()`:
+      ! Can't find `y` in environment.
+
 # can't explicitly select grouping columns (#6522)
 
     Code

--- a/tests/testthat/_snaps/across.md
+++ b/tests/testthat/_snaps/across.md
@@ -235,36 +235,24 @@
     Code
       mutate(gdf, y = c_across(g))
     Condition
-      Warning:
-      There was 1 warning in `mutate()`.
-      i In argument `y = c_across(g)`.
+      Error in `mutate()`:
+      i In argument: `y = c_across(g)`.
       i In group 1: `g = 1`.
-      Caused by warning:
-      ! Using an external vector in selections was deprecated in tidyselect 1.1.0.
-      i Please use `all_of()` or `any_of()` instead.
-        # Was:
-        data %>% select(g)
-      
-        # Now:
-        data %>% select(all_of(g))
-      
-      See <https://tidyselect.r-lib.org/reference/faq-external-vector.html>.
-    Output
-      # A tibble: 1 x 3
-      # Groups:   g [1]
-            g     x     y
-        <dbl> <dbl> <dbl>
-      1     1     2     2
+      Caused by error in `c_across_setup()`:
+      ! Can't subset columns that don't exist.
+      x Column `g` doesn't exist.
 
 # `all_of()` is evaluated in the correct environment (#6522)
 
     Code
       mutate(df, z = c_across(all_of(y)))
-    Output
-      # A tibble: 1 x 3
-            x     y     z
-        <dbl> <dbl> <dbl>
-      1     1     2     2
+    Condition
+      Error in `mutate()`:
+      i In argument: `z = c_across(all_of(y))`.
+      Caused by error in `c_across_setup()`:
+      ! Problem while evaluating `all_of(y)`.
+      Caused by error in `as_indices_impl()`:
+      ! object 'y' not found
 
 # across() applies old `.cols = everything()` default with a warning
 

--- a/tests/testthat/_snaps/across.md
+++ b/tests/testthat/_snaps/across.md
@@ -237,8 +237,8 @@
     Condition
       Error in `mutate()`:
       i In argument: `z = c_across(c(y = x))`.
-      Caused by error in `env_get_list()`:
-      ! Can't find `y` in environment.
+      Caused by error in `c_across()`:
+      ! Can't rename variables in this context.
 
 # can't explicitly select grouping columns (#6522)
 

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -970,6 +970,15 @@ test_that("selects and combines columns", {
   expect_equal(out$z, list(1:4))
 })
 
+test_that("can't rename during selection (#6522)", {
+  df <- tibble(x = 1)
+
+  # TODO: This is the wrong error. Renaming shouldn't be allowed.
+  expect_snapshot(error = TRUE, {
+    mutate(df, z = c_across(c(y = x)))
+  })
+})
+
 test_that("can't explicitly select grouping columns (#6522)", {
   # Related to removing the mask layer from the quosure environments
   df <- tibble(g = 1, x = 2)

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -970,6 +970,35 @@ test_that("selects and combines columns", {
   expect_equal(out$z, list(1:4))
 })
 
+test_that("can't explicitly select grouping columns (#6522)", {
+  # Related to removing the mask layer from the quosure environments
+  df <- tibble(g = 1, x = 2)
+  gdf <- group_by(df, g)
+
+  # TODO: This is not right. It should error.
+  expect_snapshot({
+    mutate(gdf, y = c_across(g))
+  })
+})
+
+test_that("`all_of()` is evaluated in the correct environment (#6522)", {
+  # Related to removing the mask layer from the quosure environments
+  df <- tibble(x = 1, y = 2)
+
+  # TODO: This is not right. It should error.
+  expect_snapshot({
+    mutate(df, z = c_across(all_of(y)))
+  })
+
+  y <- "x"
+  # TODO: This is not right. Should be `"x"`.
+  #expect <- df[["x"]]
+  expect <- df[["y"]]
+
+  out <- mutate(df, z = c_across(all_of(y)))
+  expect_identical(out$z, expect)
+})
+
 # cols deprecation --------------------------------------------------------
 
 test_that("across() applies old `.cols = everything()` default with a warning", {

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -973,7 +973,6 @@ test_that("selects and combines columns", {
 test_that("can't rename during selection (#6522)", {
   df <- tibble(x = 1)
 
-  # TODO: This is the wrong error. Renaming shouldn't be allowed.
   expect_snapshot(error = TRUE, {
     mutate(df, z = c_across(c(y = x)))
   })

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -975,8 +975,7 @@ test_that("can't explicitly select grouping columns (#6522)", {
   df <- tibble(g = 1, x = 2)
   gdf <- group_by(df, g)
 
-  # TODO: This is not right. It should error.
-  expect_snapshot({
+  expect_snapshot(error = TRUE, {
     mutate(gdf, y = c_across(g))
   })
 })
@@ -985,15 +984,12 @@ test_that("`all_of()` is evaluated in the correct environment (#6522)", {
   # Related to removing the mask layer from the quosure environments
   df <- tibble(x = 1, y = 2)
 
-  # TODO: This is not right. It should error.
-  expect_snapshot({
+  expect_snapshot(error = TRUE, {
     mutate(df, z = c_across(all_of(y)))
   })
 
   y <- "x"
-  # TODO: This is not right. Should be `"x"`.
-  #expect <- df[["x"]]
-  expect <- df[["y"]]
+  expect <- df[["x"]]
 
   out <- mutate(df, z = c_across(all_of(y)))
   expect_identical(out$z, expect)


### PR DESCRIPTION
Closes #6522 

I knew something was fishy here. We needed to use `quo_set_env_to_data_mask_top()` in `c_across()` like we already do for `pick()` and `across()`. Without it, `all_of()` didn't work correctly and we were accidentally allowing grouping variables to be selected.

While I was there, I also:
- Passed the `error_call` through to `eval_select()` for better error calls
- Set `allow_rename = FALSE` to get a better error message. It already threw an error, but it was an obscure one.