### PR TITLE
Use latest roxygen2 local reproducible defaults

### DIFF
--- a/R/select.R
+++ b/R/select.R
@@ -42,10 +42,7 @@
 #'   knitr::knit_child("man/rmd/select.Rmd"),
 #'   tibble.print_min = 4,
 #'   tibble.max_extra_cols = 8,
-#'   digits = 2,
-#'   crayon.enabled = FALSE,
-#'   cli.unicode = FALSE,
-#'   width = 80
+#'   digits = 2
 #' )
 #' cat(result, sep = "\n")
 #' ```

--- a/R/select.R
+++ b/R/select.R
@@ -42,6 +42,7 @@
 #'   knitr::knit_child("man/rmd/select.Rmd"),
 #'   tibble.print_min = 4,
 #'   tibble.max_extra_cols = 8,
+#'   pillar.min_title_chars = 20,
 #'   digits = 2
 #' )
 #' cat(result, sep = "\n")

--- a/man/rmd/select.Rmd
+++ b/man/rmd/select.Rmd
@@ -10,7 +10,7 @@ The selection language can be used in functions like
 `dplyr::select()` or `tidyr::pivot_longer()`. Let's first attach
 the tidyverse:
 
-```{r, comment = "#>", collapse = TRUE}
+```{r}
 library(tidyverse)
 
 # For better printing
@@ -19,7 +19,7 @@ iris <- as_tibble(iris)
 
 Select variables by name:
 
-```{r, comment = "#>", collapse = TRUE}
+```{r}
 starwars %>% select(height)
 
 iris %>% pivot_longer(Sepal.Length)
@@ -28,14 +28,14 @@ iris %>% pivot_longer(Sepal.Length)
 Select multiple variables by separating them with commas. Note how
 the order of columns is determined by the order of inputs:
 
-```{r, comment = "#>", collapse = TRUE}
+```{r}
 starwars %>% select(homeworld, height, mass)
 ```
 
 Functions like `tidyr::pivot_longer()` don't take variables with
 dots. In this case use `c()` to select multiple variables:
 
-```{r, comment = "#>", collapse = TRUE}
+```{r}
 iris %>% pivot_longer(c(Sepal.Length, Petal.Length))
 ```
 
@@ -43,13 +43,13 @@ iris %>% pivot_longer(c(Sepal.Length, Petal.Length))
 
 The `:` operator selects a range of consecutive variables:
 
-```{r, comment = "#>", collapse = TRUE}
+```{r}
 starwars %>% select(name:mass)
 ```
 
 The `!` operator negates a selection:
 
-```{r, comment = "#>", collapse = TRUE}
+```{r}
 starwars %>% select(!(name:mass))
 
 iris %>% select(!c(Sepal.Length, Petal.Length))
@@ -59,7 +59,7 @@ iris %>% select(!ends_with("Width"))
 
 `&` and `|` take the intersection or the union of two selections:
 
-```{r, comment = "#>", collapse = TRUE}
+```{r}
 iris %>% select(starts_with("Petal") & ends_with("Width"))
 
 iris %>% select(starts_with("Petal") | ends_with("Width"))
@@ -68,6 +68,6 @@ iris %>% select(starts_with("Petal") | ends_with("Width"))
 To take the difference between two selections, combine the `&` and
 `!` operators:
 
-```{r, comment = "#>", collapse = TRUE}
+```{r}
 iris %>% select(starts_with("Petal") & !ends_with("Width"))
 ```

--- a/man/select.Rd
+++ b/man/select.Rd
@@ -172,15 +172,14 @@ The \code{!} operator negates a selection:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{starwars \%>\% select(!(name:mass))
 #> # A tibble: 87 x 11
-#>   hair_color skin_c~1 eye_c~2 birth~3 sex   gender homew~4 species films vehic~5
-#>   <chr>      <chr>    <chr>     <dbl> <chr> <chr>  <chr>   <chr>   <lis> <list> 
-#> 1 blond      fair     blue       19   male  mascu~ Tatooi~ Human   <chr> <chr>  
-#> 2 <NA>       gold     yellow    112   none  mascu~ Tatooi~ Droid   <chr> <chr>  
-#> 3 <NA>       white, ~ red        33   none  mascu~ Naboo   Droid   <chr> <chr>  
-#> 4 none       white    yellow     41.9 male  mascu~ Tatooi~ Human   <chr> <chr>  
-#> # ... with 83 more rows, 1 more variable: starships <list>, and abbreviated
-#> #   variable names 1: skin_color, 2: eye_color, 3: birth_year, 4: homeworld,
-#> #   5: vehicles
+#>   hair_color skin_color  eye_color birth_year sex   gender    homeworld species
+#>   <chr>      <chr>       <chr>          <dbl> <chr> <chr>     <chr>     <chr>  
+#> 1 blond      fair        blue            19   male  masculine Tatooine  Human  
+#> 2 <NA>       gold        yellow         112   none  masculine Tatooine  Droid  
+#> 3 <NA>       white, blue red             33   none  masculine Naboo     Droid  
+#> 4 none       white       yellow          41.9 male  masculine Tatooine  Human  
+#> # ... with 83 more rows, and 3 more variables: films <list>, vehicles <list>,
+#> #   starships <list>
 
 iris \%>\% select(!c(Sepal.Length, Petal.Length))
 #> # A tibble: 150 x 3


### PR DESCRIPTION
roxygen2 now sets `crayon.enabled`, `cli.unicode`, and `width` for us in inline code chunks. It also sets the knitr options `comment = "#>", collapse = TRUE` so we don't need that either.

Also added the `pillar.min_title_chars = 20` option to the `select.Rmd` rendering, as this is going to be the new pillar default in the next release. Since I already set this in my `.Rprofile`, it was changing `select.Rd` every time I ran document interactively, which was annoying