### PR TITLE
Fix `...length2()` with missing dots

### DIFF
--- a/R/slice.R
+++ b/R/slice.R
@@ -550,7 +550,13 @@ dplyr_local_slice_by_arg <- function(by_arg, frame = caller_env()) {
 
 # Backports for R 3.5.0 utils
 ...length2 <- function(frame = caller_env()) {
-  length(env_get(frame, "..."))
+  dots <- env_get(frame, "...")
+
+  if (is_missing(dots)) {
+    0L
+  } else {
+    length(dots)
+  }
 }
 ...elt2 <- function(i, frame = caller_env()) {
   eval_bare(sym(paste0("..", i)), frame)


### PR DESCRIPTION
Minor bug I discovered while poking around `slice_rows()`

In main:

```r
impl <- function(...) {
  dplyr:::...length2()
}

impl()
#> [1] 1
impl(1)
#> [1] 1
impl(1, 2)
#> [1] 2
```

This PR

``` r
impl <- function(...) {
  dplyr:::...length2()
}

impl()
#> [1] 0
impl(1)
#> [1] 1
impl(1, 2)
#> [1] 2
```

The problem is that when you don't supply any dots, `env_get(nm = "...")` ends up returning a missing-arg rather than a DOTSXP, which has a `length()` of 1.

`...length()` does work correctly in this case, but it does so by defining this special `length_DOTS()` macro that avoids this issue https://github.com/wch/r-source/blob/431d589d479358a11ace2a0b7443fb519bf0ce05/src/main/envir.c#L1410

CC @lionel- you might be interested in this corner case