### PR TITLE
Mention the `<list_of>` class in the return value of `group_split()`

### DIFF
--- a/R/group-split.R
+++ b/R/group-split.R
@@ -22,7 +22,10 @@
 #'   forwarded to [group_by()].
 #' @param .keep Should the grouping columns be kept?
 #' @returns A list of tibbles. Each tibble contains the rows of `.tbl` for the
-#'  associated group and all the columns, including the grouping variables.
+#'   associated group and all the columns, including the grouping variables.
+#'   Note that this returns a [list_of][vctrs::list_of()] which is slightly
+#'   stricter than a simple list but is useful for representing lists where
+#'   every element has the same type.
 #' @family grouping functions
 #' @export
 #' @examples

--- a/man/group_split.Rd
+++ b/man/group_split.Rd
@@ -17,6 +17,9 @@ forwarded to \code{\link[=group_by]{group_by()}}.}
 \value{
 A list of tibbles. Each tibble contains the rows of \code{.tbl} for the
 associated group and all the columns, including the grouping variables.
+Note that this returns a \link[vctrs:list_of]{list_of} which is slightly
+stricter than a simple list but is useful for representing lists where
+every element has the same type.
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}


### PR DESCRIPTION
Closes https://github.com/tidyverse/dplyr/issues/6510

I think we mainly just need to tweak the documentation here 