### PR TITLE
Allow `unmatched` to be a size 2 character vector for inner joins

### DIFF
--- a/R/join.R
+++ b/R/join.R
@@ -138,9 +138,12 @@
 #'
 #'   `unmatched` is intended to protect you from accidentally dropping rows
 #'   during a join. It only checks for unmatched keys in the input that could
-#'   potentially drop rows. For example, in `left_join()` only `y` is
-#'   checked for unmatched keys, because all keys from `x` are always retained,
-#'   even if they don't have a match.
+#'   potentially drop rows.
+#'   - For left joins, it checks `y`.
+#'   - For right joins, it checks `x`.
+#'   - For inner joins, it checks both `x` and `y`. In this case, `unmatched` is
+#'     also allowed to be a character vector of length 2 to specify the behavior
+#'     for `x` and `y` independently.
 #' @family joins
 #' @examples
 #' band_members %>% inner_join(band_instruments)
@@ -487,7 +490,6 @@ nest_join.data.frame <- function(x,
 
   check_keep(keep)
   na_matches <- check_na_matches(na_matches)
-  unmatched <- check_unmatched(unmatched)
 
   if (is.null(name)) {
     name <- as_label(enexpr(y))
@@ -574,7 +576,6 @@ join_mutate <- function(x,
 
   na_matches <- check_na_matches(na_matches, error_call = error_call)
   check_keep(keep, error_call = error_call)
-  unmatched <- check_unmatched(unmatched, error_call = error_call)
 
   x_names <- tbl_vars(x)
   y_names <- tbl_vars(y)
@@ -748,17 +749,6 @@ check_na_matches <- function(na_matches,
     arg = na_matches,
     values = c("na", "never"),
     arg_nm = "na_matches",
-    error_call = error_call
-  )
-}
-
-check_unmatched <- function(unmatched, ..., error_call = caller_env()) {
-  check_dots_empty0(...)
-
-  arg_match0(
-    arg = unmatched,
-    values = c("drop", "error"),
-    arg_nm = "unmatched",
     error_call = error_call
   )
 }

--- a/man/mutate-joins.Rd
+++ b/man/mutate-joins.Rd
@@ -196,9 +196,14 @@ be handled?
 
 \code{unmatched} is intended to protect you from accidentally dropping rows
 during a join. It only checks for unmatched keys in the input that could
-potentially drop rows. For example, in \code{left_join()} only \code{y} is
-checked for unmatched keys, because all keys from \code{x} are always retained,
-even if they don't have a match.}
+potentially drop rows.
+\itemize{
+\item For left joins, it checks \code{y}.
+\item For right joins, it checks \code{x}.
+\item For inner joins, it checks both \code{x} and \code{y}. In this case, \code{unmatched} is
+also allowed to be a character vector of length 2 to specify the behavior
+for \code{x} and \code{y} independently.
+}}
 }
 \value{
 An object of the same type as \code{x} (including the same groups). The order of

--- a/man/nest_join.Rd
+++ b/man/nest_join.Rd
@@ -80,9 +80,14 @@ be handled?
 
 \code{unmatched} is intended to protect you from accidentally dropping rows
 during a join. It only checks for unmatched keys in the input that could
-potentially drop rows. For example, in \code{left_join()} only \code{y} is
-checked for unmatched keys, because all keys from \code{x} are always retained,
-even if they don't have a match.}
+potentially drop rows.
+\itemize{
+\item For left joins, it checks \code{y}.
+\item For right joins, it checks \code{x}.
+\item For inner joins, it checks both \code{x} and \code{y}. In this case, \code{unmatched} is
+also allowed to be a character vector of length 2 to specify the behavior
+for \code{x} and \code{y} independently.
+}}
 }
 \value{
 The output:

--- a/tests/testthat/_snaps/join-rows.md
+++ b/tests/testthat/_snaps/join-rows.md
@@ -18,6 +18,15 @@
       i Row 1 of `x` matches multiple rows.
       i If multiple matches are expected, set `multiple = "all"` to silence this warning.
 
+# join_rows() allows `unmatched` to be specified independently for inner joins
+
+    Code
+      join_rows(c(1, 3), c(1, 2), type = "inner", unmatched = c("drop", "error"))
+    Condition
+      Error:
+      ! Each row of `y` must be matched by `x`.
+      i Row 2 of `y` was not matched.
+
 # join_rows() expects incompatible type errors to have been handled by join_cast_common()
 
     Code
@@ -100,8 +109,28 @@
 ---
 
     Code
+      join_rows(data.frame(x = c(1, 2)), data.frame(x = 1), type = "inner",
+      unmatched = c("error", "drop"))
+    Condition
+      Error:
+      ! Each row of `x` must have a match in `y`.
+      i Row 2 of `x` does not have a match.
+
+---
+
+    Code
       join_rows(data.frame(x = 1), data.frame(x = c(1, 2)), type = "inner",
       unmatched = "error")
+    Condition
+      Error:
+      ! Each row of `y` must be matched by `x`.
+      i Row 2 of `y` was not matched.
+
+---
+
+    Code
+      join_rows(data.frame(x = 1), data.frame(x = c(1, 2)), type = "inner",
+      unmatched = c("drop", "error"))
     Condition
       Error:
       ! Each row of `y` must be matched by `x`.
@@ -180,8 +209,28 @@
 ---
 
     Code
+      join_rows(data.frame(x = 1), data.frame(x = c(1, NA)), type = "inner",
+      unmatched = c("drop", "error"), na_matches = "na")
+    Condition
+      Error:
+      ! Each row of `y` must be matched by `x`.
+      i Row 2 of `y` was not matched.
+
+---
+
+    Code
       join_rows(data.frame(x = c(1, NA)), data.frame(x = 1), type = "inner",
       unmatched = "error", na_matches = "na")
+    Condition
+      Error:
+      ! Each row of `x` must have a match in `y`.
+      i Row 2 of `x` does not have a match.
+
+---
+
+    Code
+      join_rows(data.frame(x = c(1, NA)), data.frame(x = 1), type = "inner",
+      unmatched = c("error", "drop"), na_matches = "na")
     Condition
       Error:
       ! Each row of `x` must have a match in `y`.
@@ -196,4 +245,43 @@
       Error:
       ! Each row of `x` must have a match in `y`.
       i Row 1 of `x` does not have a match.
+
+# join_rows() validates `unmatched`
+
+    Code
+      join_rows(df, df, unmatched = 1)
+    Condition
+      Error:
+      ! `unmatched` must be a character vector, not a number.
+    Code
+      join_rows(df, df, unmatched = "foo")
+    Condition
+      Error:
+      ! `unmatched` must be one of "drop" or "error", not "foo".
+    Code
+      join_rows(df, df, type = "left", unmatched = character())
+    Condition
+      Error:
+      ! `unmatched` must be length 1, not 0.
+    Code
+      join_rows(df, df, type = "left", unmatched = c("drop", "error"))
+    Condition
+      Error:
+      ! `unmatched` must be length 1, not 2.
+    Code
+      join_rows(df, df, type = "inner", unmatched = character())
+    Condition
+      Error:
+      ! `unmatched` must be length 1 or 2, not 0.
+    Code
+      join_rows(df, df, type = "inner", unmatched = c("drop", "error", "error"))
+    Condition
+      Error:
+      ! `unmatched` must be length 1 or 2, not 3.
+    Code
+      join_rows(df, df, type = "inner", unmatched = c("drop", "dr"))
+    Condition
+      Error:
+      ! `unmatched` must be one of "drop" or "error", not "dr".
+      i Did you mean "drop"?
 

--- a/tests/testthat/_snaps/join.md
+++ b/tests/testthat/_snaps/join.md
@@ -32,11 +32,6 @@
       Error:
       ! `na_matches` must be one of "na" or "never", not "foo".
     Code
-      join_mutate(df, df, by = "x", type = "left", unmatched = "foo")
-    Condition
-      Error:
-      ! `unmatched` must be one of "drop" or "error", not "foo".
-    Code
       join_mutate(df, df, by = "x", type = "left", keep = 1)
     Condition
       Error:
@@ -207,9 +202,4 @@
     Condition
       Error in `nest_join()`:
       ! `na_matches` must be a string or character vector.
-    Code
-      nest_join(df1, df2, unmatched = 1)
-    Condition
-      Error in `nest_join()`:
-      ! `unmatched` must be a string or character vector.
 

--- a/tests/testthat/test-join.R
+++ b/tests/testthat/test-join.R
@@ -255,7 +255,6 @@ test_that("join_mutate() validates arguments", {
     join_mutate(df, df, by = 1, type = "left")
     join_mutate(df, df, by = "x", type = "left", suffix = 1)
     join_mutate(df, df, by = "x", type = "left", na_matches = "foo")
-    join_mutate(df, df, by = "x", type = "left", unmatched = "foo")
     join_mutate(df, df, by = "x", type = "left", keep = 1)
   })
 })
@@ -432,7 +431,6 @@ test_that("validates inputs", {
     nest_join(df1, df2, keep = 1)
     nest_join(df1, df2, name = 1)
     nest_join(df1, df2, na_matches = 1)
-    nest_join(df1, df2, unmatched = 1)
   })
 
 })


### PR DESCRIPTION
Closes #6566

`unmatched` allows you to error if the input that has the _potential_ to drop rows would actually drop them. So:
- For left joins, it checks `y`
- For right joins, it checks `x`
- For inner joins, it checks `x` and `y`
- For full joins, it doesn't check either input, so `unmatched` isn't an argument to `full_join()`

We previously required that `unmatched` was a size 1 character vector, but this means that you can't control the behavior of `x` and `y` independently for inner joins. I think this is reasonable to want to be able to do. It comes up when you want each row in the `x` table to have exactly 1 match in `y`, but you don't care about what happens to unmatched rows in `y`.

This is exactly the case of the `employees` / `parties` example. You want each `employee` to be matched to exactly 1 party, but you don't really care if there happens to be a party with 0 employees celebrated at it.

Below I create an example of this where the Q4 party happens to not have any employees celebrated at it, so it gets dropped and we are ok with that.

Side note: I think this combination of `multiple` and `unmatched` actually makes `inner_join()` much more useful than we implied here https://dplyr.tidyverse.org/dev/reference/mutate-joins.html#inner-join. It becomes very useful for adding "quality control" checks to this common case where you expect each row in `x` to have exactly 1 match in `y`, and you want to be alerted if this isn't the case. You don't get this with `left_join()`, for example. Since it unconditionally keeps all `x` rows you can't check if any of them don't have a match in `y`.

```r
library(dplyr, warn.conflicts = FALSE)
library(clock)
set.seed(12345)

parties <- tibble(
  q = c(1:4),
  party = date_parse(c("2022-01-10", "2022-04-04", "2022-07-11", "2022-10-03")),
  start = date_parse(c("2022-01-01", "2022-04-01", "2022-07-01", "2022-10-01")),
  end = date_parse(c("2022-03-31", "2022-06-30", "2022-09-30", "2022-12-31"))
)

# Not sampling anything from the 4th quarter here
employees <- tibble(
  name = wakefield::name(100),
  birthday = date_parse("2022-01-01") + (sample(250, 100, replace = TRUE) - 1)
)

parties
#> # A tibble: 4 × 4
#>       q party      start      end       
#>   <int> <date>     <date>     <date>    
#> 1     1 2022-01-10 2022-01-01 2022-03-31
#> 2     2 2022-04-04 2022-04-01 2022-06-30
#> 3     3 2022-07-11 2022-07-01 2022-09-30
#> 4     4 2022-10-03 2022-10-01 2022-12-31
employees
#> # A tibble: 100 × 2
#>    name       birthday  
#>    <variable> <date>    
#>  1 Seager     2022-08-26
#>  2 Nathion    2022-01-21
#>  3 Sametra    2022-06-13
#>  4 Netty      2022-05-12
#>  5 Yalissa    2022-05-28
#>  6 Mirai      2022-08-20
#>  7 Toyoko     2022-05-14
#>  8 Earlene    2022-08-22
#>  9 Abbegayle  2022-08-23
#> 10 Valyssa    2022-08-30
#> # … with 90 more rows

# Max birthday is in Q3, so the Q4 `2022-10-03` party will be "unmatched"
employees %>% 
  slice_max(birthday, n = 1)
#> # A tibble: 1 × 2
#>   name       birthday  
#>   <variable> <date>    
#> 1 Rubie      2022-09-04

# - Checks that each `employee` has exactly 1 match
#   (through a combo of `unmatched = "error"` and `multiple = "error"`)
# - Drops unmatched `parties`, because we are more interested in the LHS table
#   (through `unmatched = "drop"`)
employees |>
  inner_join(
    parties,
    join_by(between(birthday, start, end)),
    unmatched = c("error", "drop"),
    multiple = "error"
  )
#> # A tibble: 100 × 6
#>    name       birthday       q party      start      end       
#>    <variable> <date>     <int> <date>     <date>     <date>    
#>  1 Seager     2022-08-26     3 2022-07-11 2022-07-01 2022-09-30
#>  2 Nathion    2022-01-21     1 2022-01-10 2022-01-01 2022-03-31
#>  3 Sametra    2022-06-13     2 2022-04-04 2022-04-01 2022-06-30
#>  4 Netty      2022-05-12     2 2022-04-04 2022-04-01 2022-06-30
#>  5 Yalissa    2022-05-28     2 2022-04-04 2022-04-01 2022-06-30
#>  6 Mirai      2022-08-20     3 2022-07-11 2022-07-01 2022-09-30
#>  7 Toyoko     2022-05-14     2 2022-04-04 2022-04-01 2022-06-30
#>  8 Earlene    2022-08-22     3 2022-07-11 2022-07-01 2022-09-30
#>  9 Abbegayle  2022-08-23     3 2022-07-11 2022-07-01 2022-09-30
#> 10 Valyssa    2022-08-30     3 2022-07-11 2022-07-01 2022-09-30
#> # … with 90 more rows
```
