### PR TITLE
WIP: Avoid stripping attributes in dplyr_reconstruct()

### DIFF
--- a/R/generics.R
+++ b/R/generics.R
@@ -179,13 +179,6 @@ dplyr_col_modify.rowwise_df <- function(data, cols) {
 #' @export
 #' @rdname dplyr_extending
 dplyr_reconstruct <- function(data, template) {
-  # Strip attributes before dispatch to make it easier to implement
-  # methods and prevent unexpected leaking of irrelevant attributes.
-  data <- dplyr_new_data_frame(data)
-  return(dplyr_reconstruct_dispatch(data, template))
-  UseMethod("dplyr_reconstruct", template)
-}
-dplyr_reconstruct_dispatch <- function(data, template) {
   UseMethod("dplyr_reconstruct", template)
 }
 

--- a/tests/testthat/test-generics.R
+++ b/tests/testthat/test-generics.R
@@ -121,6 +121,8 @@ test_that("compact row names are retained", {
 })
 
 test_that("dplyr_reconstruct() strips attributes before dispatch", {
+  skip("FIXME: replace with meaningful test that checks that row names are not touched.")
+
   local_methods(
     dplyr_reconstruct.dplyr_foobar = function(data, template) {
       out <<- data


### PR DESCRIPTION
Reverts #5277.

This avoids materialization of the lazy relational object.

We don't need this if https://github.com/duckdblabs/duckplyr/commit/9ceb8157d1cc2e17e1f27b6b09afd5fdc58670b7 is deemed okay.