### PR TITLE
Move `check_dots_unnamed()` into the method

### DIFF
--- a/R/slice.R
+++ b/R/slice.R
@@ -120,8 +120,6 @@
 #' filter(mtcars, row_number() == n())
 #' filter(mtcars, between(row_number(), 5, n()))
 slice <- function(.data, ..., .by = NULL, .preserve = FALSE) {
-  check_dots_unnamed()
-
   by <- enquo(.by)
 
   if (!quo_is_null(by) && !is_false(.preserve)) {
@@ -133,6 +131,8 @@ slice <- function(.data, ..., .by = NULL, .preserve = FALSE) {
 
 #' @export
 slice.data.frame <- function(.data, ..., .by = NULL, .preserve = FALSE) {
+  check_dots_unnamed()
+
   dots <- enquos(...)
 
   by <- compute_by(


### PR DESCRIPTION
Tweaks https://github.com/tidyverse/dplyr/pull/6558

Turns out that putting `check_dots_unnamed()` in the generic means that extension authors aren't able to add their own extra arguments (this came up with the dm revdep)

```r
slice <- function(.data, ..., .by = NULL) {
  rlang::check_dots_unnamed()
  UseMethod("slice")
} 

slice.my_class <- function(.data, ..., .my_arg = NULL) {
  list(.data, .my_arg)
}

df <- vctrs::new_data_frame(class = "my_class")

slice(df)
#> [[1]]
#> data frame with 0 columns and 0 rows
#> 
#> [[2]]
#> NULL

slice(df, .my_arg = 1)
#> Error in `slice()`:
#> ! Arguments in `...` must be passed by position, not name.
#> ✖ Problematic argument:
#> • .my_arg = 1
```

Moving the check to the method fixes that problem.

We are still left with the issue where extensions authors can't call `NextMethod()` if they have any extra arguments, but this was already broken due to how S3 works so I'm not worried about that case:

```r
slice <- function(.data, ..., .by = NULL) {
  UseMethod("slice")
}

slice.data.frame <- function(.data, ..., .by = NULL) {
  rlang::check_dots_unnamed()
  .data
}

slice.my_class <- function(.data, ..., .my_arg = NULL) {
  NextMethod()
}

df <- vctrs::new_data_frame(class = "my_class")

slice(df)
#> data frame with 0 columns and 0 rows

slice(df, .my_arg = 1)
#> Error in `slice()`:
#> ! Arguments in `...` must be passed by position, not name.
#> ✖ Problematic argument:
#> • .my_arg = .my_arg

#> Backtrace:
#>     ▆
#>  1. ├─global slice(df, .my_arg = 1)
#>  2. ├─global slice.my_class(df, .my_arg = 1)
#>  3. ├─base::NextMethod()
#>  4. └─global slice.data.frame(df, .my_arg = 1)
#>  5.   └─rlang::check_dots_unnamed()
#>  6.     └─rlang:::action_dots(...)
#>  7.       ├─base (local) try_dots(...)
#>  8.       └─rlang (local) action(...)
```

Here is proof that this already didn't work with CRAN dplyr. The `...` are passed through to the next method _including_ the optional arg, which results in a faulty `slice()` call, so anyone doing this already had broken code

```r
library(dplyr)

slice.my_class <- function(.data, ..., .my_arg = NULL) {
  NextMethod()
}

df <- vctrs::new_data_frame(list(x = 1:2), class = "my_class")
df
#>   x
#> 1 1
#> 2 2

slice(df, .my_arg = 1)
#>   x
#> 1 1
```