### PR TITLE
Add a `bind` alias to `bind_rows()`

### DIFF
--- a/R/bind-rows.R
+++ b/R/bind-rows.R
@@ -11,6 +11,7 @@
 #'   create an output column that identifies each input. The column will use
 #'   names if available, otherwise it will use positions.
 #' @returns A data frame the same type as the first element of `...`.
+#' @aliases bind
 #' @export
 #' @examples
 #' df1 <- tibble(x = 1:2, y = letters[1:2])

--- a/man/bind_rows.Rd
+++ b/man/bind_rows.Rd
@@ -2,6 +2,7 @@
 % Please edit documentation in R/bind-rows.R
 \name{bind_rows}
 \alias{bind_rows}
+\alias{bind}
 \title{Bind multiple data frames by row}
 \usage{
 bind_rows(..., .id = NULL)


### PR DESCRIPTION
~18 packages in https://github.com/tidyverse/dplyr/issues/6262 "failed" because they link to `bind_rows()` or `bind_cols()`, which had a topic name of `bind`, and that no longer exists now that those functions are on two different pages.

I've added a `bind` alias that goes to `bind_rows()`, since that is by far the more common one.

There are maybe 2 or 3 packages that were linking to `bind_cols()`, so this alias will redirect to `bind_rows()` for them now, but all they need to do is redocument and that will fix it, so I'm not worried.

I think CRAN would probably ignore these failures anyways, but this is an easy enough fix to get rid of them altogether 