### PR TITLE
Minor improvements to `join_by()` errors

### DIFF
--- a/R/join-by.R
+++ b/R/join-by.R
@@ -238,7 +238,7 @@ join_by <- function(...) {
 
   if (!is_null(names(exprs))) {
     abort(c(
-      "`join_by()` expressions can't be named.",
+      "Can't name join expressions.",
       i = "Did you use `=` instead of `==`?"
     ))
   }
@@ -403,7 +403,7 @@ join_by_common <- function(x_names,
 parse_join_by_expr <- function(expr, i, error_call) {
   if (is_missing(expr)) {
     message <- c(
-      "Join by expressions can't be missing.",
+      "Expressions can't be missing.",
       x = glue("Expression {i} is missing.")
     )
     abort(message, call = error_call)
@@ -411,7 +411,7 @@ parse_join_by_expr <- function(expr, i, error_call) {
 
   if (length(expr) == 0L) {
     message <- c(
-      "Join by expressions can't be empty.",
+      "Expressions can't be empty.",
       x = glue("Expression {i} is empty.")
     )
     abort(message, call = error_call)
@@ -454,7 +454,7 @@ parse_join_by_expr <- function(expr, i, error_call) {
 
 stop_invalid_dollar_sign <- function(expr, i, call) {
   message <- c(
-    "When specifying a single column name, `$` cannot be used.",
+    "Can't use `$` when specifying a single column name.",
     i = glue("Expression {i} is {err_expr(expr)}.")
   )
 
@@ -467,7 +467,7 @@ stop_invalid_top_expression <- function(expr, i, call) {
   options <- glue_collapse(options, sep = ", ", last = ", or ")
 
   message <- c(
-    glue("Join by expressions must use one of: {options}."),
+    glue("Expressions must use one of: {options}."),
     i = glue("Expression {i} is {err_expr(expr)}.")
   )
 
@@ -489,7 +489,7 @@ parse_join_by_name <- function(expr,
 
   message <- c(
     paste0(
-      "`join_by()` expressions cannot contain computed columns, ",
+      "Expressions can't contain computed columns, ",
       "and can only reference columns by name or by explicitly specifying ",
       "a side, like `x$col` or `y$col`."
     ),

--- a/tests/testthat/_snaps/join-by.md
+++ b/tests/testthat/_snaps/join-by.md
@@ -13,7 +13,7 @@
       fn(a)
     Condition
       Error in `join_by()`:
-      ! Join by expressions can't be missing.
+      ! Expressions can't be missing.
       x Expression 2 is missing.
 
 ---
@@ -77,7 +77,7 @@
       join_by(a = b)
     Condition
       Error in `join_by()`:
-      ! `join_by()` expressions can't be named.
+      ! Can't name join expressions.
       i Did you use `=` instead of `==`?
 
 ---
@@ -86,7 +86,7 @@
       join_by(NULL)
     Condition
       Error in `join_by()`:
-      ! Join by expressions can't be empty.
+      ! Expressions can't be empty.
       x Expression 1 is empty.
 
 ---
@@ -95,7 +95,7 @@
       join_by(foo(x > y))
     Condition
       Error in `join_by()`:
-      ! Join by expressions must use one of: `==`, `>=`, `>`, `<=`, `<`, `closest()`, `between()`, `overlaps()`, or `within()`.
+      ! Expressions must use one of: `==`, `>=`, `>`, `<=`, `<`, `closest()`, `between()`, `overlaps()`, or `within()`.
       i Expression 1 is `foo(x > y)`.
 
 ---
@@ -104,7 +104,7 @@
       join_by(x == y, x^y)
     Condition
       Error in `join_by()`:
-      ! Join by expressions must use one of: `==`, `>=`, `>`, `<=`, `<`, `closest()`, `between()`, `overlaps()`, or `within()`.
+      ! Expressions must use one of: `==`, `>=`, `>`, `<=`, `<`, `closest()`, `between()`, `overlaps()`, or `within()`.
       i Expression 2 is `x^y`.
 
 ---
@@ -113,7 +113,7 @@
       join_by(x + 1 == y)
     Condition
       Error in `join_by()`:
-      ! `join_by()` expressions cannot contain computed columns, and can only reference columns by name or by explicitly specifying a side, like `x$col` or `y$col`.
+      ! Expressions can't contain computed columns, and can only reference columns by name or by explicitly specifying a side, like `x$col` or `y$col`.
       i Expression 1 contains `x + 1`.
 
 ---
@@ -122,7 +122,7 @@
       join_by(x == y + 1)
     Condition
       Error in `join_by()`:
-      ! `join_by()` expressions cannot contain computed columns, and can only reference columns by name or by explicitly specifying a side, like `x$col` or `y$col`.
+      ! Expressions can't contain computed columns, and can only reference columns by name or by explicitly specifying a side, like `x$col` or `y$col`.
       i Expression 1 contains `y + 1`.
 
 ---
@@ -140,7 +140,7 @@
       join_by(x$a)
     Condition
       Error in `join_by()`:
-      ! When specifying a single column name, `$` cannot be used.
+      ! Can't use `$` when specifying a single column name.
       i Expression 1 is `x$a`.
 
 ---


### PR DESCRIPTION
- No need to mention `join_by()` in the error because it is part of the call
- Otherwise updating a few of the errors to the more modern style of starting with `Can't` where it seemed useful