### PR TITLE
Move `across()` dots deprecation from `deprecate_warn()` to `deprecate_soft()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -189,9 +189,10 @@
     soft-deprecated, because there was no good alternative until now, but itis
     discouraged and will be soft-deprecated in the next minor release.
 
-* Passing `...` to `across()` is deprecated because it's ambiguous when those
-  arguments are evaluated. Now, instead of (e.g.) `across(a:b, mean, na.rm = TRUE)`
-  you should write `across(a:b, ~ mean(.x, na.rm = TRUE))` (#6073).
+* Passing `...` to `across()` is soft-deprecated because it's ambiguous when
+  those arguments are evaluated. Now, instead of (e.g.)
+  `across(a:b, mean, na.rm = TRUE)` you should write
+  `across(a:b, ~ mean(.x, na.rm = TRUE))` (#6073).
 
 * `all_equal()` is deprecated. We've advised against it for some time, and 
   we explicitly recommend you use `all.equal()`, manually reordering the rows 

--- a/R/across.R
+++ b/R/across.R
@@ -218,7 +218,7 @@ across <- function(.cols,
       " " = "# Now",
       " " = "across(a:b, \\(x) mean(x, na.rm = TRUE))"
     )
-    lifecycle::deprecate_warn(
+    lifecycle::deprecate_soft(
       when = "1.1.0",
       what = "across(...)",
       details = details


### PR DESCRIPTION
Closes #6620 
Alters https://github.com/tidyverse/dplyr/pull/6365

This is a new deprecation and is likely to affect quite a few people, so we should start with soft-deprecation. Practically, it came up in revdeps where the warning was being propagated through a dependency package that the revdep package author didn't control.