### PR TITLE
Inline lambdas supplied in lists

### DIFF
--- a/R/across.R
+++ b/R/across.R
@@ -913,7 +913,7 @@ quo_eval_fns <- function(quo, mask, error_call = caller_env()) {
   validate <- function(x) {
     if (is_formula(x) || is_function(x)) {
       # If the function or formula inherits from the data-less quosure
-      # mask, we we have a lambda that was directly supplied and
+      # mask, we have a lambda that was directly supplied and
       # evaluated here. We inline it if possible.
       if (identical(get_env(x), sentinel_env)) {
         if (is_inlinable_function(x)) {


### PR DESCRIPTION
I realised that with the lambda detection set up in #6550, we can now easily inline lambdas supplied in lists. This PR changes the detection of inlinable lambdas to use the environment-sentinel approach instead of a metaprogramming approach. This simplifies things a bit and makes the expansion behaviour more consistent and predictable.

```r
gdf <- tibble(g = seq_len(1e5), x = g) %>% group_by(g)

bench::mark(
  expr = gdf %>% mutate(x_1 = identity(x), x_2 = identity(x)),
  formula = gdf %>% mutate(across(x, list(~ identity(.), ~ identity(.)))),
  lambda = gdf %>% mutate(across(x, list(\(.) identity(.), \(.) identity(.)))),
  iterations = 20
)[1:8]

#> # Before
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:by>   <dbl> <int> <dbl>
#> 1 expr          177ms    180ms      5.54     13MB    6.10    20    22
#> 2 formula       240ms    244ms      3.87     13MB    7.75    20    40
#> 3 lambda        205ms    210ms      4.73     13MB    7.34    20    31

#> # After
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:by>   <dbl> <int> <dbl>
#> 1 expr          177ms    182ms      5.46     14MB    6.83    20    25
#> 2 formula       178ms    182ms      5.09   13.1MB    6.88    20    27
#> 3 lambda        176ms    180ms      5.50   13.2MB    7.15    20    26
```