### PR TITLE
Speed up `add_suffixes()`.

### DIFF
--- a/R/join-cols.R
+++ b/R/join-cols.R
@@ -162,14 +162,19 @@ add_suffixes <- function(x, y, suffix) {
     return(x)
   }
 
-  out <- rep_along(x, na_chr)
-  for (i in seq_along(x)) {
-    nm <- x[[i]]
-    while (nm %in% y || nm %in% out[seq_len(i - 1)]) {
-      nm <- paste0(nm, suffix)
+  if (isTRUE(any(endsWith(c(x, y), suffix)))) {
+    out <- rep_along(x, na_chr)
+    for (i in seq_along(x)) {
+      nm <- x[[i]]
+      while (nm %in% y || nm %in% out[seq_len(i - 1)]) {
+        nm <- paste0(nm, suffix)
+      }
+      out[[i]] <- nm
     }
-
-    out[[i]] <- nm
+  } else {
+    out <- x
+    x_in_y <- x %in% y
+    out[x_in_y] <- paste0(x[x_in_y], suffix)
   }
   out
 }


### PR DESCRIPTION
For the (common) case where neither `x` nor `y` have strings ending in `suffix` there is a speedup available. This is important for joining very wide data, where `add_suffixes()` is the longest-running part.

Before this PR, the following code takes >300s to complete. Now it is down below 2s.

``` r
x <- matrix(runif(2e5), nrow = 2) |>
  magrittr::set_colnames(paste0("x", seq_len(1e5))) |>
  dplyr::as_tibble() |>
  dplyr::mutate(k = c("a", "b"))

y <- matrix(runif(2e5), nrow = 2) |>
  magrittr::set_colnames(paste0("y", seq_len(1e5))) |>
  dplyr::as_tibble() |>
  dplyr::mutate(k = c("b", "a"))

system.time(dplyr::inner_join(x, y, by = "k"))
#>    user  system elapsed 
#>   1.153   0.033   1.189
```

<sup>Created on 2023-01-10 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>