### PR TITLE
Vectorize `add_suffixes()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -339,6 +339,9 @@ package, bringing greater consistency and improved performance.
 * Joins now reference the correct column in `y` when a type error is thrown
   while joining on two columns with different names (#6465).
 
+* Joins on very wide tables are no longer limited by the application of `suffix`
+  (#6642).
+
 * `*_join()` now error if you supply them with additional arguments that
   aren't used (#6228).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -339,8 +339,8 @@ package, bringing greater consistency and improved performance.
 * Joins now reference the correct column in `y` when a type error is thrown
   while joining on two columns with different names (#6465).
 
-* Joins on very wide tables are no longer limited by the application of `suffix`
-  (#6642).
+* Joins on very wide tables are no longer bottlenecked by the application of
+  `suffix` (#6642).
 
 * `*_join()` now error if you supply them with additional arguments that
   aren't used (#6228).

--- a/R/join-cols.R
+++ b/R/join-cols.R
@@ -157,21 +157,27 @@ standardise_join_suffix <- function(x,
   list(x = x[[1]], y = x[[2]])
 }
 
+# `join_cols()` checks that `x` and `y` are individually unique,
+# which plays into assumptions made here
 add_suffixes <- function(x, y, suffix) {
   if (identical(suffix, "")) {
     return(x)
   }
 
-  out <- rep_along(x, na_chr)
-  for (i in seq_along(x)) {
-    nm <- x[[i]]
-    while (nm %in% y || nm %in% out[seq_len(i - 1)]) {
-      nm <- paste0(nm, suffix)
-    }
+  x <- c(y, x)
 
-    out[[i]] <- nm
+  # Never marks the "first" duplicate (i.e. never anything in `y`)
+  dup <- duplicated(x)
+
+  while (any(dup)) {
+    x[dup] <- paste0(x[dup], suffix)
+    dup <- duplicated(x)
   }
-  out
+
+  loc <- seq2(length(y) + 1L, length(x))
+  x <- x[loc]
+
+  x
 }
 
 join_cast_common <- function(x, y, vars, error_call = caller_env()) {


### PR DESCRIPTION
Closes https://github.com/tidyverse/dplyr/pull/6636

Alternate approach that truly vectorizes the calculation. I'm about 95% sure this is correct. It passes all tests and we do have a decent number of tests that check corner cases of `suffix` so I'm fairly confident about it.