### PR TITLE
error in `across()` when supplied `...` without a `.fns` argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -355,6 +355,9 @@ package, bringing greater consistency and improved performance.
 * Functions supplied to `across()` are no longer masked by columns (#6545). For
   instance, `across(1:2, mean)` will now work as expected even if there is a
   column called `mean`.
+  
+* `across()` will now error when supplied `...` without a `.fns` argument 
+  (#6638).
 
 * `arrange()` now correctly ignores `NULL` inputs (#6193).
 

--- a/R/across.R
+++ b/R/across.R
@@ -192,6 +192,10 @@ across <- function(.cols,
     # Silent restoration to old defaults of `.fns` for now.
     # TODO: Escalate this to formal deprecation.
     .fns <- NULL
+
+    # Catch if dots are non-empty with no `.fns` supplied.
+    # Mainly catches typos, e.g. `.funs` (#6638).
+    check_dots_empty0(...)
   } else {
     .fns <- quo_eval_fns(fns_quo, mask = fns_quo_env, error_call = error_call)
   }

--- a/tests/testthat/_snaps/across.md
+++ b/tests/testthat/_snaps/across.md
@@ -473,6 +473,18 @@
       i Please supply `cols` instead.
       i Run `dplyr::last_dplyr_warnings()` to see the 1 remaining warning.
 
+# across errors with non-empty dots and no `.fns` supplied (#6638)
+
+    Code
+      mutate(df, across(x, .funs = ~ . * 1000))
+    Condition
+      Error in `mutate()`:
+      i In argument: `across(x, .funs = ~. * 1000)`.
+      Caused by error in `across()`:
+      ! `...` must be empty.
+      x Problematic argument:
+      * .funs = ~. * 1000
+
 # across(...) is deprecated
 
     Code

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -1185,6 +1185,15 @@ test_that("if_any() and if_all() apply old `.fns = NULL` default", {
   expect_identical(filter(df, (if_all(everything()))), df[3,])
 })
 
+test_that("across errors with non-empty dots and no `.fns` supplied (#6638)", {
+  df <- tibble(x = 1)
+
+  expect_snapshot(
+    error = TRUE,
+    mutate(df, across(x, .funs = ~ . * 1000))
+  )
+})
+
 # dots --------------------------------------------------------------------
 
 test_that("across(...) is deprecated", {


### PR DESCRIPTION
Closes #6638. cc @DavisVaughan 