### PR TITLE
Better document `.by` vs `by` and catch typos in `filter()` and `slice*()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## New features
 
-* `.by` is an experimental alternative to `group_by()` that supports 
+* `by`/`.by` is an experimental alternative to `group_by()` that supports 
   per-operation grouping for `mutate()`, `summarise()`, `filter()`, and the 
   `slice()` family (#6528).
   

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## New features
 
-* `by`/`.by` is an experimental alternative to `group_by()` that supports 
+* `.by`/`by` is an experimental alternative to `group_by()` that supports 
   per-operation grouping for `mutate()`, `summarise()`, `filter()`, and the 
   `slice()` family (#6528).
   

--- a/R/by.R
+++ b/R/by.R
@@ -12,7 +12,7 @@
 #' @keywords internal
 NULL
 
-#' Per-operation grouping with `by`/`.by`
+#' Per-operation grouping with `.by`/`by`
 #'
 #' ```{r, echo = FALSE, results = "asis"}
 #' result <- rlang::with_options(

--- a/R/by.R
+++ b/R/by.R
@@ -124,3 +124,41 @@ eval_select_by <- function(by,
 new_by <- function(type, names, data) {
   structure(list(type = type, names = names, data = data), class = "dplyr_by")
 }
+
+check_by_typo <- function(...,
+                          by = NULL,
+                          error_call = caller_env()) {
+  check_by_typo_impl(
+    wrong = "by",
+    right = ".by",
+    by = {{ by }},
+    error_call = error_call
+  )
+}
+check_dot_by_typo <- function(...,
+                              .by = NULL,
+                              error_call = caller_env()) {
+  check_by_typo_impl(
+    wrong = ".by",
+    right = "by",
+    by = {{ .by }},
+    error_call = error_call
+  )
+}
+check_by_typo_impl <- function(wrong,
+                               right,
+                               by = NULL,
+                               error_call = caller_env()) {
+  by <- enquo(by)
+
+  if (quo_is_null(by)) {
+    return(invisible())
+  }
+
+  message <- c(
+    "Can't specify an argument named {.code {wrong}} in this verb.",
+    i = "Did you mean to use {.code {right}} instead?"
+  )
+
+  cli::cli_abort(message, call = error_call)
+}

--- a/R/by.R
+++ b/R/by.R
@@ -12,7 +12,7 @@
 #' @keywords internal
 NULL
 
-#' Per-operation grouping with `.by`
+#' Per-operation grouping with `by`/`.by`
 #'
 #' ```{r, echo = FALSE, results = "asis"}
 #' result <- rlang::with_options(

--- a/R/filter.R
+++ b/R/filter.R
@@ -107,6 +107,8 @@
 #'   )
 #' # Learn more in ?dplyr_data_masking
 filter <- function(.data, ..., .by = NULL, .preserve = FALSE) {
+  check_by_typo(...)
+
   by <- enquo(.by)
 
   if (!quo_is_null(by) && !is_false(.preserve)) {

--- a/R/slice.R
+++ b/R/slice.R
@@ -120,6 +120,8 @@
 #' filter(mtcars, row_number() == n())
 #' filter(mtcars, between(row_number(), 5, n()))
 slice <- function(.data, ..., .by = NULL, .preserve = FALSE) {
+  check_by_typo(...)
+
   by <- enquo(.by)
 
   if (!quo_is_null(by) && !is_false(.preserve)) {
@@ -149,6 +151,7 @@ slice.data.frame <- function(.data, ..., .by = NULL, .preserve = FALSE) {
 #' @export
 #' @rdname slice
 slice_head <- function(.data, ..., n, prop, by = NULL) {
+  check_dot_by_typo(...)
   check_slice_unnamed_n_prop(..., n = n, prop = prop)
 
   UseMethod("slice_head")
@@ -172,6 +175,7 @@ slice_head.data.frame <- function(.data, ..., n, prop, by = NULL) {
 #' @export
 #' @rdname slice
 slice_tail <- function(.data, ..., n, prop, by = NULL) {
+  check_dot_by_typo(...)
   check_slice_unnamed_n_prop(..., n = n, prop = prop)
 
   UseMethod("slice_tail")
@@ -206,6 +210,7 @@ slice_tail.data.frame <- function(.data, ..., n, prop, by = NULL) {
 #'   reach `n`/`prop`.
 slice_min <- function(.data, order_by, ..., n, prop, by = NULL, with_ties = TRUE, na_rm = FALSE) {
   check_required(order_by)
+  check_dot_by_typo(...)
   check_slice_unnamed_n_prop(..., n = n, prop = prop)
   check_bool(with_ties)
   check_bool(na_rm)
@@ -245,6 +250,7 @@ slice_min.data.frame <- function(.data, order_by, ..., n, prop, by = NULL, with_
 #' @rdname slice
 slice_max <- function(.data, order_by, ..., n, prop, by = NULL, with_ties = TRUE, na_rm = FALSE) {
   check_required(order_by)
+  check_dot_by_typo(...)
   check_slice_unnamed_n_prop(..., n = n, prop = prop)
   check_bool(with_ties)
   check_bool(na_rm)
@@ -289,6 +295,7 @@ slice_max.data.frame <- function(.data, order_by, ..., n, prop, by = NULL, with_
 #'   This must evaluate to a vector of non-negative numbers the same length as
 #'   the input. Weights are automatically standardised to sum to 1.
 slice_sample <- function(.data, ..., n, prop, by = NULL, weight_by = NULL, replace = FALSE) {
+  check_dot_by_typo(...)
   check_slice_unnamed_n_prop(..., n = n, prop = prop)
   check_bool(replace)
 

--- a/man/dplyr_by.Rd
+++ b/man/dplyr_by.Rd
@@ -2,27 +2,38 @@
 % Please edit documentation in R/by.R
 \name{dplyr_by}
 \alias{dplyr_by}
-\title{Per-operation grouping with \code{.by}}
+\title{Per-operation grouping with \code{by}/\code{.by}}
 \description{
 There are two ways to group in dplyr:
 \itemize{
 \item Persistent grouping with \code{\link[=group_by]{group_by()}}
-\item Per-operation grouping with \code{.by}
+\item Per-operation grouping with \code{by}/\code{.by}
 }
 
 This help page is dedicated to explaining where and why you might want to use the latter.
+
+Depending on the dplyr verb, the per-operation grouping argument may be named \code{by} or \code{.by}.
+The \emph{Supported verbs} section below outlines this on a case-by-case basis.
+The remainder of this page will refer to \code{.by} for simplicity.
+
 Grouping radically affects the computation of the dplyr verb you use it with, and one of the goals of \code{.by} is to allow you to place that grouping specification alongside the code that actually uses it.
 As an added benefit, with \code{.by} you no longer need to remember to \code{\link[=ungroup]{ungroup()}} after \code{\link[=summarise]{summarise()}}, and \code{summarise()} won't ever message you about how it's handling the groups!
 
-This great idea comes from \href{https://CRAN.R-project.org/package=data.table}{data.table}, which allows you to specify \code{by} alongside modifications in \code{j}, like: \code{dt[, .(x = mean(x)), by = g]}.
+This idea comes from \href{https://CRAN.R-project.org/package=data.table}{data.table}, which allows you to specify \code{by} alongside modifications in \code{j}, like: \code{dt[, .(x = mean(x)), by = g]}.
 \subsection{Supported verbs}{
 \itemize{
-\item \code{\link[=mutate]{mutate()}}
-\item \code{\link[=summarise]{summarise()}}
-\item \code{\link[=reframe]{reframe()}}
-\item \code{\link[=filter]{filter()}}
-\item \code{\link[=slice]{slice()}} and its variants, such as \code{\link[=slice_head]{slice_head()}}
+\item \code{\link[=mutate]{mutate(.by = )}}
+\item \code{\link[=summarise]{summarise(.by = )}}
+\item \code{\link[=reframe]{reframe(.by = )}}
+\item \code{\link[=filter]{filter(.by = )}}
+\item \code{\link[=slice]{slice(.by = )}}
+\item \code{\link[=slice_head]{slice_head(by = )}} and \code{\link[=slice_tail]{slice_tail(by = )}}
+\item \code{\link[=slice_min]{slice_min(by = )}} and \code{\link[=slice_max]{slice_max(by = )}}
+\item \code{\link[=slice_sample]{slice_sample(by = )}}
 }
+
+Note that some dplyr verbs use \code{by} while others use \code{.by}.
+This is a purely technical difference.
 }
 
 \subsection{Differences between \code{.by} and \code{group_by()}}{\tabular{ll}{
@@ -146,7 +157,8 @@ For example, you could append the mean cost per region onto the original data fr
 
 Or you could slice out the maximum cost per combination of id and region:
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{expenses \%>\%
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{# Note that the argument is named `by` in `slice_max()`
+expenses \%>\%
   slice_max(cost, n = 1, by = c(id, region))
 #> # A tibble: 5 x 3
 #>      id region  cost

--- a/man/dplyr_by.Rd
+++ b/man/dplyr_by.Rd
@@ -2,17 +2,17 @@
 % Please edit documentation in R/by.R
 \name{dplyr_by}
 \alias{dplyr_by}
-\title{Per-operation grouping with \code{by}/\code{.by}}
+\title{Per-operation grouping with \code{.by}/\code{by}}
 \description{
 There are two ways to group in dplyr:
 \itemize{
 \item Persistent grouping with \code{\link[=group_by]{group_by()}}
-\item Per-operation grouping with \code{by}/\code{.by}
+\item Per-operation grouping with \code{.by}/\code{by}
 }
 
 This help page is dedicated to explaining where and why you might want to use the latter.
 
-Depending on the dplyr verb, the per-operation grouping argument may be named \code{by} or \code{.by}.
+Depending on the dplyr verb, the per-operation grouping argument may be named \code{.by} or \code{by}.
 The \emph{Supported verbs} section below outlines this on a case-by-case basis.
 The remainder of this page will refer to \code{.by} for simplicity.
 

--- a/man/rmd/by.Rmd
+++ b/man/rmd/by.Rmd
@@ -12,11 +12,11 @@ There are two ways to group in dplyr:
 
 -   Persistent grouping with [group_by()]
 
--   Per-operation grouping with `by`/`.by`
+-   Per-operation grouping with `.by`/`by`
 
 This help page is dedicated to explaining where and why you might want to use the latter.
 
-Depending on the dplyr verb, the per-operation grouping argument may be named `by` or `.by`.
+Depending on the dplyr verb, the per-operation grouping argument may be named `.by` or `by`.
 The *Supported verbs* section below outlines this on a case-by-case basis.
 The remainder of this page will refer to `.by` for simplicity.
 

--- a/man/rmd/by.Rmd
+++ b/man/rmd/by.Rmd
@@ -12,30 +12,44 @@ There are two ways to group in dplyr:
 
 -   Persistent grouping with [group_by()]
 
--   Per-operation grouping with `.by`
+-   Per-operation grouping with `by`/`.by`
 
 This help page is dedicated to explaining where and why you might want to use the latter.
+
+Depending on the dplyr verb, the per-operation grouping argument may be named `by` or `.by`.
+The *Supported verbs* section below outlines this on a case-by-case basis.
+The remainder of this page will refer to `.by` for simplicity.
+
 Grouping radically affects the computation of the dplyr verb you use it with, and one of the goals of `.by` is to allow you to place that grouping specification alongside the code that actually uses it.
 As an added benefit, with `.by` you no longer need to remember to [ungroup()] after [summarise()], and `summarise()` won't ever message you about how it's handling the groups!
 
-This great idea comes from [data.table](https://CRAN.R-project.org/package=data.table), which allows you to specify `by` alongside modifications in `j`, like: `dt[, .(x = mean(x)), by = g]`.
+This idea comes from [data.table](https://CRAN.R-project.org/package=data.table), which allows you to specify `by` alongside modifications in `j`, like: `dt[, .(x = mean(x)), by = g]`.
 
 ### Supported verbs
 
--   [mutate()]
+-   [`mutate(.by = )`][mutate()]
 
--   [summarise()]
+-   [`summarise(.by = )`][summarise()]
 
--   [reframe()]
+-   [`reframe(.by = )`][reframe()]
 
--   [filter()]
+-   [`filter(.by = )`][filter()]
 
--   [slice()] and its variants, such as [slice_head()]
+-   [`slice(.by = )`][slice()]
+
+-   [`slice_head(by = )`][slice_head()] and [`slice_tail(by = )`][slice_tail()]
+
+-   [`slice_min(by = )`][slice_min()] and [`slice_max(by = )`][slice_max()]
+
+-   [`slice_sample(by = )`][slice_sample()]
+
+Note that some dplyr verbs use `by` while others use `.by`.
+This is a purely technical difference.
 
 ### Differences between `.by` and `group_by()`
 
 | `.by`                                                   | `group_by()`                                                 |
-|---------------------------------------------------------|--------------------------------------------------------------|
+|----------------------------------|-------------------------------------|
 | Grouping only affects a single verb                     | Grouping is persistent across multiple verbs                 |
 | Selects variables with [tidy-select][dplyr_tidy_select] | Computes expressions with [data-masking][dplyr_data_masking] |
 | Summaries use existing order of group keys              | Summaries sort group keys in ascending order                 |
@@ -109,6 +123,7 @@ expenses %>%
 Or you could slice out the maximum cost per combination of id and region:
 
 ```{r}
+# Note that the argument is named `by` in `slice_max()`
 expenses %>%
   slice_max(cost, n = 1, by = c(id, region))
 ```

--- a/man/rmd/by.Rmd
+++ b/man/rmd/by.Rmd
@@ -49,7 +49,7 @@ This is a purely technical difference.
 ### Differences between `.by` and `group_by()`
 
 | `.by`                                                   | `group_by()`                                                 |
-|----------------------------------|-------------------------------------|
+|---------------------------------------------------------|--------------------------------------------------------------|
 | Grouping only affects a single verb                     | Grouping is persistent across multiple verbs                 |
 | Selects variables with [tidy-select][dplyr_tidy_select] | Computes expressions with [data-masking][dplyr_data_masking] |
 | Summaries use existing order of group keys              | Summaries sort group keys in ascending order                 |

--- a/tests/testthat/_snaps/filter.md
+++ b/tests/testthat/_snaps/filter.md
@@ -253,3 +253,12 @@
       Error in `filter()`:
       ! Can't supply `.by` when `.data` is a rowwise data frame.
 
+# catches `by` typo (#6647)
+
+    Code
+      filter(df, by = x)
+    Condition
+      Error in `filter()`:
+      ! Can't specify an argument named `by` in this verb.
+      i Did you mean to use `.by` instead?
+

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -50,12 +50,12 @@
 # `...` can't be named (#6554)
 
     Code
-      slice(df, 1, by = g)
+      slice(df, 1, foo = g)
     Condition
       Error in `slice()`:
       ! Arguments in `...` must be passed by position, not name.
       x Problematic argument:
-      * by = g
+      * foo = g
 
 # can't use `.by` with `.preserve`
 
@@ -80,6 +80,15 @@
     Condition
       Error in `slice()`:
       ! Can't supply `.by` when `.data` is a rowwise data frame.
+
+# catches `by` typo (#6647)
+
+    Code
+      slice(df, by = x)
+    Condition
+      Error in `slice()`:
+      ! Can't specify an argument named `by` in this verb.
+      i Did you mean to use `.by` instead?
 
 # slice_helpers() call get_slice_size()
 
@@ -257,6 +266,39 @@
     Condition
       Error in `slice_sample()`:
       ! Can't supply `by` when `.data` is a grouped data frame.
+
+# slice_helper catches `.by` typo (#6647)
+
+    Code
+      slice_head(df, n = 1, .by = x)
+    Condition
+      Error in `slice_head()`:
+      ! Can't specify an argument named `.by` in this verb.
+      i Did you mean to use `by` instead?
+    Code
+      slice_tail(df, n = 1, .by = x)
+    Condition
+      Error in `slice_tail()`:
+      ! Can't specify an argument named `.by` in this verb.
+      i Did you mean to use `by` instead?
+    Code
+      slice_min(df, order_by = x, .by = x)
+    Condition
+      Error in `slice_min()`:
+      ! Can't specify an argument named `.by` in this verb.
+      i Did you mean to use `by` instead?
+    Code
+      slice_max(df, order_by = x, .by = x)
+    Condition
+      Error in `slice_max()`:
+      ! Can't specify an argument named `.by` in this verb.
+      i Did you mean to use `by` instead?
+    Code
+      slice_sample(df, n = 1, .by = x)
+    Condition
+      Error in `slice_sample()`:
+      ! Can't specify an argument named `.by` in this verb.
+      i Did you mean to use `by` instead?
 
 # slice_min/max() check size of `order_by=` (#5922)
 

--- a/tests/testthat/test-filter.R
+++ b/tests/testthat/test-filter.R
@@ -678,3 +678,11 @@ test_that("catches `.by` with rowwise-df", {
     filter(rdf, .by = x)
   })
 })
+
+test_that("catches `by` typo (#6647)", {
+  df <- tibble(x = 1)
+
+  expect_snapshot(error = TRUE, {
+    filter(df, by = x)
+  })
+})

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -99,9 +99,8 @@ test_that("user errors are correctly labelled", {
 test_that("`...` can't be named (#6554)", {
   df <- tibble(g = 1, x = 1)
 
-  # Avoids accidentally matching to `.by`
   expect_snapshot(error = TRUE, {
-    slice(df, 1, by = g)
+    slice(df, 1, foo = g)
   })
 })
 
@@ -200,6 +199,14 @@ test_that("catches `.by` with rowwise-df", {
 
   expect_snapshot(error = TRUE, {
     slice(rdf, .by = x)
+  })
+})
+
+test_that("catches `by` typo (#6647)", {
+  df <- tibble(x = 1)
+
+  expect_snapshot(error = TRUE, {
+    slice(df, by = x)
   })
 })
 
@@ -343,6 +350,18 @@ test_that("slice_helper `by` errors use correct error context and correct `by_ar
     slice_min(gdf, order_by = x, by = x)
     slice_max(gdf, order_by = x, by = x)
     slice_sample(gdf, n = 1, by = x)
+  })
+})
+
+test_that("slice_helper catches `.by` typo (#6647)", {
+  df <- tibble(x = 1)
+
+  expect_snapshot(error = TRUE, {
+    slice_head(df, n = 1, .by = x)
+    slice_tail(df, n = 1, .by = x)
+    slice_min(df, order_by = x, .by = x)
+    slice_max(df, order_by = x, .by = x)
+    slice_sample(df, n = 1, .by = x)
   })
 })
 


### PR DESCRIPTION
Closes #6647

- The `?dplyr_by` docs now do a better job of documenting that you may see either one of these depending on the dplyr verb. In particular the _Supported verbs_ section now tells you which verb uses which form of `by`.
- `filter()` now catches if you accidentally type `by =`
- `slice()` now catches if you accidentally type `by =`
- `slice_*()` now catches if you accidentally type `.by =`

As mentioned in #6647, we can't catch typos in `mutate()`, `summarise()` or `reframe()`, which all use `.by`. This is because `by` is a valid column name in those cases. But since we typically talk about per operation grouping using `.by`, this is what most people will reach for, so they are less likely to be confused in these three functions.