### PR TITLE
Note instability of `nest_by()` and `group_nest/split()`

### DIFF
--- a/R/colwise-mutate.R
+++ b/R/colwise-mutate.R
@@ -75,7 +75,7 @@
 #'
 #' Name collisions in the new columns are disambiguated using a unique suffix.
 #'
-#' @section Life cycle:
+#' @section Lifecycle:
 #'
 #' The functions are maturing, because the naming scheme and the
 #' disambiguation algorithm are subject to change in dplyr 0.9.0.
@@ -196,7 +196,7 @@ summarize_at <- summarise_at
 #'   `transmute_if()`.
 #'
 #' @inheritSection summarise_all Naming
-#' @inheritSection summarise_all Life cycle
+#' @inheritSection summarise_all Lifecycle
 #'
 #' @examples
 #' iris <- as_tibble(iris)

--- a/R/group-nest.R
+++ b/R/group-nest.R
@@ -10,7 +10,7 @@ group_nest_impl <- function(.tbl, .key, keep = FALSE){
 #'
 #' Nest a tibble using a grouping specification
 #'
-#' @section Life cycle:
+#' @section Lifecycle:
 #' `group_nest()` is not stable because [`tidyr::nest(.by =)`][tidyr::nest()]
 #' provides very similar behavior. It may be deprecated in the future.
 #'

--- a/R/group-nest.R
+++ b/R/group-nest.R
@@ -10,6 +10,10 @@ group_nest_impl <- function(.tbl, .key, keep = FALSE){
 #'
 #' Nest a tibble using a grouping specification
 #'
+#' @section Life cycle:
+#' `group_nest()` is not stable because [`tidyr::nest(.by =)`][tidyr::nest()]
+#' provides very similar behavior. It may be deprecated in the future.
+#'
 #' @section Grouped data frames:
 #'
 #' The primary use case for [group_nest()] is with already grouped data frames,

--- a/R/group-split.R
+++ b/R/group-split.R
@@ -17,6 +17,13 @@
 #' is generally not very useful as you want have easy access to the group
 #' metadata.
 #'
+#' @section Life cycle:
+#' `group_split()` is not stable because you can achieve very similar results by
+#' manipulating the nested column returned from
+#' [`tidyr::nest(.by =)`][tidyr::nest()]. That also retains the group keys all
+#' within a single data structure. `group_split()` may be deprecated in the
+#' future.
+#'
 #' @param .tbl A tbl.
 #' @param ... If `.tbl` is an ungrouped data frame, a grouping specification,
 #'   forwarded to [group_by()].
@@ -26,6 +33,7 @@
 #'   Note that this returns a [list_of][vctrs::list_of()] which is slightly
 #'   stricter than a simple list but is useful for representing lists where
 #'   every element has the same type.
+#' @keywords internal
 #' @family grouping functions
 #' @export
 #' @examples

--- a/R/group-split.R
+++ b/R/group-split.R
@@ -17,7 +17,7 @@
 #' is generally not very useful as you want have easy access to the group
 #' metadata.
 #'
-#' @section Life cycle:
+#' @section Lifecycle:
 #' `group_split()` is not stable because you can achieve very similar results by
 #' manipulating the nested column returned from
 #' [`tidyr::nest(.by =)`][tidyr::nest()]. That also retains the group keys all

--- a/R/nest-by.R
+++ b/R/nest-by.R
@@ -30,7 +30,7 @@
 #'   reframe(data)
 #' ```
 #'
-#' @section Life cycle:
+#' @section Lifecycle:
 #' `nest_by()` is not stable because [`tidyr::nest(.by =)`][tidyr::nest()]
 #' provides very similar behavior. It may be deprecated in the future.
 #'

--- a/R/nest-by.R
+++ b/R/nest-by.R
@@ -30,6 +30,10 @@
 #'   reframe(data)
 #' ```
 #'
+#' @section Life cycle:
+#' `nest_by()` is not stable because [`tidyr::nest(.by =)`][tidyr::nest()]
+#' provides very similar behavior. It may be deprecated in the future.
+#'
 #' @return
 #' A [rowwise] data frame. The output has the following properties:
 #'

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -109,7 +109,6 @@ reference:
   - group_map
   - group_modify
   - group_trim
-  - group_split
 
 - title: Superseded
   desc: >

--- a/man/group_nest.Rd
+++ b/man/group_nest.Rd
@@ -25,6 +25,12 @@ with matching rows of the remaining columns.
 
 Nest a tibble using a grouping specification
 }
+\section{Life cycle}{
+
+\code{group_nest()} is not stable because \code{\link[tidyr:nest]{tidyr::nest(.by =)}}
+provides very similar behavior. It may be deprecated in the future.
+}
+
 \section{Grouped data frames}{
 
 

--- a/man/group_nest.Rd
+++ b/man/group_nest.Rd
@@ -25,7 +25,7 @@ with matching rows of the remaining columns.
 
 Nest a tibble using a grouping specification
 }
-\section{Life cycle}{
+\section{Lifecycle}{
 
 \code{group_nest()} is not stable because \code{\link[tidyr:nest]{tidyr::nest(.by =)}}
 provides very similar behavior. It may be deprecated in the future.

--- a/man/group_split.Rd
+++ b/man/group_split.Rd
@@ -38,6 +38,15 @@ You can pass \code{...} to group and split an ungrouped data frame, but this
 is generally not very useful as you want have easy access to the group
 metadata.
 }
+\section{Life cycle}{
+
+\code{group_split()} is not stable because you can achieve very similar results by
+manipulating the nested column returned from
+\code{\link[tidyr:nest]{tidyr::nest(.by =)}}. That also retains the group keys all
+within a single data structure. \code{group_split()} may be deprecated in the
+future.
+}
+
 \examples{
 ir <- iris \%>\% group_by(Species)
 
@@ -52,3 +61,4 @@ Other grouping functions:
 \code{\link{group_trim}()}
 }
 \concept{grouping functions}
+\keyword{internal}

--- a/man/group_split.Rd
+++ b/man/group_split.Rd
@@ -38,7 +38,7 @@ You can pass \code{...} to group and split an ungrouped data frame, but this
 is generally not very useful as you want have easy access to the group
 metadata.
 }
-\section{Life cycle}{
+\section{Lifecycle}{
 
 \code{group_split()} is not stable because you can achieve very similar results by
 manipulating the nested column returned from

--- a/man/mutate_all.Rd
+++ b/man/mutate_all.Rd
@@ -115,7 +115,7 @@ If a variable in \code{.vars} is named, a new column by that name will be create
 Name collisions in the new columns are disambiguated using a unique suffix.
 }
 
-\section{Life cycle}{
+\section{Lifecycle}{
 
 
 The functions are maturing, because the naming scheme and the

--- a/man/nest_by.Rd
+++ b/man/nest_by.Rd
@@ -63,7 +63,7 @@ If you want to unnest a nested data frame, you can either use
   reframe(data)
 }\if{html}{\out{</div>}}
 }
-\section{Life cycle}{
+\section{Lifecycle}{
 
 \code{nest_by()} is not stable because \code{\link[tidyr:nest]{tidyr::nest(.by =)}}
 provides very similar behavior. It may be deprecated in the future.

--- a/man/nest_by.Rd
+++ b/man/nest_by.Rd
@@ -63,6 +63,12 @@ If you want to unnest a nested data frame, you can either use
   reframe(data)
 }\if{html}{\out{</div>}}
 }
+\section{Life cycle}{
+
+\code{nest_by()} is not stable because \code{\link[tidyr:nest]{tidyr::nest(.by =)}}
+provides very similar behavior. It may be deprecated in the future.
+}
+
 \section{Methods}{
 
 This function is a \strong{generic}, which means that packages can provide

--- a/man/summarise_all.Rd
+++ b/man/summarise_all.Rd
@@ -117,7 +117,7 @@ If a variable in \code{.vars} is named, a new column by that name will be create
 Name collisions in the new columns are disambiguated using a unique suffix.
 }
 
-\section{Life cycle}{
+\section{Lifecycle}{
 
 
 The functions are maturing, because the naming scheme and the


### PR DESCRIPTION
Closes https://github.com/tidyverse/dplyr/issues/6639

- No NEWS bullet (I'm not really sure what it would say)
- All still experimental
- The `Life cycle` section is something rlang does. i.e. `?rlang::int`
- Marked `group_split()` as internal and removed pkgdown reference index