### PR TITLE
Ensure that `rows_insert()` checks that `y` contains `by` before casting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -436,6 +436,8 @@ package, bringing greater consistency and improved performance.
 * `rename_with()` now checks that the result of `.fn` is the right type and size
   (#6561).
 
+* `rows_insert()` now checks that `y` contains the `by` columns (#6652).
+
 * `setequal()` ignores differences between freely coercible types (e.g. integer 
   and double) (#6114) and ignores duplicated rows (#6057).
 

--- a/tests/testthat/_snaps/rows.md
+++ b/tests/testthat/_snaps/rows.md
@@ -40,6 +40,26 @@
       ! Can't convert from `y$value` <double> to `x$value` <integer> due to loss of precision.
       * Locations: 1
 
+# rows_insert() checks that `x` and `y` contain `by` (#6652)
+
+    Code
+      (expect_error(rows_insert(x, y, by = "c")))
+    Output
+      <error/rlang_error>
+      Error in `rows_insert()`:
+      ! All columns specified through `by` must exist in `x` and `y`.
+      i The following columns are missing from `x`: `c`.
+
+---
+
+    Code
+      (expect_error(rows_insert(x, y, by = c("a", "b"))))
+    Output
+      <error/rlang_error>
+      Error in `rows_insert()`:
+      ! All columns specified through `by` must exist in `x` and `y`.
+      i The following columns are missing from `y`: `b`.
+
 # `conflict` is validated
 
     Code
@@ -244,10 +264,10 @@
       Error in `rows_delete()`:
       ! Can't combine `x$key` <integer> and `y$key` <character>.
 
-# rows_check_containment() checks that `y` columns are in `x`
+# rows_check_x_contains_y() checks that `y` columns are in `x`
 
     Code
-      (expect_error(rows_check_containment(x, y)))
+      (expect_error(rows_check_x_contains_y(x, y)))
     Output
       <error/rlang_error>
       Error:
@@ -291,34 +311,34 @@
       Error:
       ! `by` must be unnamed.
 
-# rows_select_key() checks that all `by` columns are in `x`
+# rows_check_contains_by() checks that all `by` columns are in `x`
 
     Code
-      (expect_error(rows_select_key(x, "y", arg = "x")))
+      (expect_error(rows_check_contains_by(x, "y", arg = "x")))
     Output
       <error/rlang_error>
       Error:
       ! All columns specified through `by` must exist in `x` and `y`.
       i The following columns are missing from `x`: `y`.
     Code
-      (expect_error(rows_select_key(x, c("y", "x", "z"), arg = "y")))
+      (expect_error(rows_check_contains_by(x, c("y", "x", "z"), arg = "y")))
     Output
       <error/rlang_error>
       Error:
       ! All columns specified through `by` must exist in `x` and `y`.
       i The following columns are missing from `y`: `y` and `z`.
 
-# rows_select_key() optionally requires uniqueness
+# rows_check_unique() requires uniqueness
 
     Code
-      (expect_error(rows_select_key(x, "x", arg = "x", unique = TRUE)))
+      (expect_error(rows_check_unique(x["x"], "x")))
     Output
       <error/rlang_error>
       Error:
       ! `x` key values must be unique.
       i The following rows contain duplicate key values: `c(1, 2, 3)`.
     Code
-      (expect_error(rows_select_key(x, c("x", "y"), arg = "y", unique = TRUE)))
+      (expect_error(rows_check_unique(x[c("x", "y")], "y")))
     Output
       <error/rlang_error>
       Error:

--- a/tests/testthat/test-rows.R
+++ b/tests/testthat/test-rows.R
@@ -79,6 +79,18 @@ test_that("rows_insert() casts values to the type of `x`", {
   })
 })
 
+test_that("rows_insert() checks that `x` and `y` contain `by` (#6652)", {
+  x <- tibble(a = 1, b = 2)
+  y <- tibble(a = 1)
+
+  expect_snapshot({
+    (expect_error(rows_insert(x, y, by = "c")))
+  })
+  expect_snapshot({
+    (expect_error(rows_insert(x, y, by = c("a", "b"))))
+  })
+})
+
 test_that("`conflict` is validated", {
   x <- tibble(a = 1)
   y <- tibble(a = 2)
@@ -468,11 +480,11 @@ test_that("rows_delete() casts keys to their common type for matching but retain
 # ------------------------------------------------------------------------------
 # Common errors
 
-test_that("rows_check_containment() checks that `y` columns are in `x`", {
+test_that("rows_check_x_contains_y() checks that `y` columns are in `x`", {
   x <- tibble(a = 1)
   y <- tibble(a = 1, b = 2)
 
-  expect_snapshot((expect_error(rows_check_containment(x, y))))
+  expect_snapshot((expect_error(rows_check_x_contains_y(x, y))))
 })
 
 test_that("rows_check_by() checks that `y` has at least 1 column before using it (#6061)", {
@@ -501,31 +513,22 @@ test_that("rows_check_by() validates `by`", {
   })
 })
 
-test_that("rows_select_key() selects the key columns", {
-  x <- tibble(x = 1, y = 2, z = 3)
-
-  expect_identical(
-    rows_select_key(x, c("z", "x"), "x"),
-    x[c("z", "x")]
-  )
-})
-
-test_that("rows_select_key() checks that all `by` columns are in `x`", {
+test_that("rows_check_contains_by() checks that all `by` columns are in `x`", {
   x <- tibble(x = 1)
 
   expect_snapshot({
-    (expect_error(rows_select_key(x, "y", arg = "x")))
-    (expect_error(rows_select_key(x, c("y", "x", "z"), arg = "y")))
+    (expect_error(rows_check_contains_by(x, "y", arg = "x")))
+    (expect_error(rows_check_contains_by(x, c("y", "x", "z"), arg = "y")))
   })
 })
 
-test_that("rows_select_key() optionally requires uniqueness", {
+test_that("rows_check_unique() requires uniqueness", {
   x <- tibble(x = c(1, 1, 1), y = c(2, 3, 2), z = c(1, 2, 3))
 
-  expect_identical(rows_select_key(x, "z", arg = "x", unique = TRUE), x["z"])
+  expect_silent(rows_check_unique(x, "x"))
 
   expect_snapshot({
-    (expect_error(rows_select_key(x, "x", arg = "x", unique = TRUE)))
-    (expect_error(rows_select_key(x, c("x", "y"), arg = "y", unique = TRUE)))
+    (expect_error(rows_check_unique(x["x"], "x")))
+    (expect_error(rows_check_unique(x[c("x", "y")], "y")))
   })
 })


### PR DESCRIPTION
Closes https://github.com/tidyverse/dplyr/issues/6652

The easiest way to fix this is to realize that `rows_select_key()` was doing too much. It was doing 3 things:
- Checking that the input contained the `by` cols
- Selection with `x[by]`
- Optional uniqueness checks

I have split this into the 3 individual responsibilities:
- `rows_check_contains_by()`
- `dplyr_col_select()`
- `rows_check_unique()`

This solves the problem with `rows_insert()` because the casting of `y` to the type of `x` was happening before the check that `y` contained the `by` columns. Since `x` contained the `by` columns, the cast made it look like `y` did too. The correct ordering of the operations in `rows_insert()` is:
- `rows_check_contains_by()`
- `rows_cast_y()`
- `dplyr_col_select()`
- `rows_check_unique()`

Which is some proof that we really did need to split `rows_select_key()` into its individual pieces to be able to call them in the right order here.