### PR TITLE
Add join helper aliases and link to `join_by()` from `between()`

### DIFF
--- a/R/funs.R
+++ b/R/funs.R
@@ -14,6 +14,10 @@
 #' @returns
 #' A logical vector the same size as `x`.
 #'
+#' @seealso
+#' [join_by()] if you are looking for documentation for the `between()` overlap
+#' join helper.
+#'
 #' @export
 #' @examples
 #' between(1:12, 7, 9)

--- a/R/join-by.R
+++ b/R/join-by.R
@@ -134,6 +134,8 @@
 #'   interpreted as if that column name was duplicated on each side of `==`,
 #'   i.e. `x` is interpreted as `x == x`.
 #'
+#' @aliases closest overlaps within
+#'
 #' @export
 #' @examples
 #' sales <- tibble(

--- a/man/between.Rd
+++ b/man/between.Rd
@@ -32,3 +32,7 @@ x[between(x, -1, 1)]
 # On a tibble using `filter()`
 filter(starwars, between(height, 100, 150))
 }
+\seealso{
+\code{\link[=join_by]{join_by()}} if you are looking for documentation for the \code{between()} overlap
+join helper.
+}

--- a/man/join_by.Rd
+++ b/man/join_by.Rd
@@ -2,6 +2,9 @@
 % Please edit documentation in R/join-by.R
 \name{join_by}
 \alias{join_by}
+\alias{closest}
+\alias{overlaps}
+\alias{within}
 \title{Join specifications}
 \usage{
 join_by(...)


### PR DESCRIPTION
Closes https://github.com/tidyverse/dplyr/issues/6595

This is like an 85% improvement I think.

- Alias `overlaps` to `join_by()` (no conflicts)
- Alias `closest` to `join_by()` (no conflicts)
- Alias `within` to `join_by()`. Conflicts with `base::within()` so `?within` brings up 2 help pages to choose from. 🤷 
- Can't alias `between` to `join_by()` because we already have `dplyr::between()`. So instead I gave the help docs of `between()` a `@seealso` tag for `join_by()`

So now only `between()` generates a link when you are on the `join_by()` help page

<img width="722" alt="Screen Shot 2023-01-25 at 3 16 50 PM" src="https://user-images.githubusercontent.com/19150088/214681406-a44de3de-7f98-4c0e-9f96-03cc67851e1d.png">

And all the helpers generate links when you are on other pages like NEWS. The `overlaps()` and `within()` ones link correctly. `between()` links to `dplyr::between()`, of course.

<img width="759" alt="Screen Shot 2023-01-25 at 3 17 56 PM" src="https://user-images.githubusercontent.com/19150088/214681479-1a4ef315-057c-470e-ae4f-7d036007afdd.png">
