### PR TITLE
Use a slightly more relaxed check for the old variant of cross join

### DIFF
--- a/R/join.R
+++ b/R/join.R
@@ -785,7 +785,20 @@ check_keep <- function(keep, error_call = caller_env()) {
 }
 
 is_cross_by <- function(x) {
-  identical(x, character()) || identical(x, list(x = character(), y = character()))
+  if (is_character(x, n = 0L)) {
+    # `character()` or `named character()`
+    return(TRUE)
+  }
+
+  if (is_list(x, n = 2L) &&
+      is_character(x[["x"]], n = 0L) &&
+      is_character(x[["y"]], n = 0L)) {
+    # `list(x = character(), y = character())`
+    # (possibly with named empty character elements)
+    return(TRUE)
+  }
+
+  FALSE
 }
 
 warn_join_cross_by <- function(env = caller_env(),

--- a/tests/testthat/_snaps/join.md
+++ b/tests/testthat/_snaps/join.md
@@ -234,6 +234,15 @@
       Using `by = character()` to perform a cross join was deprecated in dplyr 1.1.0.
       i Please use `cross_join()` instead.
 
+# `by = named character()` for a cross join works
+
+    Code
+      out <- left_join(df1, df2, by = by)
+    Condition
+      Warning:
+      Using `by = character()` to perform a cross join was deprecated in dplyr 1.1.0.
+      i Please use `cross_join()` instead.
+
 # `by = list(x = character(), y = character())` for a cross join is deprecated (#6604)
 
     Code

--- a/tests/testthat/test-join.R
+++ b/tests/testthat/test-join.R
@@ -551,6 +551,22 @@ test_that("`by = character()` for a cross join is deprecated (#6604)", {
   })
 })
 
+test_that("`by = named character()` for a cross join works", {
+  # Used by the sift package
+  df1 <- tibble(x = 1:2)
+  df2 <- tibble(y = 1:2)
+
+  by <- set_names(character(), nm = character())
+
+  expect_snapshot({
+    out <- left_join(df1, df2, by = by)
+  })
+  expect_identical(
+    out,
+    cross_join(df1, df2)
+  )
+})
+
 test_that("`by = list(x = character(), y = character())` for a cross join is deprecated (#6604)", {
   df1 <- tibble(x = 1:2)
   df2 <- tibble(y = 1:2)


### PR DESCRIPTION
The sift package was passing a named empty `character()` object through as `by` and we didn't catch that