### PR TITLE
Add link to 1.1.0 posts to pkgdown Releases dropdown

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -157,6 +157,8 @@ articles:
 
 news:
   releases:
+  - text: "Version 1.1.0"
+    href: https://www.tidyverse.org/tags/dplyr-1-1-0/
   - text: "Version 1.0.0"
     href: https://www.tidyverse.org/blog/2020/06/dplyr-1-0-0/
   - text: "Version 0.8.3"


### PR DESCRIPTION
* Adds link to the dplyr-1-1-0 tag as the "Version 1.1.0" link in the Releases section of the pkgdown header. 

_n.b._ We've not done this previously (e.g. with 1.0.0, which also had several posts), but it seems to make sense in this case, as there's no one post of reference.

If we do this, it'd probably be worth adding the tag to the 1.1.0 is coming soon post (https://www.tidyverse.org/blog/2022/11/dplyr-1-1-0-is-coming-soon/)