### PR TITLE
Add `rename_with()` example of using `paste0(recycle0 = TRUE)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dplyr (development version)
 
+* `rename_with()` now includes an example of using `paste0(recycle0 = TRUE)` to
+  correctly handle empty selections (#6688).
+
 # dplyr 1.1.0
 
 ## New features

--- a/R/rename.R
+++ b/R/rename.R
@@ -44,6 +44,21 @@
 #' rename_with(iris, toupper)
 #' rename_with(iris, toupper, starts_with("Petal"))
 #' rename_with(iris, ~ tolower(gsub(".", "_", .x, fixed = TRUE)))
+#'
+#' @examplesIf getRversion() > "4.0.1"
+#' # If your renaming function uses `paste0()`, make sure to set
+#' # `recycle0 = TRUE` to ensure that empty selections are recycled correctly
+#' try(rename_with(
+#'   iris,
+#'   ~ paste0("prefix_", .x),
+#'   starts_with("nonexistent")
+#' ))
+#'
+#' rename_with(
+#'   iris,
+#'   ~ paste0("prefix_", .x, recycle0 = TRUE),
+#'   starts_with("nonexistent")
+#' )
 #' @export
 rename <- function(.data, ...) {
   UseMethod("rename")

--- a/man/rename.Rd
+++ b/man/rename.Rd
@@ -67,6 +67,22 @@ rename(iris, any_of(lookup))
 rename_with(iris, toupper)
 rename_with(iris, toupper, starts_with("Petal"))
 rename_with(iris, ~ tolower(gsub(".", "_", .x, fixed = TRUE)))
+
+\dontshow{if (getRversion() > "4.0.1") (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+# If your renaming function uses `paste0()`, make sure to set
+# `recycle0 = TRUE` to ensure that empty selections are recycled correctly
+try(rename_with(
+  iris,
+  ~ paste0("prefix_", .x),
+  starts_with("nonexistent")
+))
+
+rename_with(
+  iris,
+  ~ paste0("prefix_", .x, recycle0 = TRUE),
+  starts_with("nonexistent")
+)
+\dontshow{\}) # examplesIf}
 }
 \seealso{
 Other single table verbs: 


### PR DESCRIPTION
Closes #6688

I think that documentation is really the best we can do here? It seems worth calling this specific case out, at least.