### PR TITLE
Add tests for `arrange()` with `numeric_version`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     tibble (>= 2.1.3),
     tidyselect (>= 1.2.0),
     utils,
-    vctrs (>= 0.5.2)
+    vctrs (>= 0.5.2.9000)
 Suggests: 
     bench,
     broom,
@@ -66,4 +66,5 @@ LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 Remotes:
-    r-lib/rlang
+    r-lib/rlang,
+    r-lib/vctrs#1782

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -67,4 +67,4 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 Remotes:
     r-lib/rlang,
-    r-lib/vctrs#1782
+    r-lib/vctrs

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dplyr (development version)
 
+* `arrange()` can once again sort the `numeric_version` type from base R
+  (#6680).
+
 * Fixed an issue where using `<-` within a grouped `mutate()` or `summarise()`
   could cross contaminate other groups (#6666).
 

--- a/tests/testthat/test-arrange.R
+++ b/tests/testthat/test-arrange.R
@@ -105,6 +105,15 @@ test_that("arrange ignores NULLs (#6193)", {
   expect_equal(out$x, 2:1)
 })
 
+test_that("`arrange()` works with `numeric_version` (#6680)", {
+  x <- numeric_version(c("1.11", "1.2.3", "1.2.2"))
+  df <- tibble(x = x)
+
+  expect <- df[c(3, 2, 1),]
+
+  expect_identical(arrange(df, x), expect)
+})
+
 # locale --------------------------------------------------------------
 
 test_that("arrange defaults to the C locale", {
@@ -417,6 +426,17 @@ test_that("legacy - arrange handles S4 classes (#1105)", {
 
   df <- tibble(x = 1:3, y = TestS4(3:1))
   expect_equal(arrange(df, y), df[3:1, ])
+})
+
+test_that("legacy - `arrange()` works with `numeric_version` (#6680)", {
+  local_options(dplyr.legacy_locale = TRUE)
+
+  x <- numeric_version(c("1.11", "1.2.3", "1.2.2"))
+  df <- tibble(x = x)
+
+  expect <- df[c(3, 2, 1),]
+
+  expect_identical(arrange(df, x), expect)
 })
 
 test_that("legacy - arrange works with two columns when the first has a data frame proxy (#6268)", {


### PR DESCRIPTION
Closes #6680
Needs https://github.com/r-lib/vctrs/pull/1782