### PR TITLE
Evaluate each group expression in a fresh data mask

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,4 +66,4 @@ LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 Remotes:
-    r-lib/rlang
+    r-lib/rlang#1555

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
     methods,
     pillar (>= 1.5.1),
     R6,
-    rlang (>= 1.0.6),
+    rlang (>= 1.0.6.9000),
     tibble (>= 2.1.3),
     tidyselect (>= 1.2.0),
     utils,
@@ -65,3 +65,5 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
+Remotes:
+    r-lib/rlang

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,4 +66,4 @@ LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 Remotes:
-    r-lib/rlang#1555
+    r-lib/rlang

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dplyr (development version)
 
+* Fixed an issue where using `<-` within a grouped `mutate()` or `summarise()`
+  could cross contaminate other groups (#6666).
+
 * Deprecation warnings thrown by `filter()` now mention the correct package
   where the problem originated from (#6679).
 

--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -24,7 +24,7 @@ DataMask <- R6Class("DataMask",
       private$rowwise <- by$type == "rowwise"
 
       private$chops <- .Call(dplyr_lazy_vec_chop_impl, data, rows, private$grouped, private$rowwise)
-      private$mask <- .Call(dplyr_data_masks_setup, private$chops, data, rows)
+      private$env_bindings <- .Call(dplyr_make_column_bindings, private$chops, data)
 
       private$keys <- group_keys0(by$data)
       private$by_names <- by$names
@@ -41,11 +41,11 @@ DataMask <- R6Class("DataMask",
         }
       }
 
-      .Call(`dplyr_mask_add`, private, name, result, chunks)
+      .Call(`dplyr_binding_add`, private, name, result, chunks)
     },
 
     remove = function(name) {
-      .Call(`dplyr_mask_remove`, private, name)
+      .Call(`dplyr_binding_remove`, private, name)
     },
 
     resolve = function(name) {
@@ -93,7 +93,7 @@ DataMask <- R6Class("DataMask",
     },
 
     current_cols = function(vars) {
-      env_get_list(parent.env(private$mask), vars)
+      env_get_list(private$env_bindings, vars)
     },
 
     current_rows = function() {
@@ -190,11 +190,16 @@ DataMask <- R6Class("DataMask",
     },
 
     get_env_bindings = function() {
-      parent.env(private$mask)
+      private$env_bindings
     },
 
     get_rlang_mask = function() {
-      private$mask
+      # Mimicking the data mask that is created during typical
+      # expression evaluations, like in `DataMask$eval_all_mutate()`.
+      # Important to insert a `.data` pronoun!
+      mask <- new_data_mask(private$env_bindings)
+      mask[[".data"]] <- as_data_pronoun(private$env_bindings)
+      mask
     }
 
   ),
@@ -208,10 +213,12 @@ DataMask <- R6Class("DataMask",
     # - .current_group: scalar integer that identifies the current group
     chops = NULL,
 
-    # dynamic data mask, with active bindings for each column
-    # this is an rlang data mask, as such the bindings are actually
-    # in the parent environment of `mask`
-    mask = NULL,
+    # Environment with active bindings for each column.
+    # Expressions are evaluated in a fresh data mask created from this
+    # environment. Each group gets its own newly created data mask to avoid
+    # cross group contamination of the data mask by lexical side effects, like
+    # usage of `<-` (#6666).
+    env_bindings = NULL,
 
     # ptypes of all the variables
     current_data = list(),

--- a/src/chop.cpp
+++ b/src/chop.cpp
@@ -89,7 +89,7 @@ SEXP dplyr_lazy_vec_chop(SEXP data, SEXP rows, SEXP ffi_grouped, SEXP ffi_rowwis
   return chops_env;
 }
 
-void add_mask_binding(SEXP name, SEXP env_bindings, SEXP env_chops) {
+void add_column_binding(SEXP name, SEXP env_bindings, SEXP env_chops) {
   SEXP body = PROTECT(Rf_lang3(dplyr::functions::dot_subset2, name, dplyr::symbols::dot_current_group));
   SEXP fun  = PROTECT(Rf_lang3(dplyr::functions::function, R_NilValue, body));
   SEXP binding = PROTECT(Rf_eval(fun, env_chops));
@@ -98,25 +98,25 @@ void add_mask_binding(SEXP name, SEXP env_bindings, SEXP env_chops) {
   UNPROTECT(3);
 }
 
-SEXP dplyr_data_masks_setup(SEXP env_chops, SEXP data, SEXP rows) {
-  SEXP names = PROTECT(Rf_getAttrib(data, R_NamesSymbol));
-  const SEXP* p_names = STRING_PTR_RO(names);
+SEXP dplyr_make_column_bindings(SEXP env_chops, SEXP data) {
   R_xlen_t n_columns = XLENGTH(data);
 
-  // create dynamic mask with one active binding per column
-  R_xlen_t mask_size = XLENGTH(data) + 20;
-  SEXP env_bindings = PROTECT(new_environment(mask_size, R_EmptyEnv));
+  SEXP names = PROTECT(Rf_getAttrib(data, R_NamesSymbol));
+  const SEXP* p_names = STRING_PTR_RO(names);
+
+  // Create environment with one active binding per column.
+  // Leave some extra room for new columns added by `dplyr_binding_add()`.
+  R_xlen_t size = n_columns + 20;
+  SEXP env_bindings = PROTECT(new_environment(size, R_EmptyEnv));
+
   for (R_xlen_t i = 0; i < n_columns; i++) {
     SEXP name = PROTECT(rlang::str_as_symbol(p_names[i]));
-    add_mask_binding(name, env_bindings, env_chops);
+    add_column_binding(name, env_bindings, env_chops);
     UNPROTECT(1);
   }
-  SEXP mask = PROTECT(rlang::new_data_mask(env_bindings, R_NilValue));
-  SEXP pronoun = PROTECT(rlang::as_data_pronoun(env_bindings));
-  Rf_defineVar(dplyr::symbols::dot_data, pronoun, mask);
 
-  UNPROTECT(4);
-  return mask;
+  UNPROTECT(2);
+  return env_bindings;
 }
 
 SEXP env_resolved(SEXP env, SEXP names) {

--- a/src/chop.cpp
+++ b/src/chop.cpp
@@ -89,34 +89,34 @@ SEXP dplyr_lazy_vec_chop(SEXP data, SEXP rows, SEXP ffi_grouped, SEXP ffi_rowwis
   return chops_env;
 }
 
-void add_column_binding(SEXP name, SEXP env_bindings, SEXP env_chops) {
+void add_mask_binding(SEXP name, SEXP env_mask_bindings, SEXP env_chops) {
   SEXP body = PROTECT(Rf_lang3(dplyr::functions::dot_subset2, name, dplyr::symbols::dot_current_group));
   SEXP fun  = PROTECT(Rf_lang3(dplyr::functions::function, R_NilValue, body));
   SEXP binding = PROTECT(Rf_eval(fun, env_chops));
-  R_MakeActiveBinding(name, binding, env_bindings);
+  R_MakeActiveBinding(name, binding, env_mask_bindings);
 
   UNPROTECT(3);
 }
 
-SEXP dplyr_make_column_bindings(SEXP env_chops, SEXP data) {
+SEXP dplyr_make_mask_bindings(SEXP env_chops, SEXP data) {
   R_xlen_t n_columns = XLENGTH(data);
 
   SEXP names = PROTECT(Rf_getAttrib(data, R_NamesSymbol));
   const SEXP* p_names = STRING_PTR_RO(names);
 
   // Create environment with one active binding per column.
-  // Leave some extra room for new columns added by `dplyr_binding_add()`.
+  // Leave some extra room for new columns added by `dplyr_mask_binding_add()`.
   R_xlen_t size = n_columns + 20;
-  SEXP env_bindings = PROTECT(new_environment(size, R_EmptyEnv));
+  SEXP env_mask_bindings = PROTECT(new_environment(size, R_EmptyEnv));
 
   for (R_xlen_t i = 0; i < n_columns; i++) {
     SEXP name = PROTECT(rlang::str_as_symbol(p_names[i]));
-    add_column_binding(name, env_bindings, env_chops);
+    add_mask_binding(name, env_mask_bindings, env_chops);
     UNPROTECT(1);
   }
 
   UNPROTECT(2);
-  return env_bindings;
+  return env_mask_bindings;
 }
 
 SEXP env_resolved(SEXP env, SEXP names) {

--- a/src/dplyr.h
+++ b/src/dplyr.h
@@ -47,12 +47,12 @@ struct symbols {
   static SEXP dplyr_internal_signal;
   static SEXP dot_indices;
   static SEXP chops;
-  static SEXP mask;
   static SEXP vec_is_list;
   static SEXP new_env;
   static SEXP dot_data;
   static SEXP used;
   static SEXP across;
+  static SEXP env_bindings;
 };
 
 struct vectors {
@@ -109,33 +109,45 @@ SEXP dplyr_summarise_recycle_chunks_in_place(SEXP list_of_chunks, SEXP list_of_r
 SEXP dplyr_group_indices(SEXP data, SEXP rows);
 SEXP dplyr_group_keys(SEXP group_data);
 
-SEXP dplyr_mask_remove(SEXP env_private, SEXP s_name);
-SEXP dplyr_mask_add(SEXP env_private, SEXP s_name, SEXP ptype, SEXP chunks);
+SEXP dplyr_binding_remove(SEXP env_private, SEXP s_name);
+SEXP dplyr_binding_add(SEXP env_private, SEXP s_name, SEXP ptype, SEXP chunks);
 
 SEXP dplyr_lazy_vec_chop(SEXP data, SEXP rows, SEXP ffi_grouped, SEXP ffi_rowwise);
-SEXP dplyr_data_masks_setup(SEXP chops, SEXP data, SEXP rows);
+SEXP dplyr_make_column_bindings(SEXP chops, SEXP data);
 SEXP env_resolved(SEXP env, SEXP names);
-void add_mask_binding(SEXP name, SEXP env_bindings, SEXP env_chops);
+void add_column_binding(SEXP name, SEXP env_bindings, SEXP env_chops);
 
 SEXP dplyr_extract_chunks(SEXP df_list, SEXP df_ptype);
 
-#define DPLYR_MASK_INIT()                                                                    \
-SEXP rows = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::rows));                   \
-R_xlen_t ngroups = XLENGTH(rows);                                                            \
-SEXP caller = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::caller));               \
-SEXP mask = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::mask));                   \
-SEXP chops_env = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::chops));               \
-SEXP current_group = PROTECT(Rf_findVarInFrame(ENCLOS(chops_env), dplyr::symbols::dot_current_group)) ;\
-int* p_current_group = INTEGER(current_group);                  \
-*p_current_group = 0
+#define DPLYR_MASK_INIT()                                                                                \
+  SEXP rows = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::rows));                             \
+  R_xlen_t ngroups = XLENGTH(rows);                                                                      \
+  SEXP caller = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::caller));                         \
+  SEXP env_bindings = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::env_bindings));             \
+  SEXP pronoun = PROTECT(rlang::as_data_pronoun(env_bindings));                                          \
+  SEXP chops_env = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::chops));                       \
+  SEXP current_group = PROTECT(Rf_findVarInFrame(ENCLOS(chops_env), dplyr::symbols::dot_current_group)); \
+  int* p_current_group = INTEGER(current_group);                                                         \
+  *p_current_group = 0
 
 #define DPLYR_MASK_FINALISE()                                  \
-UNPROTECT(5);                                                  \
-*p_current_group = 0
+  UNPROTECT(6);                                                \
+  *p_current_group = 0
 
-#define DPLYR_MASK_SET_GROUP(INDEX) *p_current_group = INDEX + 1
+// At each iteration, we create a fresh data mask so that lexical side effects,
+// such as using `<-` in a `mutate()`, don't persist between groups
+#define DPLYR_MASK_ITERATION_INIT()                                    \
+  SEXP mask = PROTECT(rlang::new_data_mask(env_bindings, R_NilValue)); \
+  Rf_defineVar(dplyr::symbols::dot_data, pronoun, mask)
 
-#define DPLYR_MASK_EVAL(quo) rlang::eval_tidy(quo, mask, caller)
+#define DPLYR_MASK_ITERATION_FINALISE()                        \
+  UNPROTECT(1)
+
+#define DPLYR_MASK_SET_GROUP(INDEX)                            \
+  *p_current_group = INDEX + 1
+
+#define DPLYR_MASK_EVAL(quo)                                   \
+  rlang::eval_tidy(quo, mask, caller)
 
 #define DPLYR_ERROR_INIT(n)                                    \
   SEXP error_data = PROTECT(Rf_allocVector(VECSXP, n));              \

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -200,6 +200,7 @@ SEXP dplyr_mask_eval_all_filter(SEXP quos,
   int* p_keep = LOGICAL(keep);
 
   for (R_xlen_t i = 0; i < ngroups; ++i) {
+    DPLYR_MASK_ITERATION_INIT();
     DPLYR_MASK_SET_GROUP(i);
 
     const bool first = i == 0;
@@ -224,6 +225,7 @@ SEXP dplyr_mask_eval_all_filter(SEXP quos,
     }
 
     UNPROTECT(1);
+    DPLYR_MASK_ITERATION_FINALISE();
   }
 
   UNPROTECT(1);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -52,12 +52,12 @@ SEXP symbols::dplyr_internal_error = Rf_install("dplyr_internal_error");
 SEXP symbols::dplyr_internal_signal = Rf_install("dplyr_internal_signal");
 SEXP symbols::dot_indices = Rf_install(".indices");
 SEXP symbols::chops = Rf_install("chops");
-SEXP symbols::mask = Rf_install("mask");
 SEXP symbols::vec_is_list = Rf_install("vec_is_list");
 SEXP symbols::new_env = Rf_install("new.env");
 SEXP symbols::dot_data = Rf_install(".data");
 SEXP symbols::used = Rf_install("used");
 SEXP symbols::across = Rf_install("across");
+SEXP symbols::env_bindings = Rf_install("env_bindings");
 
 SEXP vectors::classes_vctrs_list_of = get_classes_vctrs_list_of();
 SEXP vectors::empty_int_vector = get_empty_int_vector();
@@ -111,11 +111,11 @@ static const R_CallMethodDef CallEntries[] = {
   {"dplyr_group_indices", (DL_FUNC)& dplyr_group_indices, 2},
   {"dplyr_group_keys", (DL_FUNC)& dplyr_group_keys, 1},
 
-  {"dplyr_mask_remove", (DL_FUNC)& dplyr_mask_remove, 2},
-  {"dplyr_mask_add", (DL_FUNC)& dplyr_mask_add, 4},
+  {"dplyr_binding_remove", (DL_FUNC)& dplyr_binding_remove, 2},
+  {"dplyr_binding_add", (DL_FUNC)& dplyr_binding_add, 4},
 
   {"dplyr_lazy_vec_chop_impl", (DL_FUNC)& dplyr_lazy_vec_chop, 4},
-  {"dplyr_data_masks_setup", (DL_FUNC)& dplyr_data_masks_setup, 3},
+  {"dplyr_make_column_bindings", (DL_FUNC)& dplyr_make_column_bindings, 2},
   {"env_resolved", (DL_FUNC)& env_resolved, 2},
 
   {"dplyr_extract_chunks", (DL_FUNC)& dplyr_extract_chunks, 2},

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -57,7 +57,7 @@ SEXP symbols::new_env = Rf_install("new.env");
 SEXP symbols::dot_data = Rf_install(".data");
 SEXP symbols::used = Rf_install("used");
 SEXP symbols::across = Rf_install("across");
-SEXP symbols::env_bindings = Rf_install("env_bindings");
+SEXP symbols::env_mask_bindings = Rf_install("env_mask_bindings");
 
 SEXP vectors::classes_vctrs_list_of = get_classes_vctrs_list_of();
 SEXP vectors::empty_int_vector = get_empty_int_vector();
@@ -111,11 +111,11 @@ static const R_CallMethodDef CallEntries[] = {
   {"dplyr_group_indices", (DL_FUNC)& dplyr_group_indices, 2},
   {"dplyr_group_keys", (DL_FUNC)& dplyr_group_keys, 1},
 
-  {"dplyr_binding_remove", (DL_FUNC)& dplyr_binding_remove, 2},
-  {"dplyr_binding_add", (DL_FUNC)& dplyr_binding_add, 4},
+  {"dplyr_mask_binding_remove", (DL_FUNC)& dplyr_mask_binding_remove, 2},
+  {"dplyr_mask_binding_add", (DL_FUNC)& dplyr_mask_binding_add, 4},
 
   {"dplyr_lazy_vec_chop_impl", (DL_FUNC)& dplyr_lazy_vec_chop, 4},
-  {"dplyr_make_column_bindings", (DL_FUNC)& dplyr_make_column_bindings, 2},
+  {"dplyr_make_mask_bindings", (DL_FUNC)& dplyr_make_mask_bindings, 2},
   {"env_resolved", (DL_FUNC)& env_resolved, 2},
 
   {"dplyr_extract_chunks", (DL_FUNC)& dplyr_extract_chunks, 2},

--- a/src/mask.cpp
+++ b/src/mask.cpp
@@ -31,7 +31,7 @@ SEXP integers_append(SEXP ints, int x) {
   return new_ints;
 }
 
-SEXP dplyr_binding_add(SEXP env_private, SEXP s_name, SEXP ptype, SEXP chunks) {
+SEXP dplyr_mask_binding_add(SEXP env_private, SEXP s_name, SEXP ptype, SEXP chunks) {
   SEXP name = STRING_ELT(s_name, 0);
 
   // we assume control over these
@@ -66,14 +66,14 @@ SEXP dplyr_binding_add(SEXP env_private, SEXP s_name, SEXP ptype, SEXP chunks) {
   SEXP chops = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::chops));
   Rf_defineVar(sym_name, chunks, chops);
 
-  SEXP env_bindings = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::env_bindings));
-  add_column_binding(sym_name, env_bindings, chops);
+  SEXP env_mask_bindings = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::env_mask_bindings));
+  add_mask_binding(sym_name, env_mask_bindings, chops);
 
   UNPROTECT(5);
   return R_NilValue;
 }
 
-SEXP dplyr_binding_remove(SEXP env_private, SEXP s_name) {
+SEXP dplyr_mask_binding_remove(SEXP env_private, SEXP s_name) {
   SEXP name = STRING_ELT(s_name, 0);
 
   SEXP current_data = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::current_data));
@@ -99,9 +99,9 @@ SEXP dplyr_binding_remove(SEXP env_private, SEXP s_name) {
     SEXP sym_name = PROTECT(rlang::str_as_symbol(name));
 
     SEXP chops = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::chops));
-    SEXP env_bindings = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::env_bindings));
+    SEXP env_mask_bindings = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::env_mask_bindings));
 
-    rlang::env_unbind(env_bindings, sym_name);
+    rlang::env_unbind(env_mask_bindings, sym_name);
     rlang::env_unbind(chops, sym_name);
 
     UNPROTECT(5);

--- a/src/mask.cpp
+++ b/src/mask.cpp
@@ -31,7 +31,7 @@ SEXP integers_append(SEXP ints, int x) {
   return new_ints;
 }
 
-SEXP dplyr_mask_add(SEXP env_private, SEXP s_name, SEXP ptype, SEXP chunks) {
+SEXP dplyr_binding_add(SEXP env_private, SEXP s_name, SEXP ptype, SEXP chunks) {
   SEXP name = STRING_ELT(s_name, 0);
 
   // we assume control over these
@@ -66,14 +66,14 @@ SEXP dplyr_mask_add(SEXP env_private, SEXP s_name, SEXP ptype, SEXP chunks) {
   SEXP chops = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::chops));
   Rf_defineVar(sym_name, chunks, chops);
 
-  SEXP mask = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::mask));
-  add_mask_binding(sym_name, ENCLOS(mask), chops);
+  SEXP env_bindings = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::env_bindings));
+  add_column_binding(sym_name, env_bindings, chops);
 
   UNPROTECT(5);
   return R_NilValue;
 }
 
-SEXP dplyr_mask_remove(SEXP env_private, SEXP s_name) {
+SEXP dplyr_binding_remove(SEXP env_private, SEXP s_name) {
   SEXP name = STRING_ELT(s_name, 0);
 
   SEXP current_data = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::current_data));
@@ -99,9 +99,9 @@ SEXP dplyr_mask_remove(SEXP env_private, SEXP s_name) {
     SEXP sym_name = PROTECT(rlang::str_as_symbol(name));
 
     SEXP chops = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::chops));
-    SEXP mask = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::mask));
+    SEXP env_bindings = PROTECT(Rf_findVarInFrame(env_private, dplyr::symbols::env_bindings));
 
-    rlang::env_unbind(ENCLOS(mask), sym_name);
+    rlang::env_unbind(env_bindings, sym_name);
     rlang::env_unbind(chops, sym_name);
 
     UNPROTECT(5);

--- a/src/mutate.cpp
+++ b/src/mutate.cpp
@@ -30,6 +30,7 @@ SEXP dplyr_mask_eval_all_mutate(SEXP quo, SEXP env_private) {
 
   const SEXP* p_rows = VECTOR_PTR_RO(rows);
   for (R_xlen_t i = 0; i < ngroups; i++) {
+    DPLYR_MASK_ITERATION_INIT();
     DPLYR_MASK_SET_GROUP(i);
     R_xlen_t n_i = XLENGTH(p_rows[i]);
     SEXP result_i = PROTECT(DPLYR_MASK_EVAL(quo));
@@ -61,6 +62,7 @@ SEXP dplyr_mask_eval_all_mutate(SEXP quo, SEXP env_private) {
     }
 
     UNPROTECT(1);
+    DPLYR_MASK_ITERATION_FINALISE();
   }
 
   if (seen_null && seen_vec) {

--- a/src/slice.cpp
+++ b/src/slice.cpp
@@ -6,8 +6,10 @@ SEXP dplyr_mask_eval_all(SEXP quo, SEXP env_private) {
   SEXP chunks = PROTECT(Rf_allocVector(VECSXP, ngroups));
 
   for (R_xlen_t i = 0; i < ngroups; i++) {
+    DPLYR_MASK_ITERATION_INIT();
     DPLYR_MASK_SET_GROUP(i);
     SET_VECTOR_ELT(chunks, i, DPLYR_MASK_EVAL(quo));
+    DPLYR_MASK_ITERATION_FINALISE();
   }
 
   UNPROTECT(1);

--- a/src/summarise.cpp
+++ b/src/summarise.cpp
@@ -31,6 +31,7 @@ SEXP dplyr_mask_eval_all_summarise(SEXP quo, SEXP env_private) {
   R_xlen_t n_null = 0;
   SEXP chunks = PROTECT(Rf_allocVector(VECSXP, ngroups));
   for (R_xlen_t i = 0; i < ngroups; i++) {
+    DPLYR_MASK_ITERATION_INIT();
     DPLYR_MASK_SET_GROUP(i);
 
     SEXP result_i = PROTECT(DPLYR_MASK_EVAL(quo));
@@ -43,6 +44,7 @@ SEXP dplyr_mask_eval_all_summarise(SEXP quo, SEXP env_private) {
     }
 
     UNPROTECT(1);
+    DPLYR_MASK_ITERATION_FINALISE();
   }
   DPLYR_MASK_FINALISE();
   UNPROTECT(1);

--- a/tests/testthat/_snaps/across.md
+++ b/tests/testthat/_snaps/across.md
@@ -283,6 +283,18 @@
       Caused by error in `fn()`:
       ! the ... list contains fewer than 2 elements
 
+# anonymous function `.fns` can access the `.data` pronoun even when not inlined
+
+    Code
+      mutate(df, across(y, fn))
+    Condition
+      Error in `mutate()`:
+      i In argument: `across(y, fn)`.
+      Caused by error in `across()`:
+      ! Can't compute column `y`.
+      Caused by error:
+      ! Can't subset `.data` outside of a data mask context.
+
 # can't rename during selection (#6522)
 
     Code

--- a/tests/testthat/_snaps/join-rows.md
+++ b/tests/testthat/_snaps/join-rows.md
@@ -252,7 +252,7 @@
       join_rows(df, df, unmatched = 1)
     Condition
       Error:
-      ! `unmatched` must be a character vector, not a number.
+      ! `unmatched` must be a character vector, not the number 1.
     Code
       join_rows(df, df, unmatched = "foo")
     Condition

--- a/tests/testthat/_snaps/mutate.md
+++ b/tests/testthat/_snaps/mutate.md
@@ -88,6 +88,21 @@
       Caused by error:
       ! unused argument (base::quote(2))
 
+# can't share local variables across expressions (#6666)
+
+    Code
+      mutate(df, x2 = {
+        foo <- x
+        x
+      }, y2 = {
+        foo
+      })
+    Condition
+      Error in `mutate()`:
+      i In argument: `y2 = { ... }`.
+      Caused by error:
+      ! object 'foo' not found
+
 # rowwise mutate un-lists existing size-1 list-columns (#6302)
 
     Code

--- a/tests/testthat/_snaps/mutate.md
+++ b/tests/testthat/_snaps/mutate.md
@@ -47,6 +47,47 @@
       ! `y` must be size 1, not 10.
       i Did you mean: `y = list(.env$y)` ?
 
+# can't overwrite column active bindings (#6666)
+
+    Code
+      mutate(df, y = {
+        x <<- 2
+        x
+      })
+    Condition
+      Error in `mutate()`:
+      i In argument: `y = { ... }`.
+      Caused by error:
+      ! unused argument (base::quote(2))
+
+---
+
+    Code
+      mutate(df, .by = g, y = {
+        x <<- 2
+        x
+      })
+    Condition
+      Error in `mutate()`:
+      i In argument: `y = { ... }`.
+      i In group 1: `g = 1`.
+      Caused by error:
+      ! unused argument (base::quote(2))
+
+---
+
+    Code
+      mutate(gdf, y = {
+        x <<- 2
+        x
+      })
+    Condition
+      Error in `mutate()`:
+      i In argument: `y = { ... }`.
+      i In group 1: `g = 1`.
+      Caused by error:
+      ! unused argument (base::quote(2))
+
 # rowwise mutate un-lists existing size-1 list-columns (#6302)
 
     Code

--- a/tests/testthat/_snaps/rows.md
+++ b/tests/testthat/_snaps/rows.md
@@ -73,7 +73,7 @@
     Output
       <error/rlang_error>
       Error in `rows_insert()`:
-      ! `conflict` must be a character vector, not a number.
+      ! `conflict` must be a character vector, not the number 1.
 
 # rows_append() casts to the type of `x`
 
@@ -148,7 +148,7 @@
     Output
       <error/rlang_error>
       Error in `rows_update()`:
-      ! `unmatched` must be a character vector, not a number.
+      ! `unmatched` must be a character vector, not the number 1.
 
 # rows_patch() requires `y` keys to exist in `x` by default
 

--- a/tests/testthat/_snaps/summarise.md
+++ b/tests/testthat/_snaps/summarise.md
@@ -1,3 +1,44 @@
+# can't overwrite column active bindings (#6666)
+
+    Code
+      summarise(df, y = {
+        x <<- x + 2L
+        mean(x)
+      })
+    Condition
+      Error in `summarise()`:
+      i In argument: `y = { ... }`.
+      Caused by error:
+      ! unused argument (base::quote(3:6))
+
+---
+
+    Code
+      summarise(df, .by = g, y = {
+        x <<- x + 2L
+        mean(x)
+      })
+    Condition
+      Error in `summarise()`:
+      i In argument: `y = { ... }`.
+      i In group 1: `g = 1`.
+      Caused by error:
+      ! unused argument (base::quote(3:4))
+
+---
+
+    Code
+      summarise(gdf, y = {
+        x <<- x + 2L
+        mean(x)
+      })
+    Condition
+      Error in `summarise()`:
+      i In argument: `y = { ... }`.
+      i In group 1: `g = 1`.
+      Caused by error:
+      ! unused argument (base::quote(3:4))
+
 # can't use `.by` with `.groups`
 
     Code

--- a/tests/testthat/test-mutate.R
+++ b/tests/testthat/test-mutate.R
@@ -121,6 +121,8 @@ test_that("mutate() supports constants (#6056, #6305)", {
 })
 
 test_that("can't overwrite column active bindings (#6666)", {
+  skip_if(getRversion() < "3.6.3", message = "Active binding error changed")
+
   df <- tibble(g = 1:2, x = 3:4)
   gdf <- group_by(df, g)
 

--- a/tests/testthat/test-mutate.R
+++ b/tests/testthat/test-mutate.R
@@ -182,6 +182,23 @@ test_that("`across()` inline expansions that use `<-` don't affect the mask (#66
   expect_identical(out$x, c(5L, 6L))
 })
 
+test_that("can't share local variables across expressions (#6666)", {
+  df <- tibble(x = 1:2, y = 3:4)
+
+  expect_snapshot(error = TRUE, {
+    mutate(
+      df,
+      x2 = {
+        foo <- x
+        x
+      },
+      y2 = {
+        foo
+      }
+    )
+  })
+})
+
 # column types ------------------------------------------------------------
 
 test_that("glue() is supported", {

--- a/tests/testthat/test-summarise.R
+++ b/tests/testthat/test-summarise.R
@@ -141,6 +141,49 @@ test_that("named data frame results with 0 columns participate in recycling (#65
   )
 })
 
+test_that("can't overwrite column active bindings (#6666)", {
+  df <- tibble(g = c(1, 1, 2, 2), x = 1:4)
+  gdf <- group_by(df, g)
+
+  # The error seen here comes from trying to `<-` to an active binding when
+  # the active binding function has 0 arguments.
+  expect_snapshot(error = TRUE, {
+    summarise(df, y = {
+      x <<- x + 2L
+      mean(x)
+    })
+  })
+  expect_snapshot(error = TRUE, {
+    summarise(df, .by = g, y = {
+      x <<- x + 2L
+      mean(x)
+    })
+  })
+  expect_snapshot(error = TRUE, {
+    summarise(gdf, y = {
+      x <<- x + 2L
+      mean(x)
+    })
+  })
+})
+
+test_that("assigning with `<-` doesn't affect the mask (#6666)", {
+  df <- tibble(g = c(1, 1, 2, 2), x = 1:4)
+  gdf <- group_by(df, g)
+
+  out <- summarise(df, .by = g, y = {
+    x <- x + 4L
+    mean(x)
+  })
+  expect_identical(out$y, c(5.5, 7.5))
+
+  out <- summarise(gdf, y = {
+    x <- x + 4L
+    mean(x)
+  })
+  expect_identical(out$y, c(5.5, 7.5))
+})
+
 # grouping ----------------------------------------------------------------
 
 test_that("peels off a single layer of grouping", {

--- a/tests/testthat/test-summarise.R
+++ b/tests/testthat/test-summarise.R
@@ -142,6 +142,8 @@ test_that("named data frame results with 0 columns participate in recycling (#65
 })
 
 test_that("can't overwrite column active bindings (#6666)", {
+  skip_if(getRversion() < "3.6.3", message = "Active binding error changed")
+
   df <- tibble(g = c(1, 1, 2, 2), x = 1:4)
   gdf <- group_by(df, g)
 


### PR DESCRIPTION
Closes https://github.com/tidyverse/dplyr/issues/6666

This is a bit of a tricky one.

The issues in #6666 are caused by the fact that every evaluation within a single `mutate()` call (both across multiple expressions and across groups within the same expression) share the same data mask.

This means that assignments with `<-` in one expression can affect downstream expressions or group evaluations. This is most problematic when the assignment is like `x <- ` where `x` is a column in the original data frame. That assignment will _mask_ the active binding we set up for `x`, so it will no longer evaluate to the correct expression in the following expressions or groups.

My idea here is to create a _fresh_ data mask for each individual evaluation (again, both across expressions and across groups). This ensures that each evaluation is done in a clean environment that shouldn't be polluted by previous evaluations.

This works, but the main downside is that it was slower due to the repeated data mask creation. With https://github.com/r-lib/rlang/pull/1553 and https://github.com/r-lib/rlang/pull/1555, I'm hopeful that I've fixed most of the performance issues as long as the user has R >=4.1.0 (which includes the C function `R_NewEnv()`, otherwise mask creation involves an R callback to `new.env()`). In that case, the overhead is barely noticeable.

Below is a set of the absolute worst possible cases, which involves an expression that essentially does nothing, like `identity(x)`, so we basically just measure the overhead of `mutate()`. I've tested over various group sizes. As soon as you add in any expressions that do any "work," the difference in performance isn't noticeable because the expression itself dominates the timings (I show one of these as the last example).

As long as the user has R >=4.1.0 (released May 2021), then they probably won't notice any changes at all. 

I've included timings with CRAN rlang to show that those 2 rlang PRs really do make a difference, and that we should wait for dev rlang to hit CRAN before sending dplyr in, even though _technically_ we don't have to.

One way to interpret these benchmarks is that with 100k groups, this "fresh" data mask idea adds ~50ms of overhead, which seems reasonable for the safety it gets us.

``` r
library(dplyr)

# 1,000 groups
df <- tibble(g = seq_len(1000), x = seq_along(g))
bench::mark(mutate(df, y = identity(x), .by = g), iterations = 1000)

# CRAN dplyr, CRAN rlang
#> # A tibble: 1 × 6
#>   expression                                min   median itr/s…¹ mem_a…² gc/se…³
#>   <bch:expr>                           <bch:tm> <bch:tm>   <dbl> <bch:b>   <dbl>
#> 1 mutate(df, y = identity(x), .by = g)   4.12ms   5.02ms    194.  2.36MB    11.3
#> # … with abbreviated variable names ¹​`itr/sec`, ²​mem_alloc, ³​`gc/sec`

# This PR, dev rlang, R >=4.1.0
#> # A tibble: 1 × 6
#>   expression                                min   median itr/s…¹ mem_a…² gc/se…³
#>   <bch:expr>                           <bch:tm> <bch:tm>   <dbl> <bch:b>   <dbl>
#> 1 mutate(df, y = identity(x), .by = g)   4.33ms   5.27ms    188.  3.52MB    14.8
#> # … with abbreviated variable names ¹​`itr/sec`, ²​mem_alloc, ³​`gc/sec`

# This PR, dev rlang, R <4.1.0
#> # A tibble: 1 × 6
#>   expression                                min   median itr/s…¹ mem_a…² gc/se…³
#>   <bch:expr>                           <bch:tm> <bch:tm>   <dbl> <bch:b>   <dbl>
#> 1 mutate(df, y = identity(x), .by = g)    3.8ms   5.75ms    173.  2.45MB    20.8
#> # … with abbreviated variable names ¹​`itr/sec`, ²​mem_alloc, ³​`gc/sec`

# This PR, CRAN rlang
#> # A tibble: 1 × 6
#>   expression                                min   median itr/s…¹ mem_a…² gc/se…³
#>   <bch:expr>                           <bch:tm> <bch:tm>   <dbl> <bch:b>   <dbl>
#> 1 mutate(df, y = identity(x), .by = g)   5.96ms   7.42ms    134.  4.06MB    19.4
#> # … with abbreviated variable names ¹​`itr/sec`, ²​mem_alloc, ³​`gc/sec`
```

```r
# 10,000 groups
df <- tibble(g = seq_len(10000), x = seq_along(g))
bench::mark(mutate(df, y = identity(x), .by = g), iterations = 100)

# CRAN dplyr, CRAN rlang
#> # A tibble: 1 × 6
#>   expression                                min   median itr/s…¹ mem_a…² gc/se…³
#>   <bch:expr>                           <bch:tm> <bch:tm>   <dbl> <bch:b>   <dbl>
#> 1 mutate(df, y = identity(x), .by = g)   22.8ms   24.8ms    40.3  1.56MB    30.4
#> # … with abbreviated variable names ¹​`itr/sec`, ²​mem_alloc, ³​`gc/sec`

# This PR, dev rlang, R >=4.1.0
#> # A tibble: 1 × 6
#>   expression                                min   median itr/s…¹ mem_a…² gc/se…³
#>   <bch:expr>                           <bch:tm> <bch:tm>   <dbl> <bch:b>   <dbl>
#> 1 mutate(df, y = identity(x), .by = g)   23.8ms   26.1ms    38.0  1.56MB    80.8
#> # … with abbreviated variable names ¹​`itr/sec`, ²​mem_alloc, ³​`gc/sec`

# This PR, dev rlang, R <4.1.0
#> # A tibble: 1 × 6
#>   expression                                min   median itr/s…¹ mem_a…² gc/se…³
#>   <bch:expr>                           <bch:tm> <bch:tm>   <dbl> <bch:b>   <dbl>
#> 1 mutate(df, y = identity(x), .by = g)   25.2ms   28.9ms    35.5  1.56MB    976.
#> # … with abbreviated variable names ¹​`itr/sec`, ²​mem_alloc, ³​`gc/sec`

# This PR, CRAN rlang
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression                                min   median itr/s…¹ mem_a…² gc/se…³
#>   <bch:expr>                           <bch:tm> <bch:tm>   <dbl> <bch:b>   <dbl>
#> 1 mutate(df, y = identity(x), .by = g)   47.9ms   56.1ms    17.5  12.3MB    26.7
#> # … with abbreviated variable names ¹​`itr/sec`, ²​mem_alloc, ³​`gc/sec`
```

```r
# 100,000 groups
df <- tibble(g = seq_len(100000), x = seq_along(g))
bench::mark(mutate(df, y = identity(x), .by = g), iterations = 10)

# CRAN dplyr, CRAN rlang
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression                                min   median itr/s…¹ mem_a…² gc/se…³
#>   <bch:expr>                           <bch:tm> <bch:tm>   <dbl> <bch:b>   <dbl>
#> 1 mutate(df, y = identity(x), .by = g)    204ms    217ms    4.26  15.1MB    11.9
#> # … with abbreviated variable names ¹​`itr/sec`, ²​mem_alloc, ³​`gc/sec`

# This PR, dev rlang, R >=4.1.0
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression                                min   median itr/s…¹ mem_a…² gc/se…³
#>   <bch:expr>                           <bch:tm> <bch:tm>   <dbl> <bch:b>   <dbl>
#> 1 mutate(df, y = identity(x), .by = g)    234ms    263ms    3.67  15.1MB    17.1
#> # … with abbreviated variable names ¹​`itr/sec`, ²​mem_alloc, ³​`gc/sec`

# This PR, dev rlang, R <4.1.0
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression                                min   median itr/s…¹ mem_a…² gc/se…³
#>   <bch:expr>                           <bch:tm> <bch:tm>   <dbl> <bch:b>   <dbl>
#> 1 mutate(df, y = identity(x), .by = g)    256ms    311ms    3.11  15.1MB    19.7
#> # … with abbreviated variable names ¹​`itr/sec`, ²​mem_alloc, ³​`gc/sec`

# This PR, CRAN rlang
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression                                min   median itr/s…¹ mem_a…² gc/se…³
#>   <bch:expr>                           <bch:tm> <bch:tm>   <dbl> <bch:b>   <dbl>
#> 1 mutate(df, y = identity(x), .by = g)    476ms    540ms    1.78   123MB    10.7
#> # … with abbreviated variable names ¹​`itr/sec`, ²​mem_alloc, ³​`gc/sec`
```

Here is an example of "work" being done by the `summarise()` call by computing a `mean()`. Can't really notice the data mask creation overhead here, even on <4.1.0.

```r
library(dplyr)

set.seed(123)

# 100k possible groups
dictionary <- seq_len(100000)
g <- sample(dictionary, 10000000, replace = TRUE)
x <- sample(10, length(g), replace = TRUE)

# 10,000,000 rows
df <- tibble(g = g, x = x)

# 100k groups
vctrs::vec_unique_count(df$g)
#> [1] 100000

bench::mark(summarise(df, x = mean(x), .by = g), iterations = 50)

# CRAN dplyr, CRAN rlang
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression                               min   median itr/se…¹ mem_a…² gc/se…³
#>   <bch:expr>                          <bch:tm> <bch:tm>    <dbl> <bch:b>   <dbl>
#> 1 summarise(df, x = mean(x), .by = g)    1.26s    1.62s    0.610   306MB    2.89
#> # … with abbreviated variable names ¹​`itr/sec`, ²​mem_alloc, ³​`gc/sec`

# This PR, dev rlang, R >=4.1.0
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression                               min   median itr/se…¹ mem_a…² gc/se…³
#>   <bch:expr>                          <bch:tm> <bch:tm>    <dbl> <bch:b>   <dbl>
#> 1 summarise(df, x = mean(x), .by = g)    1.32s    1.48s    0.642   306MB    3.76
#> # … with abbreviated variable names ¹​`itr/sec`, ²​mem_alloc, ³​`gc/sec`

# This PR, dev rlang, R <4.1.0
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression                               min   median itr/se…¹ mem_a…² gc/se…³
#>   <bch:expr>                          <bch:tm> <bch:tm>    <dbl> <bch:b>   <dbl>
#> 1 summarise(df, x = mean(x), .by = g)    1.22s    1.42s    0.665   306MB    4.21
#> # … with abbreviated variable names ¹​`itr/sec`, ²​mem_alloc, ³​`gc/sec`
```