### PR TITLE
Pass correct `user_env` through to all `filter()` warnings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dplyr (development version)
 
+* Deprecation warnings thrown by `filter()` now mention the correct package
+  where the problem originated from (#6679).
+
 * The developer documentation in `?dplyr_extending` has been refreshed and
   brought up to date with all changes made in 1.1.0 (#6695).
 

--- a/R/filter.R
+++ b/R/filter.R
@@ -134,14 +134,18 @@ filter.data.frame <- function(.data, ..., .by = NULL, .preserve = FALSE) {
   dplyr_row_slice(.data, loc, preserve = .preserve)
 }
 
-filter_rows <- function(data, dots, by, error_call = caller_env()) {
+filter_rows <- function(data,
+                        dots,
+                        by,
+                        error_call = caller_env(),
+                        user_env = caller_env(2)) {
   error_call <- dplyr_error_call(error_call)
 
   mask <- DataMask$new(data, by, "filter", error_call = error_call)
   on.exit(mask$forget(), add = TRUE)
 
   dots <- filter_expand(dots, mask = mask, error_call = error_call)
-  filter_eval(dots, mask = mask, error_call = error_call)
+  filter_eval(dots, mask = mask, error_call = error_call, user_env = user_env)
 }
 
 check_filter <- function(dots, error_call = caller_env()) {
@@ -187,7 +191,10 @@ filter_expand <- function(dots, mask, error_call = caller_env()) {
   new_quosures(flatten(dots))
 }
 
-filter_eval <- function(dots, mask, error_call = caller_env()) {
+filter_eval <- function(dots,
+                        mask,
+                        error_call = caller_env(),
+                        user_env = caller_env(2)) {
   env_filter <- env()
   warnings_state <- env(warnings = list())
 
@@ -217,13 +224,13 @@ filter_eval <- function(dots, mask, error_call = caller_env()) {
       warning_handler(cnd)
     },
     `dplyr:::signal_filter_one_column_matrix` = function(e) {
-      warn_filter_one_column_matrix(call = error_call)
+      warn_filter_one_column_matrix(env = error_call, user_env = user_env)
     },
     `dplyr:::signal_filter_across` = function(e) {
-      warn_filter_across(call = error_call)
+      warn_filter_across(env = error_call, user_env = user_env)
     },
     `dplyr:::signal_filter_data_frame` = function(e) {
-      warn_filter_data_frame(call = error_call)
+      warn_filter_data_frame(env = error_call, user_env = user_env)
     }
   )
 
@@ -258,31 +265,34 @@ filter_bullets <- function(cnd, ...) {
   glue("`..{index}` must be of size {or_1(expected_size)}, not size {size}.")
 }
 
-warn_filter_one_column_matrix <- function(call) {
+warn_filter_one_column_matrix <- function(env, user_env) {
   lifecycle::deprecate_warn(
     when = "1.1.0",
     what = I("Using one column matrices in `filter()`"),
     with = I("one dimensional logical vectors"),
-    env = call
+    env = env,
+    user_env = user_env
   )
 }
 
-warn_filter_across <- function(call) {
+warn_filter_across <- function(env, user_env) {
   lifecycle::deprecate_warn(
     when = "1.0.8",
     what = I("Using `across()` in `filter()`"),
     with = I("`if_any()` or `if_all()`"),
     always = TRUE,
-    env = call
+    env = env,
+    user_env = user_env
   )
 }
 
-warn_filter_data_frame <- function(call) {
+warn_filter_data_frame <- function(env, user_env) {
   lifecycle::deprecate_warn(
     when = "1.0.8",
     what = I("Returning data frames from `filter()` expressions"),
     with = I("`if_any()` or `if_all()`"),
     always = TRUE,
-    env = call
+    env = env,
+    user_env = user_env
   )
 }


### PR DESCRIPTION
Closes https://github.com/tidyverse/dplyr/issues/6679

We weren't passing the `user_env` through to `deprecate_warn()` (probably because it didn't exist at the time).

The example from #6679 now reports the right package

```r
df2 <- df |> tabyl(procedure_name)
#> Warning: Using one column matrices in `filter()` was deprecated in dplyr 1.1.0.
#> ℹ Please use one dimensional logical vectors instead.
#> ℹ The deprecated feature was likely used in the janitor package.
#>   Please report the issue at <https://github.com/sfirke/janitor/issues>.
```