### PR TITLE
Speed up `nth()` family

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # dplyr (development version)
 
+* `nth()` now errors informatively if `n` is `NA` (#6682).
+
+* Fixed performance regression related to `nth()`, `first()`, and `last()`
+  (#6682).
+
 * `arrange()` can once again sort the `numeric_version` type from base R
   (#6680).
 

--- a/R/nth-value.R
+++ b/R/nth-value.R
@@ -105,6 +105,10 @@ nth <- function(x, n, order_by = NULL, default = NULL, na_rm = FALSE) {
     }
   }
 
+  if (is.na(n)) {
+    abort("`n` can't be `NA`.")
+  }
+
   if (n < 0L) {
     # Negative values index from RHS
     n <- size + n + 1L

--- a/R/nth-value.R
+++ b/R/nth-value.R
@@ -165,7 +165,9 @@ vec_slice2 <- function(x, i) {
   # Our unimplemented vctrs equivalent of `[[`
   # https://github.com/r-lib/vctrs/pull/1228/
 
-  i <- vec_as_location2(i, vec_size(x))
+  # A real implementation would use this, but it is too slow right now
+  # and we know `i` is a valid integer index (#6682)
+  # i <- vec_as_location2(i, vec_size(x))
 
   if (vec_is_list(x)) {
     out <- .subset2(x, i)

--- a/tests/testthat/_snaps/nth-value.md
+++ b/tests/testthat/_snaps/nth-value.md
@@ -46,6 +46,14 @@
       Error in `nth()`:
       ! `n` must have size 1, not size 2.
 
+---
+
+    Code
+      nth(1:10, n = NA_integer_)
+    Condition
+      Error in `nth()`:
+      ! `n` can't be `NA`.
+
 # `x` must be a vector
 
     Code

--- a/tests/testthat/test-nth-value.R
+++ b/tests/testthat/test-nth-value.R
@@ -163,6 +163,9 @@ test_that("`n` is validated (#5466)", {
   expect_snapshot(error = TRUE, {
     nth(1:10, n = 1:2)
   })
+  expect_snapshot(error = TRUE, {
+    nth(1:10, n = NA_integer_)
+  })
 })
 
 test_that("`x` must be a vector", {


### PR DESCRIPTION
Closes https://github.com/tidyverse/dplyr/issues/6682

I'm not too worried about `vec_as_location2()` actually being slow right now. We can improve that later when we finally add `vec_slice2()` for real.

``` r
library(dplyr)

x <- 1:5

bench::mark(first(x), iterations = 100000)

# CRAN dplyr 1.1.0
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 first(x)     49.5µs   65.2µs    15182.     152KB     16.7

# This PR
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 first(x)     18.9µs   25.2µs    38844.     133KB     15.5
```

Further improvements will come from vctrs with https://github.com/r-lib/vctrs/issues/1785 and https://github.com/r-lib/vctrs/issues/1784