### PR TITLE
Improve performance of `case_when()` and `case_match()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr (development version)
 
+* A major performance regression in `case_when()` has been fixed (#6674).
+
 * Fixed an issue where expressions involving infix operators had an abnormally
   large amount of overhead (#6681).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # dplyr (development version)
 
-* A major performance regression in `case_when()` has been fixed (#6674).
+* A major performance regression in `case_when()` has been fixed. It is still a
+  little slower than in dplyr 1.0.10, but we plan to improve this further in the
+  future (#6674).
 
 * Fixed an issue where expressions involving infix operators had an abnormally
   large amount of overhead (#6681).

--- a/R/case-match.R
+++ b/R/case-match.R
@@ -128,15 +128,11 @@ case_match <- function(.x,
                        .ptype = NULL) {
   args <- list2(...)
 
-  default_env <- caller_env()
-  dots_env <- current_env()
-  error_call <- current_env()
-
   args <- case_formula_evaluate(
     args = args,
-    default_env = default_env,
-    dots_env = dots_env,
-    error_call = error_call
+    default_env = caller_env(),
+    dots_env = current_env(),
+    error_call = current_env()
   )
 
   haystacks <- args$lhs
@@ -152,6 +148,6 @@ case_match <- function(.x,
     default = .default,
     default_arg = ".default",
     ptype = .ptype,
-    call = error_call
+    call = current_env()
   )
 }

--- a/R/case-when.R
+++ b/R/case-when.R
@@ -155,15 +155,11 @@ case_when <- function(...,
                       .size = NULL) {
   args <- list2(...)
 
-  default_env <- caller_env()
-  dots_env <- current_env()
-  error_call <- current_env()
-
   args <- case_formula_evaluate(
     args = args,
-    default_env = default_env,
-    dots_env = dots_env,
-    error_call = error_call
+    default_env = caller_env(),
+    dots_env = current_env(),
+    error_call = current_env()
   )
 
   conditions <- args$lhs
@@ -171,10 +167,10 @@ case_when <- function(...,
 
   # `case_when()`'s formula interface finds the common size of ALL of its inputs.
   # This is what allows `TRUE ~` to work.
-  .size <- vec_size_common(!!!conditions, !!!values, .size = .size, .call = error_call)
+  .size <- vec_size_common(!!!conditions, !!!values, .size = .size)
 
-  conditions <- vec_recycle_common(!!!conditions, .size = .size, .call = error_call)
-  values <- vec_recycle_common(!!!values, .size = .size, .call = error_call)
+  conditions <- vec_recycle_common(!!!conditions, .size = .size)
+  values <- vec_recycle_common(!!!values, .size = .size)
 
   vec_case_when(
     conditions = conditions,
@@ -185,7 +181,7 @@ case_when <- function(...,
     default_arg = ".default",
     ptype = .ptype,
     size = .size,
-    call = error_call
+    call = current_env()
   )
 }
 

--- a/R/case-when.R
+++ b/R/case-when.R
@@ -246,7 +246,7 @@ case_formula_evaluate <- function(args,
   # expressions. But `as_label()` is much too slow for that to be useful in
   # a grouped `mutate()`. We need a way to add ALTREP lazy names that only get
   # materialized on demand (i.e. on error). Until then, we fall back to the
-  # positional names (like `..1` or `..3`) with info about LHS/RHS (#6674).
+  # positional names (like `..1` or `..3`) with info about left/right (#6674).
   #
   # # Add the expressions as names for `lhs` and `rhs` for nice errors.
   # # These names also get passed on to the underlying vctrs backend.
@@ -258,8 +258,8 @@ case_formula_evaluate <- function(args,
   # rhs_names <- map_chr(rhs_names, as_label)
   # names(rhs) <- rhs_names
   if (n_args > 0L) {
-    names(lhs) <- paste0("..", seq_args, " (LHS)")
-    names(rhs) <- paste0("..", seq_args, " (RHS)")
+    names(lhs) <- paste0("..", seq_args, " (left)")
+    names(rhs) <- paste0("..", seq_args, " (right)")
   }
 
   list(

--- a/R/case-when.R
+++ b/R/case-when.R
@@ -194,20 +194,25 @@ case_formula_evaluate <- function(args,
   n_args <- length(args)
   seq_args <- seq_len(n_args)
 
+  pairs <- map2(
+    .x = args,
+    .y = seq_args,
+    .f = function(x, i) {
+      validate_and_split_formula(
+        x = x,
+        i = i,
+        default_env = default_env,
+        dots_env = dots_env,
+        error_call = error_call
+      )
+    }
+  )
+
   lhs <- vector("list", n_args)
   rhs <- vector("list", n_args)
 
-  quos_pairs <- map2(
-    .x = args,
-    .y = seq_len(n_args),
-    .f = validate_and_split_formula,
-    default_env = default_env,
-    dots_env = dots_env,
-    error_call = error_call
-  )
-
-  for (i in seq_len(n_args)) {
-    pair <- quos_pairs[[i]]
+  for (i in seq_args) {
+    pair <- pairs[[i]]
 
     lhs_elt <- with_case_errors(
       eval_tidy(pair$lhs, env = default_env),

--- a/tests/testthat/_snaps/case-match.md
+++ b/tests/testthat/_snaps/case-match.md
@@ -20,7 +20,7 @@
       case_match(1, 1 ~ 1L, .default = "x")
     Condition
       Error in `case_match()`:
-      ! Can't combine `1L` <integer> and `.default` <character>.
+      ! Can't combine `..1 (RHS)` <integer> and `.default` <character>.
 
 # `NULL` formula element throws meaningful error
 
@@ -28,7 +28,7 @@
       case_match(1, 1 ~ NULL)
     Condition
       Error in `case_match()`:
-      ! `NULL` must be a vector, not `NULL`.
+      ! `..1 (RHS)` must be a vector, not `NULL`.
 
 ---
 
@@ -36,7 +36,7 @@
       case_match(1, NULL ~ 1)
     Condition
       Error in `case_match()`:
-      ! `NULL` must be a vector, not `NULL`.
+      ! `..1 (LHS)` must be a vector, not `NULL`.
 
 # throws chained errors when formula evaluation fails
 

--- a/tests/testthat/_snaps/case-match.md
+++ b/tests/testthat/_snaps/case-match.md
@@ -20,7 +20,7 @@
       case_match(1, 1 ~ 1L, .default = "x")
     Condition
       Error in `case_match()`:
-      ! Can't combine `..1 (RHS)` <integer> and `.default` <character>.
+      ! Can't combine `..1 (right)` <integer> and `.default` <character>.
 
 # `NULL` formula element throws meaningful error
 
@@ -28,7 +28,7 @@
       case_match(1, 1 ~ NULL)
     Condition
       Error in `case_match()`:
-      ! `..1 (RHS)` must be a vector, not `NULL`.
+      ! `..1 (right)` must be a vector, not `NULL`.
 
 ---
 
@@ -36,7 +36,7 @@
       case_match(1, NULL ~ 1)
     Condition
       Error in `case_match()`:
-      ! `..1 (LHS)` must be a vector, not `NULL`.
+      ! `..1 (left)` must be a vector, not `NULL`.
 
 # throws chained errors when formula evaluation fails
 

--- a/tests/testthat/_snaps/case-when.md
+++ b/tests/testthat/_snaps/case-when.md
@@ -12,7 +12,7 @@
       case_when(TRUE ~ 1L, .default = "x")
     Condition
       Error in `case_when()`:
-      ! Can't combine `..1 (RHS)` <integer> and `.default` <character>.
+      ! Can't combine `..1 (right)` <integer> and `.default` <character>.
 
 # passes through `.size` correctly
 
@@ -20,7 +20,7 @@
       case_when(TRUE ~ 1:2, .size = 3)
     Condition
       Error in `case_when()`:
-      ! Can't recycle `..1 (RHS)` (size 2) to size 3.
+      ! Can't recycle `..1 (right)` (size 2) to size 3.
 
 # invalid type errors are correct (#6261) (#6206)
 
@@ -28,7 +28,7 @@
       case_when(TRUE ~ 1, TRUE ~ "x")
     Condition
       Error in `case_when()`:
-      ! Can't combine `..1 (RHS)` <double> and `..2 (RHS)` <character>.
+      ! Can't combine `..1 (right)` <double> and `..2 (right)` <character>.
 
 # `NULL` formula element throws meaningful error
 
@@ -36,7 +36,7 @@
       case_when(1 ~ NULL)
     Condition
       Error in `case_when()`:
-      ! `..1 (RHS)` must be a vector, not `NULL`.
+      ! `..1 (right)` must be a vector, not `NULL`.
 
 ---
 
@@ -44,7 +44,7 @@
       case_when(NULL ~ 1)
     Condition
       Error in `case_when()`:
-      ! `..1 (LHS)` must be a vector, not `NULL`.
+      ! `..1 (left)` must be a vector, not `NULL`.
 
 # throws chained errors when formula evaluation fails
 
@@ -73,20 +73,20 @@
     Output
       <error/vctrs_error_incompatible_size>
       Error in `case_when()`:
-      ! Can't recycle `..1 (LHS)` (size 2) to match `..1 (RHS)` (size 3).
+      ! Can't recycle `..1 (left)` (size 2) to match `..1 (right)` (size 3).
     Code
       (expect_error(case_when(c(TRUE, FALSE) ~ 1, c(FALSE, TRUE, FALSE) ~ 2, c(FALSE,
         TRUE, FALSE, NA) ~ 3)))
     Output
       <error/vctrs_error_incompatible_size>
       Error in `case_when()`:
-      ! Can't recycle `..1 (LHS)` (size 2) to match `..2 (LHS)` (size 3).
+      ! Can't recycle `..1 (left)` (size 2) to match `..2 (left)` (size 3).
     Code
       (expect_error(case_when(50 ~ 1:3)))
     Output
       <error/vctrs_error_assert_ptype>
       Error in `case_when()`:
-      ! `..1 (LHS)` must be a vector with type <logical>.
+      ! `..1 (left)` must be a vector with type <logical>.
       Instead, it has type <double>.
     Code
       (expect_error(case_when(paste(50))))

--- a/tests/testthat/_snaps/case-when.md
+++ b/tests/testthat/_snaps/case-when.md
@@ -12,7 +12,7 @@
       case_when(TRUE ~ 1L, .default = "x")
     Condition
       Error in `case_when()`:
-      ! Can't combine `1L` <integer> and `.default` <character>.
+      ! Can't combine `..1 (RHS)` <integer> and `.default` <character>.
 
 # passes through `.size` correctly
 
@@ -20,7 +20,7 @@
       case_when(TRUE ~ 1:2, .size = 3)
     Condition
       Error in `case_when()`:
-      ! Can't recycle `1:2` (size 2) to size 3.
+      ! Can't recycle `..1 (RHS)` (size 2) to size 3.
 
 # invalid type errors are correct (#6261) (#6206)
 
@@ -28,7 +28,7 @@
       case_when(TRUE ~ 1, TRUE ~ "x")
     Condition
       Error in `case_when()`:
-      ! Can't combine `1` <double> and `"x"` <character>.
+      ! Can't combine `..1 (RHS)` <double> and `..2 (RHS)` <character>.
 
 # `NULL` formula element throws meaningful error
 
@@ -36,7 +36,7 @@
       case_when(1 ~ NULL)
     Condition
       Error in `case_when()`:
-      ! `NULL` must be a vector, not `NULL`.
+      ! `..1 (RHS)` must be a vector, not `NULL`.
 
 ---
 
@@ -44,7 +44,7 @@
       case_when(NULL ~ 1)
     Condition
       Error in `case_when()`:
-      ! `NULL` must be a vector, not `NULL`.
+      ! `..1 (LHS)` must be a vector, not `NULL`.
 
 # throws chained errors when formula evaluation fails
 
@@ -73,20 +73,20 @@
     Output
       <error/vctrs_error_incompatible_size>
       Error in `case_when()`:
-      ! Can't recycle `c(TRUE, FALSE)` (size 2) to match `1:3` (size 3).
+      ! Can't recycle `..1 (LHS)` (size 2) to match `..1 (RHS)` (size 3).
     Code
       (expect_error(case_when(c(TRUE, FALSE) ~ 1, c(FALSE, TRUE, FALSE) ~ 2, c(FALSE,
         TRUE, FALSE, NA) ~ 3)))
     Output
       <error/vctrs_error_incompatible_size>
       Error in `case_when()`:
-      ! Can't recycle `c(TRUE, FALSE)` (size 2) to match `c(FALSE, TRUE, FALSE)` (size 3).
+      ! Can't recycle `..1 (LHS)` (size 2) to match `..2 (LHS)` (size 3).
     Code
       (expect_error(case_when(50 ~ 1:3)))
     Output
       <error/vctrs_error_assert_ptype>
       Error in `case_when()`:
-      ! `50` must be a vector with type <logical>.
+      ! `..1 (LHS)` must be a vector with type <logical>.
       Instead, it has type <double>.
     Code
       (expect_error(case_when(paste(50))))


### PR DESCRIPTION
Closes https://github.com/tidyverse/dplyr/issues/6674

Three improvements to make these decently fast again:

- Minor: Calls to `current_env()` and `caller_env()` are now lazy (only evaluated when needed) (needs https://github.com/r-lib/rlang/issues/1558)

- Major: We no longer call `as_label()` to turn the expressions into labels which were being used as informative names that showed up in error messages. This stinks, but `as_label()` is just too slow to be used eagerly like this. We can revisit this again in the future if we add a lazy ALTREP character vector which could materialize the `as_label()` calls on demand (i.e. at error time). In the meantime, we now use positional names that also include LHS/RHS information, like `..2 (RHS)`, which ends up being decent.

- Major: I was previously wrapping the evaluation of the lhs/rhs of the formulas in `with_case_errors()` to give an informative indexed error about which formula failed to evaluate. This got slow as you increased the number of expressions in `case_when()` (2 * N expressions = number of `with_case_errors()` calls) because it uses `try_fetch()`, which is built on `tryCatch()`, which is in R not C (probably a good Luke project!). I've changed it up so 1 call to `with_case_errors()` now wraps the entire evaluation loop, and we track some index information to use in the error if one occurs.

Sadly the private option added in rlang (https://github.com/r-lib/rlang/commit/33db700d556b0b85a1fe78e14a53f95ac9248004) wasn't enough to make `as_label()` fast enough to be used eagerly like this. But the `infix_overflows()` call there is a big part of the performance degradation we see in my benchmarks below.

When I work on https://github.com/tidyverse/dplyr/issues/6678 that will end up also knocking off another 50us or so from switching away from `vec_assert()` in `vec_case_when()` and `if_else()`.

After that, any other improvements will come from moving `vec_case_when()` to C in vctrs.

Right now we are in the 2-4x slower range. After https://github.com/tidyverse/dplyr/issues/6678 I expect to be 2x slower most of the time. I think we can do a release with that. Then the C implementation in vctrs should fix the rest.

```r
library(dplyr)

# Size 1
x <- 1L

bench::mark(
  one = case_when(x == 1L ~ TRUE), 
  two = case_when(x == 1L ~ TRUE, x == 2L ~ NA),
  three = case_when(x == 1L ~ TRUE, x == 2L ~ NA, TRUE ~ FALSE),
  iterations = 50000,
  check = FALSE
)

# dplyr 1.0.10
#> # A tibble: 3 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 one          56.8µs   74.7µs    12802.     168KB     18.2
#> 2 two          75.5µs   95.4µs    10514.        0B     22.5
#> 3 three        97.4µs  120.2µs     8390.        0B     23.9

# This PR
#> # A tibble: 3 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 one           209µs    278µs     3388.   503.8KB     11.3
#> 2 two           242µs    326µs     2879.     1.3KB     12.2
#> 3 three         272µs    350µs     2787.     1.3KB     14.3

# dplyr 1.1.0 (smacked by the infix-overflow `as_label()` performance issue)
# (note that i had to go down to only 5,000 iterations here)
#> # A tibble: 3 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 one          1.67ms   2.12ms      477.    1.01MB     16.6
#> 2 two          3.14ms   3.86ms      261.    3.36KB     18.2
#> 3 three        3.27ms   4.32ms      228.    3.36KB     16.5
```

```r
library(dplyr)

# Size 1000
x <- 1:1000

bench::mark(
  one = case_when(x < 200 ~ TRUE), 
  two = case_when(x < 200 ~ TRUE, x < 500 ~ NA),
  three = case_when(x < 200 ~ TRUE, x < 500 ~ NA, TRUE ~ FALSE),
  iterations = 50000,
  check = FALSE
)

# dplyr 1.0.10
#> # A tibble: 3 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 one          73.2µs   92.2µs    10873.    60.1KB     17.0
#> 2 two         108.6µs  136.9µs     7383.   100.9KB     17.3
#> 3 three       136.1µs  171.2µs     5914.   130.6KB     18.3

# This PR
#> # A tibble: 3 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 one           222µs    271µs     3720.    44.1KB     14.4
#> 2 two           279µs    334µs     3011.    60.1KB     15.4
#> 3 three         318µs    382µs     2649.      70KB     16.5

# dplyr 1.1.0
#> # A tibble: 3 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 one          2.03ms   2.39ms      400.      45KB     15.0
#> 2 two          3.98ms   4.45ms      222.    62.2KB     16.6
#> 3 three         4.1ms   4.64ms      211.      72KB     16.6
```