### PR TITLE
Use rlang private option when creating error context labels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dplyr (development version)
 
+* Fixed an issue where expressions involving infix operators had an abnormally
+  large amount of overhead (#6681).
+
 * `nth()` now errors informatively if `n` is `NA` (#6682).
 
 * Fixed performance regression related to `nth()`, `first()`, and `last()`

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -68,7 +68,7 @@ quo_as_label <- function(quo)  {
   if (is_data_pronoun(expr)) {
     deparse(expr)[[1]]
   } else{
-    as_label(expr)
+    with_no_rlang_infix_labeling(as_label(expr))
   }
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -75,3 +75,10 @@ node_walk_replace <- function(node, old, new) {
 cli_collapse <- function(x, last = " and ") {
   cli::cli_vec(x, style = list("vec-last" = last))
 }
+
+with_no_rlang_infix_labeling <- function(expr) {
+  # TODO: Temporary patch for a slowdown seen with `rlang::as_label()` and infix
+  # operators. A real solution likely involves lazy ALTREP vectors (#6681).
+  # https://github.com/r-lib/rlang/commit/33db700d556b0b85a1fe78e14a53f95ac9248004
+  with_options("rlang:::use_as_label_infix" = FALSE, expr)
+}


### PR DESCRIPTION
Closes https://github.com/tidyverse/dplyr/issues/6681

Here is the crux of the issue

``` r
quo <- quo(1 + 1)

bench::mark(
  as_label(quo),
  with_no_rlang_infix_labeling(as_label(quo))
)
#> # A tibble: 2 × 6
#>   expression                                       min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                                  <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 as_label(quo)                                 1.41ms   1.99ms      496.      992B    11.3 
#> 2 with_no_rlang_infix_labeling(as_label(quo))  185.4µs 247.46µs     4041.      704B     8.60

quo <- quo(mean(x) + mean(x) + mean(x) + mean(x) + mean(x) + mean(x) + mean(x) + mean(x))

# these do look different now, but the performance was killer
as_label(quo)
#> [1] "... + mean(x)"
with_no_rlang_infix_labeling(as_label(quo))
#> [1] "+..."

bench::mark(
  as_label(quo),
  with_no_rlang_infix_labeling(as_label(quo)),
  check = FALSE
)
#> # A tibble: 2 × 6
#>   expression                                       min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                                  <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 as_label(quo)                                 46.2ms     50ms      19.7    13.6KB     39.4
#> 2 with_no_rlang_infix_labeling(as_label(quo))  388.1µs    511µs    1911.       704B     11.2
```

Proof that the original issues are fixed:

https://github.com/tidyverse/dplyr/issues/6681#issue-1568832364:

``` r
df <- tibble::tibble(x = 1:10000)

bench::mark(
  b1 = dplyr::summarize(
    df,
    res = (1 + 1)
  ),
  b2 = dplyr::summarize(
    df,
    res = 1 + 1
  )
)
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 b1            1.4ms   1.76ms      572.    4.53MB     12.9
#> 2 b2            1.4ms    1.7ms      609.    5.31KB     12.6
```

https://github.com/tidyverse/dplyr/issues/6681#issuecomment-1421544064:

``` r
df <- tibble::tibble(x = 1:10000)

bench::mark(
  b1 = dplyr::summarize(
    df,
    res = (mean(x) + mean(x) + mean(x) + mean(x) + mean(x) + mean(x) + mean(x) + mean(x))
  ),
  b2 = dplyr::summarize(
    df,
    res = mean(x) + mean(x) + mean(x) + mean(x) + mean(x) + mean(x) + mean(x) + mean(x)
  )
)
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 b1           2.52ms   2.72ms      359.    4.56MB    13.1 
#> 2 b2           2.55ms   2.77ms      319.    5.31KB     8.35
```

<sup>Created on 2023-02-10 with [reprex v2.0.2.9000](https://reprex.tidyverse.org)</sup>