### PR TITLE
Use `check_logical()` rather than `vec_assert()` in `if_else()` and `vec_case_when()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dplyr (development version)
 
+* `if_else()` and `case_when()` again accept logical conditions that have
+  attributes (#6678).
+
 * `slice_sample()` now works when the input has a column named `replace`.
   `slice_min()` and `slice_max()` now work when the input has columns named
   `na_rm` or `with_ties` (#6725).

--- a/R/if-else.R
+++ b/R/if-else.R
@@ -60,11 +60,7 @@ if_else <- function(condition,
   check_dots_empty0(...)
 
   # Assert early since we `!` the `condition`
-  vec_assert(
-    x = condition,
-    ptype = logical(),
-    arg = "condition"
-  )
+  check_logical(condition)
 
   conditions <- list(
     condition = condition,

--- a/R/utils.R
+++ b/R/utils.R
@@ -82,29 +82,3 @@ with_no_rlang_infix_labeling <- function(expr) {
   # https://github.com/r-lib/rlang/commit/33db700d556b0b85a1fe78e14a53f95ac9248004
   with_options("rlang:::use_as_label_infix" = FALSE, expr)
 }
-
-# TODO: Update rlang compat files and use that version
-# https://github.com/r-lib/rlang/pull/1560
-check_logical <- function(x,
-                          ...,
-                          allow_null = FALSE,
-                          arg = caller_arg(x),
-                          call = caller_env()) {
-  if (!missing(x)) {
-    if (is_logical(x)) {
-      return(invisible(NULL))
-    }
-    if (allow_null && is_null(x)) {
-      return(invisible(NULL))
-    }
-  }
-
-  stop_input_type(
-    x,
-    "a logical vector",
-    ...,
-    allow_null = allow_null,
-    arg = arg,
-    call = call
-  )
-}

--- a/R/utils.R
+++ b/R/utils.R
@@ -82,3 +82,29 @@ with_no_rlang_infix_labeling <- function(expr) {
   # https://github.com/r-lib/rlang/commit/33db700d556b0b85a1fe78e14a53f95ac9248004
   with_options("rlang:::use_as_label_infix" = FALSE, expr)
 }
+
+# TODO: Update rlang compat files and use that version
+# https://github.com/r-lib/rlang/pull/1560
+check_logical <- function(x,
+                          ...,
+                          allow_null = FALSE,
+                          arg = caller_arg(x),
+                          call = caller_env()) {
+  if (!missing(x)) {
+    if (is_logical(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a logical vector",
+    ...,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}

--- a/R/vec-case-when.R
+++ b/R/vec-case-when.R
@@ -51,13 +51,7 @@ vec_case_when <- function(conditions,
   for (i in seq_len(n_conditions)) {
     condition <- conditions[[i]]
     condition_arg <- condition_args[[i]]
-
-    vec_assert(
-      x = condition,
-      ptype = logical(),
-      arg = condition_arg,
-      call = call
-    )
+    check_logical(condition, arg = condition_arg, call = call)
   }
 
   size <- vec_size_common(

--- a/tests/testthat/_snaps/case-when.md
+++ b/tests/testthat/_snaps/case-when.md
@@ -44,7 +44,7 @@
       case_when(NULL ~ 1)
     Condition
       Error in `case_when()`:
-      ! `..1 (left)` must be a vector, not `NULL`.
+      ! `..1 (left)` must be a logical vector, not `NULL`.
 
 # throws chained errors when formula evaluation fails
 
@@ -84,10 +84,9 @@
     Code
       (expect_error(case_when(50 ~ 1:3)))
     Output
-      <error/vctrs_error_assert_ptype>
+      <error/rlang_error>
       Error in `case_when()`:
-      ! `..1 (left)` must be a vector with type <logical>.
-      Instead, it has type <double>.
+      ! `..1 (left)` must be a logical vector, not a double vector.
     Code
       (expect_error(case_when(paste(50))))
     Output

--- a/tests/testthat/_snaps/if-else.md
+++ b/tests/testthat/_snaps/if-else.md
@@ -20,8 +20,7 @@
       if_else(1:10, 1, 2)
     Condition
       Error in `if_else()`:
-      ! `condition` must be a vector with type <logical>.
-      Instead, it has type <integer>.
+      ! `condition` must be a logical vector, not an integer vector.
 
 # `true`, `false`, and `missing` must recycle to the size of `condition`
 

--- a/tests/testthat/_snaps/vec-case-when.md
+++ b/tests/testthat/_snaps/vec-case-when.md
@@ -92,8 +92,7 @@
       vec_case_when(list(1), list(2))
     Condition
       Error in `vec_case_when()`:
-      ! `conditions[[1]]` must be a vector with type <logical>.
-      Instead, it has type <double>.
+      ! `conditions[[1]]` must be a logical vector, not the number 1.
 
 ---
 
@@ -101,8 +100,7 @@
       vec_case_when(list(TRUE, 3.5), list(2, 4))
     Condition
       Error in `vec_case_when()`:
-      ! `conditions[[2]]` must be a vector with type <logical>.
-      Instead, it has type <double>.
+      ! `conditions[[2]]` must be a logical vector, not the number 3.5.
 
 # `size` overrides the `conditions` sizes
 
@@ -193,8 +191,7 @@
       vec_case_when(list(x = 1.5), list(1))
     Condition
       Error in `vec_case_when()`:
-      ! `conditions$x` must be a vector with type <logical>.
-      Instead, it has type <double>.
+      ! `conditions$x` must be a logical vector, not the number 1.5.
 
 ---
 
@@ -202,8 +199,7 @@
       vec_case_when(list(x = 1.5), list(1), conditions_arg = "foo")
     Condition
       Error in `vec_case_when()`:
-      ! `foo$x` must be a vector with type <logical>.
-      Instead, it has type <double>.
+      ! `foo$x` must be a logical vector, not the number 1.5.
 
 ---
 
@@ -211,8 +207,7 @@
       vec_case_when(list(x = 1.5), list(1), conditions_arg = "")
     Condition
       Error in `vec_case_when()`:
-      ! `x` must be a vector with type <logical>.
-      Instead, it has type <double>.
+      ! `x` must be a logical vector, not the number 1.5.
 
 ---
 

--- a/tests/testthat/test-case-when.R
+++ b/tests/testthat/test-case-when.R
@@ -120,6 +120,11 @@ test_that("case_when() can be used inside mutate()", {
   expect_identical(out, c(2, 2, 1, 0))
 })
 
+test_that("case_when() accepts logical conditions with attributes (#6678)", {
+  x <- structure(c(FALSE, TRUE), label = "foo")
+  expect_identical(case_when(x ~ 1, .default = 2), c(2, 1))
+})
+
 test_that("can pass quosures to case_when()", {
   fs <- local({
     x <- 3:1

--- a/tests/testthat/test-if-else.R
+++ b/tests/testthat/test-if-else.R
@@ -63,6 +63,11 @@ test_that("can recycle to size 0 `condition`", {
   expect_identical(if_else(logical(), 1, 2, missing = 3), double())
 })
 
+test_that("accepts logical conditions with attributes (#6678)", {
+  x <- structure(TRUE, label = "foo")
+  expect_identical(if_else(x, 1, 2), 1)
+})
+
 test_that("`condition` must be logical (and isn't cast to logical!)", {
   expect_snapshot(error = TRUE, {
     if_else(1:10, 1, 2)

--- a/tests/testthat/test-vec-case-when.R
+++ b/tests/testthat/test-vec-case-when.R
@@ -305,6 +305,16 @@ test_that("`conditions` must be logical (and aren't cast to logical!)", {
   })
 })
 
+test_that("`conditions` are allowed to have attributes", {
+  x <- structure(c(FALSE, TRUE), label = "foo")
+  expect_identical(vec_case_when(list(x), list(1), default = 2), c(2, 1))
+})
+
+test_that("`conditions` can be classed logicals", {
+  x <- structure(c(FALSE, TRUE), class = "my_logical")
+  expect_identical(vec_case_when(list(x), list(1), default = 2), c(2, 1))
+})
+
 test_that("`size` overrides the `conditions` sizes", {
   expect_snapshot(error = TRUE, {
     vec_case_when(list(TRUE), list(1), size = 5)


### PR DESCRIPTION
Closes https://github.com/tidyverse/dplyr/issues/6678

As mentioned in #6711, this also improves the performance of `case_when()` a little further:

``` r
library(dplyr)

# Size 1
x <- 1L

bench::mark(
  one = case_when(x == 1L ~ TRUE), 
  two = case_when(x == 1L ~ TRUE, x == 2L ~ NA),
  three = case_when(x == 1L ~ TRUE, x == 2L ~ NA, TRUE ~ FALSE),
  iterations = 50000,
  check = FALSE
)

# Main
#> # A tibble: 3 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 one           172µs    251µs     3851.   498.9KB     10.8
#> 2 two           212µs    268µs     3683.     1.3KB     13.6
#> 3 three         245µs    309µs     3214.     1.3KB     14.6

# This PR
#> # A tibble: 3 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 one           154µs    212µs     4614.   493.1KB     11.6
#> 2 two           180µs    229µs     4337.     1.3KB     13.4
#> 3 three         206µs    282µs     3277.     1.3KB     11.8
```