### PR TITLE
Use `obj_check_vector()` and `vec_check_size()`

### DIFF
--- a/R/desc.R
+++ b/R/desc.R
@@ -14,7 +14,6 @@
 #'
 #' starwars %>% arrange(desc(mass))
 desc <- function(x) {
-  vec_assert(x)
-
+  obj_check_vector(x)
   -xtfrm(x)
 }

--- a/R/lead-lag.R
+++ b/R/lead-lag.R
@@ -102,12 +102,13 @@ shift <- function(x,
     return(out)
   }
 
-  vec_assert(x, arg = "x", call = error_call)
+  obj_check_vector(x, call = error_call)
+
   check_number_whole(n)
   n <- vec_cast(n, integer(), call = error_call)
 
   if (!is.null(default)) {
-    vec_assert(default, size = 1L, arg = "default", call = error_call)
+    vec_check_size(default, size = 1L, call = error_call)
 
     default <- vec_cast(
       x = default,

--- a/R/nth-value.R
+++ b/R/nth-value.R
@@ -83,11 +83,11 @@
 nth <- function(x, n, order_by = NULL, default = NULL, na_rm = FALSE) {
   size <- vec_size(x)
 
-  vec_assert(n, size = 1L, arg = "n")
-  n <- vec_cast(n, to = integer(), x_arg = "n")
+  vec_check_size(n, size = 1L)
+  n <- vec_cast(n, to = integer())
 
   if (!is.null(order_by)) {
-    vec_assert(order_by, size = size, arg = "order_by")
+    vec_check_size(order_by, size = size)
   }
 
   default <- check_nth_default(default, x = x)
@@ -152,7 +152,7 @@ check_nth_default <- function(default, x, ..., error_call = caller_env()) {
     return(vec_init(x))
   }
 
-  vec_assert(default, size = 1L, arg = "default", call = error_call)
+  vec_check_size(default, size = 1L, call = error_call)
 
   default <- vec_cast(
     x = default,

--- a/R/order-by.R
+++ b/R/order-by.R
@@ -60,7 +60,7 @@ order_by <- function(order_by, call) {
 #' @keywords internal
 #' @export
 with_order <- function(order_by, fun, x, ...) {
-  vec_assert(order_by, size = vec_size(x), arg = "order_by")
+  vec_check_size(order_by, size = vec_size(x))
 
   o <- vec_order_radix(order_by)
   x <- vec_slice(x, o)

--- a/R/slice.R
+++ b/R/slice.R
@@ -233,7 +233,7 @@ slice_min.data.frame <- function(.data, order_by, ..., n, prop, by = NULL, with_
     local({
       n <- dplyr::n()
       order_by <- {{ order_by }}
-      vec_assert(order_by, size = n)
+      vec_check_size(order_by, size = n)
 
       slice_rank_idx(
         order_by,
@@ -273,8 +273,7 @@ slice_max.data.frame <- function(.data, order_by, ..., n, prop, by = NULL, with_
     local({
       n <- dplyr::n()
       order_by <- {{ order_by }}
-
-      vec_assert(order_by, size = n)
+      vec_check_size(order_by, size = n)
 
       slice_rank_idx(
         order_by,
@@ -319,7 +318,7 @@ slice_sample.data.frame <- function(.data, ..., n, prop, by = NULL, weight_by = 
 
       n <- dplyr::n()
       if (!is.null(weight_by)) {
-        weight_by <- vec_assert(weight_by, size = n, arg = "weight_by")
+        vec_check_size(weight_by, size = n)
       }
       sample_int(n, size(n), replace = !!replace, wt = weight_by)
     })

--- a/R/vec-case-match.R
+++ b/R/vec-case-match.R
@@ -11,7 +11,7 @@ vec_case_match <- function(needles,
                            call = current_env()) {
   check_dots_empty0(...)
 
-  vec_assert(needles, arg = needles_arg, call = call)
+  obj_check_vector(needles, arg = needles_arg, call = call)
   vec_check_list(haystacks, arg = haystacks_arg, call = call)
   list_check_all_vectors(haystacks, arg = haystacks_arg, call = call)
 

--- a/R/vec-case-when.R
+++ b/R/vec-case-when.R
@@ -96,8 +96,7 @@ vec_case_when <- function(conditions,
   for (i in seq_len(n_conditions)) {
     condition <- conditions[[i]]
     condition_arg <- condition_args[[i]]
-
-    vec_assert(condition, size = size, arg = condition_arg, call = call)
+    vec_check_size(condition, size = size, arg = condition_arg, call = call)
   }
 
   value_sizes <- list_sizes(values)
@@ -108,14 +107,13 @@ vec_case_when <- function(conditions,
     if (value_size != 1L) {
       value <- values[[i]]
       value_arg <- value_args[[i]]
-
-      vec_assert(value, size = size, arg = value_arg, call = call)
+      vec_check_size(value, size = size, arg = value_arg, call = call)
     }
   }
 
   default_size <- vec_size(default)
   if (default_size != 1L) {
-    vec_assert(default, size = size, arg = default_arg, call = call)
+    vec_check_size(default, size = size, arg = default_arg, call = call)
   }
 
   n_processed <- 0L


### PR DESCRIPTION
Closes https://github.com/tidyverse/dplyr/issues/6716

With a few more micro improvements in `case_when()`

```r
library(dplyr)

# Size 1
x <- 1L

bench::mark(
  one = case_when(x == 1L ~ TRUE), 
  two = case_when(x == 1L ~ TRUE, x == 2L ~ NA),
  three = case_when(x == 1L ~ TRUE, x == 2L ~ NA, TRUE ~ FALSE),
  iterations = 50000,
  check = FALSE
)

# Main
#> # A tibble: 3 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 one           161µs    212µs     4470.   524.3KB     11.2
#> 2 two           189µs    239µs     3960.     1.3KB     12.2
#> 3 three         212µs    277µs     3312.     1.3KB     12.0

# This PR
#> # A tibble: 3 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 one           153µs    198µs     4939.   530.3KB     12.0
#> 2 two           181µs    228µs     4192.     1.3KB     12.3
#> 3 three         194µs    258µs     3645.     1.3KB     12.3
```