### PR TITLE
Avoid infix slowdown in `dplyr_quosures()`

### DIFF
--- a/R/across.R
+++ b/R/across.R
@@ -541,7 +541,7 @@ dplyr_quosures <- function(...) {
     if (is_named) {
       name_auto <- name_given
     } else {
-      name_auto <- as_label(quosure)
+      name_auto <- with_no_rlang_infix_labeling(as_label(quosure))
     }
 
     quosures[[i]] <- new_dplyr_quosure(quosure,


### PR DESCRIPTION
CC @lionel-, found another place where this came up. I think I'll also do a follow up PR to change the implementation so the "auto name" is only generated on the fly when it is actually needed, which is typically only in `mutate()` or `summarise()` to name an unnamed expression to create a column for it, or right before an error. Which means `filter()` shouldn't have to pay this penalty at all.

CC @simonpcouch, should take off a little overhead from parsnip

```r
library(tidymodels)

bench::mark(
  model = {
    l <- linear_reg()
    fit(l, hours ~ age + college, data = gss)
  }, 
  iterations = 100
)

# Main
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 model        51.3ms   56.4ms      17.5    9.18MB     3.59

# This PR
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 model        35.7ms   42.2ms      23.8    8.66MB     2.94
```

```r
bench::mark(filter(mtcars, vs == 0, cyl == 4), iterations = 1000)

# Main
#> # A tibble: 1 × 6
#>   expression                             min   median `itr/sec` mem_al…¹ gc/se…²
#>   <bch:expr>                        <bch:tm> <bch:tm>     <dbl> <bch:by>   <dbl>
#> 1 filter(mtcars, vs == 0, cyl == 4)   4.19ms    5.3ms      190.   20.4KB    3.88
#> # … with abbreviated variable names ¹​mem_alloc, ²​`gc/sec`

# This PR
#> # A tibble: 1 × 6
#>   expression                             min   median `itr/sec` mem_al…¹ gc/se…²
#>   <bch:expr>                        <bch:tm> <bch:tm>     <dbl> <bch:by>   <dbl>
#> 1 filter(mtcars, vs == 0, cyl == 4)   1.53ms   1.73ms      571.   19.8KB    4.02
#> # … with abbreviated variable names ¹​mem_alloc, ²​`gc/sec`
```