### PR TITLE
Avoid `as_tibble()` in `group_data.tbl_df()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr (development version)
 
+* `group_data()` on ungrouped data frames is faster (#6736).
+
 * `n()` is now a little faster when there are many groups (#6727).
 
 * `if_else()` and `case_when()` again accept logical conditions that have

--- a/R/group-data.R
+++ b/R/group-data.R
@@ -51,13 +51,19 @@ group_data <- function(.data) {
 
 #' @export
 group_data.data.frame <- function(.data) {
-  rows <- new_list_of(list(seq_len(nrow(.data))), ptype = integer())
-  new_data_frame(list(.rows = rows), n = 1L)
+  size <- vec_size(.data)
+  out <- seq_len(size)
+  out <- new_list_of(list(out), ptype = integer())
+  out <- list(.rows = out)
+  out <- new_data_frame(out, n = 1L)
+  out
 }
 
 #' @export
 group_data.tbl_df <- function(.data) {
-  as_tibble(NextMethod())
+  out <- NextMethod()
+  out <- dplyr_new_tibble(out, size = 1L)
+  out
 }
 
 #' @export


### PR DESCRIPTION
And break `group_data.data.frame()` into multiple lines

This is used by `compute_by()` in the common case of an ungrouped data frame with no `.by` argument, so it is worth it to make it faster here:

``` r
library(dplyr)

df <- tibble(x = 1:5)

bench::mark(group_data(df))

# Main
#> # A tibble: 1 × 6
#>   expression          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 group_data(df)    155µs    173µs     5235.     179KB     8.19

# This PR
#> # A tibble: 1 × 6
#>   expression          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 group_data(df)   22.5µs   24.8µs    37684.     105KB     11.3
```

<sup>Created on 2023-02-17 with [reprex v2.0.2.9000](https://reprex.tidyverse.org)</sup>