### PR TITLE
Optimize `compute_by()` for the "no groups" case

### DIFF
--- a/R/by.R
+++ b/R/by.R
@@ -47,14 +47,19 @@ compute_by <- function(by,
     names <- group_vars(data)
     data <- group_data(data)
   } else {
-    by <- eval_select_by(by, data, error_call = error_call)
+    if (quo_is_null(by)) {
+      # Much faster than `eval_select_by()` for this common case
+      by <- character()
+    } else {
+      by <- eval_select_by(by, data, error_call = error_call)
+    }
 
     if (length(by) == 0L) {
       # `by = NULL` or empty selection
       type <- "ungrouped"
       names <- by
       data <- group_data(data)
-      data <- as_tibble(data)
+      data <- dplyr_new_tibble(data, size = vec_size(data))
     } else {
       type <- "grouped"
       names <- by
@@ -73,7 +78,7 @@ compute_by_groups <- function(data, names, error_call = caller_env()) {
 
   out <- dplyr_new_list(info$key)
   out[[".rows"]] <- new_list_of(info$loc, ptype = integer())
-  out <- new_tibble(out, nrow = size)
+  out <- dplyr_new_tibble(out, size = size)
 
   out
 }


### PR DESCRIPTION
~25% less overhead in `mutate()` now

``` r
library(dplyr)

df <- tibble(x = c(1, 2, 3, 4))

bench::mark(mutate(df, y = x + 1), iterations = 10000)

# Main
#> # A tibble: 1 × 6
#>   expression                 min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>            <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 mutate(df, y = x + 1)   1.72ms   1.96ms      483.    2.76MB     11.1

# This PR
#> # A tibble: 1 × 6
#>   expression                 min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>            <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 mutate(df, y = x + 1)    986µs   1.42ms      678.    2.31MB     10.1
```