### PR TITLE
Remove test related to embracing of unused missing argument

### DIFF
--- a/tests/testthat/_snaps/join-by.md
+++ b/tests/testthat/_snaps/join-by.md
@@ -7,16 +7,7 @@
       ! Must supply at least one expression.
       i If you want a cross join, use `cross_join()`.
 
-# nicely catches missing arguments when wrapped
-
-    Code
-      fn(a)
-    Condition
-      Error in `join_by()`:
-      ! Expressions can't be missing.
-      x Expression 2 is missing.
-
----
+# nicely catches required missing arguments when wrapped
 
     Code
       fn(a)

--- a/tests/testthat/test-join-by.R
+++ b/tests/testthat/test-join-by.R
@@ -229,12 +229,7 @@ test_that("can wrap `join_by()` and use embracing to inject expressions", {
   expect_identical(fn(a == b), join_by(a == b, a <= b))
 })
 
-test_that("nicely catches missing arguments when wrapped", {
-  fn <- function(x, y) {
-    join_by({{x}}, {{y}})
-  }
-  expect_snapshot(error = TRUE, fn(a))
-
+test_that("nicely catches required missing arguments when wrapped", {
   fn <- function(x, y) {
     join_by({{x}} == {{y}})
   }


### PR DESCRIPTION
This has changed in dev rlang to not error. Instead `enquos()` seems to now drop embraced arguments that are missing arguments

```r
library(rlang)

fn <- function(x, y) {
  fn2({{x}}, {{y}})
}
fn2 <- function(...) {
  enquos(...)
}

fn(a)
#> <list_of<quosure>>
#> 
#> [[1]]
#> <quosure>
#> expr: ^a
#> env:  global
```