### PR TITLE
Implement `relationship` and refine join match warning

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,21 +17,21 @@
     
   * The mutating joins gain a new `relationship` argument, allowing you to
     enforce one of the following relationship constraints between the keys of
-    `x` and `y`: `"none"`, `"one_to_one"`, `"one_to_many"`, `"many_to_one"`,
-    `"many_to_many"`, or `"warn_many_to_many"`.
+    `x` and `y`: `"none"`, `"one-to-one"`, `"one-to-many"`, `"many-to-one"`,
+    `"many-to-many"`, or `"warn-many-to-many"`.
     
-    For example, `"many_to_one"` enforces that each row in `x` can match at
+    For example, `"many-to-one"` enforces that each row in `x` can match at
     most 1 row in `y`. If a row in `x` matches >1 rows in `y`, an error is
     thrown. This option serves as the replacement for `multiple = "error"`.
     
-    For equality joins, `relationship` defaults to `"warn_many_to_many"` to
+    For equality joins, `relationship` defaults to `"warn-many-to-many"` to
     warn if an unexpected many-to-many relationship is detected, and otherwise
     defaults to `"none"` for inequality, rolling, and overlap joins.
     
   This change unfortunately does mean that if you have set `multiple = "all"` to
   avoid a warning and you happened to be doing a many-to-many style join, then
   you will need to replace `multiple = "all"` with
-  `relationship = "many_to_many"` to silence the new warning, but we believe
+  `relationship = "many-to-many"` to silence the new warning, but we believe
   this should be rare since many-to-many relationships are fairly uncommon.
 
 * `pick()` now returns a 1 row, 0 column tibble when `...` evaluates to an

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,17 +16,18 @@
     a clearly superior alternative.
     
   * The mutating joins gain a new `relationship` argument, allowing you to
-    enforce one of the following relationship constraints between the keys of
-    `x` and `y`: `"none"`, `"one-to-one"`, `"one-to-many"`, `"many-to-one"`,
-    `"many-to-many"`, or `"warn-many-to-many"`.
+    optionally enforce one of the following relationship constraints between the
+    keys of `x` and `y`: `"one-to-one"`, `"one-to-many"`, `"many-to-one"`, or
+    `"many-to-many"`.
     
     For example, `"many-to-one"` enforces that each row in `x` can match at
     most 1 row in `y`. If a row in `x` matches >1 rows in `y`, an error is
     thrown. This option serves as the replacement for `multiple = "error"`.
     
-    For equality joins, `relationship` defaults to `"warn-many-to-many"` to
-    warn if an unexpected many-to-many relationship is detected, and otherwise
-    defaults to `"none"` for inequality, rolling, and overlap joins.
+    The default behavior of `relationship` doesn't assume that there is any
+    relationship between `x` and `y`. However, for equality joins it will check
+    for the presence of a many-to-many relationship, and will warn if it detects
+    one.
     
   This change unfortunately does mean that if you have set `multiple = "all"` to
   avoid a warning and you happened to be doing a many-to-many style join, then

--- a/R/join-rows.R
+++ b/R/join-rows.R
@@ -6,8 +6,9 @@ join_rows <- function(x_key,
                       condition = "==",
                       filter = "none",
                       cross = FALSE,
-                      multiple = NULL,
+                      multiple = "all",
                       unmatched = "drop",
+                      relationship = NULL,
                       error_call = caller_env(),
                       user_env = caller_env()) {
   check_dots_empty0(...)
@@ -22,6 +23,16 @@ join_rows <- function(x_key,
   x_unmatched <- unmatched$x
   y_unmatched <- unmatched$y
 
+  # TODO: Remove this when `multiple = NULL / "error" / "warning"` is defunct
+  if (is_null(multiple)) {
+    warn_join_multiple_null(user_env = user_env)
+    multiple <- "all"
+  } else if (is_string(multiple, "error")) {
+    warn_join_multiple("error", user_env = user_env)
+  } else if (is_string(multiple, "warning")) {
+    warn_join_multiple("warning", user_env = user_env)
+  }
+
   if (cross) {
     # TODO: Remove this section when `by = character()` is defunct
 
@@ -34,16 +45,16 @@ join_rows <- function(x_key,
     condition <- "=="
     filter <- "none"
 
-    if (is_null(multiple)) {
-      # If user supplied `multiple`, that wins. Otherwise expect multiple.
-      multiple <- "all"
+    if (is_null(relationship)) {
+      # If user supplied `relationship`, that wins. Otherwise no checks.
+      relationship <- "none"
     }
   }
 
   incomplete <- standardise_join_incomplete(type, na_matches, x_unmatched)
   no_match <- standardise_join_no_match(type, x_unmatched)
   remaining <- standardise_join_remaining(type, y_unmatched)
-  multiple <- standardise_multiple(multiple, condition, filter, user_env)
+  relationship <- standardise_join_relationship(relationship, condition, user_env)
 
   matches <- dplyr_locate_matches(
     needles = x_key,
@@ -54,6 +65,7 @@ join_rows <- function(x_key,
     no_match = no_match,
     remaining = remaining,
     multiple = multiple,
+    relationship = relationship,
     needles_arg = "x",
     haystack_arg = "y",
     error_call = error_call
@@ -71,6 +83,7 @@ dplyr_locate_matches <- function(needles,
                                  no_match = NA_integer_,
                                  remaining = "drop",
                                  multiple = "all",
+                                 relationship = "none",
                                  needles_arg = "",
                                  haystack_arg = "",
                                  error_call = caller_env()) {
@@ -86,6 +99,7 @@ dplyr_locate_matches <- function(needles,
       no_match = no_match,
       remaining = remaining,
       multiple = multiple,
+      relationship = relationship,
       needles_arg = needles_arg,
       haystack_arg = haystack_arg,
       nan_distinct = TRUE
@@ -101,6 +115,18 @@ dplyr_locate_matches <- function(needles,
     },
     vctrs_error_matches_remaining = function(cnd) {
       rethrow_error_join_matches_remaining(cnd, error_call)
+    },
+    vctrs_error_matches_relationship_one_to_one = function(cnd) {
+      rethrow_error_join_relationship_one_to_one(cnd, error_call)
+    },
+    vctrs_error_matches_relationship_one_to_many = function(cnd) {
+      rethrow_error_join_relationship_one_to_many(cnd, error_call)
+    },
+    vctrs_error_matches_relationship_many_to_one = function(cnd) {
+      rethrow_error_join_relationship_many_to_one(cnd, error_call)
+    },
+    vctrs_warning_matches_relationship_many_to_many = function(cnd) {
+      rethrow_warning_join_relationship_many_to_many(cnd, error_call)
     },
     vctrs_error_matches_multiple = function(cnd) {
       rethrow_error_join_matches_multiple(cnd, error_call)
@@ -144,14 +170,74 @@ rethrow_error_join_matches_remaining <- function(cnd, call) {
   )
 }
 
-rethrow_error_join_matches_multiple <- function(cnd, call) {
+rethrow_error_join_relationship_one_to_one <- function(cnd, call) {
   i <- cnd$i
+  which <- cnd$which
 
-  stop_join(
+  if (which == "needles") {
+    x_name <- "x"
+    y_name <- "y"
+  } else {
+    x_name <- "y"
+    y_name <- "x"
+  }
+
+  stop_join_matches_multiple(
+    i = i,
+    x_name = x_name,
+    y_name = y_name,
+    class = "dplyr_error_join_relationship_one_to_one",
+    call = call
+  )
+}
+
+rethrow_error_join_relationship_one_to_many <- function(cnd, call) {
+  stop_join_matches_multiple(
+    i = cnd$i,
+    x_name = "y",
+    y_name = "x",
+    class = "dplyr_error_join_relationship_one_to_many",
+    call = call
+  )
+}
+
+rethrow_error_join_relationship_many_to_one <- function(cnd, call) {
+  stop_join_matches_multiple(
+    i = cnd$i,
+    x_name = "x",
+    y_name = "y",
+    class = "dplyr_error_join_relationship_many_to_one",
+    call = call
+  )
+}
+
+rethrow_warning_join_relationship_many_to_many <- function(cnd, call) {
+  i <- cnd$i
+  j <- cnd$j
+
+  warn_join(
     message = c(
-      glue("Each row in `x` must match at most 1 row in `y`."),
-      i = glue("Row {i} of `x` matches multiple rows.")
+      "Detected an unexpected many-to-many relationship between `x` and `y`.",
+      i = glue("Row {i} of `x` matches multiple rows in `y`."),
+      i = glue("Row {j} of `y` matches multiple rows in `x`."),
+      i = paste0(
+        "If a many-to-many relationship is expected, ",
+        "set `relationship = \"many_to_many\"` to silence this warning."
+      )
     ),
+    class = "dplyr_warning_join_relationship_many_to_many",
+    call = call
+  )
+
+  # Cancel `cnd`
+  maybe_restart("muffleWarning")
+}
+
+rethrow_error_join_matches_multiple <- function(cnd, call) {
+  stop_join_matches_multiple(
+    i = cnd$i,
+    x_name = "x",
+    y_name = "y",
     class = "dplyr_error_join_matches_multiple",
     call = call
   )
@@ -163,11 +249,7 @@ rethrow_warning_join_matches_multiple <- function(cnd, call) {
   warn_join(
     message = c(
       glue("Each row in `x` is expected to match at most 1 row in `y`."),
-      i = glue("Row {i} of `x` matches multiple rows."),
-      i = paste0(
-        "If multiple matches are expected, set `multiple = \"all\"` ",
-        "to silence this warning."
-      )
+      i = glue("Row {i} of `x` matches multiple rows.")
     ),
     class = "dplyr_warning_join_matches_multiple",
     call = call
@@ -175,6 +257,17 @@ rethrow_warning_join_matches_multiple <- function(cnd, call) {
 
   # Cancel `cnd`
   maybe_restart("muffleWarning")
+}
+
+stop_join_matches_multiple <- function(i, x_name, y_name, class, call) {
+  stop_join(
+    message = c(
+      glue("Each row in `{x_name}` must match at most 1 row in `{y_name}`."),
+      i = glue("Row {i} of `{x_name}` matches multiple rows in `{y_name}`.")
+    ),
+    class = class,
+    call = call
+  )
 }
 
 stop_join <- function(message = NULL, class = NULL, ..., call = caller_env()) {
@@ -273,29 +366,59 @@ standardise_join_remaining <- function(type, y_unmatched) {
   }
 }
 
-standardise_multiple <- function(multiple, condition, filter, user_env) {
-  if (!is_null(multiple)) {
-    # User supplied value always wins
-    return(multiple)
+standardise_join_relationship <- function(relationship, condition, user_env) {
+  if (!is_null(relationship)) {
+    # Prefer user supplied value
+    return(relationship)
   }
 
-  # "warning" for equi and rolling joins where multiple matches are surprising.
-  # "all" for non-equi joins where multiple matches are expected.
-  non_equi <- (condition != "==") & (filter == "none")
-  if (any(non_equi)) {
-    return("all")
-  }
+  # We only check for a many-to-many relationship when doing an equality join,
+  # because that is typically unexpected.
+  # - Inequality and overlap joins often generate many-to-many relationships
+  #   by nature
+  # - Rolling joins are a little trickier, but we've decided that not warning is
+  #   probably easier to explain. `relationship = "many_to_one"` can always be
+  #   used explicitly as needed.
+  any_inequality <- any(condition != "==")
 
-  if (is_direct(user_env)) {
-    # Direct calls result in a warning when there are multiple matches,
-    # because they are likely surprising and the caller will be able to set
-    # the `multiple` argument. Indirect calls don't warn, because the caller
-    # is unlikely to have access to `multiple` to silence it.
-    "warning"
+  if (any_inequality) {
+    "none"
+  } else if (!is_direct(user_env)) {
+    # Indirect calls don't warn, because the caller is unlikely to have access
+    # to `relationship` to silence it
+    "none"
   } else {
-    "all"
+    "warn_many_to_many"
   }
 }
+
+# ------------------------------------------------------------------------------
+
+warn_join_multiple <- function(what, user_env = caller_env(2)) {
+  what <- glue::glue('Specifying `multiple = "{what}"`')
+
+  lifecycle::deprecate_warn(
+    when = "1.1.1",
+    what = I(what),
+    with = I('`relationship = "many_to_one"`'),
+    user_env = user_env,
+    always = TRUE
+  )
+}
+
+warn_join_multiple_null <- function(user_env = caller_env(2)) {
+  # Only really needed in case people wrapped `left_join()` and friends and
+  # passed the old default of `NULL` through
+  lifecycle::deprecate_warn(
+    when = "1.1.1",
+    what = I("Specifying `multiple = NULL`"),
+    with = I('`multiple = "all"`'),
+    user_env = user_env,
+    always = TRUE
+  )
+}
+
+# ------------------------------------------------------------------------------
 
 # TODO: Use upstream function when exported from rlang
 # `lifecycle:::is_direct()`

--- a/R/join-rows.R
+++ b/R/join-rows.R
@@ -222,7 +222,7 @@ rethrow_warning_join_relationship_many_to_many <- function(cnd, call) {
       i = glue("Row {j} of `y` matches multiple rows in `x`."),
       i = paste0(
         "If a many-to-many relationship is expected, ",
-        "set `relationship = \"many_to_many\"` to silence this warning."
+        "set `relationship = \"many-to-many\"` to silence this warning."
       )
     ),
     class = "dplyr_warning_join_relationship_many_to_many",
@@ -377,7 +377,7 @@ standardise_join_relationship <- function(relationship, condition, user_env) {
   # - Inequality and overlap joins often generate many-to-many relationships
   #   by nature
   # - Rolling joins are a little trickier, but we've decided that not warning is
-  #   probably easier to explain. `relationship = "many_to_one"` can always be
+  #   probably easier to explain. `relationship = "many-to-one"` can always be
   #   used explicitly as needed.
   any_inequality <- any(condition != "==")
 
@@ -388,7 +388,7 @@ standardise_join_relationship <- function(relationship, condition, user_env) {
     # to `relationship` to silence it
     "none"
   } else {
-    "warn_many_to_many"
+    "warn-many-to-many"
   }
 }
 
@@ -400,7 +400,7 @@ warn_join_multiple <- function(what, user_env = caller_env(2)) {
   lifecycle::deprecate_warn(
     when = "1.1.1",
     what = I(what),
-    with = I('`relationship = "many_to_one"`'),
+    with = I('`relationship = "many-to-one"`'),
     user_env = user_env,
     always = TRUE
   )

--- a/R/join.R
+++ b/R/join.R
@@ -41,7 +41,7 @@
 #' rows returned from the join.
 #'
 #' If a many-to-many relationship is expected, silence this warning by
-#' explicitly setting `relationship = "many_to_many"`.
+#' explicitly setting `relationship = "many-to-many"`.
 #'
 #' In production code, it is best to preemptively set `relationship` to whatever
 #' relationship you expect to exist between the keys of `x` and `y`, as this
@@ -55,7 +55,7 @@
 #'
 #' Rolling joins don't warn on many-to-many relationships either, but many
 #' rolling joins follow a many-to-one relationship, so it is often useful to
-#' set `relationship = "many_to_one"` to enforce this.
+#' set `relationship = "many-to-one"` to enforce this.
 #'
 #' Note that in SQL, most database providers won't let you specify a
 #' many-to-many relationship between two tables, instead requiring that you
@@ -171,32 +171,32 @@
 #'   invalidated, an error is thrown.
 #'
 #'   - `NULL`, the default, chooses:
-#'     - `"warn_many_to_many"` for equality joins
+#'     - `"warn-many-to-many"` for equality joins
 #'     - `"none"` for inequality joins, rolling joins, and overlap joins
 #'
 #'     See the _Many-to-many relationships_ section for more details.
 #'
 #'   - `"none"` doesn't perform any relationship checks.
 #'
-#'   - `"one_to_one"` expects:
+#'   - `"one-to-one"` expects:
 #'     - Each row in `x` matches at most 1 row in `y`.
 #'     - Each row in `y` matches at most 1 row in `x`.
 #'
-#'   - `"one_to_many"` expects:
+#'   - `"one-to-many"` expects:
 #'     - Each row in `y` matches at most 1 row in `x`.
 #'
-#'   - `"many_to_one"` expects:
+#'   - `"many-to-one"` expects:
 #'     - Each row in `x` matches at most 1 row in `y`.
 #'
-#'   - `"many_to_many"` doesn't perform any relationship checks, and is
+#'   - `"many-to-many"` doesn't perform any relationship checks, and is
 #'     identical to `"none"`, but is provided to allow you to be explicit about
 #'     this relationship if you know it exists.
 #'
-#'   - `"warn_many_to_many"` doesn't assume there is any known relationship, but
+#'   - `"warn-many-to-many"` doesn't assume there is any known relationship, but
 #'     will warn if `x` and `y` have a many-to-many relationship
 #'     (which is typically unexpected), encouraging you to either take a closer
 #'     look at your inputs or make this relationship explicit by specifying
-#'     `"many_to_many"`.
+#'     `"many-to-many"`.
 #'
 #'   `relationship` doesn't handle cases where there are zero matches. For that,
 #'   see `unmatched`.
@@ -232,8 +232,8 @@
 #' df3 %>% left_join(df2)
 #'
 #' # In the rare case where a many-to-many relationship is expected, set
-#' # `relationship = "many_to_many"` to silence this warning
-#' df3 %>% left_join(df2, relationship = "many_to_many")
+#' # `relationship = "many-to-many"` to silence this warning
+#' df3 %>% left_join(df2, relationship = "many-to-many")
 #'
 #' # Use `join_by()` with a condition other than `==` to perform an inequality
 #' # join. Here we match on every instance where `df1$x > df2$x`.

--- a/R/join.R
+++ b/R/join.R
@@ -26,14 +26,41 @@
 #'
 #' * A `full_join()` keeps all observations in `x` and `y`.
 #'
-#' ## Multiple matches
+#' @section Many-to-many relationships:
 #'
-#' By default, if an observation in `x` matches multiple observations in `y`,
-#' all of the matching observations in `y` will be returned. If this occurs in
-#' an equality join or a rolling join, a warning will be thrown stating that
-#' multiple matches have been detected since this is usually surprising. If
-#' multiple matches are expected in these cases, silence this warning by
-#' explicitly setting `multiple = "all"`.
+#' By default, dplyr guards against many-to-many relationships in equality joins
+#' by throwing a warning. These occur when both of the following are true:
+#'
+#' - A row in `x` matches multiple rows in `y`.
+#' - A row in `y` matches multiple rows in `x`.
+#'
+#' This is typically surprising, as most joins involve a relationship of
+#' one-to-one, one-to-many, or many-to-one, and is often the result of an
+#' improperly specified join. Many-to-many relationships are particularly
+#' problematic because they can result in a Cartesian explosion of the number of
+#' rows returned from the join.
+#'
+#' If a many-to-many relationship is expected, silence this warning by
+#' explicitly setting `relationship = "many_to_many"`.
+#'
+#' In production code, it is best to preemptively set `relationship` to whatever
+#' relationship you expect to exist between the keys of `x` and `y`, as this
+#' forces an error to occur immediately if the data doesn't align with your
+#' expectations.
+#'
+#' Inequality joins typically result in many-to-many relationships by nature, so
+#' they don't warn on them by default, but you should still take extra care when
+#' specifying an inequality join, because they also have the capability to
+#' return a large number of rows.
+#'
+#' Rolling joins don't warn on many-to-many relationships either, but many
+#' rolling joins follow a many-to-one relationship, so it is often useful to
+#' set `relationship = "many_to_one"` to enforce this.
+#'
+#' Note that in SQL, most database providers won't let you specify a
+#' many-to-many relationship between two tables, instead requiring that you
+#' create a third _junction table_ that results in two one-to-many relationships
+#' instead.
 #'
 #' @return
 #' An object of the same type as `x` (including the same groups). The order of
@@ -119,21 +146,13 @@
 #'   for database sources and to `base::merge(incomparables = NA)`.
 #' @param multiple Handling of rows in `x` with multiple matches in `y`.
 #'   For each row of `x`:
-#'   - `"all"` returns every match detected in `y`. This is the same behavior
-#'     as SQL.
+#'   - `"all"`, the default, returns every match detected in `y`. This is the
+#'     same behavior as SQL.
 #'   - `"any"` returns one match detected in `y`, with no guarantees on which
 #'     match will be returned. It is often faster than `"first"` and `"last"`
 #'     if you just need to detect if there is at least one match.
 #'   - `"first"` returns the first match detected in `y`.
 #'   - `"last"` returns the last match detected in `y`.
-#'   - `"warning"` throws a warning if multiple matches are detected, and
-#'     then falls back to `"all"`.
-#'   - `"error"` throws an error if multiple matches are detected.
-#'
-#'   The default value of `NULL` is equivalent to `"warning"` for equality joins
-#'   and rolling joins, where multiple matches are usually surprising. If any
-#'   inequality join conditions are present, then it is equivalent to `"all"`,
-#'   since multiple matches are usually expected.
 #' @param unmatched How should unmatched keys that would result in dropped rows
 #'   be handled?
 #'   - `"drop"` drops unmatched keys from the result.
@@ -147,6 +166,40 @@
 #'   - For inner joins, it checks both `x` and `y`. In this case, `unmatched` is
 #'     also allowed to be a character vector of length 2 to specify the behavior
 #'     for `x` and `y` independently.
+#' @param relationship Handling of the expected relationship between the keys of
+#'   `x` and `y`. If the expectations chosen from the list below are
+#'   invalidated, an error is thrown.
+#'
+#'   - `NULL`, the default, chooses:
+#'     - `"warn_many_to_many"` for equality joins
+#'     - `"none"` for inequality joins, rolling joins, and overlap joins
+#'
+#'     See the _Many-to-many relationships_ section for more details.
+#'
+#'   - `"none"` doesn't perform any relationship checks.
+#'
+#'   - `"one_to_one"` expects:
+#'     - Each row in `x` matches at most 1 row in `y`.
+#'     - Each row in `y` matches at most 1 row in `x`.
+#'
+#'   - `"one_to_many"` expects:
+#'     - Each row in `y` matches at most 1 row in `x`.
+#'
+#'   - `"many_to_one"` expects:
+#'     - Each row in `x` matches at most 1 row in `y`.
+#'
+#'   - `"many_to_many"` doesn't perform any relationship checks, and is
+#'     identical to `"none"`, but is provided to allow you to be explicit about
+#'     this relationship if you know it exists.
+#'
+#'   - `"warn_many_to_many"` doesn't assume there is any known relationship, but
+#'     will warn if `x` and `y` have a many-to-many relationship
+#'     (which is typically unexpected), encouraging you to either take a closer
+#'     look at your inputs or make this relationship explicit by specifying
+#'     `"many_to_many"`.
+#'
+#'   `relationship` doesn't handle cases where there are zero matches. For that,
+#'   see `unmatched`.
 #' @family joins
 #' @examples
 #' band_members %>% inner_join(band_instruments)
@@ -166,14 +219,21 @@
 #'   full_join(band_instruments2, by = join_by(name == artist), keep = TRUE)
 #'
 #' # If a row in `x` matches multiple rows in `y`, all the rows in `y` will be
-#' # returned once for each matching row in `x`, with a warning.
+#' # returned once for each matching row in `x`.
 #' df1 <- tibble(x = 1:3)
 #' df2 <- tibble(x = c(1, 1, 2), y = c("first", "second", "third"))
 #' df1 %>% left_join(df2)
 #'
-#' # If multiple matches are expected, set `multiple` to `"all"` to silence
-#' # the warning
-#' df1 %>% left_join(df2, multiple = "all")
+#' # If a row in `y` also matches multiple rows in `x`, this is known as a
+#' # many-to-many relationship, which is typically a result of an improperly
+#' # specified join or some kind of messy data. In this case, a warning is
+#' # thrown by default:
+#' df3 <- tibble(x = c(1, 1, 1, 3))
+#' df3 %>% left_join(df2)
+#'
+#' # In the rare case where a many-to-many relationship is expected, set
+#' # `relationship = "many_to_many"` to silence this warning
+#' df3 %>% left_join(df2, relationship = "many_to_many")
 #'
 #' # Use `join_by()` with a condition other than `==` to perform an inequality
 #' # join. Here we match on every instance where `df1$x > df2$x`.
@@ -214,8 +274,9 @@ inner_join.data.frame <- function(x,
                                   ...,
                                   keep = NULL,
                                   na_matches = c("na", "never"),
-                                  multiple = NULL,
-                                  unmatched = "drop") {
+                                  multiple = "all",
+                                  unmatched = "drop",
+                                  relationship = NULL) {
   check_dots_empty0(...)
   y <- auto_copy(x, y, copy = copy)
   join_mutate(
@@ -228,6 +289,7 @@ inner_join.data.frame <- function(x,
     keep = keep,
     multiple = multiple,
     unmatched = unmatched,
+    relationship = relationship,
     user_env = caller_env()
   )
 }
@@ -254,8 +316,9 @@ left_join.data.frame <- function(x,
                                  ...,
                                  keep = NULL,
                                  na_matches = c("na", "never"),
-                                 multiple = NULL,
-                                 unmatched = "drop") {
+                                 multiple = "all",
+                                 unmatched = "drop",
+                                 relationship = NULL) {
   check_dots_empty0(...)
   y <- auto_copy(x, y, copy = copy)
   join_mutate(
@@ -268,6 +331,7 @@ left_join.data.frame <- function(x,
     keep = keep,
     multiple = multiple,
     unmatched = unmatched,
+    relationship = relationship,
     user_env = caller_env()
   )
 }
@@ -294,8 +358,9 @@ right_join.data.frame <- function(x,
                                   ...,
                                   keep = NULL,
                                   na_matches = c("na", "never"),
-                                  multiple = NULL,
-                                  unmatched = "drop") {
+                                  multiple = "all",
+                                  unmatched = "drop",
+                                  relationship = NULL) {
   check_dots_empty0(...)
   y <- auto_copy(x, y, copy = copy)
   join_mutate(
@@ -308,6 +373,7 @@ right_join.data.frame <- function(x,
     keep = keep,
     multiple = multiple,
     unmatched = unmatched,
+    relationship = relationship,
     user_env = caller_env()
   )
 }
@@ -334,7 +400,8 @@ full_join.data.frame <- function(x,
                                  ...,
                                  keep = NULL,
                                  na_matches = c("na", "never"),
-                                 multiple = NULL) {
+                                 multiple = "all",
+                                 relationship = NULL) {
   check_dots_empty0(...)
   y <- auto_copy(x, y, copy = copy)
   join_mutate(
@@ -348,6 +415,7 @@ full_join.data.frame <- function(x,
     multiple = multiple,
     # All keys from both inputs are retained. Erroring never makes sense.
     unmatched = "drop",
+    relationship = relationship,
     user_env = caller_env()
   )
 }
@@ -535,8 +603,10 @@ nest_join.data.frame <- function(x,
   # We always want to retain all of the matches. We never experience a Cartesian
   # explosion because `nrow(x) == nrow(out)` is an invariant of `nest_join()`,
   # and the whole point of `nest_join()` is to nest all of the matches for that
-  # row of `x` (#6392).
+  # row of `x` (#6392). Because we can't have a Cartesian explosion, we also
+  # don't care about many-to-many relationships.
   multiple <- "all"
+  relationship <- "none"
 
   rows <- join_rows(
     x_key = x_key,
@@ -548,6 +618,7 @@ nest_join.data.frame <- function(x,
     cross = cross,
     multiple = multiple,
     unmatched = unmatched,
+    relationship = relationship,
     user_env = caller_env()
   )
 
@@ -577,8 +648,9 @@ join_mutate <- function(x,
                         suffix = c(".x", ".y"),
                         na_matches = "na",
                         keep = NULL,
-                        multiple = NULL,
+                        multiple = "all",
                         unmatched = "drop",
+                        relationship = NULL,
                         error_call = caller_env(),
                         user_env = caller_env()) {
   check_dots_empty0(...)
@@ -635,6 +707,7 @@ join_mutate <- function(x,
     cross = cross,
     multiple = multiple,
     unmatched = unmatched,
+    relationship = relationship,
     error_call = error_call,
     user_env = user_env
   )
@@ -725,6 +798,10 @@ join_filter <- function(x,
   # We only care about whether or not any matches exist
   multiple <- "any"
 
+  # Because `multiple = "any"`, that means many-to-many relationships aren't
+  # possible
+  relationship <- "none"
+
   # Since we are actually testing the presence of matches, it doesn't make
   # sense to ever error on unmatched values.
   unmatched <- "drop"
@@ -739,6 +816,7 @@ join_filter <- function(x,
     cross = cross,
     multiple = multiple,
     unmatched = unmatched,
+    relationship = relationship,
     error_call = error_call,
     user_env = user_env
   )

--- a/man/mutate-joins.Rd
+++ b/man/mutate-joins.Rd
@@ -209,14 +209,13 @@ for \code{x} and \code{y} independently.
 \code{x} and \code{y}. If the expectations chosen from the list below are
 invalidated, an error is thrown.
 \itemize{
-\item \code{NULL}, the default, chooses:
-\itemize{
-\item \code{"warn-many-to-many"} for equality joins
-\item \code{"none"} for inequality joins, rolling joins, and overlap joins
-}
+\item \code{NULL}, the default, doesn't expect there to be any relationship between
+\code{x} and \code{y}. However, for equality joins it will check for a many-to-many
+relationship (which is typically unexpected) and will warn if one occurs,
+encouraging you to either take a closer look at your inputs or make this
+relationship explicit by specifying \code{"many-to-many"}.
 
 See the \emph{Many-to-many relationships} section for more details.
-\item \code{"none"} doesn't perform any relationship checks.
 \item \code{"one-to-one"} expects:
 \itemize{
 \item Each row in \code{x} matches at most 1 row in \code{y}.
@@ -230,14 +229,9 @@ See the \emph{Many-to-many relationships} section for more details.
 \itemize{
 \item Each row in \code{x} matches at most 1 row in \code{y}.
 }
-\item \code{"many-to-many"} doesn't perform any relationship checks, and is
-identical to \code{"none"}, but is provided to allow you to be explicit about
-this relationship if you know it exists.
-\item \code{"warn-many-to-many"} doesn't assume there is any known relationship, but
-will warn if \code{x} and \code{y} have a many-to-many relationship
-(which is typically unexpected), encouraging you to either take a closer
-look at your inputs or make this relationship explicit by specifying
-\code{"many-to-many"}.
+\item \code{"many-to-many"} doesn't perform any relationship checks, but is provided
+to allow you to be explicit about this relationship if you know it
+exists.
 }
 
 \code{relationship} doesn't handle cases where there are zero matches. For that,

--- a/man/mutate-joins.Rd
+++ b/man/mutate-joins.Rd
@@ -211,33 +211,33 @@ invalidated, an error is thrown.
 \itemize{
 \item \code{NULL}, the default, chooses:
 \itemize{
-\item \code{"warn_many_to_many"} for equality joins
+\item \code{"warn-many-to-many"} for equality joins
 \item \code{"none"} for inequality joins, rolling joins, and overlap joins
 }
 
 See the \emph{Many-to-many relationships} section for more details.
 \item \code{"none"} doesn't perform any relationship checks.
-\item \code{"one_to_one"} expects:
+\item \code{"one-to-one"} expects:
 \itemize{
 \item Each row in \code{x} matches at most 1 row in \code{y}.
 \item Each row in \code{y} matches at most 1 row in \code{x}.
 }
-\item \code{"one_to_many"} expects:
+\item \code{"one-to-many"} expects:
 \itemize{
 \item Each row in \code{y} matches at most 1 row in \code{x}.
 }
-\item \code{"many_to_one"} expects:
+\item \code{"many-to-one"} expects:
 \itemize{
 \item Each row in \code{x} matches at most 1 row in \code{y}.
 }
-\item \code{"many_to_many"} doesn't perform any relationship checks, and is
+\item \code{"many-to-many"} doesn't perform any relationship checks, and is
 identical to \code{"none"}, but is provided to allow you to be explicit about
 this relationship if you know it exists.
-\item \code{"warn_many_to_many"} doesn't assume there is any known relationship, but
+\item \code{"warn-many-to-many"} doesn't assume there is any known relationship, but
 will warn if \code{x} and \code{y} have a many-to-many relationship
 (which is typically unexpected), encouraging you to either take a closer
 look at your inputs or make this relationship explicit by specifying
-\code{"many_to_many"}.
+\code{"many-to-many"}.
 }
 
 \code{relationship} doesn't handle cases where there are zero matches. For that,
@@ -307,7 +307,7 @@ problematic because they can result in a Cartesian explosion of the number of
 rows returned from the join.
 
 If a many-to-many relationship is expected, silence this warning by
-explicitly setting \code{relationship = "many_to_many"}.
+explicitly setting \code{relationship = "many-to-many"}.
 
 In production code, it is best to preemptively set \code{relationship} to whatever
 relationship you expect to exist between the keys of \code{x} and \code{y}, as this
@@ -321,7 +321,7 @@ return a large number of rows.
 
 Rolling joins don't warn on many-to-many relationships either, but many
 rolling joins follow a many-to-one relationship, so it is often useful to
-set \code{relationship = "many_to_one"} to enforce this.
+set \code{relationship = "many-to-one"} to enforce this.
 
 Note that in SQL, most database providers won't let you specify a
 many-to-many relationship between two tables, instead requiring that you
@@ -375,8 +375,8 @@ df3 <- tibble(x = c(1, 1, 1, 3))
 df3 \%>\% left_join(df2)
 
 # In the rare case where a many-to-many relationship is expected, set
-# `relationship = "many_to_many"` to silence this warning
-df3 \%>\% left_join(df2, relationship = "many_to_many")
+# `relationship = "many-to-many"` to silence this warning
+df3 \%>\% left_join(df2, relationship = "many-to-many")
 
 # Use `join_by()` with a condition other than `==` to perform an inequality
 # join. Here we match on every instance where `df1$x > df2$x`.

--- a/man/mutate-joins.Rd
+++ b/man/mutate-joins.Rd
@@ -33,8 +33,9 @@ inner_join(
   ...,
   keep = NULL,
   na_matches = c("na", "never"),
-  multiple = NULL,
-  unmatched = "drop"
+  multiple = "all",
+  unmatched = "drop",
+  relationship = NULL
 )
 
 left_join(
@@ -56,8 +57,9 @@ left_join(
   ...,
   keep = NULL,
   na_matches = c("na", "never"),
-  multiple = NULL,
-  unmatched = "drop"
+  multiple = "all",
+  unmatched = "drop",
+  relationship = NULL
 )
 
 right_join(
@@ -79,8 +81,9 @@ right_join(
   ...,
   keep = NULL,
   na_matches = c("na", "never"),
-  multiple = NULL,
-  unmatched = "drop"
+  multiple = "all",
+  unmatched = "drop",
+  relationship = NULL
 )
 
 full_join(
@@ -102,7 +105,8 @@ full_join(
   ...,
   keep = NULL,
   na_matches = c("na", "never"),
-  multiple = NULL
+  multiple = "all",
+  relationship = NULL
 )
 }
 \arguments{
@@ -174,22 +178,14 @@ for database sources and to \code{base::merge(incomparables = NA)}.
 \item{multiple}{Handling of rows in \code{x} with multiple matches in \code{y}.
 For each row of \code{x}:
 \itemize{
-\item \code{"all"} returns every match detected in \code{y}. This is the same behavior
-as SQL.
+\item \code{"all"}, the default, returns every match detected in \code{y}. This is the
+same behavior as SQL.
 \item \code{"any"} returns one match detected in \code{y}, with no guarantees on which
 match will be returned. It is often faster than \code{"first"} and \code{"last"}
 if you just need to detect if there is at least one match.
 \item \code{"first"} returns the first match detected in \code{y}.
 \item \code{"last"} returns the last match detected in \code{y}.
-\item \code{"warning"} throws a warning if multiple matches are detected, and
-then falls back to \code{"all"}.
-\item \code{"error"} throws an error if multiple matches are detected.
-}
-
-The default value of \code{NULL} is equivalent to \code{"warning"} for equality joins
-and rolling joins, where multiple matches are usually surprising. If any
-inequality join conditions are present, then it is equivalent to \code{"all"},
-since multiple matches are usually expected.}
+}}
 
 \item{unmatched}{How should unmatched keys that would result in dropped rows
 be handled?
@@ -208,6 +204,44 @@ potentially drop rows.
 also allowed to be a character vector of length 2 to specify the behavior
 for \code{x} and \code{y} independently.
 }}
+
+\item{relationship}{Handling of the expected relationship between the keys of
+\code{x} and \code{y}. If the expectations chosen from the list below are
+invalidated, an error is thrown.
+\itemize{
+\item \code{NULL}, the default, chooses:
+\itemize{
+\item \code{"warn_many_to_many"} for equality joins
+\item \code{"none"} for inequality joins, rolling joins, and overlap joins
+}
+
+See the \emph{Many-to-many relationships} section for more details.
+\item \code{"none"} doesn't perform any relationship checks.
+\item \code{"one_to_one"} expects:
+\itemize{
+\item Each row in \code{x} matches at most 1 row in \code{y}.
+\item Each row in \code{y} matches at most 1 row in \code{x}.
+}
+\item \code{"one_to_many"} expects:
+\itemize{
+\item Each row in \code{y} matches at most 1 row in \code{x}.
+}
+\item \code{"many_to_one"} expects:
+\itemize{
+\item Each row in \code{x} matches at most 1 row in \code{y}.
+}
+\item \code{"many_to_many"} doesn't perform any relationship checks, and is
+identical to \code{"none"}, but is provided to allow you to be explicit about
+this relationship if you know it exists.
+\item \code{"warn_many_to_many"} doesn't assume there is any known relationship, but
+will warn if \code{x} and \code{y} have a many-to-many relationship
+(which is typically unexpected), encouraging you to either take a closer
+look at your inputs or make this relationship explicit by specifying
+\code{"many_to_many"}.
+}
+
+\code{relationship} doesn't handle cases where there are zero matches. For that,
+see \code{unmatched}.}
 }
 \value{
 An object of the same type as \code{x} (including the same groups). The order of
@@ -255,17 +289,46 @@ data frames:
 \item A \code{full_join()} keeps all observations in \code{x} and \code{y}.
 }
 }
-
-\subsection{Multiple matches}{
-
-By default, if an observation in \code{x} matches multiple observations in \code{y},
-all of the matching observations in \code{y} will be returned. If this occurs in
-an equality join or a rolling join, a warning will be thrown stating that
-multiple matches have been detected since this is usually surprising. If
-multiple matches are expected in these cases, silence this warning by
-explicitly setting \code{multiple = "all"}.
 }
+\section{Many-to-many relationships}{
+
+
+By default, dplyr guards against many-to-many relationships in equality joins
+by throwing a warning. These occur when both of the following are true:
+\itemize{
+\item A row in \code{x} matches multiple rows in \code{y}.
+\item A row in \code{y} matches multiple rows in \code{x}.
 }
+
+This is typically surprising, as most joins involve a relationship of
+one-to-one, one-to-many, or many-to-one, and is often the result of an
+improperly specified join. Many-to-many relationships are particularly
+problematic because they can result in a Cartesian explosion of the number of
+rows returned from the join.
+
+If a many-to-many relationship is expected, silence this warning by
+explicitly setting \code{relationship = "many_to_many"}.
+
+In production code, it is best to preemptively set \code{relationship} to whatever
+relationship you expect to exist between the keys of \code{x} and \code{y}, as this
+forces an error to occur immediately if the data doesn't align with your
+expectations.
+
+Inequality joins typically result in many-to-many relationships by nature, so
+they don't warn on them by default, but you should still take extra care when
+specifying an inequality join, because they also have the capability to
+return a large number of rows.
+
+Rolling joins don't warn on many-to-many relationships either, but many
+rolling joins follow a many-to-one relationship, so it is often useful to
+set \code{relationship = "many_to_one"} to enforce this.
+
+Note that in SQL, most database providers won't let you specify a
+many-to-many relationship between two tables, instead requiring that you
+create a third \emph{junction table} that results in two one-to-many relationships
+instead.
+}
+
 \section{Methods}{
 
 These functions are \strong{generic}s, which means that packages can provide
@@ -299,14 +362,21 @@ band_members \%>\%
   full_join(band_instruments2, by = join_by(name == artist), keep = TRUE)
 
 # If a row in `x` matches multiple rows in `y`, all the rows in `y` will be
-# returned once for each matching row in `x`, with a warning.
+# returned once for each matching row in `x`.
 df1 <- tibble(x = 1:3)
 df2 <- tibble(x = c(1, 1, 2), y = c("first", "second", "third"))
 df1 \%>\% left_join(df2)
 
-# If multiple matches are expected, set `multiple` to `"all"` to silence
-# the warning
-df1 \%>\% left_join(df2, multiple = "all")
+# If a row in `y` also matches multiple rows in `x`, this is known as a
+# many-to-many relationship, which is typically a result of an improperly
+# specified join or some kind of messy data. In this case, a warning is
+# thrown by default:
+df3 <- tibble(x = c(1, 1, 1, 3))
+df3 \%>\% left_join(df2)
+
+# In the rare case where a many-to-many relationship is expected, set
+# `relationship = "many_to_many"` to silence this warning
+df3 \%>\% left_join(df2, relationship = "many_to_many")
 
 # Use `join_by()` with a condition other than `==` to perform an inequality
 # join. Here we match on every instance where `df1$x > df2$x`.

--- a/tests/testthat/_snaps/join-rows.md
+++ b/tests/testthat/_snaps/join-rows.md
@@ -1,22 +1,13 @@
-# `multiple` default behavior is correct
+# `relationship` default behavior is correct
 
     Code
       out <- join_rows(c(1, 1), c(1, 1), condition = "==")
     Condition
       Warning:
-      Each row in `x` is expected to match at most 1 row in `y`.
-      i Row 1 of `x` matches multiple rows.
-      i If multiple matches are expected, set `multiple = "all"` to silence this warning.
-
----
-
-    Code
-      out <- join_rows(c(1, 1), c(1, 1), condition = ">=", filter = "max")
-    Condition
-      Warning:
-      Each row in `x` is expected to match at most 1 row in `y`.
-      i Row 1 of `x` matches multiple rows.
-      i If multiple matches are expected, set `multiple = "all"` to silence this warning.
+      Detected an unexpected many-to-many relationship between `x` and `y`.
+      i Row 1 of `x` matches multiple rows in `y`.
+      i Row 1 of `y` matches multiple rows in `x`.
+      i If a many-to-many relationship is expected, set `relationship = "many_to_many"` to silence this warning.
 
 # join_rows() allows `unmatched` to be specified independently for inner joins
 
@@ -38,33 +29,76 @@
       i This is an internal error that was detected in the dplyr package.
         Please report it at <https://github.com/tidyverse/dplyr/issues> with a reprex (<https://tidyverse.org/help/>) and the full backtrace.
 
-# join_rows() gives meaningful error/warning message on multiple matches
+# join_rows() gives meaningful one-to-one errors
 
     Code
-      join_rows(1, c(1, 1), multiple = "error")
+      join_rows(1, c(1, 1), relationship = "one_to_one")
     Condition
       Error:
       ! Each row in `x` must match at most 1 row in `y`.
-      i Row 1 of `x` matches multiple rows.
+      i Row 1 of `x` matches multiple rows in `y`.
 
 ---
 
     Code
-      cat(conditionMessage(cnd))
+      join_rows(c(1, 1), 1, relationship = "one_to_one")
+    Condition
+      Error:
+      ! Each row in `y` must match at most 1 row in `x`.
+      i Row 1 of `y` matches multiple rows in `x`.
+
+# join_rows() gives meaningful one-to-many errors
+
+    Code
+      join_rows(c(1, 1), 1, relationship = "one_to_many")
+    Condition
+      Error:
+      ! Each row in `y` must match at most 1 row in `x`.
+      i Row 1 of `y` matches multiple rows in `x`.
+
+# join_rows() gives meaningful many-to-one errors
+
+    Code
+      join_rows(1, c(1, 1), relationship = "many_to_one")
+    Condition
+      Error:
+      ! Each row in `x` must match at most 1 row in `y`.
+      i Row 1 of `x` matches multiple rows in `y`.
+
+# join_rows() gives meaningful many-to-many warnings
+
+    Code
+      join_rows(c(1, 1), c(1, 1), relationship = "warn_many_to_many")
+    Condition
+      Warning:
+      Detected an unexpected many-to-many relationship between `x` and `y`.
+      i Row 1 of `x` matches multiple rows in `y`.
+      i Row 1 of `y` matches multiple rows in `x`.
+      i If a many-to-many relationship is expected, set `relationship = "many_to_many"` to silence this warning.
     Output
-      Each row in `x` is expected to match at most 1 row in `y`.
-      i Row 1 of `x` matches multiple rows.
-      i If multiple matches are expected, set `multiple = "all"` to silence this warning.
+      $x
+      [1] 1 1 2 2
+      
+      $y
+      [1] 1 2 1 2
+      
 
 ---
 
     Code
-      . <- left_join(df1, df2, by = "x")
+      left_join(df, df, by = join_by(x))
     Condition
       Warning in `left_join()`:
-      Each row in `x` is expected to match at most 1 row in `y`.
-      i Row 1 of `x` matches multiple rows.
-      i If multiple matches are expected, set `multiple = "all"` to silence this warning.
+      Detected an unexpected many-to-many relationship between `x` and `y`.
+      i Row 1 of `x` matches multiple rows in `y`.
+      i Row 1 of `y` matches multiple rows in `x`.
+      i If a many-to-many relationship is expected, set `relationship = "many_to_many"` to silence this warning.
+    Output
+        x
+      1 1
+      2 1
+      3 1
+      4 1
 
 # join_rows() gives meaningful error message on unmatched rows
 
@@ -284,4 +318,84 @@
       Error:
       ! `unmatched` must be one of "drop" or "error", not "dr".
       i Did you mean "drop"?
+
+# `multiple = NULL` is deprecated and results in `'all'` (#6731)
+
+    Code
+      out <- join_rows(df1, df2, multiple = NULL)
+    Condition
+      Warning:
+      Specifying `multiple = NULL` was deprecated in dplyr 1.1.1.
+      i Please use `multiple = "all"` instead.
+
+---
+
+    Code
+      left_join(df1, df2, by = join_by(x), multiple = NULL)
+    Condition
+      Warning:
+      Specifying `multiple = NULL` was deprecated in dplyr 1.1.1.
+      i Please use `multiple = "all"` instead.
+    Output
+      # A tibble: 3 x 1
+            x
+        <dbl>
+      1     1
+      2     2
+      3     2
+
+# `multiple = 'error'` is deprecated (#6731)
+
+    Code
+      join_rows(df1, df2, multiple = "error")
+    Condition
+      Warning:
+      Specifying `multiple = "error"` was deprecated in dplyr 1.1.1.
+      i Please use `relationship = "many_to_one"` instead.
+      Error:
+      ! Each row in `x` must match at most 1 row in `y`.
+      i Row 2 of `x` matches multiple rows in `y`.
+
+---
+
+    Code
+      left_join(df1, df2, by = join_by(x), multiple = "error")
+    Condition
+      Warning:
+      Specifying `multiple = "error"` was deprecated in dplyr 1.1.1.
+      i Please use `relationship = "many_to_one"` instead.
+      Error in `left_join()`:
+      ! Each row in `x` must match at most 1 row in `y`.
+      i Row 2 of `x` matches multiple rows in `y`.
+
+# `multiple = 'warning'` is deprecated (#6731)
+
+    Code
+      out <- join_rows(df1, df2, multiple = "warning")
+    Condition
+      Warning:
+      Specifying `multiple = "warning"` was deprecated in dplyr 1.1.1.
+      i Please use `relationship = "many_to_one"` instead.
+      Warning:
+      Each row in `x` is expected to match at most 1 row in `y`.
+      i Row 2 of `x` matches multiple rows.
+
+---
+
+    Code
+      left_join(df1, df2, by = join_by(x), multiple = "warning")
+    Condition
+      Warning:
+      Specifying `multiple = "warning"` was deprecated in dplyr 1.1.1.
+      i Please use `relationship = "many_to_one"` instead.
+      Warning in `left_join()`:
+      Each row in `x` is expected to match at most 1 row in `y`.
+      i Row 2 of `x` matches multiple rows.
+    Output
+      # A tibble: 3 x 1
+            x
+        <dbl>
+      1     1
+      2     2
+      3     2
 

--- a/tests/testthat/_snaps/join-rows.md
+++ b/tests/testthat/_snaps/join-rows.md
@@ -7,7 +7,7 @@
       Detected an unexpected many-to-many relationship between `x` and `y`.
       i Row 1 of `x` matches multiple rows in `y`.
       i Row 1 of `y` matches multiple rows in `x`.
-      i If a many-to-many relationship is expected, set `relationship = "many_to_many"` to silence this warning.
+      i If a many-to-many relationship is expected, set `relationship = "many-to-many"` to silence this warning.
 
 # join_rows() allows `unmatched` to be specified independently for inner joins
 
@@ -32,7 +32,7 @@
 # join_rows() gives meaningful one-to-one errors
 
     Code
-      join_rows(1, c(1, 1), relationship = "one_to_one")
+      join_rows(1, c(1, 1), relationship = "one-to-one")
     Condition
       Error:
       ! Each row in `x` must match at most 1 row in `y`.
@@ -41,7 +41,7 @@
 ---
 
     Code
-      join_rows(c(1, 1), 1, relationship = "one_to_one")
+      join_rows(c(1, 1), 1, relationship = "one-to-one")
     Condition
       Error:
       ! Each row in `y` must match at most 1 row in `x`.
@@ -50,7 +50,7 @@
 # join_rows() gives meaningful one-to-many errors
 
     Code
-      join_rows(c(1, 1), 1, relationship = "one_to_many")
+      join_rows(c(1, 1), 1, relationship = "one-to-many")
     Condition
       Error:
       ! Each row in `y` must match at most 1 row in `x`.
@@ -59,7 +59,7 @@
 # join_rows() gives meaningful many-to-one errors
 
     Code
-      join_rows(1, c(1, 1), relationship = "many_to_one")
+      join_rows(1, c(1, 1), relationship = "many-to-one")
     Condition
       Error:
       ! Each row in `x` must match at most 1 row in `y`.
@@ -68,13 +68,13 @@
 # join_rows() gives meaningful many-to-many warnings
 
     Code
-      join_rows(c(1, 1), c(1, 1), relationship = "warn_many_to_many")
+      join_rows(c(1, 1), c(1, 1), relationship = "warn-many-to-many")
     Condition
       Warning:
       Detected an unexpected many-to-many relationship between `x` and `y`.
       i Row 1 of `x` matches multiple rows in `y`.
       i Row 1 of `y` matches multiple rows in `x`.
-      i If a many-to-many relationship is expected, set `relationship = "many_to_many"` to silence this warning.
+      i If a many-to-many relationship is expected, set `relationship = "many-to-many"` to silence this warning.
     Output
       $x
       [1] 1 1 2 2
@@ -92,7 +92,7 @@
       Detected an unexpected many-to-many relationship between `x` and `y`.
       i Row 1 of `x` matches multiple rows in `y`.
       i Row 1 of `y` matches multiple rows in `x`.
-      i If a many-to-many relationship is expected, set `relationship = "many_to_many"` to silence this warning.
+      i If a many-to-many relationship is expected, set `relationship = "many-to-many"` to silence this warning.
     Output
         x
       1 1
@@ -351,7 +351,7 @@
     Condition
       Warning:
       Specifying `multiple = "error"` was deprecated in dplyr 1.1.1.
-      i Please use `relationship = "many_to_one"` instead.
+      i Please use `relationship = "many-to-one"` instead.
       Error:
       ! Each row in `x` must match at most 1 row in `y`.
       i Row 2 of `x` matches multiple rows in `y`.
@@ -363,7 +363,7 @@
     Condition
       Warning:
       Specifying `multiple = "error"` was deprecated in dplyr 1.1.1.
-      i Please use `relationship = "many_to_one"` instead.
+      i Please use `relationship = "many-to-one"` instead.
       Error in `left_join()`:
       ! Each row in `x` must match at most 1 row in `y`.
       i Row 2 of `x` matches multiple rows in `y`.
@@ -375,7 +375,7 @@
     Condition
       Warning:
       Specifying `multiple = "warning"` was deprecated in dplyr 1.1.1.
-      i Please use `relationship = "many_to_one"` instead.
+      i Please use `relationship = "many-to-one"` instead.
       Warning:
       Each row in `x` is expected to match at most 1 row in `y`.
       i Row 2 of `x` matches multiple rows.
@@ -387,7 +387,7 @@
     Condition
       Warning:
       Specifying `multiple = "warning"` was deprecated in dplyr 1.1.1.
-      i Please use `relationship = "many_to_one"` instead.
+      i Please use `relationship = "many-to-one"` instead.
       Warning in `left_join()`:
       Each row in `x` is expected to match at most 1 row in `y`.
       i Row 2 of `x` matches multiple rows.

--- a/tests/testthat/_snaps/join-rows.md
+++ b/tests/testthat/_snaps/join-rows.md
@@ -68,7 +68,7 @@
 # join_rows() gives meaningful many-to-many warnings
 
     Code
-      join_rows(c(1, 1), c(1, 1), relationship = "warn-many-to-many")
+      join_rows(c(1, 1), c(1, 1))
     Condition
       Warning:
       Detected an unexpected many-to-many relationship between `x` and `y`.
@@ -318,6 +318,31 @@
       Error:
       ! `unmatched` must be one of "drop" or "error", not "dr".
       i Did you mean "drop"?
+
+# join_rows() validates `relationship`
+
+    Code
+      join_rows(df, df, relationship = 1)
+    Condition
+      Error:
+      ! `relationship` must be a string or character vector.
+
+---
+
+    Code
+      join_rows(df, df, relationship = "none")
+    Condition
+      Error:
+      ! `relationship` must be one of "one-to-one", "one-to-many", "many-to-one", or "many-to-many", not "none".
+
+---
+
+    Code
+      join_rows(df, df, relationship = "warn-many-to-many")
+    Condition
+      Error:
+      ! `relationship` must be one of "one-to-one", "one-to-many", "many-to-one", or "many-to-many", not "warn-many-to-many".
+      i Did you mean "many-to-many"?
 
 # `multiple = NULL` is deprecated and results in `'all'` (#6731)
 

--- a/tests/testthat/_snaps/join.md
+++ b/tests/testthat/_snaps/join.md
@@ -50,15 +50,16 @@
       Error:
       ! `na_matches` must be one of "na" or "never", not "foo".
 
-# mutating joins trigger multiple match warning
+# mutating joins trigger many-to-many warning
 
     Code
-      out <- left_join(df1, df2, join_by(x))
+      out <- left_join(df, df, join_by(x))
     Condition
       Warning in `left_join()`:
-      Each row in `x` is expected to match at most 1 row in `y`.
-      i Row 1 of `x` matches multiple rows.
-      i If multiple matches are expected, set `multiple = "all"` to silence this warning.
+      Detected an unexpected many-to-many relationship between `x` and `y`.
+      i Row 1 of `x` matches multiple rows in `y`.
+      i Row 1 of `y` matches multiple rows in `x`.
+      i If a many-to-many relationship is expected, set `relationship = "many_to_many"` to silence this warning.
 
 # mutating joins compute common columns
 
@@ -198,14 +199,14 @@
       ! Each row of `y` must be matched by `x`.
       i Row 1 of `y` was not matched.
 
-# `by = character()` technically respects `multiple`
+# `by = character()` technically respects `relationship`
 
     Code
-      left_join(df, df, by = character(), multiple = "error")
+      left_join(df, df, by = character(), relationship = "many_to_one")
     Condition
       Error in `left_join()`:
       ! Each row in `x` must match at most 1 row in `y`.
-      i Row 1 of `x` matches multiple rows.
+      i Row 1 of `x` matches multiple rows in `y`.
 
 # `by = character()` for a cross join is deprecated (#6604)
 

--- a/tests/testthat/_snaps/join.md
+++ b/tests/testthat/_snaps/join.md
@@ -59,7 +59,7 @@
       Detected an unexpected many-to-many relationship between `x` and `y`.
       i Row 1 of `x` matches multiple rows in `y`.
       i Row 1 of `y` matches multiple rows in `x`.
-      i If a many-to-many relationship is expected, set `relationship = "many_to_many"` to silence this warning.
+      i If a many-to-many relationship is expected, set `relationship = "many-to-many"` to silence this warning.
 
 # mutating joins compute common columns
 
@@ -202,7 +202,7 @@
 # `by = character()` technically respects `relationship`
 
     Code
-      left_join(df, df, by = character(), relationship = "many_to_one")
+      left_join(df, df, by = character(), relationship = "many-to-one")
     Condition
       Error in `left_join()`:
       ! Each row in `x` must match at most 1 row in `y`.

--- a/tests/testthat/test-group-by.R
+++ b/tests/testthat/test-group-by.R
@@ -55,8 +55,8 @@ test_that("joins preserve grouping", {
   df <- data.frame(x = rep(1:2, each = 4), y = rep(1:4, each = 2))
   g <- group_by(df, x)
 
-  expect_equal(group_vars(inner_join(g, g, by = c("x", "y"), relationship = "many_to_many")), "x")
-  expect_equal(group_vars(left_join(g, g, by = c("x", "y"), relationship = "many_to_many")), "x")
+  expect_equal(group_vars(inner_join(g, g, by = c("x", "y"), relationship = "many-to-many")), "x")
+  expect_equal(group_vars(left_join(g, g, by = c("x", "y"), relationship = "many-to-many")), "x")
   expect_equal(group_vars(semi_join(g, g, by = c("x", "y"))), "x")
   expect_equal(group_vars(anti_join(g, g, by = c("x", "y"))), "x")
 })

--- a/tests/testthat/test-group-by.R
+++ b/tests/testthat/test-group-by.R
@@ -55,8 +55,8 @@ test_that("joins preserve grouping", {
   df <- data.frame(x = rep(1:2, each = 4), y = rep(1:4, each = 2))
   g <- group_by(df, x)
 
-  expect_equal(group_vars(inner_join(g, g, by = c("x", "y"), multiple = "all")), "x")
-  expect_equal(group_vars(left_join(g, g, by = c("x", "y"), multiple = "all")), "x")
+  expect_equal(group_vars(inner_join(g, g, by = c("x", "y"), relationship = "many_to_many")), "x")
+  expect_equal(group_vars(left_join(g, g, by = c("x", "y"), relationship = "many_to_many")), "x")
   expect_equal(group_vars(semi_join(g, g, by = c("x", "y"))), "x")
   expect_equal(group_vars(anti_join(g, g, by = c("x", "y"))), "x")
 })

--- a/tests/testthat/test-join-rows.R
+++ b/tests/testthat/test-join-rows.R
@@ -1,18 +1,24 @@
-test_that("`multiple` default behavior is correct", {
-  # "warning" for equi and rolling joins
+test_that("`relationship` default behavior is correct", {
+  # "warn_many_to_many" for equality joins
   expect_snapshot(out <- join_rows(c(1, 1), c(1, 1), condition = "=="))
   expect_equal(out$x, c(1L, 1L, 2L, 2L))
   expect_equal(out$y, c(1L, 2L, 1L, 2L))
 
-  expect_snapshot(out <- join_rows(c(1, 1), c(1, 1), condition = ">=", filter = "max"))
+  # "none" for rolling joins
+  expect_warning(out <- join_rows(c(1, 2), c(1, 1), condition = ">=", filter = "max"), NA)
   expect_equal(out$x, c(1L, 1L, 2L, 2L))
   expect_equal(out$y, c(1L, 2L, 1L, 2L))
+  # If rolling joins warned on many-to-many relationships, it would be a little
+  # hard to explain that the above example warns, but this wouldn't just because
+  # we've removed `2` as a key from `x`:
+  # `join_rows(1, c(1, 1), condition = ">=", filter = "max")`
 
-  # "all" for non-equi and cross joins
+  # "none" for inequality joins (and overlap joins)
   expect_warning(out <- join_rows(c(1, 2), c(0, 1), condition = ">="), NA)
   expect_equal(out$x, c(1L, 1L, 2L, 2L))
   expect_equal(out$y, c(1L, 2L, 1L, 2L))
 
+  # "none" for deprecated cross joins
   expect_warning(out <- join_rows(c(1, 1), c(1, 1), cross = TRUE), NA)
   expect_equal(out$x, c(1L, 1L, 2L, 2L))
   expect_equal(out$y, c(1L, 2L, 1L, 2L))
@@ -162,15 +168,37 @@ test_that("join_rows() expects incompatible type errors to have been handled by 
   })
 })
 
-test_that("join_rows() gives meaningful error/warning message on multiple matches", {
-  expect_snapshot(error = TRUE, join_rows(1, c(1, 1), multiple = "error"))
+test_that("join_rows() gives meaningful one-to-one errors", {
+  expect_snapshot(error = TRUE, {
+    join_rows(1, c(1, 1), relationship = "one_to_one")
+  })
+  expect_snapshot(error = TRUE, {
+    join_rows(c(1, 1), 1, relationship = "one_to_one")
+  })
+})
 
-  cnd <- catch_cnd(join_rows(1, c(1, 1), multiple = "warning"), classes = "warning")
-  expect_snapshot(cat(conditionMessage(cnd)))
+test_that("join_rows() gives meaningful one-to-many errors", {
+  expect_snapshot(error = TRUE, {
+    join_rows(c(1, 1), 1, relationship = "one_to_many")
+  })
+})
 
-  df1 <- data.frame(x = 1)
-  df2 <- data.frame(x = c(1, 1))
-  expect_snapshot(. <- left_join(df1, df2, by = "x"))
+test_that("join_rows() gives meaningful many-to-one errors", {
+  expect_snapshot(error = TRUE, {
+    join_rows(1, c(1, 1), relationship = "many_to_one")
+  })
+})
+
+test_that("join_rows() gives meaningful many-to-many warnings", {
+  expect_snapshot({
+    join_rows(c(1, 1), c(1, 1), relationship = "warn_many_to_many")
+  })
+
+  # With proof that the defaults flow through user facing functions
+  df <- data.frame(x = c(1, 1))
+  expect_snapshot({
+    left_join(df, df, by = join_by(x))
+  })
 })
 
 test_that("join_rows() gives meaningful error message on unmatched rows", {
@@ -363,5 +391,49 @@ test_that("join_rows() validates `unmatched`", {
     join_rows(df, df, type = "inner", unmatched = c("drop", "error", "error"))
 
     join_rows(df, df, type = "inner", unmatched = c("drop", "dr"))
+  })
+})
+
+# Deprecated behavior ----------------------------------------------------------
+
+test_that("`multiple = NULL` is deprecated and results in `'all'` (#6731)", {
+  df1 <- tibble(x = c(1, 2))
+  df2 <- tibble(x = c(2, 1, 2))
+
+  expect_snapshot({
+    out <- join_rows(df1, df2, multiple = NULL)
+  })
+  expect_identical(out$x, c(1L, 2L, 2L))
+  expect_identical(out$y, c(2L, 1L, 3L))
+
+  expect_snapshot({
+    left_join(df1, df2, by = join_by(x), multiple = NULL)
+  })
+})
+
+test_that("`multiple = 'error'` is deprecated (#6731)", {
+  df1 <- tibble(x = c(1, 2))
+  df2 <- tibble(x = c(2, 1, 2))
+
+  expect_snapshot(error = TRUE, {
+    join_rows(df1, df2, multiple = "error")
+  })
+  expect_snapshot(error = TRUE, {
+    left_join(df1, df2, by = join_by(x), multiple = "error")
+  })
+})
+
+test_that("`multiple = 'warning'` is deprecated (#6731)", {
+  df1 <- tibble(x = c(1, 2))
+  df2 <- tibble(x = c(2, 1, 2))
+
+  expect_snapshot({
+    out <- join_rows(df1, df2, multiple = "warning")
+  })
+  expect_identical(out$x, c(1L, 2L, 2L))
+  expect_identical(out$y, c(2L, 1L, 3L))
+
+  expect_snapshot({
+    left_join(df1, df2, by = join_by(x), multiple = "warning")
   })
 })

--- a/tests/testthat/test-join-rows.R
+++ b/tests/testthat/test-join-rows.R
@@ -191,7 +191,7 @@ test_that("join_rows() gives meaningful many-to-one errors", {
 
 test_that("join_rows() gives meaningful many-to-many warnings", {
   expect_snapshot({
-    join_rows(c(1, 1), c(1, 1), relationship = "warn-many-to-many")
+    join_rows(c(1, 1), c(1, 1))
   })
 
   # With proof that the defaults flow through user facing functions
@@ -391,6 +391,22 @@ test_that("join_rows() validates `unmatched`", {
     join_rows(df, df, type = "inner", unmatched = c("drop", "error", "error"))
 
     join_rows(df, df, type = "inner", unmatched = c("drop", "dr"))
+  })
+})
+
+test_that("join_rows() validates `relationship`", {
+  df <- tibble(x = 1)
+
+  expect_snapshot(error = TRUE, {
+    join_rows(df, df, relationship = 1)
+  })
+
+  # Notably can't use the vctrs options
+  expect_snapshot(error = TRUE, {
+    join_rows(df, df, relationship = "none")
+  })
+  expect_snapshot(error = TRUE, {
+    join_rows(df, df, relationship = "warn-many-to-many")
   })
 })
 

--- a/tests/testthat/test-join-rows.R
+++ b/tests/testthat/test-join-rows.R
@@ -1,5 +1,5 @@
 test_that("`relationship` default behavior is correct", {
-  # "warn_many_to_many" for equality joins
+  # "warn-many-to-many" for equality joins
   expect_snapshot(out <- join_rows(c(1, 1), c(1, 1), condition = "=="))
   expect_equal(out$x, c(1L, 1L, 2L, 2L))
   expect_equal(out$y, c(1L, 2L, 1L, 2L))
@@ -170,28 +170,28 @@ test_that("join_rows() expects incompatible type errors to have been handled by 
 
 test_that("join_rows() gives meaningful one-to-one errors", {
   expect_snapshot(error = TRUE, {
-    join_rows(1, c(1, 1), relationship = "one_to_one")
+    join_rows(1, c(1, 1), relationship = "one-to-one")
   })
   expect_snapshot(error = TRUE, {
-    join_rows(c(1, 1), 1, relationship = "one_to_one")
+    join_rows(c(1, 1), 1, relationship = "one-to-one")
   })
 })
 
 test_that("join_rows() gives meaningful one-to-many errors", {
   expect_snapshot(error = TRUE, {
-    join_rows(c(1, 1), 1, relationship = "one_to_many")
+    join_rows(c(1, 1), 1, relationship = "one-to-many")
   })
 })
 
 test_that("join_rows() gives meaningful many-to-one errors", {
   expect_snapshot(error = TRUE, {
-    join_rows(1, c(1, 1), relationship = "many_to_one")
+    join_rows(1, c(1, 1), relationship = "many-to-one")
   })
 })
 
 test_that("join_rows() gives meaningful many-to-many warnings", {
   expect_snapshot({
-    join_rows(c(1, 1), c(1, 1), relationship = "warn_many_to_many")
+    join_rows(c(1, 1), c(1, 1), relationship = "warn-many-to-many")
   })
 
   # With proof that the defaults flow through user facing functions

--- a/tests/testthat/test-join.R
+++ b/tests/testthat/test-join.R
@@ -276,9 +276,8 @@ test_that("mutating joins don't trigger many-to-many warning when called indirec
   fn_env(fn) <- ns_env("rlang")
 
   # Indirectly calling `left_join()` through a function you don't control
-  # doesn't warn unless `relationship = "warn-many-to-many"` is explicitly set
+  # doesn't warn
   expect_no_warning(fn(df, df), class = "dplyr_warning_join_relationship_many_to_many")
-  expect_warning(fn(df, df, "warn-many-to-many"), class = "dplyr_warning_join_relationship_many_to_many")
 })
 
 test_that("mutating joins compute common columns", {

--- a/tests/testthat/test-join.R
+++ b/tests/testthat/test-join.R
@@ -276,9 +276,9 @@ test_that("mutating joins don't trigger many-to-many warning when called indirec
   fn_env(fn) <- ns_env("rlang")
 
   # Indirectly calling `left_join()` through a function you don't control
-  # doesn't warn unless `relationship = "warn_many_to_many"` is explicitly set
+  # doesn't warn unless `relationship = "warn-many-to-many"` is explicitly set
   expect_no_warning(fn(df, df), class = "dplyr_warning_join_relationship_many_to_many")
-  expect_warning(fn(df, df, "warn_many_to_many"), class = "dplyr_warning_join_relationship_many_to_many")
+  expect_warning(fn(df, df, "warn-many-to-many"), class = "dplyr_warning_join_relationship_many_to_many")
 })
 
 test_that("mutating joins compute common columns", {
@@ -457,11 +457,11 @@ test_that("joins respect zero length groups", {
   df2 <- tibble(f = factor( c(2,2,3,3), levels = 1:3), y = c(1,2,3,4)) %>%
     group_by(f)
 
-  expect_equal(group_size(left_join( df1, df2, by = "f", relationship = "many_to_many")),  c(2,4))
-  expect_equal(group_size(right_join( df1, df2, by = "f", relationship = "many_to_many")),  c(4,2))
-  expect_equal(group_size(full_join( df1, df2, by = "f", relationship = "many_to_many")),  c(2,4,2))
+  expect_equal(group_size(left_join( df1, df2, by = "f", relationship = "many-to-many")),  c(2,4))
+  expect_equal(group_size(right_join( df1, df2, by = "f", relationship = "many-to-many")),  c(4,2))
+  expect_equal(group_size(full_join( df1, df2, by = "f", relationship = "many-to-many")),  c(2,4,2))
   expect_equal(group_size(anti_join( df1, df2, by = "f")),  c(2))
-  expect_equal(group_size(inner_join( df1, df2, by = "f", relationship = "many_to_many")),  c(4))
+  expect_equal(group_size(inner_join( df1, df2, by = "f", relationship = "many-to-many")),  c(4))
 
 
   df1 <- tibble(f = factor( c(1,1,2,2), levels = 1:3), x = c(1,2,1,4)) %>%
@@ -469,11 +469,11 @@ test_that("joins respect zero length groups", {
   df2 <- tibble(f = factor( c(2,2,3,3), levels = 1:3), y = c(1,2,3,4)) %>%
     group_by(f, .drop = FALSE)
 
-  expect_equal(group_size(left_join( df1, df2, by = "f", relationship = "many_to_many")),  c(2,4,0))
-  expect_equal(group_size(right_join( df1, df2, by = "f", relationship = "many_to_many")),  c(0,4,2))
-  expect_equal(group_size(full_join( df1, df2, by = "f", relationship = "many_to_many")),  c(2,4,2))
+  expect_equal(group_size(left_join( df1, df2, by = "f", relationship = "many-to-many")),  c(2,4,0))
+  expect_equal(group_size(right_join( df1, df2, by = "f", relationship = "many-to-many")),  c(0,4,2))
+  expect_equal(group_size(full_join( df1, df2, by = "f", relationship = "many-to-many")),  c(2,4,2))
   expect_equal(group_size(anti_join( df1, df2, by = "f")),  c(2,0,0))
-  expect_equal(group_size(inner_join( df1, df2, by = "f", relationship = "many_to_many")),  c(0,4,0))
+  expect_equal(group_size(inner_join( df1, df2, by = "f", relationship = "many-to-many")),  c(0,4,0))
 })
 
 test_that("group column names reflect renamed duplicate columns (#2330)", {
@@ -525,7 +525,7 @@ test_that("`by = character()` technically respects `relationship`", {
   df <- tibble(x = 1:2)
 
   expect_snapshot(error = TRUE, {
-    left_join(df, df, by = character(), relationship = "many_to_one")
+    left_join(df, df, by = character(), relationship = "many-to-one")
   })
 })
 

--- a/tests/testthat/test-join.R
+++ b/tests/testthat/test-join.R
@@ -257,30 +257,28 @@ test_that("join_filter() validates arguments", {
   })
 })
 
-test_that("mutating joins trigger multiple match warning", {
-  df1 <- tibble(x = 1)
-  df2 <- tibble(x = c(1, 1))
-  expect_snapshot(out <- left_join(df1, df2, join_by(x)))
+test_that("mutating joins trigger many-to-many warning", {
+  df <- tibble(x = c(1, 1))
+  expect_snapshot(out <- left_join(df, df, join_by(x)))
 })
 
-test_that("mutating joins don't trigger multiple match warning when called indirectly", {
-  df1 <- tibble(x = 1)
-  df2 <- tibble(x = c(1, 1))
+test_that("mutating joins don't trigger many-to-many warning when called indirectly", {
+  df <- tibble(x = c(1, 1))
 
-  fn <- function(df1, df2, multiple = NULL) {
-    left_join(df1, df2, join_by(x), multiple = multiple)
+  fn <- function(df1, df2, relationship = NULL) {
+    left_join(df1, df2, join_by(x), relationship = relationship)
   }
 
   # Directly calling `left_join()` from a function you control results in a warning
-  expect_warning(fn(df1, df2), class = "dplyr_warning_join_matches_multiple")
+  expect_warning(fn(df, df), class = "dplyr_warning_join_relationship_many_to_many")
 
   # Now mimic calling an "rlang function" which you don't control that calls `left_join()`
   fn_env(fn) <- ns_env("rlang")
 
   # Indirectly calling `left_join()` through a function you don't control
-  # doesn't warn unless `multiple = "warning"` is explicitly set
-  expect_no_warning(fn(df1, df2), class = "dplyr_warning_join_matches_multiple")
-  expect_warning(fn(df1, df2, "warning"), class = "dplyr_warning_join_matches_multiple")
+  # doesn't warn unless `relationship = "warn_many_to_many"` is explicitly set
+  expect_no_warning(fn(df, df), class = "dplyr_warning_join_relationship_many_to_many")
+  expect_warning(fn(df, df, "warn_many_to_many"), class = "dplyr_warning_join_relationship_many_to_many")
 })
 
 test_that("mutating joins compute common columns", {
@@ -437,7 +435,7 @@ test_that("joins preserve groups", {
   gf1 <- tibble(a = 1:3) %>% group_by(a)
   gf2 <- tibble(a = rep(1:4, 2), b = 1) %>% group_by(b)
 
-  i <- count_regroups(out <- inner_join(gf1, gf2, by = "a", multiple = "all"))
+  i <- count_regroups(out <- inner_join(gf1, gf2, by = "a"))
   expect_equal(i, 1L)
   expect_equal(group_vars(out), "a")
 
@@ -459,11 +457,11 @@ test_that("joins respect zero length groups", {
   df2 <- tibble(f = factor( c(2,2,3,3), levels = 1:3), y = c(1,2,3,4)) %>%
     group_by(f)
 
-  expect_equal(group_size(left_join( df1, df2, by = "f", multiple = "all")),  c(2,4))
-  expect_equal(group_size(right_join( df1, df2, by = "f", multiple = "all")),  c(4,2))
-  expect_equal(group_size(full_join( df1, df2, by = "f", multiple = "all")),  c(2,4,2))
+  expect_equal(group_size(left_join( df1, df2, by = "f", relationship = "many_to_many")),  c(2,4))
+  expect_equal(group_size(right_join( df1, df2, by = "f", relationship = "many_to_many")),  c(4,2))
+  expect_equal(group_size(full_join( df1, df2, by = "f", relationship = "many_to_many")),  c(2,4,2))
   expect_equal(group_size(anti_join( df1, df2, by = "f")),  c(2))
-  expect_equal(group_size(inner_join( df1, df2, by = "f", multiple = "all")),  c(4))
+  expect_equal(group_size(inner_join( df1, df2, by = "f", relationship = "many_to_many")),  c(4))
 
 
   df1 <- tibble(f = factor( c(1,1,2,2), levels = 1:3), x = c(1,2,1,4)) %>%
@@ -471,11 +469,11 @@ test_that("joins respect zero length groups", {
   df2 <- tibble(f = factor( c(2,2,3,3), levels = 1:3), y = c(1,2,3,4)) %>%
     group_by(f, .drop = FALSE)
 
-  expect_equal(group_size(left_join( df1, df2, by = "f", multiple = "all")),  c(2,4,0))
-  expect_equal(group_size(right_join( df1, df2, by = "f", multiple = "all")),  c(0,4,2))
-  expect_equal(group_size(full_join( df1, df2, by = "f", multiple = "all")),  c(2,4,2))
+  expect_equal(group_size(left_join( df1, df2, by = "f", relationship = "many_to_many")),  c(2,4,0))
+  expect_equal(group_size(right_join( df1, df2, by = "f", relationship = "many_to_many")),  c(0,4,2))
+  expect_equal(group_size(full_join( df1, df2, by = "f", relationship = "many_to_many")),  c(2,4,2))
   expect_equal(group_size(anti_join( df1, df2, by = "f")),  c(2,0,0))
-  expect_equal(group_size(inner_join( df1, df2, by = "f", multiple = "all")),  c(0,4,0))
+  expect_equal(group_size(inner_join( df1, df2, by = "f", relationship = "many_to_many")),  c(0,4,0))
 })
 
 test_that("group column names reflect renamed duplicate columns (#2330)", {
@@ -492,7 +490,7 @@ test_that("rowwise group structure is updated after a join (#5227)", {
   df1 <- rowwise(tibble(x = 1:2))
   df2 <- tibble(x = c(1:2, 2L))
 
-  x <- left_join(df1, df2, by = "x", multiple = "all")
+  x <- left_join(df1, df2, by = "x")
 
   expect_identical(group_rows(x), list_of(1L, 2L, 3L))
 })
@@ -521,13 +519,13 @@ test_that("`by = character()` technically respects `unmatched`", {
   })
 })
 
-test_that("`by = character()` technically respects `multiple`", {
+test_that("`by = character()` technically respects `relationship`", {
   local_options(lifecycle_verbosity = "quiet")
 
   df <- tibble(x = 1:2)
 
   expect_snapshot(error = TRUE, {
-    left_join(df, df, by = character(), multiple = "error")
+    left_join(df, df, by = character(), relationship = "many_to_one")
   })
 })
 


### PR DESCRIPTION
Closes https://github.com/tidyverse/dplyr/issues/6731
Closes https://github.com/tidyverse/dplyr/issues/6717
Joint PR on the vctrs side https://github.com/r-lib/vctrs/pull/1791, which contains even more detail

This PR hopefully fixes most of the complaints we've seen about the multiple match warning. At a high level:
- We previously warned on one-to-many and many-to-many relationships
- We now only warn on many-to-many relationships

As outlined in https://github.com/tidyverse/dplyr/issues/6731, only warning on many-to-many makes much more sense, as one-to-many is generally pretty useful, and is symmetric with many-to-one which we don't warn on, and that didn't make much sense. As further proof that we _should_ warn on many-to-many, most SQL dialects won't even let you create a many-to-many "relationship" between two tables; instead you have to create a 3rd junction table to break it into two one-to-many relationships.

This PR accomplishes this in two steps by:

- Changing the `multiple` default to `"all"` (same as SQL), and deprecating the `NULL`, `"error"`, and `"warning"` options
- Introducing a new `relationship` argument which replaces the `multiple = "error"` case and holistically handles multiple matches between `x` and `y`

The `relationship` argument takes on various options:

- `NULL` (default, chooses `"none"` or `"warn_many_to_many"` automatically)
- `"none"` (default for inequality, rolling, overlap joins)
- `"one_to_one"`
- `"one_to_many"`
- `"many_to_one"`
- `"many_to_many"`
- `"warn_many_to_many"` (default for equality joins)

These are inspired by [database table relationships](https://www.metabase.com/learn/databases/table-relationships), which end up being orthogonal to the idea of the "kind" of join you are doing (i.e. left/right/full/inner), so we can add an argument for this without any ambiguity or conflicts.

The choice of `relationship` activates a constraint on `x` and `y`, for example, `"many_to_one"` says that:
- Each row of `x` can match _at most 1_ row in `y`
- Each row of `y` can match _any number_ of rows in `x`

Which makes `relationship = "many_to_one"` a nice replacement for `multiple = "error"`. But we also now have `"one_to_one"` and `"one_to_many"` too!

The `"warn_many_to_many"` doesn't assume any expected relationship, but instead will check to see if a many-to-many relationship is present and will warn if it is, encouraging you to either look at your data or explicitly set `"many_to_many"` if that is expected.

Note that _at most 1_ means this doesn't handle the 0 match case, which is instead handled jointly by `unmatched` and your choice of join. Using _at most 1_ aligns exactly with the typical SQL definition for these options.