### PR TITLE
Add `list_flatten()` helper to avoid rlang deprecations

### DIFF
--- a/R/bind-cols.R
+++ b/R/bind-cols.R
@@ -28,7 +28,7 @@
 bind_cols <- function(..., .name_repair = c("unique", "universal", "check_unique", "minimal")) {
   dots <- list2(...)
 
-  dots <- squash_if(dots, vec_is_list)
+  dots <- list_flatten(dots, recursive = TRUE)
   dots <- discard(dots, is.null)
 
   # Strip names off of data frame components so that vec_cbind() unpacks them

--- a/R/bind-rows.R
+++ b/R/bind-rows.R
@@ -31,11 +31,11 @@ bind_rows <- function(..., .id = NULL) {
   dots <- list2(...)
 
   # bind_rows() has weird legacy squashing behaviour
-  is_flattenable <- function(x) vec_is_list(x) && !is_named(x)
+  is_flattenable <- function(x) !is_named(x)
   if (length(dots) == 1 && is_bare_list(dots[[1]])) {
     dots <- dots[[1]]
   }
-  dots <- flatten_if(dots, is_flattenable)
+  dots <- list_flatten(dots, fn = is_flattenable)
   dots <- discard(dots, is.null)
 
   # Used to restore type

--- a/R/filter.R
+++ b/R/filter.R
@@ -189,7 +189,9 @@ filter_expand <- function(dots, mask, error_call = caller_env()) {
     }
   )
 
-  new_quosures(flatten(dots))
+  dots <- list_flatten(dots)
+
+  new_quosures(dots)
 }
 
 filter_eval <- function(dots,

--- a/R/utils.R
+++ b/R/utils.R
@@ -48,6 +48,49 @@ dplyr_new_tibble <- function(x, size) {
   new_data_frame(x = x, n = size, class = c("tbl_df", "tbl"))
 }
 
+#' @param x A list
+#' @param fn An optional function of 1 argument to be applied to each list
+#'   element of `x`. This allows you to further refine what elements should be
+#'   flattened. `fn` should return a single `TRUE` or `FALSE`.
+#' @param recursive Should `list_flatten()` be applied recursively? If `TRUE`,
+#'   it will continue to apply `list_flatten()` as long as at least one element
+#'   of `x` was flattened in the previous iteration.
+#' @noRd
+list_flatten <- function(x, ..., fn = NULL, recursive = FALSE) {
+  check_dots_empty0(...)
+
+  vec_check_list(x)
+  x <- unclass(x)
+
+  loc <- map_lgl(x, vec_is_list)
+
+  if (!is_null(fn)) {
+    loc[loc] <- map_lgl(x[loc], fn)
+  }
+
+  not_loc <- !loc
+
+  names <- names(x)
+  if (!is_null(names)) {
+    # Always prefer inner names, even if inner elements are actually unnamed.
+    # This is what `rlang::flatten_if()` did, with a warning. We could also
+    # use `name_spec` and `name_repair` for a more complete solution.
+    names[loc] <- ""
+    names(x) <- names
+  }
+
+  x[loc] <- map(x[loc], unclass)
+  x[not_loc] <- map(x[not_loc], list)
+
+  out <- list_unchop(x, ptype = list())
+
+  if (recursive && any(loc)) {
+    out <- list_flatten(out, fn = fn, recursive = TRUE)
+  }
+
+  out
+}
+
 maybe_restart <- function(restart) {
   if (!is_null(findRestart(restart))) {
     invokeRestart(restart)

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,7 +1,72 @@
+# ------------------------------------------------------------------------------
+# quo_is_variable_reference()
+
 test_that("quo_is_variable_reference handles .data",{
   expect_true(quo_is_variable_reference(quo(x)))
   expect_true(quo_is_variable_reference(quo(.data$x)))
   expect_true(quo_is_variable_reference(quo(.data[["x"]])))
   quo <- new_quosure(quote(.data[[identity("x")]]))
   expect_false(quo_is_variable_reference(quo))
+})
+
+# ------------------------------------------------------------------------------
+# list_flatten()
+
+test_that("`list_flatten()` is a no-op on flattened lists", {
+  x <- list(1, 2)
+  expect_identical(list_flatten(x), x)
+})
+
+test_that("`list_flatten()` flattens list elements", {
+  x <- list(list(1, 2), 3, list(4))
+  expect_identical(list_flatten(x), list(1, 2, 3, 4))
+})
+
+test_that("`list_flatten()` doesn't try to be generic", {
+  my_list <- function(...) structure(list(...), class = c("my_list", "list"))
+
+  x <- my_list(list(1, 2), 3, my_list(4))
+  expect_identical(list_flatten(x), list(1, 2, 3, 4))
+
+  # The no-op case returns a bare list too
+  x <- my_list(1, 2)
+  expect_identical(list_flatten(x), list(1, 2))
+})
+
+test_that("`list_flatten()` only retains inner names of flattened elements", {
+  x <- list(a = list(1, b = 2), 3, list(d = 4), e = 5, f = list(1))
+  expect_identical(list_flatten(x), list(1, b = 2, 3, d = 4, e = 5, 1))
+})
+
+test_that("`list_flatten()` can work recursively", {
+  x <- list(list(list(1, 2), 3), 4)
+
+  # Not by default
+  expect_identical(list_flatten(x), list(list(1, 2), 3, 4))
+
+  expect_identical(list_flatten(x, recursive = TRUE), list(1, 2, 3, 4))
+})
+
+test_that("recursive `list_flatten()` handles names correctly", {
+  x <- list(a = list(b = list(1), c = list(d = 2), 3, e = 4), f = 5)
+
+  expect_identical(
+    list_flatten(x, recursive = TRUE),
+    list(1, d = 2, 3, e = 4, f = 5)
+  )
+})
+
+test_that("`list_flatten()` accepts a predicate `fn` to selectively flatten", {
+  is_flattenable <- function(x) !is_named(x)
+
+  x <- list(a = list(list(1), list(b = 2), 3), c = 4, d = list(e = 5), f = list(6))
+
+  expect_identical(
+    list_flatten(x, fn = is_flattenable),
+    list(list(1), list(b = 2), 3, c = 4, d = list(e = 5), 6)
+  )
+  expect_identical(
+    list_flatten(x, fn = is_flattenable, recursive = TRUE),
+    list(1, list(b = 2), 3, c = 4, d = list(e = 5), 6)
+  )
 })


### PR DESCRIPTION
CC @hadley @lionel- 

purrr doesn't really have any replacement for `flatten_if()` and the `squash*()` family yet.

I think this new `fn` argument could replace `flatten_if()`, and the `recursive` argument handles the squashing case.

Notably with `fn`, it is only applied to elements of the list that already pass a `vec_is_list()` check, so it just acts as a refinement of that.

---

Not really waiting on a review here, just letting you know about this in case we want to bring it to purrr too.