### PR TITLE
Always duplicate variables we plan to modify by reference

### DIFF
--- a/tests/testthat/test-mutate.R
+++ b/tests/testthat/test-mutate.R
@@ -478,6 +478,22 @@ test_that("DataMask$add() forces chunks (#4677)", {
   expect_equal(df$log_e_bf01, log(1 / 0.244))
 })
 
+test_that("DataMask uses fresh copies of group id / size variables (#6762)", {
+  df <- tibble(x = 1:2)
+
+  fn <- function() {
+    df <- tibble(a = 1)
+    # Otherwise, this nested `mutate()` can modify the same
+    # id/size variable as the outer one, which causes havoc
+    mutate(df, b = a + 1)
+  }
+
+  out <- mutate(df, y = {fn(); x})
+
+  expect_identical(out$x, 1:2)
+  expect_identical(out$y, 1:2)
+})
+
 test_that("mutate() correctly auto-names expressions (#6741)", {
   df <- tibble(a = 1L)
 


### PR DESCRIPTION
Closes https://github.com/tidyverse/dplyr/issues/6762

@lionel- this was a new one for me. The issue in #6762 was caused by a nested `mutate()` getting a reference to the exact same `dplyr:::current_group_id` as the outer `mutate()`. It seems that the `0L` value we initialize the id and size with isn't created "fresh" in each DataMask, so that is how they can get shared. Super tricky, took a long time to debug 😅 

Does this make sense to you? (No rush since you are OOO, just letting you know really)