### PR TITLE
Use `nrow()` rather than `vec_size()` in `group_data()`

### DIFF
--- a/R/group-data.R
+++ b/R/group-data.R
@@ -51,7 +51,7 @@ group_data <- function(.data) {
 
 #' @export
 group_data.data.frame <- function(.data) {
-  size <- vec_size(.data)
+  size <- nrow(.data)
   out <- seq_len(size)
   out <- new_list_of(list(out), ptype = integer())
   out <- list(.rows = out)


### PR DESCRIPTION
Only because 5 packages superclass `data.frame` rather than subclassing it, resulting in a scalar object error from vctrs

- autoReg
- mapping
- NetworkExtinction
- onemap
- PupillometryR

Really these are "bugs" from our perspective in those 5 packages, but we don't want to spend effort updating those for a patch release