### PR TITLE
Fix typo

### DIFF
--- a/vignettes/base.Rmd
+++ b/vignettes/base.Rmd
@@ -41,7 +41,7 @@ This vignette compares dplyr functions to their base R equivalents. This helps t
 
 # One table verbs
 
-The following table shows a condensed translation between dplyr verbs and their base R equivalents. The following sections describe each operation in more detail. You learn more about the dplyr verbs in their documentation and in For more `vignette("one-table")`.
+The following table shows a condensed translation between dplyr verbs and their base R equivalents. The following sections describe each operation in more detail. You learn more about the dplyr verbs in their documentation and in [R for Data Science](https://r4ds.hadley.nz/data-transform.html).
 
 | dplyr                          | base                                             |
 |------------------------------- |--------------------------------------------------|


### PR DESCRIPTION
Not sure whether the other reference was meant to be R4DS, but it would make sense. Also there's no `vignette("one-table")` (well, it's this `vignette("base")`), so removing that.

Maybe @sastoudt can comment?