### PR TITLE
Add an alias for `.data` so `?dplyr::.data` works

### DIFF
--- a/R/utils-tidy-eval.R
+++ b/R/utils-tidy-eval.R
@@ -22,8 +22,8 @@
 #'
 #' @keywords internal
 #' @name tidyeval-compat
-#' @aliases expr enquo enquos sym syms as_label
-#' @export expr enquo enquos sym syms as_label .data
+#' @aliases .data expr enquo enquos sym syms as_label
+#' @export .data expr enquo enquos sym syms as_label
 #' @aliases quo quos quo_name ensym ensyms enexpr enexprs
 #' @export quo quos quo_name ensym ensyms enexpr enexprs
 NULL

--- a/man/tidyeval-compat.Rd
+++ b/man/tidyeval-compat.Rd
@@ -2,6 +2,7 @@
 % Please edit documentation in R/utils-tidy-eval.R
 \name{tidyeval-compat}
 \alias{tidyeval-compat}
+\alias{.data}
 \alias{expr}
 \alias{enquo}
 \alias{enquos}


### PR DESCRIPTION
This should avoid this CRAN check note on r-devel, but we can't seem to reproduce it

```
* checking for missing documentation entries ... WARNING
Undocumented code objects:
  '.data'
All user-level objects in a package should have documentation entries.
See chapter 'Writing R documentation files' in the 'Writing R
Extensions' manual.
```

Purposefully not adding a bullet for `.data` in the documentation page, as it isn't actually a helper that is "no longer for normal usage".

In the long term we should move this to its own help page, possibly with `.env`, or remove it entirely.