### PR TITLE
replace as_tibble with new_tibble

### DIFF
--- a/R/group-by.R
+++ b/R/group-by.R
@@ -156,7 +156,7 @@ ungroup <- function(x, ...) {
 #' @export
 ungroup.grouped_df <- function(x, ...) {
   if (missing(...)) {
-    as_tibble(x)
+    new_tibble(x, groups = NULL)
   } else {
     old_groups <- group_vars(x)
     to_remove <- tidyselect::eval_select(
@@ -174,7 +174,7 @@ ungroup.grouped_df <- function(x, ...) {
 #' @export
 ungroup.rowwise_df <- function(x, ...) {
   check_dots_empty()
-  as_tibble(x)
+  new_tibble(x, groups = NULL)
 }
 
 #' @export


### PR DESCRIPTION
Make `ungroup()` handle attributes in a way that is consistent with other `dplyr` functions by using `new_tibble()` instead of `as_tibble()`.

This is also future-proof if it is later decided that `new_tibble()` should drop attributes.

Fixes https://github.com/tidyverse/dplyr/issues/6774 without affecting discussion in https://github.com/tidyverse/tibble/pull/769