### PR TITLE
WIP: Shortcut for count()

### DIFF
--- a/R/data-mask.R
+++ b/R/data-mask.R
@@ -82,6 +82,13 @@ DataMask <- R6Class("DataMask",
     },
 
     eval_all_summarise = function(quo) {
+      # Optimize count()
+      if (identical(quo_get_expr(quo), expr(n()))) {
+        if (identical(eval(expr(n), quo_get_env(quo)), expr(n()))) {
+          return(lengths(private$rows))
+        }
+      }
+
       # Wrap in a function called `eval()` so that rlang ignores the
       # call in error messages. This only concerns errors that occur
       # directly in `quo`.


### PR DESCRIPTION
This is an attempt to improve the run time of TPCH-21 which uses `count()` over a large table with many groups. A slippery slope.