### PR TITLE
Add tests for behavior of count()

### DIFF
--- a/tests/testthat/test-count-tally.R
+++ b/tests/testthat/test-count-tally.R
@@ -12,6 +12,12 @@ test_that("count can sort output", {
   expect_equal(out, tibble(x = c(2, 1), n = c(3, 2)))
 })
 
+test_that("count can rename grouping columns", {
+  df <- tibble(x = c(2, 1, 1, 2, 1))
+  out <- count(df, y = x)
+  expect_equal(out, tibble(y = c(1, 2), n = c(3, 2)))
+})
+
 test_that("informs if n column already present, unless overridden", {
   df1 <- tibble(n = c(1, 1, 2, 2, 2))
   expect_message(out <- count(df1, n), "already present")

--- a/tests/testthat/test-count-tally.R
+++ b/tests/testthat/test-count-tally.R
@@ -1,5 +1,17 @@
 # count -------------------------------------------------------------------
 
+test_that("count sorts output by default", {
+  df <- tibble(x = c(2, 1, 1, 2, 1))
+  out <- count(df, x)
+  expect_equal(out, tibble(x = c(1, 2), n = c(3, 2)))
+})
+
+test_that("count can sort output", {
+  df <- tibble(x = c(1, 1, 2, 2, 2))
+  out <- count(df, x, sort = TRUE)
+  expect_equal(out, tibble(x = c(2, 1), n = c(3, 2)))
+})
+
 test_that("informs if n column already present, unless overridden", {
   df1 <- tibble(n = c(1, 1, 2, 2, 2))
   expect_message(out <- count(df1, n), "already present")

--- a/tests/testthat/test-count-tally.R
+++ b/tests/testthat/test-count-tally.R
@@ -1,18 +1,20 @@
 # count -------------------------------------------------------------------
 
-test_that("count sorts output by default", {
+test_that("count sorts output by keys by default", {
+  # Due to usage of `summarise()` internally
   df <- tibble(x = c(2, 1, 1, 2, 1))
   out <- count(df, x)
   expect_equal(out, tibble(x = c(1, 2), n = c(3, 2)))
 })
 
-test_that("count can sort output", {
+test_that("count can sort output by `n`", {
   df <- tibble(x = c(1, 1, 2, 2, 2))
   out <- count(df, x, sort = TRUE)
   expect_equal(out, tibble(x = c(2, 1), n = c(3, 2)))
 })
 
 test_that("count can rename grouping columns", {
+  # But should it really allow this?
   df <- tibble(x = c(2, 1, 1, 2, 1))
   out <- count(df, y = x)
   expect_equal(out, tibble(y = c(1, 2), n = c(3, 2)))


### PR DESCRIPTION
None of the existing tests was triggered when the sort order wasn't established.

I see that `summarize(.by = ...)` has a different default (of returning in the order of appearance), I wonder what the long-term intention for `count()` is.