### PR TITLE
Add tests to ensure `across()` allows tidyselect renaming

### DIFF
--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -841,6 +841,29 @@ test_that("across() can access lexical scope (#5862)", {
   )
 })
 
+test_that("across() allows renaming in `.cols` (#6895)", {
+  df <- tibble(x = 1, y = 2, z = 3)
+  cols <- set_names(c("x", "y"), c("a", "b"))
+
+  expect_identical(
+    mutate(df, across(all_of(cols), identity)),
+    mutate(df, a = x, b = y)
+  )
+  expect_identical(
+    mutate(df, (across(all_of(cols), identity))),
+    mutate(df, a = x, b = y)
+  )
+
+  expect_identical(
+    mutate(df, across(all_of(cols), identity, .names = "{.col}_name")),
+    mutate(df, a_name = x, b_name = y)
+  )
+  expect_identical(
+    mutate(df, (across(all_of(cols), identity, .names = "{.col}_name"))),
+    mutate(df, a_name = x, b_name = y)
+  )
+})
+
 test_that("if_any() and if_all() expansions deal with no inputs or single inputs", {
   d <- data.frame(x = 1)
 


### PR DESCRIPTION
Closes https://github.com/tidyverse/dplyr/issues/6895

@hadley I think this is a valid usage of `across()` + renaming-in-tidyselect, do you agree?

``` r
library(dplyr, warn.conflicts = FALSE)
library(rlang)

df <- tibble::tibble(a = 1, b = 2, c = 3)

cols <- set_names(c("a", "b"), c("x", "y"))

df %>%
  mutate(
    across(
      .cols = all_of(cols),
      .fns = ~ .x + 10
    )
  )
#> # A tibble: 1 × 5
#>       a     b     c     x     y
#>   <dbl> <dbl> <dbl> <dbl> <dbl>
#> 1     1     2     3    11    12
```

Extracted from https://github.com/tidyverse/dplyr/issues/6895#issuecomment-1660770953, adding a test because I didn't see any and want to ensure this continues to work.