### PR TITLE
Test that `summarize()` strips off the subclass

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ BugReports: https://github.com/tidyverse/dplyr/issues
 Depends:
     R (>= 3.5.0)
 Imports:
-    cli (>= 3.4.0),
+    cli (>= 3.6.2),
     generics,
     glue (>= 1.3.2),
     lifecycle (>= 1.0.3),
@@ -30,7 +30,7 @@ Imports:
     methods,
     pillar (>= 1.9.0),
     R6,
-    rlang (>= 1.1.0),
+    rlang (>= 1.1.3),
     tibble (>= 3.2.0),
     tidyselect (>= 1.2.0),
     utils,

--- a/R/generics.R
+++ b/R/generics.R
@@ -63,7 +63,9 @@
 #'
 #' * `summarise()` and `reframe()` work similarly to `mutate()` but the data
 #'   modified by `dplyr_col_modify()` comes from `group_data()` or is built
-#'   from `.by`.
+#'   from `.by`. Note that this means that the data frames returned by
+#'   `summarise()` and `reframe()` are fundamentally new data frames, and
+#'   will not retain any custom subclasses or attributes.
 #'
 #' * `select()` uses 1d `[` to select columns, then `names<-` to rename them.
 #'   `rename()` just uses `names<-`. `relocate()` just uses 1d `[`.

--- a/man/dplyr_extending.Rd
+++ b/man/dplyr_extending.Rd
@@ -82,7 +82,9 @@ It also uses 1d \code{[} to implement \code{.keep}, and will call \code{relocate
 either \code{.before} or \code{.after} are supplied.
 \item \code{summarise()} and \code{reframe()} work similarly to \code{mutate()} but the data
 modified by \code{dplyr_col_modify()} comes from \code{group_data()} or is built
-from \code{.by}.
+from \code{.by}. Note that this means that the data frames returned by
+\code{summarise()} and \code{reframe()} are fundamentally new data frames, and
+will not retain any custom subclasses or attributes.
 \item \code{select()} uses 1d \code{[} to select columns, then \verb{names<-} to rename them.
 \code{rename()} just uses \verb{names<-}. \code{relocate()} just uses 1d \code{[}.
 \item \code{inner_join()}, \code{left_join()}, \code{right_join()}, and \code{full_join()}

--- a/tests/testthat/_snaps/context.md
+++ b/tests/testthat/_snaps/context.md
@@ -40,5 +40,5 @@
     Code
       group_labels_details(c(a = 1, b = 2))
     Output
-      [1] "`a = 1`, `b = 2`"
+      [1] "`a = 1` and `b = 2`"
 

--- a/tests/testthat/_snaps/summarise.md
+++ b/tests/testthat/_snaps/summarise.md
@@ -124,7 +124,7 @@
       <error/rlang_error>
       Error in `summarise()`:
       i In argument: `a = rlang::env(a = 1)`.
-      i In group 1: `x = 1`, `y = 1`.
+      i In group 1: `x = 1` and `y = 1`.
       Caused by error:
       ! `a` must be a vector, not an environment.
     Code

--- a/tests/testthat/test-summarise.R
+++ b/tests/testthat/test-summarise.R
@@ -75,6 +75,20 @@ test_that("preserved class, but not attributes", {
   expect_null(attr(out, "res"))
 })
 
+test_that("strips off subclass", {
+  df <- new_data_frame(list(a = 1), class = "myclass")
+  out <- df %>% summarise(n = n())
+  expect_s3_class(out, "data.frame", exact = TRUE)
+  out <- df %>% summarise(.by = a, n = n())
+  expect_s3_class(out, "data.frame", exact = TRUE)
+
+  df <- new_tibble(list(a = 1), class = "myclass")
+  out <- df %>% summarise(n = n())
+  expect_s3_class(out, class(tibble()), exact = TRUE)
+  out <- df %>% summarise(.by = a, n = n())
+  expect_s3_class(out, class(tibble()), exact = TRUE)
+})
+
 test_that("works with unquoted values", {
   df <- tibble(g = c(1, 1, 2, 2, 2), x = 1:5)
   expect_equal(summarise(df, out = !!1), tibble(out = 1))

--- a/tests/testthat/test-summarise.R
+++ b/tests/testthat/test-summarise.R
@@ -60,22 +60,23 @@ test_that("no expressions yields grouping data", {
   expect_equal(summarise(gf, !!!list()), tibble(x = 1:2))
 })
 
-test_that("preserved class, but not attributes", {
+test_that("doesn't preserve attributes", {
   df <- structure(
     data.frame(x = 1:10, g1 = rep(1:2, each = 5), g2 = rep(1:5, 2)),
     meta = "this is important"
   )
 
   out <- df %>% summarise(n = n())
-  expect_s3_class(out, "data.frame", exact = TRUE)
   expect_null(attr(out, "res"))
 
   out <- df %>% group_by(g1) %>% summarise(n = n())
-  # expect_s3_class(out, "data.frame", exact = TRUE)
   expect_null(attr(out, "res"))
 })
 
 test_that("strips off subclass", {
+  # We consider the data frame returned by `summarise()` to be
+  # "fundamentally a new data frame"
+
   df <- new_data_frame(list(a = 1), class = "myclass")
   out <- df %>% summarise(n = n())
   expect_s3_class(out, "data.frame", exact = TRUE)
@@ -87,6 +88,14 @@ test_that("strips off subclass", {
   expect_s3_class(out, class(tibble()), exact = TRUE)
   out <- df %>% summarise(.by = a, n = n())
   expect_s3_class(out, class(tibble()), exact = TRUE)
+
+  gdf <- group_by(tibble(a = 1), a)
+  df <- gdf
+  class(df) <- c("myclass", class(gdf))
+  out <- df %>% summarise(n = n(), .groups = "drop")
+  expect_s3_class(out, class(tibble()), exact = TRUE)
+  out <- df %>% summarise(n = n(), .groups = "keep")
+  expect_s3_class(out, class(gdf), exact = TRUE)
 })
 
 test_that("works with unquoted values", {


### PR DESCRIPTION
I saw these tests in at least two tidyverse/tidymodels packages, but no equivalent test in dplyr. If this is intended, should we test and perhaps also document here?