### PR TITLE
Bump minimum R version to 3.6.0 and make related tweaks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ License: MIT + file LICENSE
 URL: https://dplyr.tidyverse.org, https://github.com/tidyverse/dplyr
 BugReports: https://github.com/tidyverse/dplyr/issues
 Depends:
-    R (>= 3.5.0)
+    R (>= 3.6.0)
 Imports:
     cli (>= 3.6.2),
     generics,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr (development version)
 
+* R >=3.6.0 is now explicitly required (#7026).
+
 # dplyr 1.1.4
 
 * `join_by()` now allows its helper functions to be namespaced with `dplyr::`,

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -501,13 +501,9 @@ check_muffled_warning <- function(cnd) {
 
   # Cancel early exits, e.g. from an exiting handler. This way we can
   # still instrument caught warnings to avoid confusing
-  # inconsistencies. This doesn't work on versions of R older than
-  # 3.5.0 because they don't include this change:
-  # https://github.com/wch/r-source/commit/688eaebf. So with
-  # `tryCatch(warning = )`, the original warning `cnd` will be caught
-  # instead of the instrumented warning.
+  # inconsistencies.
   on.exit(
-    if (can_return_from_exit && early_exit) {
+    if (early_exit) {
       return(FALSE)
     }
   )
@@ -523,7 +519,3 @@ check_muffled_warning <- function(cnd) {
   early_exit <- FALSE
   muffled
 }
-
-on_load(
-  can_return_from_exit <- getRversion() >= "3.5.0"
-)

--- a/R/slice.R
+++ b/R/slice.R
@@ -358,13 +358,13 @@ slice_eval <- function(mask,
                        user_env = caller_env(2)) {
   index <- 0L
   impl <- function(...) {
-    n <- ...length2()
+    n <- ...length()
     out <- vector("list", n)
 
     for (i in seq_len(n)) {
       index <<- i
 
-      slice_idx <- ...elt2(i)
+      slice_idx <- ...elt(i)
 
       if (is.matrix(slice_idx) && ncol(slice_idx) == 1) {
         lifecycle::deprecate_warn(
@@ -587,18 +587,4 @@ on_load({
 })
 dplyr_local_slice_by_arg <- function(by_arg, frame = caller_env()) {
   local_bindings(slice_by_arg = by_arg, .env = the, .frame = frame)
-}
-
-# Backports for R 3.5.0 utils
-...length2 <- function(frame = caller_env()) {
-  dots <- env_get(frame, "...")
-
-  if (is_missing(dots)) {
-    0L
-  } else {
-    length(dots)
-  }
-}
-...elt2 <- function(i, frame = caller_env()) {
-  eval_bare(sym(paste0("..", i)), frame)
 }

--- a/tests/testthat/helper-lazy.R
+++ b/tests/testthat/helper-lazy.R
@@ -1,6 +1,4 @@
 skip_if_no_lazy_character <- function() {
-  skip_if(getRversion() <= "3.5.0")
-
   new_lazy_character <- import_vctrs("new_lazy_character", optional = TRUE)
   lazy_character_is_materialized <- import_vctrs("lazy_character_is_materialized", optional = TRUE)
 


### PR DESCRIPTION
Also closes #7022 - we can't remove all that code because we call those helpers in the tests, and I'd like to keep the "skip" in place in case we ever change things in vctrs (it is part of an unexported API so we aren't promising to keep it stable). But we can remove the version check there now.