### PR TITLE
.keep = "transmute" is implemented in mutate.

### DIFF
--- a/R/transmute.R
+++ b/R/transmute.R
@@ -5,7 +5,7 @@
 #'
 #' `transmute()` creates a new data frame containing only the specified
 #' computations. It's superseded because you can perform the same job
-#' with `mutate(.keep = "none")`.
+#' with `mutate(.keep = "transmute")`.
 #'
 #' @inheritParams mutate
 #' @section Methods:
@@ -29,7 +29,7 @@
 #' @export
 transmute <- function(.data, ...) {
   # dplyr 1.1.0
-  lifecycle::signal_stage("superseded", "transmute()", I("mutate(.keep = 'none')"))
+  lifecycle::signal_stage("superseded", "transmute()", I("mutate(.keep = 'transmute')"))
 
   UseMethod("transmute")
 }

--- a/man/mutate.Rd
+++ b/man/mutate.Rd
@@ -11,7 +11,7 @@ mutate(.data, ...)
   .data,
   ...,
   .by = NULL,
-  .keep = c("all", "used", "unused", "none"),
+  .keep = c("all", "used", "unused", "none", "transmute"),
   .before = NULL,
   .after = NULL
 )
@@ -51,6 +51,8 @@ columns. This is useful if you generate new columns, but no longer need
 the columns used to generate them.
 \item \code{"none"} doesn't retain any extra columns from \code{.data}. Only the grouping
 variables and columns created by \code{...} are kept.
+\item \code{"transmute"} equivalent to "none," but preserves the column order in the
+mutate.
 }}
 
 \item{.before, .after}{<\code{\link[=dplyr_tidy_select]{tidy-select}}> Optionally, control where new columns

--- a/man/transmute.Rd
+++ b/man/transmute.Rd
@@ -41,7 +41,7 @@ specified by \code{...}.
 
 \code{transmute()} creates a new data frame containing only the specified
 computations. It's superseded because you can perform the same job
-with \code{mutate(.keep = "none")}.
+with \code{mutate(.keep = "transmute")}.
 }
 \section{Methods}{
 


### PR DESCRIPTION
Hi @hadley and @DavisVaughan,

This merge request aims to align the mutate functionality with that of transmute. Presently, the documentation states that the equivalent of transmute is mutate(.keep="none"). However, it's important to note that this function retains the column order, unlike transmute.

After reviewing the bug reported here: https://github.com/tidyverse/dplyr/issues/6861, I concur that there should be a fifth variant of keep, named "transmute."

This proposal should also be implemented in the following tidyverse libraries:
- [ ] [dtplyr](https://github.com/tidyverse/dtplyr)  
- [ ] [dbplyr](https://github.com/tidyverse/dbplyr)  

And in the following third party libraries:
- [ ] [duckplyr](https://github.com/duckdblabs/duckplyr)
- [ ] [arrow](https://github.com/apache/arrow/r)
- [ ] [tidypolars](https://github.com/etiennebacher/tidypolars)

This change opens the possibility of un-superseded transmute. For example, you could implement that when a user calls transmute, it internally executes mutate(.keep="transmute"). This would greatly benefit veteran users who have extensively used transmute in their projects. Additionally, it improves code readability, as a simple transmute call is clearer than mutate(.keep="transmute").

Below I leave an example comparing transmute with mutate(.keep = "transmute")

```
example <- tibble(
  group = c("a", "a", "b", "b"),
  old = c(1, 2, 3, 4)
)

# transmute --------------------------------------------------------------------

example %>% transmute(
  group,
  new = old * 2,
  old
)

# A tibble: 4 × 3
  group   new   old
  <chr> <dbl> <dbl>
1 a         2     1
2 a         4     2
3 b         6     3
4 b         8     4

# mutate(.keep = "transmute") --------------------------------------------------

example %>% mutate(
  .keep = "transmute",
  group,
  new = old * 2,
  old
)

# A tibble: 4 × 3
  group   new   old
  <chr> <dbl> <dbl>
1 a         2     1
2 a         4     2
3 b         6     3
4 b         8     4

# group_by + transmute ---------------------------------------------------------

example %>% 
  group_by(group) %>% 
  transmute(
    new = sum(old),
    old
) %>% 
 ungroup()

# A tibble: 4 × 3
  group   new   old
  <chr> <dbl> <dbl>
1 a         3     1
2 a         3     2
3 b         7     3
4 b         7     4

# group_by + mutate(.keep = "transmute") ---------------------------------------

example %>% 
  group_by(group) %>% 
  mutate(
    .keep = "transmute",
    new = sum(old),
    old
) %>% 
 ungroup()

# A tibble: 4 × 3
  group   new   old
  <chr> <dbl> <dbl>
1 a         3     1
2 a         3     2
3 b         7     3
4 b         7     4

# mutate(.keep = "transmute", by = ...) ----------------------------------------

example %>%  
  mutate(
    .keep = "transmute",
    .by = "group",
    new = sum(old),
    old
  )

# A tibble: 4 × 3
  group   new   old
  <chr> <dbl> <dbl>
1 a         3     1
2 a         3     2
3 b         7     3
4 b         7     4

```

Regards,

