### PR TITLE
Add documentation clarifying appropriate use of weights in `slice_sample()`

### DIFF
--- a/R/slice.R
+++ b/R/slice.R
@@ -19,6 +19,12 @@
 #' intrinsic notion of row order. If you want to perform the equivalent
 #' operation, use [filter()] and [row_number()].
 #'
+#' For `slice_sample()`, note that the weights provided in `weight_by` are
+#' passed through to the `prob` argument of [base::sample.int()]. This means
+#' they cannot be used to reconstruct summary statistics from the underlying
+#' population. See [this discussion](https://stats.stackexchange.com/q/639211/)
+#' for more details.
+#'
 #' @family single table verbs
 #' @inheritParams args_by
 #' @inheritParams arrange
@@ -93,11 +99,9 @@
 #' mtcars %>% slice_sample(n = 5)
 #' mtcars %>% slice_sample(n = 5, replace = TRUE)
 #'
-#' # you can optionally weight by a variable - this code weights by the
+#' # You can optionally weight by a variable - this code weights by the
 #' # physical weight of the cars, so heavy cars are more likely to get
-#' # selected. Note that the weights cannot then be used to reconstruct
-#' # summary statistics from the underlying population. See
-#' # https://stats.stackexchange.com/q/639211/ for more details.
+#' # selected.
 #' mtcars %>% slice_sample(weight_by = wt, n = 5)
 #'
 #' # Group wise operation ----------------------------------------
@@ -295,9 +299,8 @@ slice_max.data.frame <- function(.data, order_by, ..., n, prop, by = NULL, with_
 #' @param weight_by <[`data-masking`][rlang::args_data_masking]> Sampling
 #'   weights. This must evaluate to a vector of non-negative numbers the same
 #'   length as the input. Weights are automatically standardised to sum to 1.
-#'   Note that these weights cannot be used to reconstruct summary statistics
-#'   via, for example, Horvitz-Thompson estimators. See
-#'   https://stats.stackexchange.com/q/639211/ for more details.
+#'   See the `Details` section for more technical details regarding these
+#'   weights.
 slice_sample <- function(.data, ..., n, prop, by = NULL, weight_by = NULL, replace = FALSE) {
   check_dot_by_typo(...)
   check_slice_unnamed_n_prop(..., n = n, prop = prop)

--- a/R/slice.R
+++ b/R/slice.R
@@ -95,7 +95,9 @@
 #'
 #' # you can optionally weight by a variable - this code weights by the
 #' # physical weight of the cars, so heavy cars are more likely to get
-#' # selected
+#' # selected. Note that the weights cannot then be used to reconstruct
+#' # summary statistics from the underlying population. See
+#' # https://stats.stackexchange.com/q/639211/ for more details.
 #' mtcars %>% slice_sample(weight_by = wt, n = 5)
 #'
 #' # Group wise operation ----------------------------------------
@@ -293,6 +295,9 @@ slice_max.data.frame <- function(.data, order_by, ..., n, prop, by = NULL, with_
 #' @param weight_by <[`data-masking`][rlang::args_data_masking]> Sampling
 #'   weights. This must evaluate to a vector of non-negative numbers the same
 #'   length as the input. Weights are automatically standardised to sum to 1.
+#'   Note that these weights cannot be used to reconstruct summary statistics
+#'   via, for example, Horvitz-Thompson estimators. See
+#'   https://stats.stackexchange.com/q/639211/ for more details.
 slice_sample <- function(.data, ..., n, prop, by = NULL, weight_by = NULL, replace = FALSE) {
   check_dot_by_typo(...)
   check_slice_unnamed_n_prop(..., n = n, prop = prop)

--- a/man/slice.Rd
+++ b/man/slice.Rd
@@ -90,9 +90,8 @@ reach \code{n}/\code{prop}.}
 \item{weight_by}{<\code{\link[rlang:args_data_masking]{data-masking}}> Sampling
 weights. This must evaluate to a vector of non-negative numbers the same
 length as the input. Weights are automatically standardised to sum to 1.
-Note that these weights cannot be used to reconstruct summary statistics
-via, for example, Horvitz-Thompson estimators. See
-https://stats.stackexchange.com/q/639211/ for more details.}
+See the \code{Details} section for more technical details regarding these
+weights.}
 
 \item{replace}{Should sampling be performed with (\code{TRUE}) or without
 (\code{FALSE}, the default) replacement.}
@@ -126,6 +125,12 @@ each group.
 Slice does not work with relational databases because they have no
 intrinsic notion of row order. If you want to perform the equivalent
 operation, use \code{\link[=filter]{filter()}} and \code{\link[=row_number]{row_number()}}.
+
+For \code{slice_sample()}, note that the weights provided in \code{weight_by} are
+passed through to the \code{prob} argument of \code{\link[base:sample]{base::sample.int()}}. This means
+they cannot be used to reconstruct summary statistics from the underlying
+population. See \href{https://stats.stackexchange.com/q/639211/}{this discussion}
+for more details.
 }
 \section{Methods}{
 
@@ -173,11 +178,9 @@ mtcars \%>\% slice_min(tibble(cyl, mpg), n = 1)
 mtcars \%>\% slice_sample(n = 5)
 mtcars \%>\% slice_sample(n = 5, replace = TRUE)
 
-# you can optionally weight by a variable - this code weights by the
+# You can optionally weight by a variable - this code weights by the
 # physical weight of the cars, so heavy cars are more likely to get
-# selected. Note that the weights cannot then be used to reconstruct
-# summary statistics from the underlying population. See
-# https://stats.stackexchange.com/q/639211/ for more details.
+# selected.
 mtcars \%>\% slice_sample(weight_by = wt, n = 5)
 
 # Group wise operation ----------------------------------------

--- a/man/slice.Rd
+++ b/man/slice.Rd
@@ -89,7 +89,10 @@ reach \code{n}/\code{prop}.}
 
 \item{weight_by}{<\code{\link[rlang:args_data_masking]{data-masking}}> Sampling
 weights. This must evaluate to a vector of non-negative numbers the same
-length as the input. Weights are automatically standardised to sum to 1.}
+length as the input. Weights are automatically standardised to sum to 1.
+Note that these weights cannot be used to reconstruct summary statistics
+via, for example, Horvitz-Thompson estimators. See
+https://stats.stackexchange.com/q/639211/ for more details.}
 
 \item{replace}{Should sampling be performed with (\code{TRUE}) or without
 (\code{FALSE}, the default) replacement.}
@@ -172,7 +175,9 @@ mtcars \%>\% slice_sample(n = 5, replace = TRUE)
 
 # you can optionally weight by a variable - this code weights by the
 # physical weight of the cars, so heavy cars are more likely to get
-# selected
+# selected. Note that the weights cannot then be used to reconstruct
+# summary statistics from the underlying population. See
+# https://stats.stackexchange.com/q/639211/ for more details.
 mtcars \%>\% slice_sample(weight_by = wt, n = 5)
 
 # Group wise operation ----------------------------------------


### PR DESCRIPTION
Users may be led astray by the current language describing weighted sampling via `slice_sample()`. As discussed in https://stats.stackexchange.com/q/639211/ and elaborated on in issue #6848, there's more nuance to how weights might be used for sampling. The current base R algorithm which `slice_sample()` relies on does not use the sampling weights in a way that conform to how a user might suspect the weights ought to work, as in Horvitz Thompson estimation for example. 

I've added appropriate details here in the documentation including the above link for further details.