### PR TITLE
Fix `if_any()` and `if_all()` behavior with zero-column selections

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,10 @@
 
 * R >=3.6.0 is now explicitly required (#7026).
 
+* `if_any()` and `if_all()` are now fully consistent with `any()` and `all()`. 
+  In particular, when called with empty inputs `if_any()` returns `FALSE` and 
+  `if_all()` returns `TRUE` (#7059, @jrwinget).
+
 # dplyr 1.1.4
 
 * `join_by()` now allows its helper functions to be namespaced with `dplyr::`,

--- a/R/across.R
+++ b/R/across.R
@@ -658,7 +658,7 @@ expand_if_across <- function(quo) {
   # Select all rows if there are no inputs for if_all(),
   # but select no rows if there are no inputs for if_any().
   if (!length(quos)) {
-    return(list(quo(empty)))
+    return(list(quo(!!empty)))
   }
 
   combine <- function(x, y) {

--- a/R/across.R
+++ b/R/across.R
@@ -12,18 +12,19 @@
 #' the predicate is `TRUE` for *any* of the selected columns, `if_all()`
 #' is `TRUE` when the predicate is `TRUE` for *all* selected columns.
 #'
-#' **Important Behavior:** When there are no selected columns:
-#'
-#' - `if_any()` will return `FALSE`, consistent with the behavior of
-#'   `any()` when called without inputs.
-#' - `if_all()` will return `TRUE`, consistent with the behavior of
-#'   `all()` when called without inputs.
-#'
 #' If you just need to select columns without applying a transformation to each
 #' of them, then you probably want to use [pick()] instead.
 #'
 #' `across()` supersedes the family of "scoped variants" like
 #' `summarise_at()`, `summarise_if()`, and `summarise_all()`.
+#'
+#' @details
+#' When there are no selected columns:
+#'
+#' - `if_any()` will return `FALSE`, consistent with the behavior of
+#'   `any()` when called without inputs.
+#' - `if_all()` will return `TRUE`, consistent with the behavior of
+#'   `all()` when called without inputs.
 #'
 #' @param .cols <[`tidy-select`][dplyr_tidy_select]> Columns to transform.
 #'   You can't select grouping columns because they are already automatically

--- a/man/across.Rd
+++ b/man/across.Rd
@@ -86,6 +86,15 @@ of them, then you probably want to use \code{\link[=pick]{pick()}} instead.
 \code{across()} supersedes the family of "scoped variants" like
 \code{summarise_at()}, \code{summarise_if()}, and \code{summarise_all()}.
 }
+\details{
+When there are no selected columns:
+\itemize{
+\item \code{if_any()} will return \code{FALSE}, consistent with the behavior of
+\code{any()} when called without inputs.
+\item \code{if_all()} will return \code{TRUE}, consistent with the behavior of
+\code{all()} when called without inputs.
+}
+}
 \section{Timing of evaluation}{
 
 R code in dplyr verbs is generally evaluated once per group.
@@ -177,9 +186,16 @@ iris \%>\%
 iris \%>\%
   group_by(Species) \%>\%
   summarise(across(starts_with("Sepal"), mean, .names = "mean_{.col}"))
+
 iris \%>\%
   group_by(Species) \%>\%
-  summarise(across(starts_with("Sepal"), list(mean = mean, sd = sd), .names = "{.col}.{.fn}"))
+  summarise(
+    across(
+      starts_with("Sepal"),
+      list(mean = mean, sd = sd),
+      .names = "{.col}.{.fn}"
+    )
+  )
 
 # If a named external vector is used for column selection, .names will use
 # those names when constructing the output names
@@ -190,7 +206,9 @@ iris \%>\%
 # When the list is not named, .fn is replaced by the function's position
 iris \%>\%
   group_by(Species) \%>\%
-  summarise(across(starts_with("Sepal"), list(mean, sd), .names = "{.col}.fn{.fn}"))
+  summarise(
+    across(starts_with("Sepal"), list(mean, sd), .names = "{.col}.fn{.fn}")
+  )
 
 # When the functions in .fns return a data frame, you typically get a
 # "packed" data frame back
@@ -208,7 +226,9 @@ iris \%>\%
 
 # .unpack can utilize a glue specification if you don't like the defaults
 iris \%>\%
-  reframe(across(starts_with("Sepal"), quantile_df, .unpack = "{outer}.{inner}"))
+  reframe(
+    across(starts_with("Sepal"), quantile_df, .unpack = "{outer}.{inner}")
+  )
 
 # This is also useful inside mutate(), for example, with a multi-lag helper
 multilag <- function(x, lags = 1:3) {

--- a/man/select.Rd
+++ b/man/select.Rd
@@ -178,13 +178,8 @@ The \code{!} operator negates a selection:
 #> 2 <NA>       gold        yellow         112   none  masculine Tatooine  Droid  
 #> 3 <NA>       white, blue red             33   none  masculine Naboo     Droid  
 #> 4 none       white       yellow          41.9 male  masculine Tatooine  Human  
-#>   films     vehicles  starships
-#>   <list>    <list>    <list>   
-#> 1 <chr [5]> <chr [2]> <chr [2]>
-#> 2 <chr [6]> <chr [0]> <chr [0]>
-#> 3 <chr [7]> <chr [0]> <chr [0]>
-#> 4 <chr [4]> <chr [0]> <chr [1]>
 #> # i 83 more rows
+#> # i 3 more variables: films <list>, vehicles <list>, starships <list>
 
 iris \%>\% select(!c(Sepal.Length, Petal.Length))
 #> # A tibble: 150 x 3

--- a/man/select.Rd
+++ b/man/select.Rd
@@ -178,8 +178,13 @@ The \code{!} operator negates a selection:
 #> 2 <NA>       gold        yellow         112   none  masculine Tatooine  Droid  
 #> 3 <NA>       white, blue red             33   none  masculine Naboo     Droid  
 #> 4 none       white       yellow          41.9 male  masculine Tatooine  Human  
+#>   films     vehicles  starships
+#>   <list>    <list>    <list>   
+#> 1 <chr [5]> <chr [2]> <chr [2]>
+#> 2 <chr [6]> <chr [0]> <chr [0]>
+#> 3 <chr [7]> <chr [0]> <chr [0]>
+#> 4 <chr [4]> <chr [0]> <chr [1]>
 #> # i 83 more rows
-#> # i 3 more variables: films <list>, vehicles <list>, starships <list>
 
 iris \%>\% select(!c(Sepal.Length, Petal.Length))
 #> # A tibble: 150 x 3

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -870,7 +870,7 @@ test_that("if_any() and if_all() expansions deal with no inputs or single inputs
   # No inputs
   expect_equal(
     filter(d, if_any(starts_with("c"), ~ FALSE)),
-    filter(d)
+    filter(d, FALSE)
   )
   expect_equal(
     filter(d, if_all(starts_with("c"), ~ FALSE)),
@@ -888,7 +888,7 @@ test_that("if_any() and if_all() expansions deal with no inputs or single inputs
   )
 })
 
-test_that("if_any() on zero-column selection behaves as expected in filter", {
+test_that("if_any() on zero-column selection behaves like any() (#7059)", {
   tbl <- tibble(
     x1 = 1:5,
     x2 = c(-1, 4, 5, 4, 1),
@@ -897,11 +897,11 @@ test_that("if_any() on zero-column selection behaves as expected in filter", {
 
   expect_equal(
     filter(tbl, if_any(c(), ~ is.na(.x))),
-    filter(tbl, FALSE)
+    tbl[0, ]
   )
 })
 
-test_that("if_all() on zero-column selection behaves as expected in filter", {
+test_that("if_all() on zero-column selection behaves like all() (#7059)", {
   tbl <- tibble(
     x1 = 1:5,
     x2 = c(-1, 4, 5, 4, 1),
@@ -910,7 +910,7 @@ test_that("if_all() on zero-column selection behaves as expected in filter", {
 
   expect_equal(
     filter(tbl, if_all(c(), ~ is.na(.x))),
-    filter(tbl, TRUE)
+    tbl
   )
 })
 

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -888,6 +888,32 @@ test_that("if_any() and if_all() expansions deal with no inputs or single inputs
   )
 })
 
+test_that("if_any() on zero-column selection behaves as expected in filter", {
+  tbl <- tibble(
+    x1 = 1:5,
+    x2 = c(-1, 4, 5, 4, 1),
+    y = c(1, 4, 2, 4, 9),
+  )
+
+  expect_equal(
+    filter(tbl, if_any(c(), ~ is.na(.x))),
+    filter(tbl, FALSE)
+  )
+})
+
+test_that("if_all() on zero-column selection behaves as expected in filter", {
+  tbl <- tibble(
+    x1 = 1:5,
+    x2 = c(-1, 4, 5, 4, 1),
+    y = c(1, 4, 2, 4, 9),
+  )
+
+  expect_equal(
+    filter(tbl, if_all(c(), ~ is.na(.x))),
+    filter(tbl, TRUE)
+  )
+})
+
 test_that("if_any() and if_all() wrapped deal with no inputs or single inputs", {
   d <- data.frame(x = 1)
 


### PR DESCRIPTION
Fixes #7059

This commit addresses the unexpected behavior of `if_any()` and `if_all()` when no columns are selected. Specifically, `if_any()` now returns `FALSE`, and `if_all()` returns `TRUE` in cases where no columns match the selection criteria.

Additionally, tests have been added to ensure the correct behavior of these functions in both `filter()` and `mutate()` contexts, including the scenarios highlighted by the `reprex` example. This ensures that empty selections behave consistently with the logical expectations.