### PR TITLE
Add `group_split()` on the reference page on the website

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -108,6 +108,7 @@ reference:
   - group_cols
   - group_map
   - group_modify
+  - group_split
   - group_trim
 
 - title: Superseded


### PR DESCRIPTION
Close #7043 