### PR TITLE
Add group_split to the pkgdown reference page

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -109,6 +109,7 @@ reference:
   - group_map
   - group_modify
   - group_trim
+  - group_split
 
 - title: Superseded
   desc: >


### PR DESCRIPTION
The reference page for the pkgdown site is missing the experimental function `group_split()`. I presume this should be featured on the reference page as it exported by the package?