### PR TITLE
Add logic to catch single named logical expressions

### DIFF
--- a/R/filter.R
+++ b/R/filter.R
@@ -154,11 +154,11 @@ check_filter <- function(dots, error_call = caller_env()) {
 
   for (i in which(named)) {
     quo <- dots[[i]]
-
-    # only allow named logical vectors, anything else
-    # is suspicious
     expr <- quo_get_expr(quo)
-    if (!is.logical(expr)) {
+
+    # Allow named logical vectors but catch bare
+    # logical values and anything else
+    if (!is.logical(expr) || (is.logical(expr) && length(expr) == 1)) {
       name <- names(dots)[i]
       bullets <- c(
         "We detected a named input.",


### PR DESCRIPTION
This PR would close #7105. This is a potential solution that adds logic to `check_filter`. This solution stops single, named logical expressions. 

```r
mtcars$big_cyl <- mtcars$cyl > 4

filter(mtcars, big_cyl = TRUE) |>
  nrow()
#> Error in `filter()`:
#> ! We detected a named input.
#> ℹ This usually means that you've used `=` instead of `==`.
#> ℹ Did you mean `big_cyl == TRUE`?
#> 
filter(mtcars, big_cyl == TRUE) |>
  nrow()
#> [1] 21
#>
```

But still allows for named logical vectors:

```r
filters <- mtcars %>%
  transmute(
    cyl %in% 6:8,
    hp / drat > 50
  )

expect_identical(
  mtcars %>% filter(!!!unname(filters)),
  mtcars %>% filter(!!!filters)
)
```
