### PR TITLE
remove defunct functions from prior to 1.0

### DIFF
--- a/R/defunct.R
+++ b/R/defunct.R
@@ -11,63 +11,6 @@
 #' @name defunct
 NULL
 
-#' @usage # Deprecated in 0.5.0 -------------------------------------
-#' @name defunct
-NULL
-
-#' @export
-#' @rdname defunct
-id <- function(.variables, drop = FALSE) {
-  lifecycle::deprecate_stop("0.5.0", "id()", "vctrs::vec_group_id()")
-}
-
-#' @usage # Deprecated in 0.7.0 -------------------------------------
-#' @name defunct
-NULL
-
-#' @export
-#' @rdname defunct
-failwith <- function(default = NULL, f, quiet = FALSE) {
-  lifecycle::deprecate_stop("0.7.0", "failwith()", "purrr::possibly()")
-}
-
-#' @usage # Deprecated in 0.8.* -------------------------------------
-#' @name defunct
-NULL
-
-#' @export
-#' @rdname defunct
-select_vars <- function(vars = chr(), ..., include = chr(), exclude = chr()) {
-  lifecycle::deprecate_stop(
-    "0.8.4",
-    "select_vars()",
-    "tidyselect::vars_select()"
-  )
-}
-#' @export
-#' @rdname defunct
-rename_vars <- function(vars = chr(), ..., strict = TRUE) {
-  lifecycle::deprecate_stop(
-    "0.8.4",
-    "rename_vars()",
-    "tidyselect::vars_rename()"
-  )
-}
-#' @export
-#' @rdname defunct
-select_var <- function(vars, var = -1) {
-  lifecycle::deprecate_stop("0.8.4", "select_var()", "tidyselect::vars_pull()")
-}
-#' @export
-#' @rdname defunct
-current_vars <- function(...) {
-  lifecycle::deprecate_stop(
-    "0.8.4",
-    "current_vars()",
-    "tidyselect::peek_vars()"
-  )
-}
-
 #' @usage # Deprecated in 1.0.0 -------------------------------------
 #' @name defunct
 NULL


### PR DESCRIPTION
I just had an issue with gt + a tidy evaluation of a column named id and that directed me to a defunct error. I saw that this has been deprecated for a while, so might be time to just remove those.

Just needs news + `devtools::document()`. I don't mind doing it if you agree with the PR!