### PR TITLE
Moved reframe() to stable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Authors@R: c(
   )
 Description: A fast, consistent tool for working with data frame like
     objects, both in memory and out of memory.
-License: MIT + file LICENSE
+License: MIT + file LICENSEv
 URL: https://dplyr.tidyverse.org, https://github.com/tidyverse/dplyr
 BugReports: https://github.com/tidyverse/dplyr/issues
 Depends:

--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,8 @@
   In particular, when called with empty inputs `if_any()` returns `FALSE` and
   `if_all()` returns `TRUE` (#7059, @jrwinget).
 
+* `reframe()` has moved from experimental to stable.
+
 # dplyr 1.1.4
 
 * `join_by()` now allows its helper functions to be namespaced with `dplyr::`,

--- a/R/reframe.R
+++ b/R/reframe.R
@@ -1,7 +1,6 @@
 #' Transform each group to an arbitrary number of rows
 #'
 #' @description
-#' `r lifecycle::badge("experimental")`
 #'
 #' While [summarise()] requires that each argument returns a single value, and
 #' [mutate()] requires that each argument returns the same number of rows as the

--- a/man/reframe.Rd
+++ b/man/reframe.Rd
@@ -36,8 +36,6 @@ fundamentally creates a new data frame.
 }
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-
 While \code{\link[=summarise]{summarise()}} requires that each argument returns a single value, and
 \code{\link[=mutate]{mutate()}} requires that each argument returns the same number of rows as the
 input, \code{reframe()} is a more general workhorse with no requirements on the


### PR DESCRIPTION
The `reframe()` function has been moved from experimental to stable.

Fixes #7667.