### PR TITLE
Switch `if_else()` to `vec_if_else()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     tibble (>= 3.2.0),
     tidyselect (>= 1.2.0),
     utils,
-    vctrs (>= 0.6.4)
+    vctrs (>= 0.6.5.9000)
 Suggests:
     bench,
     broom,
@@ -66,3 +66,5 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
+Remotes:
+    r-lib/vctrs

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr (development version)
 
+* `if_else()` has gotten significantly faster and uses much less memory due to a rewrite in C via `vctrs::vec_if_else()` (#7723).
+
 * Passing `size` to `if_else()` is now deprecated. The output size is always taken from the `condition` (#7722).
 
 * `bind_rows()` now replaces empty (or `NA`) element names in a list with its numeric index while preserving existing names (#7719, @Meghansaha).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr (development version)
 
+* `if_else()` no longer allows `condition` to be a logical array. It must be a logical vector with no `dim` attribute (#7723).
+
 * `if_else()` has gotten significantly faster and uses much less memory due to a rewrite in C via `vctrs::vec_if_else()` (#7723).
 
 * Passing `size` to `if_else()` is now deprecated. The output size is always taken from the `condition` (#7722).

--- a/R/if-else.R
+++ b/R/if-else.R
@@ -35,6 +35,8 @@
 #' `FALSE`, the matching values from `false`, and where it is `NA`, the matching
 #' values from `missing`, if provided, otherwise a missing value will be used.
 #'
+#' @seealso [vctrs::vec_if_else()]
+#'
 #' @export
 #' @examples
 #' x <- c(-5:5, NA)
@@ -66,26 +68,12 @@ if_else <- function(
     lifecycle::deprecate_warn("1.2.0", "if_else(size = )")
   }
 
-  # Assert early since we `!` the `condition`
-  check_logical(condition)
-
-  conditions <- list(
+  vec_if_else(
     condition = condition,
-    !condition
-  )
-  values <- list(
     true = true,
-    false = false
-  )
-
-  vec_case_when(
-    conditions = conditions,
-    values = values,
-    conditions_arg = "",
-    values_arg = "",
-    default = missing,
-    default_arg = "missing",
+    false = false,
+    missing = missing,
     ptype = ptype,
-    call = current_env()
+    error_call = current_env()
   )
 }

--- a/man/if_else.Rd
+++ b/man/if_else.Rd
@@ -67,3 +67,6 @@ if_else(x \%in\% c("a", "b", "c"), x, NA)
 starwars |>
   mutate(category = if_else(height < 100, "short", "tall"), .keep = "used")
 }
+\seealso{
+\code{\link[vctrs:vec_if_else]{vctrs::vec_if_else()}}
+}

--- a/tests/testthat/_snaps/if-else.md
+++ b/tests/testthat/_snaps/if-else.md
@@ -22,6 +22,14 @@
       Error in `if_else()`:
       ! `condition` must be a logical vector, not an integer vector.
 
+# `condition` can't be an array (#7723)
+
+    Code
+      if_else(array(TRUE), 1, 2)
+    Condition
+      Error in `if_else()`:
+      ! `condition` must be a logical vector, not a logical vector.
+
 # `true`, `false`, and `missing` must recycle to the size of `condition`
 
     Code

--- a/tests/testthat/_snaps/if-else.md
+++ b/tests/testthat/_snaps/if-else.md
@@ -12,7 +12,7 @@
       if_else(TRUE, 1, 2, missing = "x")
     Condition
       Error in `if_else()`:
-      ! Can't combine `true` <double> and `missing` <character>.
+      ! Can't combine `missing` <character> and <double>.
 
 # `condition` must be logical (and isn't cast to logical!)
 
@@ -28,7 +28,7 @@
       if_else(x < 2, bad, x)
     Condition
       Error in `if_else()`:
-      ! `true` must have size 3, not size 2.
+      ! Can't recycle `true` (size 2) to size 3.
 
 ---
 
@@ -36,7 +36,7 @@
       if_else(x < 2, x, bad)
     Condition
       Error in `if_else()`:
-      ! `false` must have size 3, not size 2.
+      ! Can't recycle `false` (size 2) to size 3.
 
 ---
 
@@ -44,7 +44,7 @@
       if_else(x < 2, x, x, missing = bad)
     Condition
       Error in `if_else()`:
-      ! `missing` must have size 3, not size 2.
+      ! Can't recycle `missing` (size 2) to size 3.
 
 # must have empty dots
 

--- a/tests/testthat/_snaps/if-else.md
+++ b/tests/testthat/_snaps/if-else.md
@@ -12,7 +12,7 @@
       if_else(TRUE, 1, 2, missing = "x")
     Condition
       Error in `if_else()`:
-      ! Can't combine `missing` <character> and <double>.
+      ! Can't combine `true` <double> and `missing` <character>.
 
 # `condition` must be logical (and isn't cast to logical!)
 

--- a/tests/testthat/test-if-else.R
+++ b/tests/testthat/test-if-else.R
@@ -74,6 +74,14 @@ test_that("`condition` must be logical (and isn't cast to logical!)", {
   })
 })
 
+test_that("`condition` can't be an array (#7723)", {
+  expect_snapshot(error = TRUE, {
+    # TODO: Error message will improve with
+    # https://github.com/r-lib/rlang/pull/1832
+    if_else(array(TRUE), 1, 2)
+  })
+})
+
 test_that("`true`, `false`, and `missing` must recycle to the size of `condition`", {
   x <- 1:3
   bad <- 1:2


### PR DESCRIPTION
Branched from #7722 

See https://github.com/r-lib/vctrs/pull/2030 for benchmarks!

One thing of note is that `vec_if_else()` disallows arrays for `condition`. I am not yet sure if we are going to have to provide a compat layer for 1D arrays in `if_else()` itself. We will have to run revdeps, and then add a test on the dplyr side if we need this. `"c6431dd7-a51a-4fe5-81a9-b889d0a1510a"`