### PR TITLE
Soft-deprecate `case_when()` with all size 1 LHS and any size >1 RHS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr (development version)
 
+* `case_when()` now determines the output size from only the LHS inputs, rather than from both the LHS and RHS inputs. This allows the legacy behavior of `TRUE ~` to continue to work, while improving `case_when()`'s safety by guarding against some silent confusing failure cases (#7082).
+
 * The following vector functions have gotten significantly faster and use much less memory due to a rewrite in C via vctrs (#7723):
 
   * `if_else()`

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,33 @@
 # dplyr (development version)
 
-* `case_when()` now determines the output size from only the LHS inputs, rather than from both the LHS and RHS inputs. This allows the legacy behavior of `TRUE ~` to continue to work, while improving `case_when()`'s safety by guarding against some silent confusing failure cases (#7082).
+* In `case_when()`, supplying all size 1 LHS inputs along with a size >1 RHS input is now soft-deprecated. This is an improper usage of `case_when()` that should instead be a series of if statements, like:
+
+  ```
+  # Scalars!
+  code <- 1L
+  flavor <- "vanilla"
+
+  # Previously
+  case_when(
+    code == 1L && flavor == "chocolate" ~ x,
+    code == 1L && flavor == "vanilla" ~ y,
+    code == 2L && flavor == "vanilla" ~ z,
+    .default = default
+  )
+
+  # Now
+  if (code == 1L && flavor == "chocolate") {
+    x
+  } else if (code == 1L && flavor == "vanilla") {
+    y
+  } else if (code == 2L && flavor == "vanilla") {
+    z
+  } else {
+    default
+  }
+  ```
+
+  The recycling behavior that allows this style of `case_when()` to work is unsafe, and can result in silent bugs that we'd like to guard against with an error in the future (#7082).
 
 * The following vector functions have gotten significantly faster and use much less memory due to a rewrite in C via vctrs (#7723):
 

--- a/R/case-when.R
+++ b/R/case-when.R
@@ -163,17 +163,15 @@ case_when <- function(..., .default = NULL, .ptype = NULL, .size = NULL) {
   conditions <- args$lhs
   values <- args$rhs
 
-  # Unfortunate historical behavior patch:
-  #
-  # `case_when()`'s formula interface finds the common size of all LHS inputs.
-  # This is what allows `TRUE ~` to work. Unfortunately, this has caused a lot
-  # of confusion over the years when `TRUE ~` isn't involved (#7082) and we wish
-  # that we could enforce that all LHS inputs must be the same size (without
-  # recycling).
-  #
-  # Additionally, for `case_when()`, the LHS common size is the size that each
-  # RHS value must recycle to.
-  .size <- vec_size_common(!!!conditions, .size = .size)
+  .size <- case_when_size_common(
+    conditions = conditions,
+    values = values,
+    size = .size
+  )
+
+  # Only recycle `conditions`. Expect that `vec_case_when()` requires all
+  # `conditions` to be the same size, but can efficiently recycle `values`
+  # at the C level without extra allocations.
   conditions <- vec_recycle_common(!!!conditions, .size = .size)
 
   vec_case_when(
@@ -187,6 +185,148 @@ case_when <- function(..., .default = NULL, .ptype = NULL, .size = NULL) {
     size = .size,
     call = current_env()
   )
+}
+
+# Size common computation for `case_when()`
+#
+# `case_when()`'s formula interface historically finds the common size of ALL
+# inputs. This is not good, ideally it would force all LHS inputs to have the
+# same size (with no recycling), and then recycle all RHS inputs to that size
+# inferred from the LHS. That is how `vec_case_when()` works.
+#
+# We can't change this easily for two reasons:
+#
+# - `TRUE ~` must continue to work for legacy reasons, so at the very least all
+#   LHS inputs must be recycled against each other. We are okay with this.
+#
+# - Many packages (60+) use `case_when()` with scalar LHSs but vector RHSs,
+#   requiring that all inputs by recycled against each other. This usage should
+#   be replaced with a series of if statements. This is a highly inefficient use
+#   of `case_when()` because each scalar LHS has to be recycled to the size
+#   determined from the RHS, which is a big waste of memory and time. This
+#   behavior can also allow real bugs to slip through silently (#7082), which is
+#   bad. To combat this case, we specially detect this and throw a deprecation
+#   warning.
+#
+# There are four cases to consider:
+#
+# 1. `size_conditions == 1, size_values == 1`
+#
+#    Fine, use size 1
+#
+# 2. `size_conditions == 1, size_values != 1`
+#
+#    Use `size_values` for historical reasons, but warn against this. This is
+#    people doing off-label usage of `case_when()` when they should be using a
+#    series of if statements.
+#
+# 3. `size_conditions != 1, size_values == 1`
+#
+#    Fine, use `size_conditions`
+#
+# 4. `size_conditions != 1, size_values != 1`
+#
+#    If `size_conditions == size_values`, good to go, else throw an error by
+#    recalling `vec_size_common()` with all inputs.
+case_when_size_common <- function(
+  conditions,
+  values,
+  size,
+  ...,
+  user_env = caller_env(2),
+  error_call = caller_env()
+) {
+  # These error if there are any size incompatibilites within LHS and RHS inputs,
+  # but not across LHS and RHS inputs
+  size_conditions <- vec_size_common(
+    !!!conditions,
+    .size = size,
+    .call = error_call
+  )
+  size_values <- vec_size_common(
+    !!!values,
+    .size = size,
+    .call = error_call
+  )
+
+  if (size_conditions == 1L && size_values == 1L) {
+    return(1L)
+  }
+
+  if (size_conditions == 1L && size_values != 1L) {
+    warn_case_when_scalar_lhs_vector_rhs(
+      env = error_call,
+      user_env = user_env
+    )
+    return(size_values)
+  }
+
+  if (size_conditions != 1L && size_values == 1L) {
+    return(size_conditions)
+  }
+
+  if (size_conditions != 1L && size_values != 1L) {
+    if (size_conditions == size_values) {
+      return(size_conditions)
+    }
+
+    # Errors
+    vec_size_common(
+      !!!conditions,
+      !!!values,
+      .size = size,
+      .call = error_call
+    )
+
+    abort("`vec_size_common()` should have errored.", .internal = TRUE)
+  }
+
+  abort("All cases should have been covered.", .internal = TRUE)
+}
+
+warn_case_when_scalar_lhs_vector_rhs <- function(
+  env,
+  user_env
+) {
+  what <- I(
+    "Calling `case_when()` with size 1 LHS inputs and size >1 RHS inputs"
+  )
+
+  details <- no_cli_wrapping(paste(
+    sep = "\n",
+    "This `case_when()` statement can result in subtle silent bugs and is very inefficient.",
+    "",
+    "  Please use a series of if statements instead:",
+    "",
+    "  ```",
+    "  # Previously",
+    "  case_when(scalar_lhs1 ~ rhs1, scalar_lhs2 ~ rhs2, .default = default)",
+    "",
+    "  # Now",
+    "  if (scalar_lhs1) {",
+    "    rhs1",
+    "  } else if (scalar_lhs2) {",
+    "    rhs2",
+    "  } else {",
+    "    default",
+    "  }",
+    "  ```"
+  ))
+
+  lifecycle::deprecate_soft(
+    when = "1.2.0",
+    what = what,
+    details = details,
+    env = env,
+    user_env = user_env
+  )
+}
+
+# Suppress cli wrapping https://cli.r-lib.org/reference/inline-markup.html#wrapping
+no_cli_wrapping <- function(x) {
+  x <- gsub(" ", "\u00a0", x, fixed = TRUE)
+  x <- gsub("\n", "\f", x, fixed = TRUE)
+  x
 }
 
 case_formula_evaluate <- function(args, default_env, dots_env, error_call) {

--- a/man/case_when.Rd
+++ b/man/case_when.Rd
@@ -15,10 +15,10 @@ The LHS inputs must evaluate to logical vectors.
 
 The RHS inputs will be coerced to their common type.
 
-All inputs will be recycled to their common size. That said, we encourage
-all LHS inputs to be the same size. Recycling is mainly useful for RHS
-inputs, where you might supply a size 1 input that will be recycled to the
-size of the LHS inputs.
+For historical reasons, all LHS inputs will be recycled to their common
+size. That said, we encourage all LHS inputs to be the same size, which you
+can optionally enforce with \code{.size}. All RHS inputs will be recycled to the
+common size of the LHS inputs.
 
 \code{NULL} inputs are ignored.}
 
@@ -26,7 +26,7 @@ size of the LHS inputs.
 \code{FALSE} or \code{NA}.
 
 \code{.default} must be size 1 or the same size as the common size computed
-from \code{...}.
+from the LHS inputs.
 
 \code{.default} participates in the computation of the common type with the RHS
 inputs.
@@ -44,12 +44,14 @@ If \code{NULL}, the default, a missing value will be used.}
 supplied, this overrides the common type of the RHS inputs.}
 
 \item{.size}{An optional size declaring the desired output size. If supplied,
-this overrides the common size computed from \code{...}.}
+this overrides the common size computed from the LHS inputs.}
 }
 \value{
-A vector with the same size as the common size computed from the
-inputs in \code{...} and the same type as the common type of the RHS inputs
-in \code{...}.
+A vector
+\itemize{
+\item The size of the vector is the common size of the LHS inputs, or \code{.size}.
+\item The type of the vector is the common type of the RHS inputs, or \code{.ptype}.
+}
 }
 \description{
 This function allows you to vectorise multiple \code{\link[=if_else]{if_else()}} statements. Each

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -1,146 +1,160 @@
 # Revdeps
 
-## Failed to check (132)
+## Failed to check (66)
 
-|package              |version |error |warning |note |
-|:--------------------|:-------|:-----|:-------|:----|
-|abstr                |?       |      |        |     |
-|NA                   |?       |      |        |     |
-|bdl                  |?       |      |        |     |
-|cancensus            |?       |      |        |     |
-|CCAMLRGIS            |?       |      |        |     |
-|choroplethr          |3.7.1   |1     |        |     |
-|cleanTS              |0.1.1   |1     |        |     |
-|CoordinateCleaner    |2.0-20  |1     |        |     |
-|CopernicusMarine     |?       |      |        |     |
-|NA                   |?       |      |        |     |
-|ctsem                |3.7.2   |1     |        |     |
-|cubble               |?       |      |        |     |
-|cyclestreets         |?       |      |        |     |
-|NA                   |?       |      |        |     |
-|dbmss                |?       |      |        |     |
-|dycdtools            |?       |      |        |     |
-|dynamicSDM           |?       |      |        |     |
-|edbuildmapr          |?       |      |        |     |
-|EFDR                 |?       |      |        |     |
-|eflm                 |0.3.0   |1     |        |     |
-|EnvExpInd            |?       |      |        |     |
-|NA                   |?       |      |        |     |
-|NA                   |?       |      |        |     |
-|NA                   |?       |      |        |     |
-|eSDM                 |?       |      |        |     |
-|fgdr                 |?       |      |        |     |
-|NA                   |?       |      |        |     |
-|NA                   |?       |      |        |     |
-|FORTLS               |?       |      |        |     |
-|FRK                  |?       |      |        |     |
-|fsr                  |?       |      |        |     |
-|GeodesiCL            |1.0.0   |1     |        |     |
-|ggchangepoint        |?       |      |        |     |
-|ggOceanMaps          |?       |      |        |     |
-|ggspatial            |?       |      |        |     |
-|glottospace          |?       |      |        |     |
-|GREENeR              |?       |      |        |     |
-|gumboot              |?       |      |        |     |
-|gwavr                |?       |      |        |     |
-|GWPR.light           |?       |      |        |     |
-|happign              |?       |      |        |     |
-|himach               |?       |      |        |     |
-|HYPEtools            |?       |      |        |     |
-|hypsoLoop            |?       |      |        |     |
-|incidence2           |1.2.3   |1     |        |     |
-|NA                   |?       |      |        |     |
-|intSDM               |1.0.5   |1     |        |1    |
-|NA                   |?       |      |        |     |
-|itsdm                |?       |      |        |     |
-|jpgrid               |?       |      |        |     |
-|jpmesh               |?       |      |        |     |
-|NA                   |?       |      |        |     |
-|MainExistingDatasets |?       |      |        |     |
-|NA                   |?       |      |        |     |
-|manydata             |0.8.2   |1     |        |     |
-|mapboxapi            |?       |      |        |     |
-|mapme.biodiversity   |?       |      |        |     |
-|mapping              |?       |      |        |     |
-|mapscanner           |?       |      |        |     |
-|MazamaSpatialPlots   |?       |      |        |     |
-|NA                   |?       |      |        |     |
-|meteoland            |?       |      |        |     |
-|NA                   |?       |      |        |     |
-|NA                   |?       |      |        |     |
-|motif                |?       |      |        |     |
-|MSclassifR           |?       |      |        |     |
-|naturaList           |?       |      |        |     |
-|ncdfgeom             |?       |      |        |     |
-|nhdplusTools         |?       |      |        |     |
-|nhdR                 |?       |      |        |     |
-|NA                   |?       |      |        |     |
-|occCite              |?       |      |        |     |
-|oceanexplorer        |?       |      |        |     |
-|oceanis              |?       |      |        |     |
-|OpenLand             |?       |      |        |     |
-|palaeoSig            |?       |      |        |     |
-|NA                   |?       |      |        |     |
-|NA                   |?       |      |        |     |
-|PopGenHelpR          |?       |      |        |     |
-|ppcSpatial           |?       |      |        |     |
-|prioriactions        |?       |      |        |     |
-|PSS.Health           |0.6.1   |1     |        |     |
-|rangeModelMetadata   |?       |      |        |     |
-|rbenvo               |?       |      |        |     |
-|rcontroll            |?       |      |        |     |
-|NA                   |?       |      |        |     |
-|redist               |?       |      |        |     |
-|NA                   |?       |      |        |     |
-|roads                |?       |      |        |     |
-|Rsagacmd             |?       |      |        |     |
-|rsinaica             |?       |      |        |     |
-|saeSim               |0.11.0  |1     |        |     |
-|sandwichr            |?       |      |        |     |
-|NA                   |?       |      |        |     |
-|SDGdetector          |2.7.1   |1     |        |     |
-|SDLfilter            |?       |      |        |     |
-|sfnetworks           |?       |      |        |     |
-|ShellChron           |?       |      |        |     |
-|NA                   |?       |      |        |     |
-|simodels             |?       |      |        |     |
-|simplevis            |?       |      |        |     |
-|slendr               |?       |      |        |     |
-|sociome              |2.1.0   |1     |        |1    |
-|SPARTAAS             |1.1.0   |1     |        |     |
-|spatgeom             |?       |      |        |     |
-|SpatialKDE           |?       |      |        |     |
-|spatialrisk          |?       |      |        |     |
-|spDates              |?       |      |        |     |
-|spnaf                |?       |      |        |     |
-|spNetwork            |?       |      |        |     |
-|spqdep               |?       |      |        |     |
-|NA                   |?       |      |        |     |
-|stplanr              |?       |      |        |     |
-|stppSim              |?       |      |        |     |
-|NA                   |?       |      |        |     |
-|stxplore             |?       |      |        |     |
-|SUNGEO               |?       |      |        |     |
-|swfscAirDAS          |0.2.3   |1     |        |     |
-|SWTools              |?       |      |        |     |
-|NA                   |?       |      |        |     |
-|telemac              |?       |      |        |     |
-|NA                   |?       |      |        |     |
-|trackdf              |?       |      |        |     |
-|TUFLOWR              |?       |      |        |     |
-|VancouvR             |?       |      |        |     |
-|wallace              |?       |      |        |     |
-|waterquality         |?       |      |        |     |
-|NA                   |?       |      |        |     |
-|waves                |0.2.4   |1     |        |     |
-|wdpar                |?       |      |        |     |
-|NA                   |?       |      |        |     |
-|zipcodeR             |0.3.5   |1     |        |     |
+|package             |version |error |warning |note |
+|:-------------------|:-------|:-----|:-------|:----|
+|apa                 |?       |      |        |     |
+|apaTables           |?       |      |        |     |
+|apaText             |?       |      |        |     |
+|arealDB             |0.9.4   |1     |        |     |
+|bayesdfa            |1.3.4   |1     |        |     |
+|cinaR               |?       |      |        |     |
+|ClusterGVis         |?       |      |        |     |
+|cocktailApp         |0.2.3   |1     |        |     |
+|CytoML              |?       |      |        |     |
+|DSMolgenisArmadillo |?       |      |        |     |
+|dsTidyverse         |?       |      |        |     |
+|dsTidyverseClient   |?       |      |        |     |
+|dySEM               |?       |      |        |     |
+|EcoEnsemble         |1.1.2   |1     |        |     |
+|FAfA                |?       |      |        |     |
+|FAIRmaterials       |0.4.2.1 |1     |        |     |
+|flowWorkspace       |?       |      |        |     |
+|genekitr            |?       |      |        |     |
+|GeneSelectR         |?       |      |        |     |
+|ggmosaic            |0.3.3   |1     |        |     |
+|ggmulti             |1.0.7   |1     |        |     |
+|ggpicrust2          |?       |      |        |     |
+|ggsem               |?       |      |        |     |
+|Grouphmap           |?       |      |        |     |
+|immcp               |?       |      |        |     |
+|jmv                 |?       |      |        |     |
+|lcsm                |?       |      |        |     |
+|loon.shiny          |?       |      |        |     |
+|lvnet               |?       |      |        |     |
+|metajam             |0.3.1   |1     |        |     |
+|ModStatR            |?       |      |        |     |
+|multiModTest        |?       |      |        |     |
+|multinma            |0.8.1   |1     |        |     |
+|myTAI               |?       |      |        |     |
+|NanoMethViz         |?       |      |        |     |
+|negligible          |?       |      |        |     |
+|nesRdata            |0.3.1   |1     |        |     |
+|numbat              |?       |      |        |     |
+|OlinkAnalyze        |?       |      |        |     |
+|ontologics          |0.7.4   |1     |        |     |
+|pctax               |?       |      |        |     |
+|pkgstats            |?       |      |        |     |
+|psychonetrics       |?       |      |        |     |
+|psycModel           |?       |      |        |     |
+|pwr2ppl             |?       |      |        |     |
+|rattle              |?       |      |        |     |
+|rdflib              |0.2.9   |1     |        |     |
+|ReporterScore       |?       |      |        |     |
+|rshift              |3.1.2   |1     |        |     |
+|RVA                 |?       |      |        |     |
+|SCpubr              |?       |      |        |     |
+|semdrw              |?       |      |        |     |
+|semtree             |?       |      |        |     |
+|sprtt               |?       |      |        |     |
+|ssdGSA              |?       |      |        |     |
+|SurprisalAnalysis   |?       |      |        |     |
+|Surrogate           |?       |      |        |     |
+|tabledown           |?       |      |        |     |
+|TestAnaAPP          |?       |      |        |     |
+|tidybins            |?       |      |        |     |
+|tidycomm            |?       |      |        |     |
+|tinyarray           |?       |      |        |     |
+|TransProR           |?       |      |        |     |
+|tricolore           |1.2.4   |1     |        |     |
+|TriDimRegression    |1.0.2   |1     |        |     |
+|ufs                 |?       |      |        |     |
 
-## New problems (2)
+## New problems (82)
 
-|package    |version |error  |warning |note |
-|:----------|:-------|:------|:-------|:----|
-|[exuber](problems.md#exuber)|1.0.1   |__+1__ |        |1    |
-|[modelplotr](problems.md#modelplotr)|1.1.0   |       |__+1__  |     |
+|package           |version  |error  |warning |note |
+|:-----------------|:--------|:------|:-------|:----|
+|[activAnalyzer](problems.md#activanalyzer)|2.1.2    |__+3__ |        |1    |
+|[admiral](problems.md#admiral)|1.3.1    |__+3__ |        |2    |
+|[admiralmetabolic](problems.md#admiralmetabolic)|0.2.0    |__+1__ |        |     |
+|[admiralneuro](problems.md#admiralneuro)|0.1.0    |__+1__ |        |     |
+|[admiralonco](problems.md#admiralonco)|1.3.0    |__+1__ |        |     |
+|[admiralophtha](problems.md#admiralophtha)|1.3.0    |__+1__ |        |     |
+|[admiralpeds](problems.md#admiralpeds)|0.2.1    |__+1__ |        |     |
+|[admiralvaccine](problems.md#admiralvaccine)|0.5.0    |__+1__ |        |     |
+|[AeroSampleR](problems.md#aerosampler)|0.2.0    |__+2__ |        |1    |
+|[aggreCAT](problems.md#aggrecat)|1.0.0    |__+1__ |        |2    |
+|[ale](problems.md#ale)|0.5.3    |__+1__ |        |     |
+|[arcpullr](problems.md#arcpullr)|0.3.0    |__+1__ |        |1    |
+|[BayesGrowth](problems.md#bayesgrowth)|1.0.0    |__+1__ |        |2    |
+|[BiVariAn](problems.md#bivarian)|1.0.2    |__+2__ |        |     |
+|[bp](problems.md#bp)|2.1.0    |__+2__ |        |1    |
+|[brandr](problems.md#brandr)|0.1.0    |__+2__ |        |     |
+|[bulkreadr](problems.md#bulkreadr)|1.2.1    |__+3__ |        |     |
+|[canadianmaps](problems.md#canadianmaps)|2.0.0    |__+1__ |        |3    |
+|[care4cmodel](problems.md#care4cmodel)|1.0.3    |__+2__ |        |     |
+|[CATAcode](problems.md#catacode)|1.0.0    |__+1__ |        |     |
+|[CGPfunctions](problems.md#cgpfunctions)|0.6.3    |__+2__ |        |1    |
+|[cocoon](problems.md#cocoon)|0.2.1    |__+3__ |        |     |
+|[ConSciR](problems.md#conscir)|0.3.0    |__+1__ |        |     |
+|[cpsvote](problems.md#cpsvote)|0.1.0    |__+1__ |        |     |
+|[debkeepr](problems.md#debkeepr)|0.1.1    |__+2__ |        |1    |
+|[DeSciDe](problems.md#descide)|1.0.2    |__+1__ |        |     |
+|[describedata](problems.md#describedata)|0.1.1    |__+1__ |        |     |
+|[discord](problems.md#discord)|1.2.4.1  |__+1__ |        |     |
+|[DisImpact](problems.md#disimpact)|0.0.21   |__+3__ |        |     |
+|[duckplyr](problems.md#duckplyr)|1.1.2    |__+1__ |        |1    |
+|[dynwrap](problems.md#dynwrap)|1.2.4    |__+2__ |        |     |
+|[ecocomDP](problems.md#ecocomdp)|1.3.2    |__+2__ |        |     |
+|[efdm](problems.md#efdm)|0.2.1    |__+1__ |        |     |
+|[emery](problems.md#emery)|0.6.0    |__+1__ |        |     |
+|[eph](problems.md#eph)|1.0.2    |__+3__ |        |1    |
+|[epikit](problems.md#epikit)|0.1.6    |__+1__ |        |     |
+|[findSVI](problems.md#findsvi)|0.2.0    |__+1__ |        |1    |
+|[flowchart](problems.md#flowchart)|0.9.0    |__+1__ |        |     |
+|[fluxible](problems.md#fluxible)|1.3.3    |__+3__ |        |     |
+|[ggfacto](problems.md#ggfacto)|0.3.2    |__+1__ |        |     |
+|[gglyph](problems.md#gglyph)|0.2.0    |__+3__ |        |     |
+|[ggstatsplot](problems.md#ggstatsplot)|0.13.2   |__+1__ |        |     |
+|[ggsurveillance](problems.md#ggsurveillance)|0.5.1    |__+2__ |        |1    |
+|[goldilocks](problems.md#goldilocks)|0.4.0    |__+1__ |        |     |
+|[Goodreader](problems.md#goodreader)|0.1.2    |__+1__ |        |     |
+|[gtreg](problems.md#gtreg)|0.4.1    |__+2__ |        |     |
+|[heiscore](problems.md#heiscore)|0.1.4    |__+1__ |        |1    |
+|[heuristicsmineR](problems.md#heuristicsminer)|0.3.0    |__+1__ |        |1    |
+|[iglu](problems.md#iglu)|4.2.2    |__+2__ |        |     |
+|[inspectdf](problems.md#inspectdf)|0.0.12.1 |__+1__ |        |     |
+|[iNZightPlots](problems.md#inzightplots)|2.16.0   |__+1__ |        |1    |
+|[iNZightTools](problems.md#inzighttools)|2.0.3    |__+2__ |        |     |
+|[iNZightTS](problems.md#inzightts)|2.0.2    |__+2__ |        |1    |
+|[mantis](problems.md#mantis)|0.4.3    |__+1__ |        |     |
+|[matlib](problems.md#matlib)|1.0.0    |__+2__ |        |1    |
+|[metan](problems.md#metan)|1.19.0   |__+1__ |        |     |
+|[processmapR](problems.md#processmapr)|0.5.7    |__+2__ |        |     |
+|[radsafer](problems.md#radsafer)|2.3.0    |__+1__ |        |     |
+|[REDCapTidieR](problems.md#redcaptidier)|1.2.4    |__+2__ |        |     |
+|[retroharmonize](problems.md#retroharmonize)|0.2.0    |__+2__ |        |2    |
+|[rfars](problems.md#rfars)|2.0.0    |__+1__ |        |2    |
+|[rFIA](problems.md#rfia)|1.1.2    |__+1__ |        |1    |
+|[risk.assessr](problems.md#riskassessr)|2.0.1    |__+1__ |        |     |
+|[scSpatialSIM](problems.md#scspatialsim)|0.1.3.4  |__+1__ |        |     |
+|[sdtmval](problems.md#sdtmval)|0.4.1    |__+2__ |        |     |
+|[shinyHugePlot](problems.md#shinyhugeplot)|0.3.0    |__+1__ |        |     |
+|[SingleCaseES](problems.md#singlecasees)|0.7.3    |__+1__ |        |     |
+|[srppp](problems.md#srppp)|1.1.0    |__+2__ |        |     |
+|[statsExpressions](problems.md#statsexpressions)|1.7.1    |__+1__ |        |     |
+|[STICr](problems.md#sticr)|1.1.1    |__+1__ |        |     |
+|[surveyexplorer](problems.md#surveyexplorer)|0.2.0    |__+2__ |        |     |
+|[tabxplor](problems.md#tabxplor)|1.3.1    |__+3__ |        |     |
+|[tcpl](problems.md#tcpl)|3.3.0    |__+1__ |        |     |
+|[tidyCDISC](problems.md#tidycdisc)|0.2.1    |__+1__ |        |1    |
+|[tidydice](problems.md#tidydice)|1.0.0    |__+2__ |        |     |
+|[tidyfinance](problems.md#tidyfinance)|0.4.4    |__+2__ |        |     |
+|[TreatmentPatterns](problems.md#treatmentpatterns)|3.1.1    |__+2__ |        |1    |
+|[trendtestR](problems.md#trendtestr)|1.0.1    |__+2__ |        |     |
+|[vcdExtra](problems.md#vcdextra)|0.8-6    |__+1__ |        |1    |
+|[vigicaen](problems.md#vigicaen)|0.16.1   |__+2__ |        |1    |
+|[vital](problems.md#vital)|2.0.0    |__+2__ |        |     |
+|[xlr](problems.md#xlr)|1.0.3    |__+1__ |        |     |
 

--- a/revdep/cran.md
+++ b/revdep/cran.md
@@ -1,124 +1,366 @@
 ## revdepcheck results
 
-We checked 3423 reverse dependencies (3395 from CRAN + 28 from Bioconductor), comparing R CMD check results across CRAN and dev versions of this package.
+We checked 5328 reverse dependencies (5323 from CRAN + 5 from Bioconductor), comparing R CMD check results across CRAN and dev versions of this package.
 
- * We saw 2 new problems
- * We failed to check 104 packages
+ * We saw 82 new problems
+ * We failed to check 61 packages
 
 Issues with CRAN packages are summarised below.
 
 ### New problems
 (This reports the first line of each new failure)
 
-* exuber
+* activAnalyzer
+  checking examples ... ERROR
+  checking tests ... ERROR
+  checking re-building of vignette outputs ... ERROR
+
+* admiral
+  checking examples ... ERROR
+  checking tests ... ERROR
+  checking re-building of vignette outputs ... ERROR
+
+* admiralmetabolic
+  checking re-building of vignette outputs ... ERROR
+
+* admiralneuro
+  checking re-building of vignette outputs ... ERROR
+
+* admiralonco
+  checking re-building of vignette outputs ... ERROR
+
+* admiralophtha
+  checking re-building of vignette outputs ... ERROR
+
+* admiralpeds
+  checking re-building of vignette outputs ... ERROR
+
+* admiralvaccine
+  checking re-building of vignette outputs ... ERROR
+
+* AeroSampleR
+  checking examples ... ERROR
+  checking re-building of vignette outputs ... ERROR
+
+* aggreCAT
   checking tests ... ERROR
 
-* modelplotr
-  checking re-building of vignette outputs ... WARNING
+* ale
+  checking tests ... ERROR
+
+* arcpullr
+  checking tests ... ERROR
+
+* BayesGrowth
+  checking re-building of vignette outputs ... ERROR
+
+* BiVariAn
+  checking examples ... ERROR
+  checking tests ... ERROR
+
+* bp
+  checking examples ... ERROR
+  checking re-building of vignette outputs ... ERROR
+
+* brandr
+  checking examples ... ERROR
+  checking tests ... ERROR
+
+* bulkreadr
+  checking examples ... ERROR
+  checking tests ... ERROR
+  checking re-building of vignette outputs ... ERROR
+
+* canadianmaps
+  checking tests ... ERROR
+
+* care4cmodel
+  checking examples ... ERROR
+  checking re-building of vignette outputs ... ERROR
+
+* CATAcode
+  checking re-building of vignette outputs ... ERROR
+
+* CGPfunctions
+  checking examples ... ERROR
+  checking re-building of vignette outputs ... ERROR
+
+* cocoon
+  checking examples ... ERROR
+  checking tests ... ERROR
+  checking re-building of vignette outputs ... ERROR
+
+* ConSciR
+  checking examples ... ERROR
+
+* cpsvote
+  checking examples ... ERROR
+
+* debkeepr
+  checking examples ... ERROR
+  checking tests ... ERROR
+
+* DeSciDe
+  checking examples ... ERROR
+
+* describedata
+  checking examples ... ERROR
+
+* discord
+  checking re-building of vignette outputs ... ERROR
+
+* DisImpact
+  checking examples ... ERROR
+  checking tests ... ERROR
+  checking re-building of vignette outputs ... ERROR
+
+* duckplyr
+  checking tests ... ERROR
+
+* dynwrap
+  checking examples ... ERROR
+  checking tests ... ERROR
+
+* ecocomDP
+  checking examples ... ERROR
+  checking re-building of vignette outputs ... ERROR
+
+* efdm
+  checking re-building of vignette outputs ... ERROR
+
+* emery
+  checking re-building of vignette outputs ... ERROR
+
+* eph
+  checking examples ... ERROR
+  checking tests ... ERROR
+  checking re-building of vignette outputs ... ERROR
+
+* epikit
+  checking tests ... ERROR
+
+* findSVI
+  checking tests ... ERROR
+
+* flowchart
+  checking tests ... ERROR
+
+* fluxible
+  checking examples ... ERROR
+  checking tests ... ERROR
+  checking re-building of vignette outputs ... ERROR
+
+* ggfacto
+  checking examples ... ERROR
+
+* gglyph
+  checking examples ... ERROR
+  checking tests ... ERROR
+  checking re-building of vignette outputs ... ERROR
+
+* ggstatsplot
+  checking tests ... ERROR
+
+* ggsurveillance
+  checking examples ... ERROR
+  checking tests ... ERROR
+
+* goldilocks
+  checking tests ... ERROR
+
+* Goodreader
+  checking tests ... ERROR
+
+* gtreg
+  checking examples ... ERROR
+  checking tests ... ERROR
+
+* heiscore
+  checking examples ... ERROR
+
+* heuristicsmineR
+  checking examples ... ERROR
+
+* iglu
+  checking examples ... ERROR
+  checking re-building of vignette outputs ... ERROR
+
+* inspectdf
+  checking examples ... ERROR
+
+* iNZightPlots
+  checking tests ... ERROR
+
+* iNZightTools
+  checking examples ... ERROR
+  checking tests ... ERROR
+
+* iNZightTS
+  checking examples ... ERROR
+  checking tests ... ERROR
+
+* mantis
+  checking tests ... ERROR
+
+* matlib
+  checking examples ... ERROR
+  checking re-building of vignette outputs ... ERROR
+
+* metan
+  checking re-building of vignette outputs ... ERROR
+
+* processmapR
+  checking examples ... ERROR
+  checking tests ... ERROR
+
+* radsafer
+  checking examples ... ERROR
+
+* REDCapTidieR
+  checking examples ... ERROR
+  checking tests ... ERROR
+
+* retroharmonize
+  checking examples ... ERROR
+  checking tests ... ERROR
+
+* rfars
+  checking re-building of vignette outputs ... ERROR
+
+* rFIA
+  checking examples ... ERROR
+
+* risk.assessr
+  checking tests ... ERROR
+
+* scSpatialSIM
+  checking re-building of vignette outputs ... ERROR
+
+* sdtmval
+  checking examples ... ERROR
+  checking tests ... ERROR
+
+* shinyHugePlot
+  checking examples ... ERROR
+
+* SingleCaseES
+  checking tests ... ERROR
+
+* srppp
+  checking tests ... ERROR
+  checking re-building of vignette outputs ... ERROR
+
+* statsExpressions
+  checking tests ... ERROR
+
+* STICr
+  checking examples ... ERROR
+
+* surveyexplorer
+  checking examples ... ERROR
+  checking tests ... ERROR
+
+* tabxplor
+  checking examples ... ERROR
+  checking tests ... ERROR
+  checking re-building of vignette outputs ... ERROR
+
+* tcpl
+  checking tests ... ERROR
+
+* tidyCDISC
+  checking tests ... ERROR
+
+* tidydice
+  checking tests ... ERROR
+  checking re-building of vignette outputs ... ERROR
+
+* tidyfinance
+  checking examples ... ERROR
+  checking tests ... ERROR
+
+* TreatmentPatterns
+  checking tests ... ERROR
+  checking re-building of vignette outputs ... ERROR
+
+* trendtestR
+  checking examples ... ERROR
+  checking tests ... ERROR
+
+* vcdExtra
+  checking re-building of vignette outputs ... ERROR
+
+* vigicaen
+  checking tests ... ERROR
+  checking re-building of vignette outputs ... ERROR
+
+* vital
+  checking examples ... ERROR
+  checking tests ... ERROR
+
+* xlr
+  checking tests ... ERROR
 
 ### Failed to check
 
-* abstr                (NA)
-* bdl                  (NA)
-* cancensus            (NA)
-* CCAMLRGIS            (NA)
-* choroplethr          (NA)
-* cleanTS              (NA)
-* CoordinateCleaner    (NA)
-* CopernicusMarine     (NA)
-* ctsem                (NA)
-* cubble               (NA)
-* cyclestreets         (NA)
-* dbmss                (NA)
-* dycdtools            (NA)
-* dynamicSDM           (NA)
-* edbuildmapr          (NA)
-* EFDR                 (NA)
-* eflm                 (NA)
-* EnvExpInd            (NA)
-* eSDM                 (NA)
-* fgdr                 (NA)
-* FORTLS               (NA)
-* FRK                  (NA)
-* fsr                  (NA)
-* GeodesiCL            (NA)
-* ggchangepoint        (NA)
-* ggOceanMaps          (NA)
-* ggspatial            (NA)
-* glottospace          (NA)
-* GREENeR              (NA)
-* gumboot              (NA)
-* gwavr                (NA)
-* GWPR.light           (NA)
-* happign              (NA)
-* himach               (NA)
-* HYPEtools            (NA)
-* hypsoLoop            (NA)
-* incidence2           (NA)
-* intSDM               (NA)
-* itsdm                (NA)
-* jpgrid               (NA)
-* jpmesh               (NA)
-* MainExistingDatasets (NA)
-* manydata             (NA)
-* mapboxapi            (NA)
-* mapme.biodiversity   (NA)
-* mapping              (NA)
-* mapscanner           (NA)
-* MazamaSpatialPlots   (NA)
-* meteoland            (NA)
-* motif                (NA)
-* MSclassifR           (NA)
-* naturaList           (NA)
-* ncdfgeom             (NA)
-* nhdplusTools         (NA)
-* nhdR                 (NA)
-* occCite              (NA)
-* oceanexplorer        (NA)
-* oceanis              (NA)
-* OpenLand             (NA)
-* palaeoSig            (NA)
-* PopGenHelpR          (NA)
-* ppcSpatial           (NA)
-* prioriactions        (NA)
-* PSS.Health           (NA)
-* rangeModelMetadata   (NA)
-* rbenvo               (NA)
-* rcontroll            (NA)
-* redist               (NA)
-* roads                (NA)
-* Rsagacmd             (NA)
-* rsinaica             (NA)
-* saeSim               (NA)
-* sandwichr            (NA)
-* SDGdetector          (NA)
-* SDLfilter            (NA)
-* sfnetworks           (NA)
-* ShellChron           (NA)
-* simodels             (NA)
-* simplevis            (NA)
-* slendr               (NA)
-* sociome              (NA)
-* SPARTAAS             (NA)
-* spatgeom             (NA)
-* SpatialKDE           (NA)
-* spatialrisk          (NA)
-* spDates              (NA)
-* spnaf                (NA)
-* spNetwork            (NA)
-* spqdep               (NA)
-* stplanr              (NA)
-* stppSim              (NA)
-* stxplore             (NA)
-* SUNGEO               (NA)
-* swfscAirDAS          (NA)
-* SWTools              (NA)
-* telemac              (NA)
-* trackdf              (NA)
-* TUFLOWR              (NA)
-* VancouvR             (NA)
-* wallace              (NA)
-* waterquality         (NA)
-* waves                (NA)
-* wdpar                (NA)
-* zipcodeR             (NA)
+* apa                 (NA)
+* apaTables           (NA)
+* apaText             (NA)
+* arealDB             (NA)
+* bayesdfa            (NA)
+* cinaR               (NA)
+* ClusterGVis         (NA)
+* cocktailApp         (NA)
+* DSMolgenisArmadillo (NA)
+* dsTidyverse         (NA)
+* dsTidyverseClient   (NA)
+* dySEM               (NA)
+* EcoEnsemble         (NA)
+* FAfA                (NA)
+* FAIRmaterials       (NA)
+* genekitr            (NA)
+* GeneSelectR         (NA)
+* ggmosaic            (NA)
+* ggmulti             (NA)
+* ggpicrust2          (NA)
+* ggsem               (NA)
+* Grouphmap           (NA)
+* immcp               (NA)
+* jmv                 (NA)
+* lcsm                (NA)
+* loon.shiny          (NA)
+* lvnet               (NA)
+* metajam             (NA)
+* ModStatR            (NA)
+* multiModTest        (NA)
+* multinma            (NA)
+* negligible          (NA)
+* nesRdata            (NA)
+* numbat              (NA)
+* OlinkAnalyze        (NA)
+* ontologics          (NA)
+* pctax               (NA)
+* psychonetrics       (NA)
+* psycModel           (NA)
+* pwr2ppl             (NA)
+* rattle              (NA)
+* rdflib              (NA)
+* ReporterScore       (NA)
+* rshift              (NA)
+* RVA                 (NA)
+* SCpubr              (NA)
+* semdrw              (NA)
+* semtree             (NA)
+* sprtt               (NA)
+* ssdGSA              (NA)
+* SurprisalAnalysis   (NA)
+* Surrogate           (NA)
+* tabledown           (NA)
+* TestAnaAPP          (NA)
+* tidybins            (NA)
+* tidycomm            (NA)
+* tinyarray           (NA)
+* TransProR           (NA)
+* tricolore           (NA)
+* TriDimRegression    (NA)
+* ufs                 (NA)

--- a/revdep/failures.md
+++ b/revdep/failures.md
@@ -1,214 +1,37 @@
-# abstr
+# apa (0.3.4)
 
-<details>
+* GitHub: https://github.com/dgromer/apa
+* Github mirror: https://github.com/cran/apa
+* Maintainer: Daniel Gromer <dgromer@mailbox.org>
 
-* Version: 0.4.1
-* GitHub: https://github.com/a-b-street/abstr
-* Source code: https://github.com/cran/abstr
-* Date/Publication: 2021-11-30 08:10:05 UTC
-* Number of recursive dependencies: 125
-
-Run `revdepcheck::cloud_details(, "abstr")` for more info
-
-</details>
+Run `revdepcheck::cloud_details(, "apa")` for more info
 
 ## Error before installation
 
 ### Devel
 
 ```
-* using log directory ‘/tmp/workdir/abstr/new/abstr.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
+* using log directory ‘/tmp/workdir/apa/new/apa.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
 * using session charset: UTF-8
 * using option ‘--no-manual’
-* checking for file ‘abstr/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘abstr’ version ‘0.4.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Packages required but not available: 'lwgeom', 'sf'
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/abstr/old/abstr.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘abstr/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘abstr’ version ‘0.4.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Packages required but not available: 'lwgeom', 'sf'
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# NA
-
-<details>
-
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `revdepcheck::cloud_details(, "NA")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# bdl
-
-<details>
-
-* Version: 1.0.5
-* GitHub: https://github.com/statisticspoland/R_Package_to_API_BDL
-* Source code: https://github.com/cran/bdl
-* Date/Publication: 2023-02-24 15:00:02 UTC
-* Number of recursive dependencies: 145
-
-Run `revdepcheck::cloud_details(, "bdl")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/bdl/new/bdl.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘bdl/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘bdl’ version ‘1.0.5’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/bdl/old/bdl.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘bdl/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘bdl’ version ‘1.0.5’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# cancensus
-
-<details>
-
-* Version: 0.5.5
-* GitHub: https://github.com/mountainMath/cancensus
-* Source code: https://github.com/cran/cancensus
-* Date/Publication: 2023-01-23 08:40:06 UTC
-* Number of recursive dependencies: 117
-
-Run `revdepcheck::cloud_details(, "cancensus")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/cancensus/new/cancensus.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘cancensus/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘cancensus’ version ‘0.5.5’
-* package encoding: UTF-8
-* checking package namespace information ... OK
+* checking for file ‘apa/DESCRIPTION’ ... OK
 ...
-  ‘Making_maps_with_cancensus.Rmd’ using ‘UTF-8’... OK
-  ‘Taxfiler_Data.Rmd’ using ‘UTF-8’... OK
-  ‘cancensus.Rmd’ using ‘UTF-8’... OK
-  ‘data_discovery.Rmd’ using ‘UTF-8’... OK
-  ‘intersecting_geometries.Rmd’ using ‘UTF-8’... OK
-  ‘statcan_attribute_files.Rmd’ using ‘UTF-8’... OK
-  ‘statcan_wds.Rmd’ using ‘UTF-8’... OK
-* checking re-building of vignette outputs ... OK
+* this is package ‘apa’ version ‘0.3.4’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘MBESS’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
 * DONE
-Status: 3 NOTEs
+Status: 1 ERROR
 
 
 
@@ -218,7338 +41,61 @@ Status: 3 NOTEs
 ### CRAN
 
 ```
-* using log directory ‘/tmp/workdir/cancensus/old/cancensus.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
+* using log directory ‘/tmp/workdir/apa/old/apa.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
 * using session charset: UTF-8
 * using option ‘--no-manual’
-* checking for file ‘cancensus/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘cancensus’ version ‘0.5.5’
-* package encoding: UTF-8
-* checking package namespace information ... OK
+* checking for file ‘apa/DESCRIPTION’ ... OK
 ...
-  ‘Making_maps_with_cancensus.Rmd’ using ‘UTF-8’... OK
-  ‘Taxfiler_Data.Rmd’ using ‘UTF-8’... OK
-  ‘cancensus.Rmd’ using ‘UTF-8’... OK
-  ‘data_discovery.Rmd’ using ‘UTF-8’... OK
-  ‘intersecting_geometries.Rmd’ using ‘UTF-8’... OK
-  ‘statcan_attribute_files.Rmd’ using ‘UTF-8’... OK
-  ‘statcan_wds.Rmd’ using ‘UTF-8’... OK
-* checking re-building of vignette outputs ... OK
-* DONE
-Status: 3 NOTEs
-
-
-
-
-
-```
-# CCAMLRGIS
-
-<details>
-
-* Version: 4.0.4
-* GitHub: https://github.com/ccamlr/CCAMLRGIS
-* Source code: https://github.com/cran/CCAMLRGIS
-* Date/Publication: 2023-02-07 04:12:37 UTC
-* Number of recursive dependencies: 72
-
-Run `revdepcheck::cloud_details(, "CCAMLRGIS")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/CCAMLRGIS/new/CCAMLRGIS.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘CCAMLRGIS/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘CCAMLRGIS’ version ‘4.0.4’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/CCAMLRGIS/old/CCAMLRGIS.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘CCAMLRGIS/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘CCAMLRGIS’ version ‘4.0.4’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# choroplethr
-
-<details>
-
-* Version: 3.7.1
-* GitHub: NA
-* Source code: https://github.com/cran/choroplethr
-* Date/Publication: 2022-10-05 07:10:06 UTC
-* Number of recursive dependencies: 127
-
-Run `revdepcheck::cloud_details(, "choroplethr")` for more info
-
-</details>
-
-## In both
-
-*   checking whether package ‘choroplethr’ can be installed ... ERROR
-    ```
-    Installation failed.
-    See ‘/tmp/workdir/choroplethr/new/choroplethr.Rcheck/00install.out’ for details.
-    ```
-
-## Installation
-
-### Devel
-
-```
-* installing *source* package ‘choroplethr’ ...
-** package ‘choroplethr’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** data
-** byte-compile and prepare package for lazy loading
-Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
-  there is no package called ‘sf’
-Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
-Execution halted
-ERROR: lazy loading failed for package ‘choroplethr’
-* removing ‘/tmp/workdir/choroplethr/new/choroplethr.Rcheck/choroplethr’
-
-
-```
-### CRAN
-
-```
-* installing *source* package ‘choroplethr’ ...
-** package ‘choroplethr’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** data
-** byte-compile and prepare package for lazy loading
-Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
-  there is no package called ‘sf’
-Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
-Execution halted
-ERROR: lazy loading failed for package ‘choroplethr’
-* removing ‘/tmp/workdir/choroplethr/old/choroplethr.Rcheck/choroplethr’
-
-
-```
-# cleanTS
-
-<details>
-
-* Version: 0.1.1
-* GitHub: https://github.com/Mayur1009/cleanTS
-* Source code: https://github.com/cran/cleanTS
-* Date/Publication: 2022-06-15 09:20:19 UTC
-* Number of recursive dependencies: 163
-
-Run `revdepcheck::cloud_details(, "cleanTS")` for more info
-
-</details>
-
-## In both
-
-*   checking whether package ‘cleanTS’ can be installed ... ERROR
-    ```
-    Installation failed.
-    See ‘/tmp/workdir/cleanTS/new/cleanTS.Rcheck/00install.out’ for details.
-    ```
-
-## Installation
-
-### Devel
-
-```
-* installing *source* package ‘cleanTS’ ...
-** package ‘cleanTS’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** inst
-** byte-compile and prepare package for lazy loading
-Error in loadNamespace(j <- i[[1L]], c(lib.loc, .libPaths()), versionCheck = vI[[j]]) : 
-  there is no package called ‘sf’
-Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
-Execution halted
-ERROR: lazy loading failed for package ‘cleanTS’
-* removing ‘/tmp/workdir/cleanTS/new/cleanTS.Rcheck/cleanTS’
-
-
-```
-### CRAN
-
-```
-* installing *source* package ‘cleanTS’ ...
-** package ‘cleanTS’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** inst
-** byte-compile and prepare package for lazy loading
-Error in loadNamespace(j <- i[[1L]], c(lib.loc, .libPaths()), versionCheck = vI[[j]]) : 
-  there is no package called ‘sf’
-Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
-Execution halted
-ERROR: lazy loading failed for package ‘cleanTS’
-* removing ‘/tmp/workdir/cleanTS/old/cleanTS.Rcheck/cleanTS’
-
-
-```
-# CoordinateCleaner
-
-<details>
-
-* Version: 2.0-20
-* GitHub: https://github.com/ropensci/CoordinateCleaner
-* Source code: https://github.com/cran/CoordinateCleaner
-* Date/Publication: 2021-10-21 17:10:05 UTC
-* Number of recursive dependencies: 115
-
-Run `revdepcheck::cloud_details(, "CoordinateCleaner")` for more info
-
-</details>
-
-## In both
-
-*   checking whether package ‘CoordinateCleaner’ can be installed ... ERROR
-    ```
-    Installation failed.
-    See ‘/tmp/workdir/CoordinateCleaner/new/CoordinateCleaner.Rcheck/00install.out’ for details.
-    ```
-
-## Installation
-
-### Devel
-
-```
-* installing *source* package ‘CoordinateCleaner’ ...
-** package ‘CoordinateCleaner’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** data
-*** moving datasets to lazyload DB
-** inst
-** byte-compile and prepare package for lazy loading
-Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
-  there is no package called ‘sf’
-Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
-Execution halted
-ERROR: lazy loading failed for package ‘CoordinateCleaner’
-* removing ‘/tmp/workdir/CoordinateCleaner/new/CoordinateCleaner.Rcheck/CoordinateCleaner’
-
-
-```
-### CRAN
-
-```
-* installing *source* package ‘CoordinateCleaner’ ...
-** package ‘CoordinateCleaner’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** data
-*** moving datasets to lazyload DB
-** inst
-** byte-compile and prepare package for lazy loading
-Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
-  there is no package called ‘sf’
-Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
-Execution halted
-ERROR: lazy loading failed for package ‘CoordinateCleaner’
-* removing ‘/tmp/workdir/CoordinateCleaner/old/CoordinateCleaner.Rcheck/CoordinateCleaner’
-
-
-```
-# CopernicusMarine
-
-<details>
-
-* Version: 0.0.6
-* GitHub: https://github.com/pepijn-devries/CopernicusMarine
-* Source code: https://github.com/cran/CopernicusMarine
-* Date/Publication: 2023-01-30 13:50:02 UTC
-* Number of recursive dependencies: 113
-
-Run `revdepcheck::cloud_details(, "CopernicusMarine")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/CopernicusMarine/new/CopernicusMarine.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘CopernicusMarine/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘CopernicusMarine’ version ‘0.0.6’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/CopernicusMarine/old/CopernicusMarine.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘CopernicusMarine/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘CopernicusMarine’ version ‘0.0.6’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# NA
-
-<details>
-
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `revdepcheck::cloud_details(, "NA")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# ctsem
-
-<details>
-
-* Version: 3.7.2
-* GitHub: https://github.com/cdriveraus/ctsem
-* Source code: https://github.com/cran/ctsem
-* Date/Publication: 2022-11-06 05:10:11 UTC
-* Number of recursive dependencies: 136
-
-Run `revdepcheck::cloud_details(, "ctsem")` for more info
-
-</details>
-
-## In both
-
-*   checking whether package ‘ctsem’ can be installed ... ERROR
-    ```
-    Installation failed.
-    See ‘/tmp/workdir/ctsem/new/ctsem.Rcheck/00install.out’ for details.
-    ```
-
-## Installation
-
-### Devel
-
-```
-* installing *source* package ‘ctsem’ ...
-** package ‘ctsem’ successfully unpacked and MD5 sums checked
-** using staged installation
-** libs
-"/opt/R/4.1.1/lib/R/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/ctsm.stan
-DIAGNOSTIC(S) FROM PARSER:
-Info: integer division implicitly rounds to integer. Found int division: d * d - d / 2
- Positive values rounded down, negative values rounded up or down in platform-dependent way.
-
-Wrote C++ file "stan_files/ctsm.cc"
-...
- 2340 |     T__ log_prob(std::vector<T__>& params_r__,
-      |         ^~~~~~~~
-stan_files/ctsm.hpp: In member function ‘T__ model_ctsm_namespace::model_ctsm::log_prob(std::vector<T_l>&, std::vector<int>&, std::ostream*) const [with bool propto__ = false; bool jacobian__ = false; T__ = double]’:
-stan_files/ctsm.hpp:2340:9: note: variable tracking size limit exceeded with ‘-fvar-tracking-assignments’, retrying without
-g++: fatal error: Killed signal terminated program cc1plus
-compilation terminated.
-make: *** [/opt/R/4.1.1/lib/R/etc/Makeconf:175: stan_files/ctsm.o] Error 1
-rm stan_files/ctsm.cc
-ERROR: compilation failed for package ‘ctsem’
-* removing ‘/tmp/workdir/ctsem/new/ctsem.Rcheck/ctsem’
-
-
-```
-### CRAN
-
-```
-* installing *source* package ‘ctsem’ ...
-** package ‘ctsem’ successfully unpacked and MD5 sums checked
-** using staged installation
-** libs
-"/opt/R/4.1.1/lib/R/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/ctsm.stan
-DIAGNOSTIC(S) FROM PARSER:
-Info: integer division implicitly rounds to integer. Found int division: d * d - d / 2
- Positive values rounded down, negative values rounded up or down in platform-dependent way.
-
-Wrote C++ file "stan_files/ctsm.cc"
-...
- 2340 |     T__ log_prob(std::vector<T__>& params_r__,
-      |         ^~~~~~~~
-stan_files/ctsm.hpp: In member function ‘T__ model_ctsm_namespace::model_ctsm::log_prob(std::vector<T_l>&, std::vector<int>&, std::ostream*) const [with bool propto__ = false; bool jacobian__ = false; T__ = double]’:
-stan_files/ctsm.hpp:2340:9: note: variable tracking size limit exceeded with ‘-fvar-tracking-assignments’, retrying without
-g++: fatal error: Killed signal terminated program cc1plus
-compilation terminated.
-make: *** [/opt/R/4.1.1/lib/R/etc/Makeconf:175: stan_files/ctsm.o] Error 1
-rm stan_files/ctsm.cc
-ERROR: compilation failed for package ‘ctsem’
-* removing ‘/tmp/workdir/ctsem/old/ctsem.Rcheck/ctsem’
-
-
-```
-# cubble
-
-<details>
-
-* Version: 0.2.0
-* GitHub: https://github.com/huizezhang-sherry/cubble
-* Source code: https://github.com/cran/cubble
-* Date/Publication: 2022-11-17 12:30:02 UTC
-* Number of recursive dependencies: 132
-
-Run `revdepcheck::cloud_details(, "cubble")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/cubble/new/cubble.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘cubble/DESCRIPTION’ ... OK
-* this is package ‘cubble’ version ‘0.2.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-Package suggested but not available for checking: ‘ozmaps’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/cubble/old/cubble.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘cubble/DESCRIPTION’ ... OK
-* this is package ‘cubble’ version ‘0.2.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-Package suggested but not available for checking: ‘ozmaps’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# cyclestreets
-
-<details>
-
-* Version: 0.6.0
-* GitHub: https://github.com/cyclestreets/cyclestreets-r
-* Source code: https://github.com/cran/cyclestreets
-* Date/Publication: 2023-02-17 09:30:06 UTC
-* Number of recursive dependencies: 67
-
-Run `revdepcheck::cloud_details(, "cyclestreets")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/cyclestreets/new/cyclestreets.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘cyclestreets/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘cyclestreets’ version ‘0.6.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/cyclestreets/old/cyclestreets.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘cyclestreets/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘cyclestreets’ version ‘0.6.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# NA
-
-<details>
-
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `revdepcheck::cloud_details(, "NA")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# dbmss
-
-<details>
-
-* Version: 2.8-0
-* GitHub: https://github.com/EricMarcon/dbmss
-* Source code: https://github.com/cran/dbmss
-* Date/Publication: 2023-01-06 15:10:05 UTC
-* Number of recursive dependencies: 120
-
-Run `revdepcheck::cloud_details(, "dbmss")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/dbmss/new/dbmss.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘dbmss/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘dbmss’ version ‘2.8-0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-...
-* checking for unstated dependencies in ‘tests’ ... OK
-* checking tests ... OK
-  Running ‘testthat.R’
-* checking for unstated dependencies in vignettes ... OK
-* checking package vignettes in ‘inst/doc’ ... OK
-* checking running R code from vignettes ... NONE
-  ‘dbmss.Rmd’ using ‘UTF-8’... OK
-* checking re-building of vignette outputs ... OK
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/dbmss/old/dbmss.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘dbmss/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘dbmss’ version ‘2.8-0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-...
-* checking for unstated dependencies in ‘tests’ ... OK
-* checking tests ... OK
-  Running ‘testthat.R’
-* checking for unstated dependencies in vignettes ... OK
-* checking package vignettes in ‘inst/doc’ ... OK
-* checking running R code from vignettes ... NONE
-  ‘dbmss.Rmd’ using ‘UTF-8’... OK
-* checking re-building of vignette outputs ... OK
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# dycdtools
-
-<details>
-
-* Version: 0.4.3
-* GitHub: https://github.com/SongyanYu/dycdtools
-* Source code: https://github.com/cran/dycdtools
-* Date/Publication: 2022-11-22 00:40:02 UTC
-* Number of recursive dependencies: 89
-
-Run `revdepcheck::cloud_details(, "dycdtools")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/dycdtools/new/dycdtools.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘dycdtools/DESCRIPTION’ ... OK
-* this is package ‘dycdtools’ version ‘0.4.3’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... OK
-...
-* checking if there is a namespace ... OK
-* checking for executable files ... OK
-* checking for hidden files and directories ... OK
-* checking for portable file names ... OK
-* checking for sufficient/correct file permissions ... OK
-* checking whether package ‘dycdtools’ can be installed ... ERROR
-Installation failed.
-See ‘/tmp/workdir/dycdtools/new/dycdtools.Rcheck/00install.out’ for details.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/dycdtools/old/dycdtools.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘dycdtools/DESCRIPTION’ ... OK
-* this is package ‘dycdtools’ version ‘0.4.3’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... OK
-...
-* checking if there is a namespace ... OK
-* checking for executable files ... OK
-* checking for hidden files and directories ... OK
-* checking for portable file names ... OK
-* checking for sufficient/correct file permissions ... OK
-* checking whether package ‘dycdtools’ can be installed ... ERROR
-Installation failed.
-See ‘/tmp/workdir/dycdtools/old/dycdtools.Rcheck/00install.out’ for details.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# dynamicSDM
-
-<details>
-
-* Version: 1.1
-* GitHub: https://github.com/r-a-dobson/dynamicSDM
-* Source code: https://github.com/cran/dynamicSDM
-* Date/Publication: 2023-02-27 13:22:30 UTC
-* Number of recursive dependencies: 156
-
-Run `revdepcheck::cloud_details(, "dynamicSDM")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/dynamicSDM/new/dynamicSDM.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘dynamicSDM/DESCRIPTION’ ... OK
-* this is package ‘dynamicSDM’ version ‘1.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/dynamicSDM/old/dynamicSDM.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘dynamicSDM/DESCRIPTION’ ... OK
-* this is package ‘dynamicSDM’ version ‘1.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# edbuildmapr
-
-<details>
-
-* Version: 0.3.1
-* GitHub: https://github.com/EdBuild/edbuildmapr
-* Source code: https://github.com/cran/edbuildmapr
-* Date/Publication: 2021-06-15 06:00:02 UTC
-* Number of recursive dependencies: 98
-
-Run `revdepcheck::cloud_details(, "edbuildmapr")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/edbuildmapr/new/edbuildmapr.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘edbuildmapr/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘edbuildmapr’ version ‘0.3.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/edbuildmapr/old/edbuildmapr.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘edbuildmapr/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘edbuildmapr’ version ‘0.3.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# EFDR
-
-<details>
-
-* Version: 1.2
-* GitHub: https://github.com/andrewzm/EFDR
-* Source code: https://github.com/cran/EFDR
-* Date/Publication: 2021-04-18 05:50:03 UTC
-* Number of recursive dependencies: 105
-
-Run `revdepcheck::cloud_details(, "EFDR")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/EFDR/new/EFDR.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘EFDR/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘EFDR’ version ‘1.2’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-...
-* checking installed files from ‘inst/doc’ ... OK
-* checking files in ‘vignettes’ ... OK
-* checking examples ... OK
-* checking for unstated dependencies in vignettes ... OK
-* checking package vignettes in ‘inst/doc’ ... OK
-* checking running R code from vignettes ... NONE
-  ‘EFDR_documents.Rmd’ using ‘UTF-8’... OK
-* checking re-building of vignette outputs ... OK
-* DONE
-Status: OK
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/EFDR/old/EFDR.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘EFDR/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘EFDR’ version ‘1.2’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-...
-* checking installed files from ‘inst/doc’ ... OK
-* checking files in ‘vignettes’ ... OK
-* checking examples ... OK
-* checking for unstated dependencies in vignettes ... OK
-* checking package vignettes in ‘inst/doc’ ... OK
-* checking running R code from vignettes ... NONE
-  ‘EFDR_documents.Rmd’ using ‘UTF-8’... OK
-* checking re-building of vignette outputs ... OK
-* DONE
-Status: OK
-
-
-
-
-
-```
-# eflm
-
-<details>
-
-* Version: 0.3.0
-* GitHub: https://github.com/pachadotdev/eflm
-* Source code: https://github.com/cran/eflm
-* Date/Publication: 2021-05-31 21:20:02 UTC
-* Number of recursive dependencies: 55
-
-Run `revdepcheck::cloud_details(, "eflm")` for more info
-
-</details>
-
-## In both
-
-*   checking whether package ‘eflm’ can be installed ... ERROR
-    ```
-    Installation failed.
-    See ‘/tmp/workdir/eflm/new/eflm.Rcheck/00install.out’ for details.
-    ```
-
-## Installation
-
-### Devel
-
-```
-* installing *source* package ‘eflm’ ...
-** package ‘eflm’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** inst
-** byte-compile and prepare package for lazy loading
-Error : The `x` argument of `as_tibble()` can't be missing as of tibble 3.0.0.
-Error: unable to load R code in package ‘eflm’
-Execution halted
-ERROR: lazy loading failed for package ‘eflm’
-* removing ‘/tmp/workdir/eflm/new/eflm.Rcheck/eflm’
-
-
-```
-### CRAN
-
-```
-* installing *source* package ‘eflm’ ...
-** package ‘eflm’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** inst
-** byte-compile and prepare package for lazy loading
-Error : The `x` argument of `as_tibble()` can't be missing as of tibble 3.0.0.
-Error: unable to load R code in package ‘eflm’
-Execution halted
-ERROR: lazy loading failed for package ‘eflm’
-* removing ‘/tmp/workdir/eflm/old/eflm.Rcheck/eflm’
-
-
-```
-# EnvExpInd
-
-<details>
-
-* Version: 0.1.0
-* GitHub: https://github.com/Spatial-R/EnvExpInd
-* Source code: https://github.com/cran/EnvExpInd
-* Date/Publication: 2020-10-23 15:50:02 UTC
-* Number of recursive dependencies: 67
-
-Run `revdepcheck::cloud_details(, "EnvExpInd")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/EnvExpInd/new/EnvExpInd.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘EnvExpInd/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘EnvExpInd’ version ‘0.1.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-...
-* checking installed files from ‘inst/doc’ ... OK
-* checking files in ‘vignettes’ ... OK
-* checking examples ... OK
-* checking for unstated dependencies in vignettes ... OK
-* checking package vignettes in ‘inst/doc’ ... OK
-* checking running R code from vignettes ... NONE
-  ‘environment_exposure.Rmd’ using ‘UTF-8’... OK
-* checking re-building of vignette outputs ... OK
-* DONE
-Status: OK
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/EnvExpInd/old/EnvExpInd.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘EnvExpInd/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘EnvExpInd’ version ‘0.1.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-...
-* checking installed files from ‘inst/doc’ ... OK
-* checking files in ‘vignettes’ ... OK
-* checking examples ... OK
-* checking for unstated dependencies in vignettes ... OK
-* checking package vignettes in ‘inst/doc’ ... OK
-* checking running R code from vignettes ... NONE
-  ‘environment_exposure.Rmd’ using ‘UTF-8’... OK
-* checking re-building of vignette outputs ... OK
-* DONE
-Status: OK
-
-
-
-
-
-```
-# NA
-
-<details>
-
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `revdepcheck::cloud_details(, "NA")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# NA
-
-<details>
-
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `revdepcheck::cloud_details(, "NA")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# NA
-
-<details>
-
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `revdepcheck::cloud_details(, "NA")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# eSDM
-
-<details>
-
-* Version: 0.3.7
-* GitHub: https://github.com/smwoodman/eSDM
-* Source code: https://github.com/cran/eSDM
-* Date/Publication: 2021-05-04 04:50:08 UTC
-* Number of recursive dependencies: 130
-
-Run `revdepcheck::cloud_details(, "eSDM")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/eSDM/new/eSDM.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘eSDM/DESCRIPTION’ ... OK
-* this is package ‘eSDM’ version ‘0.3.7’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/eSDM/old/eSDM.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘eSDM/DESCRIPTION’ ... OK
-* this is package ‘eSDM’ version ‘0.3.7’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# fgdr
-
-<details>
-
-* Version: 1.1.1
-* GitHub: https://github.com/uribo/fgdr
-* Source code: https://github.com/cran/fgdr
-* Date/Publication: 2022-02-22 05:00:02 UTC
-* Number of recursive dependencies: 123
-
-Run `revdepcheck::cloud_details(, "fgdr")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/fgdr/new/fgdr.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘fgdr/DESCRIPTION’ ... OK
-* this is package ‘fgdr’ version ‘1.1.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/fgdr/old/fgdr.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘fgdr/DESCRIPTION’ ... OK
-* this is package ‘fgdr’ version ‘1.1.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# NA
-
-<details>
-
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `revdepcheck::cloud_details(, "NA")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# NA
-
-<details>
-
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `revdepcheck::cloud_details(, "NA")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# FORTLS
-
-<details>
-
-* Version: 1.2.0
-* GitHub: https://github.com/Molina-Valero/FORTLS
-* Source code: https://github.com/cran/FORTLS
-* Date/Publication: 2023-01-08 16:50:05 UTC
-* Number of recursive dependencies: 176
-
-Run `revdepcheck::cloud_details(, "FORTLS")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/FORTLS/new/FORTLS.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘FORTLS/DESCRIPTION’ ... OK
-* this is package ‘FORTLS’ version ‘1.2.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/FORTLS/old/FORTLS.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘FORTLS/DESCRIPTION’ ... OK
-* this is package ‘FORTLS’ version ‘1.2.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# FRK
-
-<details>
-
-* Version: 2.1.5
-* GitHub: https://github.com/andrewzm/FRK
-* Source code: https://github.com/cran/FRK
-* Date/Publication: 2023-02-01 10:20:02 UTC
-* Number of recursive dependencies: 156
-
-Run `revdepcheck::cloud_details(, "FRK")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/FRK/new/FRK.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘FRK/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘FRK’ version ‘2.1.5’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-...
---- failed re-building ‘FRK_non-Gaussian.Rnw’
-
-SUMMARY: processing the following files failed:
-  ‘FRK_intro.Rnw’ ‘FRK_non-Gaussian.Rnw’
-
-Error: Vignette re-building failed.
-Execution halted
-
-* DONE
-Status: 1 ERROR, 1 WARNING, 2 NOTEs
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/FRK/old/FRK.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘FRK/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘FRK’ version ‘2.1.5’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-...
---- failed re-building ‘FRK_non-Gaussian.Rnw’
-
-SUMMARY: processing the following files failed:
-  ‘FRK_intro.Rnw’ ‘FRK_non-Gaussian.Rnw’
-
-Error: Vignette re-building failed.
-Execution halted
-
-* DONE
-Status: 1 ERROR, 1 WARNING, 2 NOTEs
-
-
-
-
-
-```
-# fsr
-
-<details>
-
-* Version: 1.0.2
-* GitHub: https://github.com/accarniel/fsr
-* Source code: https://github.com/cran/fsr
-* Date/Publication: 2022-07-05 02:50:02 UTC
-* Number of recursive dependencies: 71
-
-Run `revdepcheck::cloud_details(, "fsr")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/fsr/new/fsr.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘fsr/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘fsr’ version ‘1.0.2’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Packages required but not available: 'sf', 'lwgeom'
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/fsr/old/fsr.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘fsr/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘fsr’ version ‘1.0.2’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Packages required but not available: 'sf', 'lwgeom'
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# GeodesiCL
-
-<details>
-
-* Version: 1.0.0
-* GitHub: https://github.com/diegoalarc/GeodesiCL
-* Source code: https://github.com/cran/GeodesiCL
-* Date/Publication: 2021-05-25 12:20:02 UTC
-* Number of recursive dependencies: 129
-
-Run `revdepcheck::cloud_details(, "GeodesiCL")` for more info
-
-</details>
-
-## In both
-
-*   checking whether package ‘GeodesiCL’ can be installed ... ERROR
-    ```
-    Installation failed.
-    See ‘/tmp/workdir/GeodesiCL/new/GeodesiCL.Rcheck/00install.out’ for details.
-    ```
-
-## Installation
-
-### Devel
-
-```
-* installing *source* package ‘GeodesiCL’ ...
-** package ‘GeodesiCL’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** data
-*** moving datasets to lazyload DB
-** inst
-** byte-compile and prepare package for lazy loading
-Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
-  there is no package called ‘sf’
-Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
-Execution halted
-ERROR: lazy loading failed for package ‘GeodesiCL’
-* removing ‘/tmp/workdir/GeodesiCL/new/GeodesiCL.Rcheck/GeodesiCL’
-
-
-```
-### CRAN
-
-```
-* installing *source* package ‘GeodesiCL’ ...
-** package ‘GeodesiCL’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** data
-*** moving datasets to lazyload DB
-** inst
-** byte-compile and prepare package for lazy loading
-Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
-  there is no package called ‘sf’
-Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
-Execution halted
-ERROR: lazy loading failed for package ‘GeodesiCL’
-* removing ‘/tmp/workdir/GeodesiCL/old/GeodesiCL.Rcheck/GeodesiCL’
-
-
-```
-# ggchangepoint
-
-<details>
-
-* Version: 0.1.0
-* GitHub: NA
-* Source code: https://github.com/cran/ggchangepoint
-* Date/Publication: 2022-02-24 08:20:04 UTC
-* Number of recursive dependencies: 81
-
-Run `revdepcheck::cloud_details(, "ggchangepoint")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/ggchangepoint/new/ggchangepoint.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘ggchangepoint/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘ggchangepoint’ version ‘0.1.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-...
-* checking installed files from ‘inst/doc’ ... OK
-* checking files in ‘vignettes’ ... OK
-* checking examples ... OK
-* checking for unstated dependencies in vignettes ... OK
-* checking package vignettes in ‘inst/doc’ ... OK
-* checking running R code from vignettes ... NONE
-  ‘introduction.Rmd’ using ‘UTF-8’... OK
-* checking re-building of vignette outputs ... OK
-* DONE
-Status: OK
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/ggchangepoint/old/ggchangepoint.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘ggchangepoint/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘ggchangepoint’ version ‘0.1.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-...
-* checking installed files from ‘inst/doc’ ... OK
-* checking files in ‘vignettes’ ... OK
-* checking examples ... OK
-* checking for unstated dependencies in vignettes ... OK
-* checking package vignettes in ‘inst/doc’ ... OK
-* checking running R code from vignettes ... NONE
-  ‘introduction.Rmd’ using ‘UTF-8’... OK
-* checking re-building of vignette outputs ... OK
-* DONE
-Status: OK
-
-
-
-
-
-```
-# ggOceanMaps
-
-<details>
-
-* Version: 1.3.4
-* GitHub: https://github.com/MikkoVihtakari/ggOceanMaps
-* Source code: https://github.com/cran/ggOceanMaps
-* Date/Publication: 2022-09-26 11:50:02 UTC
-* Number of recursive dependencies: 92
-
-Run `revdepcheck::cloud_details(, "ggOceanMaps")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/ggOceanMaps/new/ggOceanMaps.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘ggOceanMaps/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘ggOceanMaps’ version ‘1.3.4’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/ggOceanMaps/old/ggOceanMaps.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘ggOceanMaps/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘ggOceanMaps’ version ‘1.3.4’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# ggspatial
-
-<details>
-
-* Version: 1.1.7
-* GitHub: https://github.com/paleolimbot/ggspatial
-* Source code: https://github.com/cran/ggspatial
-* Date/Publication: 2022-11-24 10:00:02 UTC
-* Number of recursive dependencies: 105
-
-Run `revdepcheck::cloud_details(, "ggspatial")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/ggspatial/new/ggspatial.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘ggspatial/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘ggspatial’ version ‘1.1.7’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-Package suggested but not available for checking: ‘lwgeom’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/ggspatial/old/ggspatial.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘ggspatial/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘ggspatial’ version ‘1.1.7’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-Package suggested but not available for checking: ‘lwgeom’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# glottospace
-
-<details>
-
-* Version: 0.0.112
-* GitHub: https://github.com/SietzeN/glottospace
-* Source code: https://github.com/cran/glottospace
-* Date/Publication: 2022-04-12 12:42:29 UTC
-* Number of recursive dependencies: 141
-
-Run `revdepcheck::cloud_details(, "glottospace")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/glottospace/new/glottospace.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘glottospace/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘glottospace’ version ‘0.0.112’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/glottospace/old/glottospace.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘glottospace/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘glottospace’ version ‘0.0.112’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# GREENeR
-
-<details>
-
-* Version: 0.1.1
-* GitHub: https://github.com/calfarog/GREENeR
-* Source code: https://github.com/cran/GREENeR
-* Date/Publication: 2022-09-07 12:10:02 UTC
-* Number of recursive dependencies: 133
-
-Run `revdepcheck::cloud_details(, "GREENeR")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/GREENeR/new/GREENeR.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘GREENeR/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘GREENeR’ version ‘0.1.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/GREENeR/old/GREENeR.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘GREENeR/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘GREENeR’ version ‘0.1.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# gumboot
-
-<details>
-
-* Version: 1.0.0
-* GitHub: NA
-* Source code: https://github.com/cran/gumboot
-* Date/Publication: 2021-08-06 08:10:01 UTC
-* Number of recursive dependencies: 101
-
-Run `revdepcheck::cloud_details(, "gumboot")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/gumboot/new/gumboot.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘gumboot/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘gumboot’ version ‘1.0.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-...
-* checking if there is a namespace ... OK
-* checking for executable files ... OK
-* checking for hidden files and directories ... OK
-* checking for portable file names ... OK
-* checking for sufficient/correct file permissions ... OK
-* checking whether package ‘gumboot’ can be installed ... ERROR
-Installation failed.
-See ‘/tmp/workdir/gumboot/new/gumboot.Rcheck/00install.out’ for details.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/gumboot/old/gumboot.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘gumboot/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘gumboot’ version ‘1.0.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-...
-* checking if there is a namespace ... OK
-* checking for executable files ... OK
-* checking for hidden files and directories ... OK
-* checking for portable file names ... OK
-* checking for sufficient/correct file permissions ... OK
-* checking whether package ‘gumboot’ can be installed ... ERROR
-Installation failed.
-See ‘/tmp/workdir/gumboot/old/gumboot.Rcheck/00install.out’ for details.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# gwavr
-
-<details>
-
-* Version: 0.2.0
-* GitHub: https://github.com/joshualerickson/gwavr
-* Source code: https://github.com/cran/gwavr
-* Date/Publication: 2022-03-28 21:30:02 UTC
-* Number of recursive dependencies: 140
-
-Run `revdepcheck::cloud_details(, "gwavr")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/gwavr/new/gwavr.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘gwavr/DESCRIPTION’ ... OK
-* this is package ‘gwavr’ version ‘0.2.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Packages required but not available: 'nhdplusTools', 'sf'
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/gwavr/old/gwavr.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘gwavr/DESCRIPTION’ ... OK
-* this is package ‘gwavr’ version ‘0.2.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Packages required but not available: 'nhdplusTools', 'sf'
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# GWPR.light
-
-<details>
-
-* Version: 0.2.1
-* GitHub: https://github.com/MichaelChaoLi-cpu/GWPR.light
-* Source code: https://github.com/cran/GWPR.light
-* Date/Publication: 2022-06-21 11:00:13 UTC
-* Number of recursive dependencies: 129
-
-Run `revdepcheck::cloud_details(, "GWPR.light")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/GWPR.light/new/GWPR.light.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘GWPR.light/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘GWPR.light’ version ‘0.2.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-...
-* checking if there is a namespace ... OK
-* checking for executable files ... OK
-* checking for hidden files and directories ... OK
-* checking for portable file names ... OK
-* checking for sufficient/correct file permissions ... OK
-* checking whether package ‘GWPR.light’ can be installed ... ERROR
-Installation failed.
-See ‘/tmp/workdir/GWPR.light/new/GWPR.light.Rcheck/00install.out’ for details.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/GWPR.light/old/GWPR.light.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘GWPR.light/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘GWPR.light’ version ‘0.2.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-...
-* checking if there is a namespace ... OK
-* checking for executable files ... OK
-* checking for hidden files and directories ... OK
-* checking for portable file names ... OK
-* checking for sufficient/correct file permissions ... OK
-* checking whether package ‘GWPR.light’ can be installed ... ERROR
-Installation failed.
-See ‘/tmp/workdir/GWPR.light/old/GWPR.light.Rcheck/00install.out’ for details.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# happign
-
-<details>
-
-* Version: 0.1.8
-* GitHub: https://github.com/paul-carteron/happign
-* Source code: https://github.com/cran/happign
-* Date/Publication: 2023-01-30 20:50:02 UTC
-* Number of recursive dependencies: 121
-
-Run `revdepcheck::cloud_details(, "happign")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/happign/new/happign.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘happign/DESCRIPTION’ ... OK
-* this is package ‘happign’ version ‘0.1.8’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/happign/old/happign.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘happign/DESCRIPTION’ ... OK
-* this is package ‘happign’ version ‘0.1.8’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# himach
-
-<details>
-
-* Version: 0.3.1
-* GitHub: https://github.com/david6marsh/himach
-* Source code: https://github.com/cran/himach
-* Date/Publication: 2022-12-05 09:30:02 UTC
-* Number of recursive dependencies: 108
-
-Run `revdepcheck::cloud_details(, "himach")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/himach/new/himach.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘himach/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘himach’ version ‘0.3.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Packages required but not available: 'lwgeom', 'sf'
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/himach/old/himach.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘himach/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘himach’ version ‘0.3.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Packages required but not available: 'lwgeom', 'sf'
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# HYPEtools
-
-<details>
-
-* Version: 1.2.0
-* GitHub: https://github.com/rcapell/HYPEtools
-* Source code: https://github.com/cran/HYPEtools
-* Date/Publication: 2023-02-10 08:50:06 UTC
-* Number of recursive dependencies: 174
-
-Run `revdepcheck::cloud_details(, "HYPEtools")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/HYPEtools/new/HYPEtools.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘HYPEtools/DESCRIPTION’ ... OK
-* this is package ‘HYPEtools’ version ‘1.2.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/HYPEtools/old/HYPEtools.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘HYPEtools/DESCRIPTION’ ... OK
-* this is package ‘HYPEtools’ version ‘1.2.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# hypsoLoop
-
-<details>
-
-* Version: 0.2.0
-* GitHub: NA
-* Source code: https://github.com/cran/hypsoLoop
-* Date/Publication: 2022-02-08 09:00:02 UTC
-* Number of recursive dependencies: 109
-
-Run `revdepcheck::cloud_details(, "hypsoLoop")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/hypsoLoop/new/hypsoLoop.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘hypsoLoop/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘hypsoLoop’ version ‘0.2.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/hypsoLoop/old/hypsoLoop.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘hypsoLoop/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘hypsoLoop’ version ‘0.2.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# incidence2
-
-<details>
-
-* Version: 1.2.3
-* GitHub: https://github.com/reconverse/incidence2
-* Source code: https://github.com/cran/incidence2
-* Date/Publication: 2021-11-07 22:00:02 UTC
-* Number of recursive dependencies: 73
-
-Run `revdepcheck::cloud_details(, "incidence2")` for more info
-
-</details>
-
-## In both
-
-*   checking whether package ‘incidence2’ can be installed ... ERROR
-    ```
-    Installation failed.
-    See ‘/tmp/workdir/incidence2/new/incidence2.Rcheck/00install.out’ for details.
-    ```
-
-## Installation
-
-### Devel
-
-```
-* installing *source* package ‘incidence2’ ...
-** package ‘incidence2’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** data
-*** moving datasets to lazyload DB
-** inst
-** byte-compile and prepare package for lazy loading
-Error : The `x` argument of `as_tibble()` can't be missing as of tibble 3.0.0.
-Error: unable to load R code in package ‘incidence2’
-Execution halted
-ERROR: lazy loading failed for package ‘incidence2’
-* removing ‘/tmp/workdir/incidence2/new/incidence2.Rcheck/incidence2’
-
-
-```
-### CRAN
-
-```
-* installing *source* package ‘incidence2’ ...
-** package ‘incidence2’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** data
-*** moving datasets to lazyload DB
-** inst
-** byte-compile and prepare package for lazy loading
-Error : The `x` argument of `as_tibble()` can't be missing as of tibble 3.0.0.
-Error: unable to load R code in package ‘incidence2’
-Execution halted
-ERROR: lazy loading failed for package ‘incidence2’
-* removing ‘/tmp/workdir/incidence2/old/incidence2.Rcheck/incidence2’
-
-
-```
-# NA
-
-<details>
-
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `revdepcheck::cloud_details(, "NA")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# intSDM
-
-<details>
-
-* Version: 1.0.5
-* GitHub: NA
-* Source code: https://github.com/cran/intSDM
-* Date/Publication: 2023-02-17 09:00:02 UTC
-* Number of recursive dependencies: 154
-
-Run `revdepcheck::cloud_details(, "intSDM")` for more info
-
-</details>
-
-## In both
-
-*   checking whether package ‘intSDM’ can be installed ... ERROR
-    ```
-    Installation failed.
-    See ‘/tmp/workdir/intSDM/new/intSDM.Rcheck/00install.out’ for details.
-    ```
-
-*   checking package dependencies ... NOTE
-    ```
-    Package suggested but not available for checking: ‘sf’
-    ```
-
-## Installation
-
-### Devel
-
-```
-* installing *source* package ‘intSDM’ ...
-** package ‘intSDM’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** data
-*** moving datasets to lazyload DB
-** inst
-** byte-compile and prepare package for lazy loading
-Error: package or namespace load failed for ‘PointedSDMs’ in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]):
- there is no package called ‘sf’
-Execution halted
-ERROR: lazy loading failed for package ‘intSDM’
-* removing ‘/tmp/workdir/intSDM/new/intSDM.Rcheck/intSDM’
-
-
-```
-### CRAN
-
-```
-* installing *source* package ‘intSDM’ ...
-** package ‘intSDM’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** data
-*** moving datasets to lazyload DB
-** inst
-** byte-compile and prepare package for lazy loading
-Error: package or namespace load failed for ‘PointedSDMs’ in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]):
- there is no package called ‘sf’
-Execution halted
-ERROR: lazy loading failed for package ‘intSDM’
-* removing ‘/tmp/workdir/intSDM/old/intSDM.Rcheck/intSDM’
-
-
-```
-# NA
-
-<details>
-
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `revdepcheck::cloud_details(, "NA")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# itsdm
-
-<details>
-
-* Version: 0.2.0
-* GitHub: https://github.com/LLeiSong/itsdm
-* Source code: https://github.com/cran/itsdm
-* Date/Publication: 2023-01-15 14:30:08 UTC
-* Number of recursive dependencies: 84
-
-Run `revdepcheck::cloud_details(, "itsdm")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/itsdm/new/itsdm.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘itsdm/DESCRIPTION’ ... OK
-* this is package ‘itsdm’ version ‘0.2.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/itsdm/old/itsdm.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘itsdm/DESCRIPTION’ ... OK
-* this is package ‘itsdm’ version ‘0.2.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# jpgrid
-
-<details>
-
-* Version: 0.3.0
-* GitHub: https://github.com/UchidaMizuki/jpgrid
-* Source code: https://github.com/cran/jpgrid
-* Date/Publication: 2023-02-11 08:50:06 UTC
-* Number of recursive dependencies: 57
-
-Run `revdepcheck::cloud_details(, "jpgrid")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/jpgrid/new/jpgrid.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘jpgrid/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘jpgrid’ version ‘0.3.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/jpgrid/old/jpgrid.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘jpgrid/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘jpgrid’ version ‘0.3.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# jpmesh
-
-<details>
-
-* Version: 2.1.0
-* GitHub: https://github.com/uribo/jpmesh
-* Source code: https://github.com/cran/jpmesh
-* Date/Publication: 2022-01-10 03:32:41 UTC
-* Number of recursive dependencies: 108
-
-Run `revdepcheck::cloud_details(, "jpmesh")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/jpmesh/new/jpmesh.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘jpmesh/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘jpmesh’ version ‘2.1.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-Package suggested but not available for checking: ‘lwgeom’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/jpmesh/old/jpmesh.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘jpmesh/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘jpmesh’ version ‘2.1.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-Package suggested but not available for checking: ‘lwgeom’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# NA
-
-<details>
-
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `revdepcheck::cloud_details(, "NA")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# MainExistingDatasets
-
-<details>
-
-* Version: 1.0.1
-* GitHub: NA
-* Source code: https://github.com/cran/MainExistingDatasets
-* Date/Publication: 2022-06-27 14:10:02 UTC
-* Number of recursive dependencies: 131
-
-Run `revdepcheck::cloud_details(, "MainExistingDatasets")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/MainExistingDatasets/new/MainExistingDatasets.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘MainExistingDatasets/DESCRIPTION’ ... OK
-* this is package ‘MainExistingDatasets’ version ‘1.0.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/MainExistingDatasets/old/MainExistingDatasets.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘MainExistingDatasets/DESCRIPTION’ ... OK
-* this is package ‘MainExistingDatasets’ version ‘1.0.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# NA
-
-<details>
-
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `revdepcheck::cloud_details(, "NA")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# manydata
-
-<details>
-
-* Version: 0.8.2
-* GitHub: https://github.com/globalgov/manydata
-* Source code: https://github.com/cran/manydata
-* Date/Publication: 2022-11-19 13:00:10 UTC
-* Number of recursive dependencies: 169
-
-Run `revdepcheck::cloud_details(, "manydata")` for more info
-
-</details>
-
-## In both
-
-*   checking whether package ‘manydata’ can be installed ... ERROR
-    ```
-    Installation failed.
-    See ‘/tmp/workdir/manydata/new/manydata.Rcheck/00install.out’ for details.
-    ```
-
-## Installation
-
-### Devel
-
-```
-* installing *source* package ‘manydata’ ...
-** package ‘manydata’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** data
-*** moving datasets to lazyload DB
-** inst
-** byte-compile and prepare package for lazy loading
-Error in loadNamespace(j <- i[[1L]], c(lib.loc, .libPaths()), versionCheck = vI[[j]]) : 
-  there is no package called ‘sf’
-Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
-Execution halted
-ERROR: lazy loading failed for package ‘manydata’
-* removing ‘/tmp/workdir/manydata/new/manydata.Rcheck/manydata’
-
-
-```
-### CRAN
-
-```
-* installing *source* package ‘manydata’ ...
-** package ‘manydata’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** data
-*** moving datasets to lazyload DB
-** inst
-** byte-compile and prepare package for lazy loading
-Error in loadNamespace(j <- i[[1L]], c(lib.loc, .libPaths()), versionCheck = vI[[j]]) : 
-  there is no package called ‘sf’
-Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
-Execution halted
-ERROR: lazy loading failed for package ‘manydata’
-* removing ‘/tmp/workdir/manydata/old/manydata.Rcheck/manydata’
-
-
-```
-# mapboxapi
-
-<details>
-
-* Version: 0.5
-* GitHub: NA
-* Source code: https://github.com/cran/mapboxapi
-* Date/Publication: 2022-09-15 16:06:12 UTC
-* Number of recursive dependencies: 154
-
-Run `revdepcheck::cloud_details(, "mapboxapi")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/mapboxapi/new/mapboxapi.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘mapboxapi/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘mapboxapi’ version ‘0.5’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/mapboxapi/old/mapboxapi.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘mapboxapi/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘mapboxapi’ version ‘0.5’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# mapme.biodiversity
-
-<details>
-
-* Version: 0.3.0
-* GitHub: https://github.com/mapme-initiative/mapme.biodiversity
-* Source code: https://github.com/cran/mapme.biodiversity
-* Date/Publication: 2023-01-21 14:10:02 UTC
-* Number of recursive dependencies: 131
-
-Run `revdepcheck::cloud_details(, "mapme.biodiversity")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/mapme.biodiversity/new/mapme.biodiversity.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘mapme.biodiversity/DESCRIPTION’ ... OK
-* this is package ‘mapme.biodiversity’ version ‘0.3.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-Package suggested but not available for checking: ‘lwgeom’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/mapme.biodiversity/old/mapme.biodiversity.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘mapme.biodiversity/DESCRIPTION’ ... OK
-* this is package ‘mapme.biodiversity’ version ‘0.3.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-Package suggested but not available for checking: ‘lwgeom’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# mapping
-
-<details>
-
-* Version: 1.3
-* GitHub: https://github.com/serafinialessio/mapping
-* Source code: https://github.com/cran/mapping
-* Date/Publication: 2021-07-22 17:40:02 UTC
-* Number of recursive dependencies: 147
-
-Run `revdepcheck::cloud_details(, "mapping")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/mapping/new/mapping.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘mapping/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘mapping’ version ‘1.3’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/mapping/old/mapping.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘mapping/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘mapping’ version ‘1.3’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# mapscanner
-
-<details>
-
-* Version: 0.0.6
-* GitHub: https://github.com/ropensci/mapscanner
-* Source code: https://github.com/cran/mapscanner
-* Date/Publication: 2021-11-25 23:10:03 UTC
-* Number of recursive dependencies: 143
-
-Run `revdepcheck::cloud_details(, "mapscanner")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/mapscanner/new/mapscanner.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘mapscanner/DESCRIPTION’ ... OK
-* this is package ‘mapscanner’ version ‘0.0.6’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-Package suggested but not available for checking: ‘lwgeom’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/mapscanner/old/mapscanner.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘mapscanner/DESCRIPTION’ ... OK
-* this is package ‘mapscanner’ version ‘0.0.6’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-Package suggested but not available for checking: ‘lwgeom’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# MazamaSpatialPlots
-
-<details>
-
-* Version: 0.2.0
-* GitHub: https://github.com/MazamaScience/MazamaSpatialPlots
-* Source code: https://github.com/cran/MazamaSpatialPlots
-* Date/Publication: 2022-11-15 21:00:08 UTC
-* Number of recursive dependencies: 180
-
-Run `revdepcheck::cloud_details(, "MazamaSpatialPlots")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/MazamaSpatialPlots/new/MazamaSpatialPlots.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘MazamaSpatialPlots/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘MazamaSpatialPlots’ version ‘0.2.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/MazamaSpatialPlots/old/MazamaSpatialPlots.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘MazamaSpatialPlots/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘MazamaSpatialPlots’ version ‘0.2.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# NA
-
-<details>
-
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `revdepcheck::cloud_details(, "NA")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# meteoland
-
-<details>
-
-* Version: 2.0.0
-* GitHub: NA
-* Source code: https://github.com/cran/meteoland
-* Date/Publication: 2023-02-17 22:20:02 UTC
-* Number of recursive dependencies: 155
-
-Run `revdepcheck::cloud_details(, "meteoland")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/meteoland/new/meteoland.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘meteoland/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘meteoland’ version ‘2.0.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/meteoland/old/meteoland.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘meteoland/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘meteoland’ version ‘2.0.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# NA
-
-<details>
-
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `revdepcheck::cloud_details(, "NA")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# NA
-
-<details>
-
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `revdepcheck::cloud_details(, "NA")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# motif
-
-<details>
-
-* Version: 0.5.2
-* GitHub: https://github.com/Nowosad/motif
-* Source code: https://github.com/cran/motif
-* Date/Publication: 2022-06-07 05:10:02 UTC
-* Number of recursive dependencies: 86
-
-Run `revdepcheck::cloud_details(, "motif")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/motif/new/motif.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘motif/DESCRIPTION’ ... OK
-* this is package ‘motif’ version ‘0.5.2’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/motif/old/motif.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘motif/DESCRIPTION’ ... OK
-* this is package ‘motif’ version ‘0.5.2’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# MSclassifR
-
-<details>
-
-* Version: 0.3.1
-* GitHub: https://github.com/agodmer/MSclassifR_examples
-* Source code: https://github.com/cran/MSclassifR
-* Date/Publication: 2022-09-29 06:10:12 UTC
-* Number of recursive dependencies: 227
-
-Run `revdepcheck::cloud_details(, "MSclassifR")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/MSclassifR/new/MSclassifR.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘MSclassifR/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘MSclassifR’ version ‘0.3.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘VSURF’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/MSclassifR/old/MSclassifR.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘MSclassifR/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘MSclassifR’ version ‘0.3.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘VSURF’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# naturaList
-
-<details>
-
-* Version: 0.5.0
-* GitHub: https://github.com/avrodrigues/naturaList
-* Source code: https://github.com/cran/naturaList
-* Date/Publication: 2022-04-20 13:30:02 UTC
-* Number of recursive dependencies: 129
-
-Run `revdepcheck::cloud_details(, "naturaList")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/naturaList/new/naturaList.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘naturaList/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘naturaList’ version ‘0.5.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-Package suggested but not available for checking: ‘lwgeom’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/naturaList/old/naturaList.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘naturaList/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘naturaList’ version ‘0.5.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-Package suggested but not available for checking: ‘lwgeom’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# ncdfgeom
-
-<details>
-
-* Version: 1.1.4
-* GitHub: https://github.com/USGS-R/ncdfgeom
-* Source code: https://github.com/cran/ncdfgeom
-* Date/Publication: 2022-11-08 22:40:02 UTC
-* Number of recursive dependencies: 90
-
-Run `revdepcheck::cloud_details(, "ncdfgeom")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/ncdfgeom/new/ncdfgeom.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘ncdfgeom/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘ncdfgeom’ version ‘1.1.4’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/ncdfgeom/old/ncdfgeom.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘ncdfgeom/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘ncdfgeom’ version ‘1.1.4’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# nhdplusTools
-
-<details>
-
-* Version: 0.6.2
-* GitHub: https://github.com/doi-usgs/nhdplusTools
-* Source code: https://github.com/cran/nhdplusTools
-* Date/Publication: 2023-03-10 09:40:14 UTC
-* Number of recursive dependencies: 167
-
-Run `revdepcheck::cloud_details(, "nhdplusTools")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/nhdplusTools/new/nhdplusTools.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘nhdplusTools/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘nhdplusTools’ version ‘0.6.2’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-Package suggested but not available for checking: ‘lwgeom’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/nhdplusTools/old/nhdplusTools.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘nhdplusTools/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘nhdplusTools’ version ‘0.6.2’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-Package suggested but not available for checking: ‘lwgeom’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# nhdR
-
-<details>
-
-* Version: 0.5.9
-* GitHub: https://github.com/jsta/nhdR
-* Source code: https://github.com/cran/nhdR
-* Date/Publication: 2022-10-09 02:10:02 UTC
-* Number of recursive dependencies: 104
-
-Run `revdepcheck::cloud_details(, "nhdR")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/nhdR/new/nhdR.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘nhdR/DESCRIPTION’ ... OK
-* this is package ‘nhdR’ version ‘0.5.9’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-Package suggested but not available for checking: ‘lwgeom’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/nhdR/old/nhdR.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘nhdR/DESCRIPTION’ ... OK
-* this is package ‘nhdR’ version ‘0.5.9’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-Package suggested but not available for checking: ‘lwgeom’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# NA
-
-<details>
-
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `revdepcheck::cloud_details(, "NA")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# occCite
-
-<details>
-
-* Version: 0.5.6
-* GitHub: https://github.com/ropensci/occCite
-* Source code: https://github.com/cran/occCite
-* Date/Publication: 2022-08-05 11:40:02 UTC
-* Number of recursive dependencies: 176
-
-Run `revdepcheck::cloud_details(, "occCite")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/occCite/new/occCite.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘occCite/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘occCite’ version ‘0.5.6’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘BIEN’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/occCite/old/occCite.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘occCite/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘occCite’ version ‘0.5.6’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘BIEN’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# oceanexplorer
-
-<details>
-
-* Version: 0.0.2
-* GitHub: https://github.com/UtrechtUniversity/oceanexplorer
-* Source code: https://github.com/cran/oceanexplorer
-* Date/Publication: 2022-09-15 09:10:08 UTC
-* Number of recursive dependencies: 158
-
-Run `revdepcheck::cloud_details(, "oceanexplorer")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/oceanexplorer/new/oceanexplorer.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘oceanexplorer/DESCRIPTION’ ... OK
-* this is package ‘oceanexplorer’ version ‘0.0.2’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/oceanexplorer/old/oceanexplorer.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘oceanexplorer/DESCRIPTION’ ... OK
-* this is package ‘oceanexplorer’ version ‘0.0.2’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# oceanis
-
-<details>
-
-* Version: 1.8.5
-* GitHub: https://github.com/insee-psar-at/oceanis-package
-* Source code: https://github.com/cran/oceanis
-* Date/Publication: 2022-07-13 13:10:02 UTC
-* Number of recursive dependencies: 117
-
-Run `revdepcheck::cloud_details(, "oceanis")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/oceanis/new/oceanis.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘oceanis/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘oceanis’ version ‘1.8.5’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Packages required but not available: 'sf', 'lwgeom'
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/oceanis/old/oceanis.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘oceanis/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘oceanis’ version ‘1.8.5’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Packages required but not available: 'sf', 'lwgeom'
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# OpenLand
-
-<details>
-
-* Version: 1.0.2
-* GitHub: https://github.com/reginalexavier/OpenLand
-* Source code: https://github.com/cran/OpenLand
-* Date/Publication: 2021-11-02 07:20:02 UTC
-* Number of recursive dependencies: 121
-
-Run `revdepcheck::cloud_details(, "OpenLand")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/OpenLand/new/OpenLand.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘OpenLand/DESCRIPTION’ ... OK
-* this is package ‘OpenLand’ version ‘1.0.2’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... OK
-...
-* checking for unstated dependencies in ‘tests’ ... OK
-* checking tests ... OK
-  Running ‘testthat.R’
-* checking for unstated dependencies in vignettes ... OK
-* checking package vignettes in ‘inst/doc’ ... OK
-* checking running R code from vignettes ... NONE
-  ‘openland_vignette.Rmd’ using ‘UTF-8’... OK
-* checking re-building of vignette outputs ... OK
-* DONE
-Status: OK
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/OpenLand/old/OpenLand.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘OpenLand/DESCRIPTION’ ... OK
-* this is package ‘OpenLand’ version ‘1.0.2’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... OK
-...
-* checking for unstated dependencies in ‘tests’ ... OK
-* checking tests ... OK
-  Running ‘testthat.R’
-* checking for unstated dependencies in vignettes ... OK
-* checking package vignettes in ‘inst/doc’ ... OK
-* checking running R code from vignettes ... NONE
-  ‘openland_vignette.Rmd’ using ‘UTF-8’... OK
-* checking re-building of vignette outputs ... OK
-* DONE
-Status: OK
-
-
-
-
-
-```
-# palaeoSig
-
-<details>
-
-* Version: 2.1-3
-* GitHub: https://github.com/richardjtelford/palaeoSig
-* Source code: https://github.com/cran/palaeoSig
-* Date/Publication: 2023-03-10 09:30:02 UTC
-* Number of recursive dependencies: 104
-
-Run `revdepcheck::cloud_details(, "palaeoSig")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/palaeoSig/new/palaeoSig.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘palaeoSig/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘palaeoSig’ version ‘2.1-3’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-...
---- failed re-building ‘randomTF-spatial.Rmd’
-
-SUMMARY: processing the following files failed:
-  ‘h-block-crossvalidation.Rmd’ ‘randomTF-spatial.Rmd’
-
-Error: Vignette re-building failed.
-Execution halted
-
-* DONE
-Status: 1 ERROR, 1 WARNING, 1 NOTE
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/palaeoSig/old/palaeoSig.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘palaeoSig/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘palaeoSig’ version ‘2.1-3’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-...
---- failed re-building ‘randomTF-spatial.Rmd’
-
-SUMMARY: processing the following files failed:
-  ‘h-block-crossvalidation.Rmd’ ‘randomTF-spatial.Rmd’
-
-Error: Vignette re-building failed.
-Execution halted
-
-* DONE
-Status: 1 ERROR, 1 WARNING, 1 NOTE
-
-
-
-
-
-```
-# NA
-
-<details>
-
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `revdepcheck::cloud_details(, "NA")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# NA
-
-<details>
-
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `revdepcheck::cloud_details(, "NA")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# PopGenHelpR
-
-<details>
-
-* Version: 1.0.0
-* GitHub: https://github.com/kfarleigh/PopGenHelpR
-* Source code: https://github.com/cran/PopGenHelpR
-* Date/Publication: 2023-02-13 08:40:05 UTC
-* Number of recursive dependencies: 187
-
-Run `revdepcheck::cloud_details(, "PopGenHelpR")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/PopGenHelpR/new/PopGenHelpR.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘PopGenHelpR/DESCRIPTION’ ... OK
-* this is package ‘PopGenHelpR’ version ‘1.0.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... OK
-...
-* checking for unstated dependencies in ‘tests’ ... OK
-* checking tests ... OK
-  Running ‘testthat.R’
-* checking for unstated dependencies in vignettes ... OK
-* checking package vignettes in ‘inst/doc’ ... OK
-* checking running R code from vignettes ... NONE
-  ‘PopGenHelpR_vignette.Rmd’ using ‘UTF-8’... OK
-* checking re-building of vignette outputs ... OK
-* DONE
-Status: OK
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/PopGenHelpR/old/PopGenHelpR.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘PopGenHelpR/DESCRIPTION’ ... OK
-* this is package ‘PopGenHelpR’ version ‘1.0.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... OK
-...
-* checking for unstated dependencies in ‘tests’ ... OK
-* checking tests ... OK
-  Running ‘testthat.R’
-* checking for unstated dependencies in vignettes ... OK
-* checking package vignettes in ‘inst/doc’ ... OK
-* checking running R code from vignettes ... NONE
-  ‘PopGenHelpR_vignette.Rmd’ using ‘UTF-8’... OK
-* checking re-building of vignette outputs ... OK
-* DONE
-Status: OK
-
-
-
-
-
-```
-# ppcSpatial
-
-<details>
-
-* Version: 0.2.0
-* GitHub: https://github.com/MYaseen208/ppcSpatial
-* Source code: https://github.com/cran/ppcSpatial
-* Date/Publication: 2018-03-07 15:54:23 UTC
-* Number of recursive dependencies: 118
-
-Run `revdepcheck::cloud_details(, "ppcSpatial")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/ppcSpatial/new/ppcSpatial.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘ppcSpatial/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘ppcSpatial’ version ‘0.2.0’
-* checking package namespace information ... OK
-* checking package dependencies ... OK
-...
-* checking if there is a namespace ... OK
-* checking for executable files ... OK
-* checking for hidden files and directories ... OK
-* checking for portable file names ... OK
-* checking for sufficient/correct file permissions ... OK
-* checking whether package ‘ppcSpatial’ can be installed ... ERROR
-Installation failed.
-See ‘/tmp/workdir/ppcSpatial/new/ppcSpatial.Rcheck/00install.out’ for details.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/ppcSpatial/old/ppcSpatial.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘ppcSpatial/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘ppcSpatial’ version ‘0.2.0’
-* checking package namespace information ... OK
-* checking package dependencies ... OK
-...
-* checking if there is a namespace ... OK
-* checking for executable files ... OK
-* checking for hidden files and directories ... OK
-* checking for portable file names ... OK
-* checking for sufficient/correct file permissions ... OK
-* checking whether package ‘ppcSpatial’ can be installed ... ERROR
-Installation failed.
-See ‘/tmp/workdir/ppcSpatial/old/ppcSpatial.Rcheck/00install.out’ for details.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# prioriactions
-
-<details>
-
-* Version: 0.4.1
-* GitHub: https://github.com/prioriactions/prioriactions
-* Source code: https://github.com/cran/prioriactions
-* Date/Publication: 2022-08-16 13:30:02 UTC
-* Number of recursive dependencies: 130
-
-Run `revdepcheck::cloud_details(, "prioriactions")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/prioriactions/new/prioriactions.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘prioriactions/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘prioriactions’ version ‘0.4.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-...
-* checking for unstated dependencies in vignettes ... OK
-* checking package vignettes in ‘inst/doc’ ... OK
-* checking running R code from vignettes ... NONE
-  ‘objectives.Rmd’ using ‘UTF-8’... OK
-  ‘sensitivities.Rmd’ using ‘UTF-8’... OK
-  ‘MitchellRiver.Rmd’ using ‘UTF-8’... OK
-  ‘prioriactions.Rmd’ using ‘UTF-8’... OK
-* checking re-building of vignette outputs ... OK
-* DONE
-Status: 2 NOTEs
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/prioriactions/old/prioriactions.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘prioriactions/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘prioriactions’ version ‘0.4.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-...
-* checking for unstated dependencies in vignettes ... OK
-* checking package vignettes in ‘inst/doc’ ... OK
-* checking running R code from vignettes ... NONE
-  ‘objectives.Rmd’ using ‘UTF-8’... OK
-  ‘sensitivities.Rmd’ using ‘UTF-8’... OK
-  ‘MitchellRiver.Rmd’ using ‘UTF-8’... OK
-  ‘prioriactions.Rmd’ using ‘UTF-8’... OK
-* checking re-building of vignette outputs ... OK
-* DONE
-Status: 2 NOTEs
-
-
-
-
-
-```
-# PSS.Health
-
-<details>
-
-* Version: 0.6.1
-* GitHub: NA
-* Source code: https://github.com/cran/PSS.Health
-* Date/Publication: 2023-02-01 17:50:11 UTC
-* Number of recursive dependencies: 187
-
-Run `revdepcheck::cloud_details(, "PSS.Health")` for more info
-
-</details>
-
-## In both
-
-*   checking whether package ‘PSS.Health’ can be installed ... ERROR
-    ```
-    Installation failed.
-    See ‘/tmp/workdir/PSS.Health/new/PSS.Health.Rcheck/00install.out’ for details.
-    ```
-
-## Installation
-
-### Devel
-
-```
-* installing *source* package ‘PSS.Health’ ...
-** package ‘PSS.Health’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** inst
-** byte-compile and prepare package for lazy loading
-Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
-  there is no package called ‘sf’
-Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
-Execution halted
-ERROR: lazy loading failed for package ‘PSS.Health’
-* removing ‘/tmp/workdir/PSS.Health/new/PSS.Health.Rcheck/PSS.Health’
-
-
-```
-### CRAN
-
-```
-* installing *source* package ‘PSS.Health’ ...
-** package ‘PSS.Health’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** inst
-** byte-compile and prepare package for lazy loading
-Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
-  there is no package called ‘sf’
-Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
-Execution halted
-ERROR: lazy loading failed for package ‘PSS.Health’
-* removing ‘/tmp/workdir/PSS.Health/old/PSS.Health.Rcheck/PSS.Health’
-
-
-```
-# rangeModelMetadata
-
-<details>
-
-* Version: 0.1.4
-* GitHub: NA
-* Source code: https://github.com/cran/rangeModelMetadata
-* Date/Publication: 2021-06-11 08:40:02 UTC
-* Number of recursive dependencies: 192
-
-Run `revdepcheck::cloud_details(, "rangeModelMetadata")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/rangeModelMetadata/new/rangeModelMetadata.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘rangeModelMetadata/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘rangeModelMetadata’ version ‘0.1.4’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-...
-* checking examples ... OK
-* checking for unstated dependencies in vignettes ... OK
-* checking package vignettes in ‘inst/doc’ ... OK
-* checking running R code from vignettes ... NONE
-  ‘rmm_Multispecies.Rmd’ using ‘UTF-8’... OK
-  ‘rmm_directory.Rmd’ using ‘UTF-8’... OK
-  ‘rmm_vignette.Rmd’ using ‘UTF-8’... OK
-* checking re-building of vignette outputs ... OK
-* DONE
-Status: 3 NOTEs
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/rangeModelMetadata/old/rangeModelMetadata.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘rangeModelMetadata/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘rangeModelMetadata’ version ‘0.1.4’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-...
-* checking examples ... OK
-* checking for unstated dependencies in vignettes ... OK
-* checking package vignettes in ‘inst/doc’ ... OK
-* checking running R code from vignettes ... NONE
-  ‘rmm_Multispecies.Rmd’ using ‘UTF-8’... OK
-  ‘rmm_directory.Rmd’ using ‘UTF-8’... OK
-  ‘rmm_vignette.Rmd’ using ‘UTF-8’... OK
-* checking re-building of vignette outputs ... OK
-* DONE
-Status: 3 NOTEs
-
-
-
-
-
-```
-# rbenvo
-
-<details>
-
-* Version: 1.0.5
-* GitHub: https://github.com/apeterson91/rbenvo
-* Source code: https://github.com/cran/rbenvo
-* Date/Publication: 2020-11-18 10:40:02 UTC
-* Number of recursive dependencies: 104
-
-Run `revdepcheck::cloud_details(, "rbenvo")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/rbenvo/new/rbenvo.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘rbenvo/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘rbenvo’ version ‘1.0.5’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-Package suggested but not available for checking: ‘lwgeom’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/rbenvo/old/rbenvo.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘rbenvo/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘rbenvo’ version ‘1.0.5’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-Package suggested but not available for checking: ‘lwgeom’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# rcontroll
-
-<details>
-
-* Version: 0.1.0
-* GitHub: https://github.com/sylvainschmitt/rcontroll
-* Source code: https://github.com/cran/rcontroll
-* Date/Publication: 2023-02-11 15:20:02 UTC
-* Number of recursive dependencies: 128
-
-Run `revdepcheck::cloud_details(, "rcontroll")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/rcontroll/new/rcontroll.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘rcontroll/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘rcontroll’ version ‘0.1.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-...
-* checking if there is a namespace ... OK
-* checking for executable files ... OK
-* checking for hidden files and directories ... OK
-* checking for portable file names ... OK
-* checking for sufficient/correct file permissions ... OK
-* checking whether package ‘rcontroll’ can be installed ... ERROR
-Installation failed.
-See ‘/tmp/workdir/rcontroll/new/rcontroll.Rcheck/00install.out’ for details.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/rcontroll/old/rcontroll.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘rcontroll/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘rcontroll’ version ‘0.1.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-...
-* checking if there is a namespace ... OK
-* checking for executable files ... OK
-* checking for hidden files and directories ... OK
-* checking for portable file names ... OK
-* checking for sufficient/correct file permissions ... OK
-* checking whether package ‘rcontroll’ can be installed ... ERROR
-Installation failed.
-See ‘/tmp/workdir/rcontroll/old/rcontroll.Rcheck/00install.out’ for details.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# NA
-
-<details>
-
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `revdepcheck::cloud_details(, "NA")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# redist
-
-<details>
-
-* Version: 4.0.1
-* GitHub: https://github.com/alarm-redist/redist
-* Source code: https://github.com/cran/redist
-* Date/Publication: 2022-06-16 06:20:07 UTC
-* Number of recursive dependencies: 150
-
-Run `revdepcheck::cloud_details(, "redist")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/redist/new/redist.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘redist/DESCRIPTION’ ... OK
-* this is package ‘redist’ version ‘4.0.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-Package suggested but not available for checking: ‘lwgeom’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/redist/old/redist.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘redist/DESCRIPTION’ ... OK
-* this is package ‘redist’ version ‘4.0.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-Package suggested but not available for checking: ‘lwgeom’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# NA
-
-<details>
-
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `revdepcheck::cloud_details(, "NA")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# roads
-
-<details>
-
-* Version: 1.1.0
-* GitHub: https://github.com/LandSciTech/roads
-* Source code: https://github.com/cran/roads
-* Date/Publication: 2023-02-02 16:10:02 UTC
-* Number of recursive dependencies: 111
-
-Run `revdepcheck::cloud_details(, "roads")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/roads/new/roads.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘roads/DESCRIPTION’ ... OK
-* this is package ‘roads’ version ‘1.1.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/roads/old/roads.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘roads/DESCRIPTION’ ... OK
-* this is package ‘roads’ version ‘1.1.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# Rsagacmd
-
-<details>
-
-* Version: 0.2.0
-* GitHub: https://github.com/stevenpawley/Rsagacmd
-* Source code: https://github.com/cran/Rsagacmd
-* Date/Publication: 2022-04-04 04:10:02 UTC
-* Number of recursive dependencies: 70
-
-Run `revdepcheck::cloud_details(, "Rsagacmd")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/Rsagacmd/new/Rsagacmd.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘Rsagacmd/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘Rsagacmd’ version ‘0.2.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/Rsagacmd/old/Rsagacmd.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘Rsagacmd/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘Rsagacmd’ version ‘0.2.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# rsinaica
-
-<details>
-
-* Version: 0.6.1
-* GitHub: https://github.com/diegovalle/rsinaica
-* Source code: https://github.com/cran/rsinaica
-* Date/Publication: 2019-02-04 21:10:03 UTC
-* Number of recursive dependencies: 126
-
-Run `revdepcheck::cloud_details(, "rsinaica")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/rsinaica/new/rsinaica.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘rsinaica/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘rsinaica’ version ‘0.6.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-...
-* checking data for non-ASCII characters ... NOTE
-  Note: found 467 marked UTF-8 strings
-* checking LazyData ... OK
-* checking data for ASCII and uncompressed saves ... OK
-* checking examples ... OK
-* checking for unstated dependencies in ‘tests’ ... OK
-* checking tests ... OK
-  Running ‘testthat.R’
-* DONE
-Status: 1 NOTE
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/rsinaica/old/rsinaica.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘rsinaica/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘rsinaica’ version ‘0.6.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-...
-* checking data for non-ASCII characters ... NOTE
-  Note: found 467 marked UTF-8 strings
-* checking LazyData ... OK
-* checking data for ASCII and uncompressed saves ... OK
-* checking examples ... OK
-* checking for unstated dependencies in ‘tests’ ... OK
-* checking tests ... OK
-  Running ‘testthat.R’
-* DONE
-Status: 1 NOTE
-
-
-
-
-
-```
-# saeSim
-
-<details>
-
-* Version: 0.11.0
-* GitHub: https://github.com/wahani/saeSim
-* Source code: https://github.com/cran/saeSim
-* Date/Publication: 2022-02-07 16:40:02 UTC
-* Number of recursive dependencies: 97
-
-Run `revdepcheck::cloud_details(, "saeSim")` for more info
-
-</details>
-
-## In both
-
-*   checking whether package ‘saeSim’ can be installed ... ERROR
-    ```
-    Installation failed.
-    See ‘/tmp/workdir/saeSim/new/saeSim.Rcheck/00install.out’ for details.
-    ```
-
-## Installation
-
-### Devel
-
-```
-* installing *source* package ‘saeSim’ ...
-** package ‘saeSim’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** inst
-** byte-compile and prepare package for lazy loading
-Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
-  there is no package called ‘sf’
-Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
-Execution halted
-ERROR: lazy loading failed for package ‘saeSim’
-* removing ‘/tmp/workdir/saeSim/new/saeSim.Rcheck/saeSim’
-
-
-```
-### CRAN
-
-```
-* installing *source* package ‘saeSim’ ...
-** package ‘saeSim’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** inst
-** byte-compile and prepare package for lazy loading
-Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
-  there is no package called ‘sf’
-Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
-Execution halted
-ERROR: lazy loading failed for package ‘saeSim’
-* removing ‘/tmp/workdir/saeSim/old/saeSim.Rcheck/saeSim’
-
-
-```
-# sandwichr
-
-<details>
-
-* Version: 1.0.3
-* GitHub: https://github.com/linyuehzzz/sandwich_spatial_interpolator
-* Source code: https://github.com/cran/sandwichr
-* Date/Publication: 2023-01-09 08:10:05 UTC
-* Number of recursive dependencies: 143
-
-Run `revdepcheck::cloud_details(, "sandwichr")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/sandwichr/new/sandwichr.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘sandwichr/DESCRIPTION’ ... OK
-* this is package ‘sandwichr’ version ‘1.0.3’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Packages required but not available: 'sf', 'lwgeom'
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/sandwichr/old/sandwichr.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘sandwichr/DESCRIPTION’ ... OK
-* this is package ‘sandwichr’ version ‘1.0.3’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Packages required but not available: 'sf', 'lwgeom'
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# NA
-
-<details>
-
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `revdepcheck::cloud_details(, "NA")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# SDGdetector
-
-<details>
-
-* Version: 2.7.1
-* GitHub: NA
-* Source code: https://github.com/cran/SDGdetector
-* Date/Publication: 2023-02-22 20:20:06 UTC
-* Number of recursive dependencies: 74
-
-Run `revdepcheck::cloud_details(, "SDGdetector")` for more info
-
-</details>
-
-## In both
-
-*   checking whether package ‘SDGdetector’ can be installed ... ERROR
-    ```
-    Installation failed.
-    See ‘/tmp/workdir/SDGdetector/new/SDGdetector.Rcheck/00install.out’ for details.
-    ```
-
-## Installation
-
-### Devel
-
-```
-* installing *source* package ‘SDGdetector’ ...
-** package ‘SDGdetector’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** data
-*** moving datasets to lazyload DB
-** inst
-** byte-compile and prepare package for lazy loading
-Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
-  there is no package called ‘sf’
-Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
-Execution halted
-ERROR: lazy loading failed for package ‘SDGdetector’
-* removing ‘/tmp/workdir/SDGdetector/new/SDGdetector.Rcheck/SDGdetector’
-
-
-```
-### CRAN
-
-```
-* installing *source* package ‘SDGdetector’ ...
-** package ‘SDGdetector’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** data
-*** moving datasets to lazyload DB
-** inst
-** byte-compile and prepare package for lazy loading
-Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
-  there is no package called ‘sf’
-Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
-Execution halted
-ERROR: lazy loading failed for package ‘SDGdetector’
-* removing ‘/tmp/workdir/SDGdetector/old/SDGdetector.Rcheck/SDGdetector’
-
-
-```
-# SDLfilter
-
-<details>
-
-* Version: 2.3.1
-* GitHub: https://github.com/TakahiroShimada/SDLfilter
-* Source code: https://github.com/cran/SDLfilter
-* Date/Publication: 2023-01-16 08:00:06 UTC
-* Number of recursive dependencies: 96
-
-Run `revdepcheck::cloud_details(, "SDLfilter")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/SDLfilter/new/SDLfilter.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘SDLfilter/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘SDLfilter’ version ‘2.3.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/SDLfilter/old/SDLfilter.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘SDLfilter/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘SDLfilter’ version ‘2.3.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# sfnetworks
-
-<details>
-
-* Version: 0.6.2
-* GitHub: https://github.com/luukvdmeer/sfnetworks
-* Source code: https://github.com/cran/sfnetworks
-* Date/Publication: 2023-02-26 19:00:02 UTC
-* Number of recursive dependencies: 105
-
-Run `revdepcheck::cloud_details(, "sfnetworks")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/sfnetworks/new/sfnetworks.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘sfnetworks/DESCRIPTION’ ... OK
-* this is package ‘sfnetworks’ version ‘0.6.2’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Packages required but not available: 'lwgeom', 'sf'
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/sfnetworks/old/sfnetworks.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘sfnetworks/DESCRIPTION’ ... OK
-* this is package ‘sfnetworks’ version ‘0.6.2’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Packages required but not available: 'lwgeom', 'sf'
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# ShellChron
-
-<details>
-
-* Version: 0.4.0
-* GitHub: https://github.com/nielsjdewinter/ShellChron
-* Source code: https://github.com/cran/ShellChron
-* Date/Publication: 2021-07-05 12:40:02 UTC
-* Number of recursive dependencies: 118
-
-Run `revdepcheck::cloud_details(, "ShellChron")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/ShellChron/new/ShellChron.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘ShellChron/DESCRIPTION’ ... OK
-* this is package ‘ShellChron’ version ‘0.4.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘rtop’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/ShellChron/old/ShellChron.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘ShellChron/DESCRIPTION’ ... OK
-* this is package ‘ShellChron’ version ‘0.4.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘rtop’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# NA
-
-<details>
-
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `revdepcheck::cloud_details(, "NA")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# simodels
-
-<details>
-
-* Version: 0.0.5
-* GitHub: https://github.com/robinlovelace/simodels
-* Source code: https://github.com/cran/simodels
-* Date/Publication: 2022-08-31 21:10:02 UTC
-* Number of recursive dependencies: 97
-
-Run `revdepcheck::cloud_details(, "simodels")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/simodels/new/simodels.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘simodels/DESCRIPTION’ ... OK
-* this is package ‘simodels’ version ‘0.0.5’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/simodels/old/simodels.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘simodels/DESCRIPTION’ ... OK
-* this is package ‘simodels’ version ‘0.0.5’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# simplevis
-
-<details>
-
-* Version: 7.0.0
-* GitHub: https://github.com/StatisticsNZ/simplevis
-* Source code: https://github.com/cran/simplevis
-* Date/Publication: 2023-01-29 20:00:02 UTC
-* Number of recursive dependencies: 122
-
-Run `revdepcheck::cloud_details(, "simplevis")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/simplevis/new/simplevis.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘simplevis/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘simplevis’ version ‘7.0.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/simplevis/old/simplevis.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘simplevis/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘simplevis’ version ‘7.0.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# slendr
-
-<details>
-
-* Version: 0.5.1
-* GitHub: https://github.com/bodkan/slendr
-* Source code: https://github.com/cran/slendr
-* Date/Publication: 2023-03-09 19:40:02 UTC
-* Number of recursive dependencies: 129
-
-Run `revdepcheck::cloud_details(, "slendr")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/slendr/new/slendr.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘slendr/DESCRIPTION’ ... OK
-* this is package ‘slendr’ version ‘0.5.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/slendr/old/slendr.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘slendr/DESCRIPTION’ ... OK
-* this is package ‘slendr’ version ‘0.5.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# sociome
-
-<details>
-
-* Version: 2.1.0
-* GitHub: https://github.com/NikKrieger/sociome
-* Source code: https://github.com/cran/sociome
-* Date/Publication: 2021-10-21 09:10:01 UTC
-* Number of recursive dependencies: 97
-
-Run `revdepcheck::cloud_details(, "sociome")` for more info
-
-</details>
-
-## In both
-
-*   checking whether package ‘sociome’ can be installed ... ERROR
-    ```
-    Installation failed.
-    See ‘/tmp/workdir/sociome/new/sociome.Rcheck/00install.out’ for details.
-    ```
-
-*   checking package dependencies ... NOTE
-    ```
-    Package suggested but not available for checking: ‘sf’
-    ```
-
-## Installation
-
-### Devel
-
-```
-* installing *source* package ‘sociome’ ...
-** package ‘sociome’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** data
-*** moving datasets to lazyload DB
-** byte-compile and prepare package for lazy loading
-Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
-  there is no package called ‘sf’
-Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
-Execution halted
-ERROR: lazy loading failed for package ‘sociome’
-* removing ‘/tmp/workdir/sociome/new/sociome.Rcheck/sociome’
-
-
-```
-### CRAN
-
-```
-* installing *source* package ‘sociome’ ...
-** package ‘sociome’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** data
-*** moving datasets to lazyload DB
-** byte-compile and prepare package for lazy loading
-Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
-  there is no package called ‘sf’
-Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
-Execution halted
-ERROR: lazy loading failed for package ‘sociome’
-* removing ‘/tmp/workdir/sociome/old/sociome.Rcheck/sociome’
-
-
-```
-# SPARTAAS
-
-<details>
-
-* Version: 1.1.0
-* GitHub: NA
-* Source code: https://github.com/cran/SPARTAAS
-* Date/Publication: 2021-10-22 14:30:02 UTC
-* Number of recursive dependencies: 184
-
-Run `revdepcheck::cloud_details(, "SPARTAAS")` for more info
-
-</details>
-
-## In both
-
-*   checking whether package ‘SPARTAAS’ can be installed ... ERROR
-    ```
-    Installation failed.
-    See ‘/tmp/workdir/SPARTAAS/new/SPARTAAS.Rcheck/00install.out’ for details.
-    ```
-
-## Installation
-
-### Devel
-
-```
-* installing *source* package ‘SPARTAAS’ ...
-** package ‘SPARTAAS’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** data
-*** moving datasets to lazyload DB
-** inst
-** byte-compile and prepare package for lazy loading
-Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
-  there is no package called ‘sf’
-Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
-Execution halted
-ERROR: lazy loading failed for package ‘SPARTAAS’
-* removing ‘/tmp/workdir/SPARTAAS/new/SPARTAAS.Rcheck/SPARTAAS’
-
-
-```
-### CRAN
-
-```
-* installing *source* package ‘SPARTAAS’ ...
-** package ‘SPARTAAS’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** data
-*** moving datasets to lazyload DB
-** inst
-** byte-compile and prepare package for lazy loading
-Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
-  there is no package called ‘sf’
-Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
-Execution halted
-ERROR: lazy loading failed for package ‘SPARTAAS’
-* removing ‘/tmp/workdir/SPARTAAS/old/SPARTAAS.Rcheck/SPARTAAS’
-
-
-```
-# spatgeom
-
-<details>
-
-* Version: 0.2.0
-* GitHub: https://github.com/maikol-solis/spatgeom
-* Source code: https://github.com/cran/spatgeom
-* Date/Publication: 2023-02-14 19:00:02 UTC
-* Number of recursive dependencies: 81
-
-Run `revdepcheck::cloud_details(, "spatgeom")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/spatgeom/new/spatgeom.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘spatgeom/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘spatgeom’ version ‘0.2.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Packages required but not available: 'sf', 'lwgeom'
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/spatgeom/old/spatgeom.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘spatgeom/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘spatgeom’ version ‘0.2.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Packages required but not available: 'sf', 'lwgeom'
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# SpatialKDE
-
-<details>
-
-* Version: 0.8.2
-* GitHub: https://github.com/JanCaha/SpatialKDE
-* Source code: https://github.com/cran/SpatialKDE
-* Date/Publication: 2023-02-18 15:10:02 UTC
-* Number of recursive dependencies: 112
-
-Run `revdepcheck::cloud_details(, "SpatialKDE")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/SpatialKDE/new/SpatialKDE.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘SpatialKDE/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘SpatialKDE’ version ‘0.8.2’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/SpatialKDE/old/SpatialKDE.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘SpatialKDE/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘SpatialKDE’ version ‘0.8.2’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# spatialrisk
-
-<details>
-
-* Version: 0.7.0
-* GitHub: https://github.com/mharinga/spatialrisk
-* Source code: https://github.com/cran/spatialrisk
-* Date/Publication: 2021-11-10 15:30:02 UTC
-* Number of recursive dependencies: 134
-
-Run `revdepcheck::cloud_details(, "spatialrisk")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/spatialrisk/new/spatialrisk.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘spatialrisk/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘spatialrisk’ version ‘0.7.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/spatialrisk/old/spatialrisk.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘spatialrisk/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘spatialrisk’ version ‘0.7.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# spDates
-
-<details>
-
-* Version: 1.1
-* GitHub: NA
-* Source code: https://github.com/cran/spDates
-* Date/Publication: 2022-10-09 10:30:02 UTC
-* Number of recursive dependencies: 82
-
-Run `revdepcheck::cloud_details(, "spDates")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/spDates/new/spDates.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘spDates/DESCRIPTION’ ... OK
-* this is package ‘spDates’ version ‘1.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... OK
-...
-* checking if there is a namespace ... OK
-* checking for executable files ... OK
-* checking for hidden files and directories ... OK
-* checking for portable file names ... OK
-* checking for sufficient/correct file permissions ... OK
-* checking whether package ‘spDates’ can be installed ... ERROR
-Installation failed.
-See ‘/tmp/workdir/spDates/new/spDates.Rcheck/00install.out’ for details.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/spDates/old/spDates.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘spDates/DESCRIPTION’ ... OK
-* this is package ‘spDates’ version ‘1.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... OK
-...
-* checking if there is a namespace ... OK
-* checking for executable files ... OK
-* checking for hidden files and directories ... OK
-* checking for portable file names ... OK
-* checking for sufficient/correct file permissions ... OK
-* checking whether package ‘spDates’ can be installed ... ERROR
-Installation failed.
-See ‘/tmp/workdir/spDates/old/spDates.Rcheck/00install.out’ for details.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# spnaf
-
-<details>
-
-* Version: 0.2.1
-* GitHub: NA
-* Source code: https://github.com/cran/spnaf
-* Date/Publication: 2022-08-25 08:20:02 UTC
-* Number of recursive dependencies: 100
-
-Run `revdepcheck::cloud_details(, "spnaf")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/spnaf/new/spnaf.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘spnaf/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘spnaf’ version ‘0.2.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/spnaf/old/spnaf.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘spnaf/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘spnaf’ version ‘0.2.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# spNetwork
-
-<details>
-
-* Version: 0.4.3.6
-* GitHub: https://github.com/JeremyGelb/spNetwork
-* Source code: https://github.com/cran/spNetwork
-* Date/Publication: 2022-11-11 08:10:02 UTC
-* Number of recursive dependencies: 149
-
-Run `revdepcheck::cloud_details(, "spNetwork")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/spNetwork/new/spNetwork.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘spNetwork/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘spNetwork’ version ‘0.4.3.6’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/spNetwork/old/spNetwork.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘spNetwork/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘spNetwork’ version ‘0.4.3.6’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# spqdep
-
-<details>
-
-* Version: 0.1.2
-* GitHub: NA
-* Source code: https://github.com/cran/spqdep
-* Date/Publication: 2022-03-28 16:20:02 UTC
-* Number of recursive dependencies: 102
-
-Run `revdepcheck::cloud_details(, "spqdep")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/spqdep/new/spqdep.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘spqdep/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘spqdep’ version ‘0.1.2’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Packages required but not available: 'sf', 'lwgeom'
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/spqdep/old/spqdep.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘spqdep/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘spqdep’ version ‘0.1.2’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Packages required but not available: 'sf', 'lwgeom'
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# NA
-
-<details>
-
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `revdepcheck::cloud_details(, "NA")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# stplanr
-
-<details>
-
-* Version: 1.0.2
-* GitHub: https://github.com/ropensci/stplanr
-* Source code: https://github.com/cran/stplanr
-* Date/Publication: 2022-11-08 12:40:02 UTC
-* Number of recursive dependencies: 166
-
-Run `revdepcheck::cloud_details(, "stplanr")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/stplanr/new/stplanr.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘stplanr/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘stplanr’ version ‘1.0.2’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Packages required but not available: 'lwgeom', 'sf'
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/stplanr/old/stplanr.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘stplanr/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘stplanr’ version ‘1.0.2’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Packages required but not available: 'lwgeom', 'sf'
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# stppSim
-
-<details>
-
-* Version: 1.2.7
-* GitHub: https://github.com/Manalytics/stppSim
-* Source code: https://github.com/cran/stppSim
-* Date/Publication: 2022-08-11 10:30:02 UTC
-* Number of recursive dependencies: 128
-
-Run `revdepcheck::cloud_details(, "stppSim")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/stppSim/new/stppSim.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘stppSim/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘stppSim’ version ‘1.2.7’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/stppSim/old/stppSim.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘stppSim/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘stppSim’ version ‘1.2.7’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# NA
-
-<details>
-
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `revdepcheck::cloud_details(, "NA")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# stxplore
-
-<details>
-
-* Version: 0.1.0
-* GitHub: NA
-* Source code: https://github.com/cran/stxplore
-* Date/Publication: 2023-02-03 10:10:02 UTC
-* Number of recursive dependencies: 102
-
-Run `revdepcheck::cloud_details(, "stxplore")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/stxplore/new/stxplore.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘stxplore/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘stxplore’ version ‘0.1.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-...
-* checking if there is a namespace ... OK
-* checking for executable files ... OK
-* checking for hidden files and directories ... OK
-* checking for portable file names ... OK
-* checking for sufficient/correct file permissions ... OK
-* checking whether package ‘stxplore’ can be installed ... ERROR
-Installation failed.
-See ‘/tmp/workdir/stxplore/new/stxplore.Rcheck/00install.out’ for details.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/stxplore/old/stxplore.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘stxplore/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘stxplore’ version ‘0.1.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-...
-* checking if there is a namespace ... OK
-* checking for executable files ... OK
-* checking for hidden files and directories ... OK
-* checking for portable file names ... OK
-* checking for sufficient/correct file permissions ... OK
-* checking whether package ‘stxplore’ can be installed ... ERROR
-Installation failed.
-See ‘/tmp/workdir/stxplore/old/stxplore.Rcheck/00install.out’ for details.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# SUNGEO
-
-<details>
-
-* Version: 0.2.292
-* GitHub: NA
-* Source code: https://github.com/cran/SUNGEO
-* Date/Publication: 2022-08-18 14:20:02 UTC
-* Number of recursive dependencies: 109
-
-Run `revdepcheck::cloud_details(, "SUNGEO")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/SUNGEO/new/SUNGEO.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘SUNGEO/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘SUNGEO’ version ‘0.2.292’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/SUNGEO/old/SUNGEO.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘SUNGEO/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘SUNGEO’ version ‘0.2.292’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# swfscAirDAS
-
-<details>
-
-* Version: 0.2.3
-* GitHub: https://github.com/smwoodman/swfscAirDAS
-* Source code: https://github.com/cran/swfscAirDAS
-* Date/Publication: 2022-06-02 03:00:02 UTC
-* Number of recursive dependencies: 105
-
-Run `revdepcheck::cloud_details(, "swfscAirDAS")` for more info
-
-</details>
-
-## In both
-
-*   checking whether package ‘swfscAirDAS’ can be installed ... ERROR
-    ```
-    Installation failed.
-    See ‘/tmp/workdir/swfscAirDAS/new/swfscAirDAS.Rcheck/00install.out’ for details.
-    ```
-
-## Installation
-
-### Devel
-
-```
-* installing *source* package ‘swfscAirDAS’ ...
-** package ‘swfscAirDAS’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** inst
-** byte-compile and prepare package for lazy loading
-Error in loadNamespace(j <- i[[1L]], c(lib.loc, .libPaths()), versionCheck = vI[[j]]) : 
-  there is no package called ‘sf’
-Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
-Execution halted
-ERROR: lazy loading failed for package ‘swfscAirDAS’
-* removing ‘/tmp/workdir/swfscAirDAS/new/swfscAirDAS.Rcheck/swfscAirDAS’
-
-
-```
-### CRAN
-
-```
-* installing *source* package ‘swfscAirDAS’ ...
-** package ‘swfscAirDAS’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** inst
-** byte-compile and prepare package for lazy loading
-Error in loadNamespace(j <- i[[1L]], c(lib.loc, .libPaths()), versionCheck = vI[[j]]) : 
-  there is no package called ‘sf’
-Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
-Execution halted
-ERROR: lazy loading failed for package ‘swfscAirDAS’
-* removing ‘/tmp/workdir/swfscAirDAS/old/swfscAirDAS.Rcheck/swfscAirDAS’
-
-
-```
-# SWTools
-
-<details>
-
-* Version: 0.2.4
-* GitHub: https://github.com/matt-s-gibbs/swtools
-* Source code: https://github.com/cran/SWTools
-* Date/Publication: 2022-07-04 06:20:02 UTC
-* Number of recursive dependencies: 110
-
-Run `revdepcheck::cloud_details(, "SWTools")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/SWTools/new/SWTools.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘SWTools/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘SWTools’ version ‘0.2.4’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/SWTools/old/SWTools.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘SWTools/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘SWTools’ version ‘0.2.4’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-# NA
-
-<details>
-
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `revdepcheck::cloud_details(, "NA")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# telemac
-
-<details>
-
-* Version: 0.1.1
-* GitHub: https://github.com/tpilz/telemac
-* Source code: https://github.com/cran/telemac
-* Date/Publication: 2022-02-07 15:50:02 UTC
-* Number of recursive dependencies: 147
-
-Run `revdepcheck::cloud_details(, "telemac")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/telemac/new/telemac.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘telemac/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘telemac’ version ‘0.1.1’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
-* DONE
-Status: 1 ERROR
-
-
-
-
-
-```
-### CRAN
-
-```
-* using log directory ‘/tmp/workdir/telemac/old/telemac.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
-* using session charset: UTF-8
-* using option ‘--no-manual’
-* checking for file ‘telemac/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘telemac’ version ‘0.1.1’
+* this is package ‘apa’ version ‘0.3.4’
 * package encoding: UTF-8
 * checking package namespace information ... OK
 * checking package dependencies ... ERROR
-Package required but not available: ‘sf’
+Package required but not available: ‘MBESS’
 
 See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
 manual.
 * DONE
 Status: 1 ERROR
-
-
-
-
 
-```
-# NA
-
-<details>
-
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `revdepcheck::cloud_details(, "NA")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-
-
-
-
-
 
-```
-### CRAN
-
-```
 
 
 
-
-
-
 ```
-# trackdf
-
-<details>
+# apaTables (2.0.8)
 
-* Version: 0.3.1
-* GitHub: https://github.com/swarm-lab/trackdf
-* Source code: https://github.com/cran/trackdf
-* Date/Publication: 2023-01-23 00:50:02 UTC
-* Number of recursive dependencies: 150
+* GitHub: https://github.com/dstanley4/apaTables
+* Github mirror: https://github.com/cran/apaTables
+* Maintainer: David Stanley <dstanley@uoguelph.ca>
 
-Run `revdepcheck::cloud_details(, "trackdf")` for more info
+Run `revdepcheck::cloud_details(, "apaTables")` for more info
 
-</details>
-
 ## Error before installation
 
 ### Devel
 
 ```
-* using log directory ‘/tmp/workdir/trackdf/new/trackdf.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
+* using log directory ‘/tmp/workdir/apaTables/new/apaTables.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
 * using session charset: UTF-8
 * using option ‘--no-manual’
-* checking for file ‘trackdf/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘trackdf’ version ‘0.3.1’
-* package encoding: UTF-8
+* checking for file ‘apaTables/DESCRIPTION’ ... OK
+* this is package ‘apaTables’ version ‘2.0.8’
 * checking package namespace information ... OK
 * checking package dependencies ... ERROR
-Package required but not available: ‘sf’
+Package required but not available: ‘MBESS’
 
-Package suggested but not available for checking: ‘moveVis’
-
 See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
 manual.
 * DONE
@@ -7563,21 +109,21 @@ Status: 1 ERROR
 ### CRAN
 
 ```
-* using log directory ‘/tmp/workdir/trackdf/old/trackdf.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
+* using log directory ‘/tmp/workdir/apaTables/old/apaTables.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
 * using session charset: UTF-8
 * using option ‘--no-manual’
-* checking for file ‘trackdf/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘trackdf’ version ‘0.3.1’
-* package encoding: UTF-8
+* checking for file ‘apaTables/DESCRIPTION’ ... OK
+* this is package ‘apaTables’ version ‘2.0.8’
 * checking package namespace information ... OK
 * checking package dependencies ... ERROR
-Package required but not available: ‘sf’
+Package required but not available: ‘MBESS’
 
-Package suggested but not available for checking: ‘moveVis’
-
 See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
 manual.
 * DONE
@@ -7588,35 +134,28 @@ Status: 1 ERROR
 
 
 ```
-# TUFLOWR
-
-<details>
+# apaText (0.1.7)
 
-* Version: 0.1.0
-* GitHub: NA
-* Source code: https://github.com/cran/TUFLOWR
-* Date/Publication: 2021-10-18 14:30:05 UTC
-* Number of recursive dependencies: 74
+* Github mirror: https://github.com/cran/apaText
+* Maintainer: David Stanley <dstanley@uoguelph.ca>
 
-Run `revdepcheck::cloud_details(, "TUFLOWR")` for more info
+Run `revdepcheck::cloud_details(, "apaText")` for more info
 
-</details>
-
 ## Error before installation
 
 ### Devel
 
 ```
-* using log directory ‘/tmp/workdir/TUFLOWR/new/TUFLOWR.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
+* using log directory ‘/tmp/workdir/apaText/new/apaText.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
 * using session charset: UTF-8
 * using option ‘--no-manual’
-* checking for file ‘TUFLOWR/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘TUFLOWR’ version ‘0.1.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
+* checking for file ‘apaText/DESCRIPTION’ ... OK
 ...
 * checking Rd metadata ... OK
 * checking Rd cross-references ... OK
@@ -7637,16 +176,16 @@ Status: OK
 ### CRAN
 
 ```
-* using log directory ‘/tmp/workdir/TUFLOWR/old/TUFLOWR.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
+* using log directory ‘/tmp/workdir/apaText/old/apaText.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
 * using session charset: UTF-8
 * using option ‘--no-manual’
-* checking for file ‘TUFLOWR/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘TUFLOWR’ version ‘0.1.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
+* checking for file ‘apaText/DESCRIPTION’ ... OK
 ...
 * checking Rd metadata ... OK
 * checking Rd cross-references ... OK
@@ -7664,39 +203,141 @@ Status: OK
 
 
 ```
-# VancouvR
+# arealDB (0.9.4)
 
-<details>
+* GitHub: https://github.com/luckinet/arealDB
+* Github mirror: https://github.com/cran/arealDB
+* Maintainer: Steffen Ehrmann <steffen.ehrmann@posteo.de>
 
-* Version: 0.1.7
-* GitHub: https://github.com/mountainMath/VancouvR
-* Source code: https://github.com/cran/VancouvR
-* Date/Publication: 2021-10-21 04:30:02 UTC
-* Number of recursive dependencies: 86
+Run `revdepcheck::cloud_details(, "arealDB")` for more info
 
-Run `revdepcheck::cloud_details(, "VancouvR")` for more info
+## In both
 
-</details>
+*   checking whether package ‘arealDB’ can be installed ... ERROR
+     ```
+     Installation failed.
+     See ‘/tmp/workdir/arealDB/new/arealDB.Rcheck/00install.out’ for details.
+     ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘arealDB’ ...
+** package ‘arealDB’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error in dyn.load(file, DLLpath = DLLpath, ...) : 
+  unable to load shared object '/usr/local/lib/R/site-library/redland/libs/redland.so':
+  librdf.so.0: cannot open shared object file: No such file or directory
+Calls: <Anonymous> ... asNamespace -> loadNamespace -> library.dynam -> dyn.load
+Execution halted
+ERROR: lazy loading failed for package ‘arealDB’
+* removing ‘/tmp/workdir/arealDB/new/arealDB.Rcheck/arealDB’
+
+
+```
+### CRAN
+
+```
+* installing *source* package ‘arealDB’ ...
+** package ‘arealDB’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error in dyn.load(file, DLLpath = DLLpath, ...) : 
+  unable to load shared object '/usr/local/lib/R/site-library/redland/libs/redland.so':
+  librdf.so.0: cannot open shared object file: No such file or directory
+Calls: <Anonymous> ... asNamespace -> loadNamespace -> library.dynam -> dyn.load
+Execution halted
+ERROR: lazy loading failed for package ‘arealDB’
+* removing ‘/tmp/workdir/arealDB/old/arealDB.Rcheck/arealDB’
+
+
+```
+# bayesdfa (1.3.4)
+
+* GitHub: https://github.com/fate-ewi/bayesdfa
+* Github mirror: https://github.com/cran/bayesdfa
+* Maintainer: Eric J. Ward <eric.ward@noaa.gov>
+
+Run `revdepcheck::cloud_details(, "bayesdfa")` for more info
+
+## In both
+
+*   checking whether package ‘bayesdfa’ can be installed ... ERROR
+     ```
+     Installation failed.
+     See ‘/tmp/workdir/bayesdfa/new/bayesdfa.Rcheck/00install.out’ for details.
+     ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘bayesdfa’ ...
+** package ‘bayesdfa’ successfully unpacked and MD5 sums checked
+** using staged installation
+Error in loadNamespace(x) : there is no package called ‘rstantools’
+Calls: loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
+Execution halted
+ERROR: configuration failed for package ‘bayesdfa’
+* removing ‘/tmp/workdir/bayesdfa/new/bayesdfa.Rcheck/bayesdfa’
+
+
+```
+### CRAN
+
+```
+* installing *source* package ‘bayesdfa’ ...
+** package ‘bayesdfa’ successfully unpacked and MD5 sums checked
+** using staged installation
+Error in loadNamespace(x) : there is no package called ‘rstantools’
+Calls: loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
+Execution halted
+ERROR: configuration failed for package ‘bayesdfa’
+* removing ‘/tmp/workdir/bayesdfa/old/bayesdfa.Rcheck/bayesdfa’
+
+
+```
+# cinaR (0.2.3)
+
+* GitHub: https://github.com/eonurk/cinaR
+* Github mirror: https://github.com/cran/cinaR
+* Maintainer: Onur Karakaslar <eonurkara@gmail.com>
+
+Run `revdepcheck::cloud_details(, "cinaR")` for more info
 
 ## Error before installation
 
 ### Devel
 
 ```
-* using log directory ‘/tmp/workdir/VancouvR/new/VancouvR.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
+* using log directory ‘/tmp/workdir/cinaR/new/cinaR.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
 * using session charset: UTF-8
 * using option ‘--no-manual’
-* checking for file ‘VancouvR/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘VancouvR’ version ‘0.1.7’
+* checking for file ‘cinaR/DESCRIPTION’ ... OK
+...
+* this is package ‘cinaR’ version ‘0.2.3’
 * package encoding: UTF-8
 * checking package namespace information ... OK
 * checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-Package suggested but not available for checking: ‘lwgeom’
+Package required but not available: ‘ChIPseeker’
 
 See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
 manual.
@@ -7711,20 +352,22 @@ Status: 1 ERROR
 ### CRAN
 
 ```
-* using log directory ‘/tmp/workdir/VancouvR/old/VancouvR.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
+* using log directory ‘/tmp/workdir/cinaR/old/cinaR.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
 * using session charset: UTF-8
 * using option ‘--no-manual’
-* checking for file ‘VancouvR/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘VancouvR’ version ‘0.1.7’
+* checking for file ‘cinaR/DESCRIPTION’ ... OK
+...
+* this is package ‘cinaR’ version ‘0.2.3’
 * package encoding: UTF-8
 * checking package namespace information ... OK
 * checking package dependencies ... ERROR
-Package required but not available: ‘sf’
-
-Package suggested but not available for checking: ‘lwgeom’
+Package required but not available: ‘ChIPseeker’
 
 See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
 manual.
@@ -7736,41 +379,261 @@ Status: 1 ERROR
 
 
 ```
-# wallace
+# ClusterGVis (0.1.4)
 
-<details>
+* GitHub: https://github.com/junjunlab/ClusterGVis
+* Github mirror: https://github.com/cran/ClusterGVis
+* Maintainer: Jun Zhang <3219030654@stu.cpu.edu.cn>
 
-* Version: 2.0.4
-* GitHub: NA
-* Source code: https://github.com/cran/wallace
-* Date/Publication: 2023-03-14 08:20:02 UTC
-* Number of recursive dependencies: 282
-
-Run `revdepcheck::cloud_details(, "wallace")` for more info
-
-</details>
+Run `revdepcheck::cloud_details(, "ClusterGVis")` for more info
 
 ## Error before installation
 
 ### Devel
 
 ```
-* using log directory ‘/tmp/workdir/wallace/new/wallace.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
+* using log directory ‘/tmp/workdir/ClusterGVis/new/ClusterGVis.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
 * using session charset: UTF-8
 * using option ‘--no-manual’
-* checking for file ‘wallace/DESCRIPTION’ ... OK
-* this is package ‘wallace’ version ‘2.0.4’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... NOTE
+* checking for file ‘ClusterGVis/DESCRIPTION’ ... OK
+...
+* checking LazyData ... OK
+* checking data for ASCII and uncompressed saves ... OK
+* checking installed files from ‘inst/doc’ ... OK
+* checking files in ‘vignettes’ ... OK
+* checking examples ... OK
+* checking for unstated dependencies in vignettes ... OK
+* checking package vignettes ... OK
+* checking re-building of vignette outputs ... OK
+* DONE
+Status: 1 NOTE
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/ClusterGVis/old/ClusterGVis.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘ClusterGVis/DESCRIPTION’ ... OK
+...
+* checking LazyData ... OK
+* checking data for ASCII and uncompressed saves ... OK
+* checking installed files from ‘inst/doc’ ... OK
+* checking files in ‘vignettes’ ... OK
+* checking examples ... OK
+* checking for unstated dependencies in vignettes ... OK
+* checking package vignettes ... OK
+* checking re-building of vignette outputs ... OK
+* DONE
+Status: 1 NOTE
+
+
+
+
+
+```
+# cocktailApp (0.2.3)
+
+* GitHub: https://github.com/shabbychef/cocktailApp
+* Github mirror: https://github.com/cran/cocktailApp
+* Maintainer: Steven E. Pav <shabbychef@gmail.com>
+
+Run `revdepcheck::cloud_details(, "cocktailApp")` for more info
+
+## In both
+
+*   checking whether package ‘cocktailApp’ can be installed ... ERROR
+     ```
+     Installation failed.
+     See ‘/tmp/workdir/cocktailApp/new/cocktailApp.Rcheck/00install.out’ for details.
+     ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘cocktailApp’ ...
+** package ‘cocktailApp’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** data
+** inst
+** byte-compile and prepare package for lazy loading
+Error: .onLoad failed in loadNamespace() for 'ggtern', details:
+  call: NULL
+  error: <ggplot2::element_line> object properties are invalid:
+- @lineend must be <character> or <NULL>, not S3<arrow>
+Execution halted
+ERROR: lazy loading failed for package ‘cocktailApp’
+* removing ‘/tmp/workdir/cocktailApp/new/cocktailApp.Rcheck/cocktailApp’
+
+
+```
+### CRAN
+
+```
+* installing *source* package ‘cocktailApp’ ...
+** package ‘cocktailApp’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** data
+** inst
+** byte-compile and prepare package for lazy loading
+Error: .onLoad failed in loadNamespace() for 'ggtern', details:
+  call: NULL
+  error: <ggplot2::element_line> object properties are invalid:
+- @lineend must be <character> or <NULL>, not S3<arrow>
+Execution halted
+ERROR: lazy loading failed for package ‘cocktailApp’
+* removing ‘/tmp/workdir/cocktailApp/old/cocktailApp.Rcheck/cocktailApp’
+
+
+```
+# CytoML (NA)
+
+* Github mirror: https://github.com/cran/CytoML
+* Maintainer: NA
+
+Run `revdepcheck::cloud_details(, "CytoML")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+
+
+
+```
+### CRAN
+
+```
+
+
+
+
+
+
+```
+# DSMolgenisArmadillo (3.0.1)
+
+* GitHub: https://github.com/molgenis/molgenis-r-datashield
+* Github mirror: https://github.com/cran/DSMolgenisArmadillo
+* Maintainer: Mariska Slofstra <m.k.slofstra@umcg.nl>
+
+Run `revdepcheck::cloud_details(, "DSMolgenisArmadillo")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/DSMolgenisArmadillo/new/DSMolgenisArmadillo.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘DSMolgenisArmadillo/DESCRIPTION’ ... OK
+...
+* checking files in ‘vignettes’ ... OK
+* checking examples ... OK
+* checking for unstated dependencies in ‘tests’ ... OK
+* checking tests ... OK
+  Running ‘testthat.R’
+* checking for unstated dependencies in vignettes ... OK
+* checking package vignettes ... OK
+* checking re-building of vignette outputs ... OK
+* DONE
+Status: 1 NOTE
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/DSMolgenisArmadillo/old/DSMolgenisArmadillo.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘DSMolgenisArmadillo/DESCRIPTION’ ... OK
+...
+* checking files in ‘vignettes’ ... OK
+* checking examples ... OK
+* checking for unstated dependencies in ‘tests’ ... OK
+* checking tests ... OK
+  Running ‘testthat.R’
+* checking for unstated dependencies in vignettes ... OK
+* checking package vignettes ... OK
+* checking re-building of vignette outputs ... OK
+* DONE
+Status: 1 NOTE
+
+
+
+
+
+```
+# dsTidyverse (1.0.4)
+
+* Github mirror: https://github.com/cran/dsTidyverse
+* Maintainer: Tim Cadman <t.j.cadman@umcg.nl>
+
+Run `revdepcheck::cloud_details(, "dsTidyverse")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/dsTidyverse/new/dsTidyverse.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘dsTidyverse/DESCRIPTION’ ... OK
 ...
 * checking for code/documentation mismatches ... OK
 * checking Rd \usage sections ... OK
 * checking Rd contents ... OK
 * checking for unstated dependencies in examples ... OK
-* checking examples ... OK
+* checking examples ... NONE
 * checking for unstated dependencies in ‘tests’ ... OK
 * checking tests ... OK
   Running ‘testthat.R’
@@ -7785,22 +648,22 @@ Status: 1 NOTE
 ### CRAN
 
 ```
-* using log directory ‘/tmp/workdir/wallace/old/wallace.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
+* using log directory ‘/tmp/workdir/dsTidyverse/old/dsTidyverse.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
 * using session charset: UTF-8
 * using option ‘--no-manual’
-* checking for file ‘wallace/DESCRIPTION’ ... OK
-* this is package ‘wallace’ version ‘2.0.4’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... NOTE
+* checking for file ‘dsTidyverse/DESCRIPTION’ ... OK
 ...
 * checking for code/documentation mismatches ... OK
 * checking Rd \usage sections ... OK
 * checking Rd contents ... OK
 * checking for unstated dependencies in examples ... OK
-* checking examples ... OK
+* checking examples ... NONE
 * checking for unstated dependencies in ‘tests’ ... OK
 * checking tests ... OK
   Running ‘testthat.R’
@@ -7812,46 +675,39 @@ Status: 1 NOTE
 
 
 ```
-# waterquality
+# dsTidyverseClient (1.0.2)
 
-<details>
+* Github mirror: https://github.com/cran/dsTidyverseClient
+* Maintainer: Tim Cadman <t.j.cadman@umcg.nl>
 
-* Version: 0.3.0
-* GitHub: https://github.com/RAJohansen/waterquality
-* Source code: https://github.com/cran/waterquality
-* Date/Publication: 2022-02-09 16:50:02 UTC
-* Number of recursive dependencies: 151
-
-Run `revdepcheck::cloud_details(, "waterquality")` for more info
-
-</details>
+Run `revdepcheck::cloud_details(, "dsTidyverseClient")` for more info
 
 ## Error before installation
 
 ### Devel
 
 ```
-* using log directory ‘/tmp/workdir/waterquality/new/waterquality.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
+* using log directory ‘/tmp/workdir/dsTidyverseClient/new/dsTidyverseClient.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
 * using session charset: UTF-8
 * using option ‘--no-manual’
-* checking for file ‘waterquality/DESCRIPTION’ ... OK
-* this is package ‘waterquality’ version ‘0.3.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... NOTE
+* checking for file ‘dsTidyverseClient/DESCRIPTION’ ... OK
 ...
---- failed re-building ‘waterquality_vignette.Rmd’
-
-SUMMARY: processing the following file failed:
-  ‘waterquality_vignette.Rmd’
-
-Error: Vignette re-building failed.
-Execution halted
-
+* checking files in ‘vignettes’ ... OK
+* checking examples ... OK
+* checking for unstated dependencies in ‘tests’ ... OK
+* checking tests ... OK
+  Running ‘testthat.R’
+* checking for unstated dependencies in vignettes ... OK
+* checking package vignettes ... OK
+* checking re-building of vignette outputs ... OK
 * DONE
-Status: 1 WARNING, 2 NOTEs
+Status: 1 NOTE
 
 
 
@@ -7861,165 +717,62 @@ Status: 1 WARNING, 2 NOTEs
 ### CRAN
 
 ```
-* using log directory ‘/tmp/workdir/waterquality/old/waterquality.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
+* using log directory ‘/tmp/workdir/dsTidyverseClient/old/dsTidyverseClient.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
 * using session charset: UTF-8
 * using option ‘--no-manual’
-* checking for file ‘waterquality/DESCRIPTION’ ... OK
-* this is package ‘waterquality’ version ‘0.3.0’
-* package encoding: UTF-8
-* checking package namespace information ... OK
-* checking package dependencies ... NOTE
+* checking for file ‘dsTidyverseClient/DESCRIPTION’ ... OK
 ...
---- failed re-building ‘waterquality_vignette.Rmd’
-
-SUMMARY: processing the following file failed:
-  ‘waterquality_vignette.Rmd’
-
-Error: Vignette re-building failed.
-Execution halted
-
+* checking files in ‘vignettes’ ... OK
+* checking examples ... OK
+* checking for unstated dependencies in ‘tests’ ... OK
+* checking tests ... OK
+  Running ‘testthat.R’
+* checking for unstated dependencies in vignettes ... OK
+* checking package vignettes ... OK
+* checking re-building of vignette outputs ... OK
 * DONE
-Status: 1 WARNING, 2 NOTEs
+Status: 1 NOTE
 
 
 
 
 
 ```
-# NA
+# dySEM (1.1.1)
 
-<details>
+* GitHub: https://github.com/jsakaluk/dySEM
+* Github mirror: https://github.com/cran/dySEM
+* Maintainer: John Sakaluk <jksakaluk@gmail.com>
 
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
-
-Run `revdepcheck::cloud_details(, "NA")` for more info
-
-</details>
+Run `revdepcheck::cloud_details(, "dySEM")` for more info
 
 ## Error before installation
 
 ### Devel
 
 ```
-
-
-
-
-
-
-```
-### CRAN
-
-```
-
-
-
-
-
-
-```
-# waves
-
-<details>
-
-* Version: 0.2.4
-* GitHub: https://github.com/GoreLab/waves
-* Source code: https://github.com/cran/waves
-* Date/Publication: 2022-03-29 21:50:02 UTC
-* Number of recursive dependencies: 165
-
-Run `revdepcheck::cloud_details(, "waves")` for more info
-
-</details>
-
-## In both
-
-*   checking whether package ‘waves’ can be installed ... ERROR
-    ```
-    Installation failed.
-    See ‘/tmp/workdir/waves/new/waves.Rcheck/00install.out’ for details.
-    ```
-
-## Installation
-
-### Devel
-
-```
-* installing *source* package ‘waves’ ...
-** package ‘waves’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** data
-*** moving datasets to lazyload DB
-** inst
-** byte-compile and prepare package for lazy loading
-Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
-  there is no package called ‘sf’
-Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
-Execution halted
-ERROR: lazy loading failed for package ‘waves’
-* removing ‘/tmp/workdir/waves/new/waves.Rcheck/waves’
-
-
-```
-### CRAN
-
-```
-* installing *source* package ‘waves’ ...
-** package ‘waves’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** data
-*** moving datasets to lazyload DB
-** inst
-** byte-compile and prepare package for lazy loading
-Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
-  there is no package called ‘sf’
-Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
-Execution halted
-ERROR: lazy loading failed for package ‘waves’
-* removing ‘/tmp/workdir/waves/old/waves.Rcheck/waves’
-
-
-```
-# wdpar
-
-<details>
-
-* Version: 1.3.4
-* GitHub: https://github.com/prioritizr/wdpar
-* Source code: https://github.com/cran/wdpar
-* Date/Publication: 2023-02-24 08:40:02 UTC
-* Number of recursive dependencies: 108
-
-Run `revdepcheck::cloud_details(, "wdpar")` for more info
-
-</details>
-
-## Error before installation
-
-### Devel
-
-```
-* using log directory ‘/tmp/workdir/wdpar/new/wdpar.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
+* using log directory ‘/tmp/workdir/dySEM/new/dySEM.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
 * using session charset: UTF-8
 * using option ‘--no-manual’
-* checking for file ‘wdpar/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘wdpar’ version ‘1.3.4’
+* checking for file ‘dySEM/DESCRIPTION’ ... OK
+...
+* this is package ‘dySEM’ version ‘1.1.1’
 * package encoding: UTF-8
 * checking package namespace information ... OK
 * checking package dependencies ... ERROR
-Packages required but not available: 'sf', 'lwgeom'
-
-Package suggested but not available for checking: ‘prepr’
+Package required but not available: ‘semPlot’
 
 See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
 manual.
@@ -8034,20 +787,22 @@ Status: 1 ERROR
 ### CRAN
 
 ```
-* using log directory ‘/tmp/workdir/wdpar/old/wdpar.Rcheck’
-* using R version 4.1.1 (2021-08-10)
-* using platform: x86_64-pc-linux-gnu (64-bit)
+* using log directory ‘/tmp/workdir/dySEM/old/dySEM.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
 * using session charset: UTF-8
 * using option ‘--no-manual’
-* checking for file ‘wdpar/DESCRIPTION’ ... OK
-* checking extension type ... Package
-* this is package ‘wdpar’ version ‘1.3.4’
+* checking for file ‘dySEM/DESCRIPTION’ ... OK
+...
+* this is package ‘dySEM’ version ‘1.1.1’
 * package encoding: UTF-8
 * checking package namespace information ... OK
 * checking package dependencies ... ERROR
-Packages required but not available: 'sf', 'lwgeom'
-
-Package suggested but not available for checking: ‘prepr’
+Package required but not available: ‘semPlot’
 
 See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
 manual.
@@ -8059,18 +814,208 @@ Status: 1 ERROR
 
 
 ```
-# NA
+# EcoEnsemble (1.1.2)
 
-<details>
+* GitHub: https://github.com/CefasRepRes/EcoEnsemble
+* Github mirror: https://github.com/cran/EcoEnsemble
+* Maintainer: Michael A. Spence <michael.spence@cefas.gov.uk>
 
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
+Run `revdepcheck::cloud_details(, "EcoEnsemble")` for more info
 
-Run `revdepcheck::cloud_details(, "NA")` for more info
+## In both
 
-</details>
+*   checking whether package ‘EcoEnsemble’ can be installed ... ERROR
+     ```
+     Installation failed.
+     See ‘/tmp/workdir/EcoEnsemble/new/EcoEnsemble.Rcheck/00install.out’ for details.
+     ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘EcoEnsemble’ ...
+** package ‘EcoEnsemble’ successfully unpacked and MD5 sums checked
+** using staged installation
+** libs
+using C++ compiler: ‘g++ (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0’
+using C++17
+
+
+g++ -std=gnu++17 -I"/opt/R/4.4.0/lib/R/include" -DNDEBUG -I"../inst/include" -I"/usr/local/lib/R/site-library/StanHeaders/include/src" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error -DUSE_STANC3 -D_HAS_AUTO_PTR_ETC=0 -I'/usr/local/lib/R/site-library/BH/include' -I'/usr/local/lib/R/site-library/Rcpp/include' -I'/usr/local/lib/R/site-library/RcppEigen/include' -I'/usr/local/lib/R/site-library/RcppParallel/include' -I'/usr/local/lib/R/site-library/rstan/include' -I'/usr/local/lib/R/site-library/StanHeaders/include' -I/usr/local/include    -I'/usr/local/lib/R/site-library/RcppParallel/include' -D_REENTRANT -DSTAN_THREADS   -fpic  -g -O2   -c KF_back.cpp -o KF_back.o
+In file included from /usr/local/lib/R/site-library/RcppEigen/include/Eigen/Core:205,
+...
+/usr/local/lib/R/site-library/StanHeaders/include/src/stan/mcmc/hmc/hamiltonians/dense_e_metric.hpp:22:0:   required from ‘double stan::mcmc::dense_e_metric<Model, BaseRNG>::T(stan::mcmc::dense_e_point&) [with Model = model_ensemble_model_hierarchical_namespace::model_ensemble_model_hierarchical; BaseRNG = boost::random::additive_combine_engine<boost::random::linear_congruential_engine<unsigned int, 40014, 0, 2147483563>, boost::random::linear_congruential_engine<unsigned int, 40692, 0, 2147483399> >]’
+/usr/local/lib/R/site-library/StanHeaders/include/src/stan/mcmc/hmc/hamiltonians/dense_e_metric.hpp:21:0:   required from here
+/usr/local/lib/R/site-library/RcppEigen/include/Eigen/src/Core/DenseCoeffsBase.h:654:74: warning: ignoring attributes on template argument ‘Eigen::internal::packet_traits<double>::type’ {aka ‘__m128d’} [-Wignored-attributes]
+  654 |   return internal::first_aligned<int(unpacket_traits<DefaultPacketType>::alignment),Derived>(m);
+      |                                                                          ^~~~~~~~~
+g++: fatal error: Killed signal terminated program cc1plus
+compilation terminated.
+make: *** [/opt/R/4.4.0/lib/R/etc/Makeconf:202: stanExports_ensemble_model_hierarchical.o] Error 1
+ERROR: compilation failed for package ‘EcoEnsemble’
+* removing ‘/tmp/workdir/EcoEnsemble/new/EcoEnsemble.Rcheck/EcoEnsemble’
+
+
+```
+### CRAN
+
+```
+* installing *source* package ‘EcoEnsemble’ ...
+** package ‘EcoEnsemble’ successfully unpacked and MD5 sums checked
+** using staged installation
+** libs
+using C++ compiler: ‘g++ (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0’
+using C++17
+
+
+g++ -std=gnu++17 -I"/opt/R/4.4.0/lib/R/include" -DNDEBUG -I"../inst/include" -I"/usr/local/lib/R/site-library/StanHeaders/include/src" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error -DUSE_STANC3 -D_HAS_AUTO_PTR_ETC=0 -I'/usr/local/lib/R/site-library/BH/include' -I'/usr/local/lib/R/site-library/Rcpp/include' -I'/usr/local/lib/R/site-library/RcppEigen/include' -I'/usr/local/lib/R/site-library/RcppParallel/include' -I'/usr/local/lib/R/site-library/rstan/include' -I'/usr/local/lib/R/site-library/StanHeaders/include' -I/usr/local/include    -I'/usr/local/lib/R/site-library/RcppParallel/include' -D_REENTRANT -DSTAN_THREADS   -fpic  -g -O2   -c KF_back.cpp -o KF_back.o
+In file included from /usr/local/lib/R/site-library/RcppEigen/include/Eigen/Core:205,
+...
+/usr/local/lib/R/site-library/StanHeaders/include/src/stan/mcmc/hmc/hamiltonians/dense_e_metric.hpp:22:0:   required from ‘double stan::mcmc::dense_e_metric<Model, BaseRNG>::T(stan::mcmc::dense_e_point&) [with Model = model_ensemble_model_hierarchical_namespace::model_ensemble_model_hierarchical; BaseRNG = boost::random::additive_combine_engine<boost::random::linear_congruential_engine<unsigned int, 40014, 0, 2147483563>, boost::random::linear_congruential_engine<unsigned int, 40692, 0, 2147483399> >]’
+/usr/local/lib/R/site-library/StanHeaders/include/src/stan/mcmc/hmc/hamiltonians/dense_e_metric.hpp:21:0:   required from here
+/usr/local/lib/R/site-library/RcppEigen/include/Eigen/src/Core/DenseCoeffsBase.h:654:74: warning: ignoring attributes on template argument ‘Eigen::internal::packet_traits<double>::type’ {aka ‘__m128d’} [-Wignored-attributes]
+  654 |   return internal::first_aligned<int(unpacket_traits<DefaultPacketType>::alignment),Derived>(m);
+      |                                                                          ^~~~~~~~~
+g++: fatal error: Killed signal terminated program cc1plus
+compilation terminated.
+make: *** [/opt/R/4.4.0/lib/R/etc/Makeconf:202: stanExports_ensemble_model_hierarchical.o] Error 1
+ERROR: compilation failed for package ‘EcoEnsemble’
+* removing ‘/tmp/workdir/EcoEnsemble/old/EcoEnsemble.Rcheck/EcoEnsemble’
+
+
+```
+# FAfA (0.3)
+
+* Github mirror: https://github.com/cran/FAfA
+* Maintainer: Abdullah Faruk KILIC <abdullahfarukkilic@gmail.com>
+
+Run `revdepcheck::cloud_details(, "FAfA")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/FAfA/new/FAfA.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘FAfA/DESCRIPTION’ ... OK
+...
+* this is package ‘FAfA’ version ‘0.3’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Packages required but not available: 'MBESS', 'semPlot'
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/FAfA/old/FAfA.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘FAfA/DESCRIPTION’ ... OK
+...
+* this is package ‘FAfA’ version ‘0.3’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Packages required but not available: 'MBESS', 'semPlot'
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+# FAIRmaterials (0.4.2.1)
+
+* Github mirror: https://github.com/cran/FAIRmaterials
+* Maintainer: Roger H French <roger.french@case.edu>
+
+Run `revdepcheck::cloud_details(, "FAIRmaterials")` for more info
+
+## In both
+
+*   checking whether package ‘FAIRmaterials’ can be installed ... ERROR
+     ```
+     Installation failed.
+     See ‘/tmp/workdir/FAIRmaterials/new/FAIRmaterials.Rcheck/00install.out’ for details.
+     ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘FAIRmaterials’ ...
+** package ‘FAIRmaterials’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error in dyn.load(file, DLLpath = DLLpath, ...) : 
+  unable to load shared object '/usr/local/lib/R/site-library/redland/libs/redland.so':
+  librdf.so.0: cannot open shared object file: No such file or directory
+Calls: <Anonymous> ... asNamespace -> loadNamespace -> library.dynam -> dyn.load
+Execution halted
+ERROR: lazy loading failed for package ‘FAIRmaterials’
+* removing ‘/tmp/workdir/FAIRmaterials/new/FAIRmaterials.Rcheck/FAIRmaterials’
+
+
+```
+### CRAN
+
+```
+* installing *source* package ‘FAIRmaterials’ ...
+** package ‘FAIRmaterials’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error in dyn.load(file, DLLpath = DLLpath, ...) : 
+  unable to load shared object '/usr/local/lib/R/site-library/redland/libs/redland.so':
+  librdf.so.0: cannot open shared object file: No such file or directory
+Calls: <Anonymous> ... asNamespace -> loadNamespace -> library.dynam -> dyn.load
+Execution halted
+ERROR: lazy loading failed for package ‘FAIRmaterials’
+* removing ‘/tmp/workdir/FAIRmaterials/old/FAIRmaterials.Rcheck/FAIRmaterials’
+
+
+```
+# flowWorkspace (NA)
+
+* Github mirror: https://github.com/cran/flowWorkspace
+* Maintainer: NA
+
+Run `revdepcheck::cloud_details(, "flowWorkspace")` for more info
 
 ## Error before installation
 
@@ -8094,67 +1039,3192 @@ Run `revdepcheck::cloud_details(, "NA")` for more info
 
 
 ```
-# zipcodeR
+# genekitr (1.2.8)
 
-<details>
+* GitHub: https://github.com/GangLiLab/genekitr
+* Github mirror: https://github.com/cran/genekitr
+* Maintainer: Yunze Liu <jieandze1314@gmail.com>
 
-* Version: 0.3.5
-* GitHub: https://github.com/gavinrozzi/zipcodeR
-* Source code: https://github.com/cran/zipcodeR
-* Date/Publication: 2022-10-03 22:00:02 UTC
-* Number of recursive dependencies: 99
+Run `revdepcheck::cloud_details(, "genekitr")` for more info
 
-Run `revdepcheck::cloud_details(, "zipcodeR")` for more info
-
-</details>
-
-## In both
-
-*   checking whether package ‘zipcodeR’ can be installed ... ERROR
-    ```
-    Installation failed.
-    See ‘/tmp/workdir/zipcodeR/new/zipcodeR.Rcheck/00install.out’ for details.
-    ```
-
-## Installation
+## Error before installation
 
 ### Devel
 
 ```
-* installing *source* package ‘zipcodeR’ ...
-** package ‘zipcodeR’ successfully unpacked and MD5 sums checked
-** using staged installation
-** R
-** data
-*** moving datasets to lazyload DB
-** inst
-** byte-compile and prepare package for lazy loading
-Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
-  there is no package called ‘sf’
-Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
-Execution halted
-ERROR: lazy loading failed for package ‘zipcodeR’
-* removing ‘/tmp/workdir/zipcodeR/new/zipcodeR.Rcheck/zipcodeR’
+* using log directory ‘/tmp/workdir/genekitr/new/genekitr.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘genekitr/DESCRIPTION’ ... OK
+...
+* this is package ‘genekitr’ version ‘1.2.8’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘clusterProfiler’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
 
 
 ```
 ### CRAN
 
 ```
-* installing *source* package ‘zipcodeR’ ...
-** package ‘zipcodeR’ successfully unpacked and MD5 sums checked
+* using log directory ‘/tmp/workdir/genekitr/old/genekitr.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘genekitr/DESCRIPTION’ ... OK
+...
+* this is package ‘genekitr’ version ‘1.2.8’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘clusterProfiler’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+# GeneSelectR (1.0.1)
+
+* GitHub: https://github.com/dzhakparov/GeneSelectR
+* Github mirror: https://github.com/cran/GeneSelectR
+* Maintainer: Damir Zhakparov <dzhakparov@gmail.com>
+
+Run `revdepcheck::cloud_details(, "GeneSelectR")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/GeneSelectR/new/GeneSelectR.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘GeneSelectR/DESCRIPTION’ ... OK
+...
+* checking files in ‘vignettes’ ... OK
+* checking examples ... OK
+* checking for unstated dependencies in ‘tests’ ... OK
+* checking tests ... OK
+  Running ‘testthat.R’
+* checking for unstated dependencies in vignettes ... OK
+* checking package vignettes ... OK
+* checking re-building of vignette outputs ... OK
+* DONE
+Status: 1 NOTE
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/GeneSelectR/old/GeneSelectR.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘GeneSelectR/DESCRIPTION’ ... OK
+...
+* checking files in ‘vignettes’ ... OK
+* checking examples ... OK
+* checking for unstated dependencies in ‘tests’ ... OK
+* checking tests ... OK
+  Running ‘testthat.R’
+* checking for unstated dependencies in vignettes ... OK
+* checking package vignettes ... OK
+* checking re-building of vignette outputs ... OK
+* DONE
+Status: 1 NOTE
+
+
+
+
+
+```
+# ggmosaic (0.3.3)
+
+* GitHub: https://github.com/haleyjeppson/ggmosaic
+* Github mirror: https://github.com/cran/ggmosaic
+* Maintainer: Haley Jeppson <hjeppson@iastate.edu>
+
+Run `revdepcheck::cloud_details(, "ggmosaic")` for more info
+
+## In both
+
+*   checking whether package ‘ggmosaic’ can be installed ... ERROR
+     ```
+     Installation failed.
+     See ‘/tmp/workdir/ggmosaic/new/ggmosaic.Rcheck/00install.out’ for details.
+     ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘ggmosaic’ ...
+** package ‘ggmosaic’ successfully unpacked and MD5 sums checked
 ** using staged installation
 ** R
 ** data
 *** moving datasets to lazyload DB
 ** inst
 ** byte-compile and prepare package for lazy loading
-Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
-  there is no package called ‘sf’
-Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
+Error in get(x, envir = ns, inherits = FALSE) : 
+  object 'is.waive' not found
+Error: unable to load R code in package ‘ggmosaic’
 Execution halted
-ERROR: lazy loading failed for package ‘zipcodeR’
-* removing ‘/tmp/workdir/zipcodeR/old/zipcodeR.Rcheck/zipcodeR’
+ERROR: lazy loading failed for package ‘ggmosaic’
+* removing ‘/tmp/workdir/ggmosaic/new/ggmosaic.Rcheck/ggmosaic’
+
+
+```
+### CRAN
+
+```
+* installing *source* package ‘ggmosaic’ ...
+** package ‘ggmosaic’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error in get(x, envir = ns, inherits = FALSE) : 
+  object 'is.waive' not found
+Error: unable to load R code in package ‘ggmosaic’
+Execution halted
+ERROR: lazy loading failed for package ‘ggmosaic’
+* removing ‘/tmp/workdir/ggmosaic/old/ggmosaic.Rcheck/ggmosaic’
+
+
+```
+# ggmulti (1.0.7)
+
+* Github mirror: https://github.com/cran/ggmulti
+* Maintainer: Zehao Xu <z267xu@gmail.com>
+
+Run `revdepcheck::cloud_details(, "ggmulti")` for more info
+
+## In both
+
+*   checking whether package ‘ggmulti’ can be installed ... ERROR
+     ```
+     Installation failed.
+     See ‘/tmp/workdir/ggmulti/new/ggmulti.Rcheck/00install.out’ for details.
+     ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘ggmulti’ ...
+** package ‘ggmulti’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error in get(x, envir = ns, inherits = FALSE) : 
+  object 'new_aes' not found
+Error: unable to load R code in package ‘ggmulti’
+Execution halted
+ERROR: lazy loading failed for package ‘ggmulti’
+* removing ‘/tmp/workdir/ggmulti/new/ggmulti.Rcheck/ggmulti’
+
+
+```
+### CRAN
+
+```
+* installing *source* package ‘ggmulti’ ...
+** package ‘ggmulti’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error in get(x, envir = ns, inherits = FALSE) : 
+  object 'new_aes' not found
+Error: unable to load R code in package ‘ggmulti’
+Execution halted
+ERROR: lazy loading failed for package ‘ggmulti’
+* removing ‘/tmp/workdir/ggmulti/old/ggmulti.Rcheck/ggmulti’
+
+
+```
+# ggpicrust2 (2.5.2)
+
+* GitHub: https://github.com/cafferychen777/ggpicrust2
+* Github mirror: https://github.com/cran/ggpicrust2
+* Maintainer: Chen Yang <cafferychen7850@gmail.com>
+
+Run `revdepcheck::cloud_details(, "ggpicrust2")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/ggpicrust2/new/ggpicrust2.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘ggpicrust2/DESCRIPTION’ ... OK
+...
+* checking Rd contents ... OK
+* checking for unstated dependencies in examples ... OK
+* checking contents of ‘data’ directory ... OK
+* checking data for non-ASCII characters ... OK
+* checking LazyData ... OK
+* checking data for ASCII and uncompressed saves ... OK
+* checking R/sysdata.rda ... OK
+* checking examples ... OK
+* DONE
+Status: 2 NOTEs
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/ggpicrust2/old/ggpicrust2.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘ggpicrust2/DESCRIPTION’ ... OK
+...
+* checking Rd contents ... OK
+* checking for unstated dependencies in examples ... OK
+* checking contents of ‘data’ directory ... OK
+* checking data for non-ASCII characters ... OK
+* checking LazyData ... OK
+* checking data for ASCII and uncompressed saves ... OK
+* checking R/sysdata.rda ... OK
+* checking examples ... OK
+* DONE
+Status: 2 NOTEs
+
+
+
+
+
+```
+# ggsem (0.2.4)
+
+* GitHub: https://github.com/smin95/ggsem
+* Github mirror: https://github.com/cran/ggsem
+* Maintainer: Seung Hyun Min <seung.min@mail.mcgill.ca>
+
+Run `revdepcheck::cloud_details(, "ggsem")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/ggsem/new/ggsem.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘ggsem/DESCRIPTION’ ... OK
+...
+* checking Rd metadata ... OK
+* checking Rd cross-references ... OK
+* checking for missing documentation entries ... OK
+* checking for code/documentation mismatches ... OK
+* checking Rd \usage sections ... OK
+* checking Rd contents ... OK
+* checking for unstated dependencies in examples ... OK
+* checking examples ... OK
+* DONE
+Status: 1 NOTE
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/ggsem/old/ggsem.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘ggsem/DESCRIPTION’ ... OK
+...
+* checking Rd metadata ... OK
+* checking Rd cross-references ... OK
+* checking for missing documentation entries ... OK
+* checking for code/documentation mismatches ... OK
+* checking Rd \usage sections ... OK
+* checking Rd contents ... OK
+* checking for unstated dependencies in examples ... OK
+* checking examples ... OK
+* DONE
+Status: 1 NOTE
+
+
+
+
+
+```
+# Grouphmap (1.0.0)
+
+* Github mirror: https://github.com/cran/Grouphmap
+* Maintainer: Yuchen Sun <yuchensun2436@163.com>
+
+Run `revdepcheck::cloud_details(, "Grouphmap")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/Grouphmap/new/Grouphmap.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘Grouphmap/DESCRIPTION’ ... OK
+...
+* this is package ‘Grouphmap’ version ‘1.0.0’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘clusterProfiler’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/Grouphmap/old/Grouphmap.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘Grouphmap/DESCRIPTION’ ... OK
+...
+* this is package ‘Grouphmap’ version ‘1.0.0’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘clusterProfiler’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+# immcp (1.0.3)
+
+* GitHub: https://github.com/YuanlongHu/immcp
+* Github mirror: https://github.com/cran/immcp
+* Maintainer: Yuanlong Hu <huyuanlong1996@163.com>
+
+Run `revdepcheck::cloud_details(, "immcp")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/immcp/new/immcp.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘immcp/DESCRIPTION’ ... OK
+...
+* this is package ‘immcp’ version ‘1.0.3’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Packages required but not available: 'clusterProfiler', 'arules'
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/immcp/old/immcp.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘immcp/DESCRIPTION’ ... OK
+...
+* this is package ‘immcp’ version ‘1.0.3’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Packages required but not available: 'clusterProfiler', 'arules'
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+# jmv (2.7.7)
+
+* GitHub: https://github.com/jamovi/jmv
+* Github mirror: https://github.com/cran/jmv
+* Maintainer: Jonathon Love <jon@thon.cc>
+
+Run `revdepcheck::cloud_details(, "jmv")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/jmv/new/jmv.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘jmv/DESCRIPTION’ ... OK
+...
+* checking for unstated dependencies in examples ... OK
+* checking contents of ‘data’ directory ... OK
+* checking data for non-ASCII characters ... OK
+* checking data for ASCII and uncompressed saves ... OK
+* checking examples ... OK
+* checking for unstated dependencies in ‘tests’ ... OK
+* checking tests ... OK
+  Running ‘testthat.R’
+* DONE
+Status: 3 NOTEs
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/jmv/old/jmv.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘jmv/DESCRIPTION’ ... OK
+...
+* checking for unstated dependencies in examples ... OK
+* checking contents of ‘data’ directory ... OK
+* checking data for non-ASCII characters ... OK
+* checking data for ASCII and uncompressed saves ... OK
+* checking examples ... OK
+* checking for unstated dependencies in ‘tests’ ... OK
+* checking tests ... OK
+  Running ‘testthat.R’
+* DONE
+Status: 3 NOTEs
+
+
+
+
+
+```
+# lcsm (0.3.2)
+
+* GitHub: https://github.com/milanwiedemann/lcsm
+* Github mirror: https://github.com/cran/lcsm
+* Maintainer: Milan Wiedemann <milan.wiedemann@gmail.com>
+
+Run `revdepcheck::cloud_details(, "lcsm")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/lcsm/new/lcsm.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘lcsm/DESCRIPTION’ ... OK
+...
+* this is package ‘lcsm’ version ‘0.3.2’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘semPlot’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/lcsm/old/lcsm.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘lcsm/DESCRIPTION’ ... OK
+...
+* this is package ‘lcsm’ version ‘0.3.2’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘semPlot’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+# loon.shiny (1.0.3)
+
+* Github mirror: https://github.com/cran/loon.shiny
+* Maintainer: Zehao Xu <z267xu@uwaterloo.ca>
+
+Run `revdepcheck::cloud_details(, "loon.shiny")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/loon.shiny/new/loon.shiny.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘loon.shiny/DESCRIPTION’ ... OK
+...
+* this is package ‘loon.shiny’ version ‘1.0.3’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Packages required but not available: 'loon', 'loon.ggplot'
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/loon.shiny/old/loon.shiny.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘loon.shiny/DESCRIPTION’ ... OK
+...
+* this is package ‘loon.shiny’ version ‘1.0.3’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Packages required but not available: 'loon', 'loon.ggplot'
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+# lvnet (0.3.5)
+
+* Github mirror: https://github.com/cran/lvnet
+* Maintainer: Sacha Epskamp <mail@sachaepskamp.com>
+
+Run `revdepcheck::cloud_details(, "lvnet")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/lvnet/new/lvnet.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘lvnet/DESCRIPTION’ ... OK
+...
+* checking extension type ... Package
+* this is package ‘lvnet’ version ‘0.3.5’
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Packages required but not available: 'OpenMx', 'semPlot'
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/lvnet/old/lvnet.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘lvnet/DESCRIPTION’ ... OK
+...
+* checking extension type ... Package
+* this is package ‘lvnet’ version ‘0.3.5’
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Packages required but not available: 'OpenMx', 'semPlot'
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+# metajam (0.3.1)
+
+* GitHub: https://github.com/NCEAS/metajam
+* Github mirror: https://github.com/cran/metajam
+* Maintainer: Julien Brun <julien.brun@alumni.duke.edu>
+
+Run `revdepcheck::cloud_details(, "metajam")` for more info
+
+## In both
+
+*   checking whether package ‘metajam’ can be installed ... ERROR
+     ```
+     Installation failed.
+     See ‘/tmp/workdir/metajam/new/metajam.Rcheck/00install.out’ for details.
+     ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘metajam’ ...
+** package ‘metajam’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error in dyn.load(file, DLLpath = DLLpath, ...) : 
+  unable to load shared object '/usr/local/lib/R/site-library/redland/libs/redland.so':
+  librdf.so.0: cannot open shared object file: No such file or directory
+Calls: <Anonymous> ... namespaceImport -> loadNamespace -> library.dynam -> dyn.load
+Execution halted
+ERROR: lazy loading failed for package ‘metajam’
+* removing ‘/tmp/workdir/metajam/new/metajam.Rcheck/metajam’
+
+
+```
+### CRAN
+
+```
+* installing *source* package ‘metajam’ ...
+** package ‘metajam’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error in dyn.load(file, DLLpath = DLLpath, ...) : 
+  unable to load shared object '/usr/local/lib/R/site-library/redland/libs/redland.so':
+  librdf.so.0: cannot open shared object file: No such file or directory
+Calls: <Anonymous> ... namespaceImport -> loadNamespace -> library.dynam -> dyn.load
+Execution halted
+ERROR: lazy loading failed for package ‘metajam’
+* removing ‘/tmp/workdir/metajam/old/metajam.Rcheck/metajam’
+
+
+```
+# ModStatR (1.4.1)
+
+* GitHub: https://github.com/fbertran/ModStatR
+* Github mirror: https://github.com/cran/ModStatR
+* Maintainer: Frederic Bertrand <frederic.bertrand@lecnam.net>
+
+Run `revdepcheck::cloud_details(, "ModStatR")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/ModStatR/new/ModStatR.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘ModStatR/DESCRIPTION’ ... OK
+...
+* checking data for non-ASCII characters ... NOTE
+  Note: found 20578 marked UTF-8 strings
+* checking LazyData ... OK
+* checking data for ASCII and uncompressed saves ... OK
+* checking examples ... OK
+* checking for unstated dependencies in ‘tests’ ... OK
+* checking tests ... OK
+  Running ‘testthat.R’
+* DONE
+Status: 3 NOTEs
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/ModStatR/old/ModStatR.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘ModStatR/DESCRIPTION’ ... OK
+...
+* checking data for non-ASCII characters ... NOTE
+  Note: found 20578 marked UTF-8 strings
+* checking LazyData ... OK
+* checking data for ASCII and uncompressed saves ... OK
+* checking examples ... OK
+* checking for unstated dependencies in ‘tests’ ... OK
+* checking tests ... OK
+  Running ‘testthat.R’
+* DONE
+Status: 3 NOTEs
+
+
+
+
+
+```
+# multiModTest (1.0)
+
+* Github mirror: https://github.com/cran/multiModTest
+* Maintainer: Wanting Jin <jinwanting5@gmail.com>
+
+Run `revdepcheck::cloud_details(, "multiModTest")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/multiModTest/new/multiModTest.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘multiModTest/DESCRIPTION’ ... OK
+...
+* this is package ‘multiModTest’ version ‘1.0’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘MBESS’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/multiModTest/old/multiModTest.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘multiModTest/DESCRIPTION’ ... OK
+...
+* this is package ‘multiModTest’ version ‘1.0’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘MBESS’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+# multinma (0.8.1)
+
+* GitHub: https://github.com/dmphillippo/multinma
+* Github mirror: https://github.com/cran/multinma
+* Maintainer: David M. Phillippo <david.phillippo@bristol.ac.uk>
+
+Run `revdepcheck::cloud_details(, "multinma")` for more info
+
+## In both
+
+*   checking whether package ‘multinma’ can be installed ... ERROR
+     ```
+     Installation failed.
+     See ‘/tmp/workdir/multinma/new/multinma.Rcheck/00install.out’ for details.
+     ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘multinma’ ...
+** package ‘multinma’ successfully unpacked and MD5 sums checked
+** using staged installation
+** libs
+using C++ compiler: ‘g++ (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0’
+using C++17
+
+
+g++ -std=gnu++17 -I"/opt/R/4.4.0/lib/R/include" -DNDEBUG -I"../inst/include" -I"/usr/local/lib/R/site-library/StanHeaders/include/src" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error -DUSE_STANC3 -D_HAS_AUTO_PTR_ETC=0 -I'/usr/local/lib/R/site-library/BH/include' -I'/usr/local/lib/R/site-library/Rcpp/include' -I'/usr/local/lib/R/site-library/RcppEigen/include' -I'/usr/local/lib/R/site-library/RcppParallel/include' -I'/usr/local/lib/R/site-library/rstan/include' -I'/usr/local/lib/R/site-library/StanHeaders/include' -I/usr/local/include    -I'/usr/local/lib/R/site-library/RcppParallel/include' -D_REENTRANT -DSTAN_THREADS   -fpic  -g -O2   -c RcppExports.cpp -o RcppExports.o
+In file included from /usr/local/lib/R/site-library/RcppEigen/include/Eigen/Core:205,
+...
+/usr/local/lib/R/site-library/StanHeaders/include/src/stan/mcmc/hmc/hamiltonians/dense_e_metric.hpp:22:0:   required from ‘double stan::mcmc::dense_e_metric<Model, BaseRNG>::T(stan::mcmc::dense_e_point&) [with Model = model_survival_param_namespace::model_survival_param; BaseRNG = boost::random::additive_combine_engine<boost::random::linear_congruential_engine<unsigned int, 40014, 0, 2147483563>, boost::random::linear_congruential_engine<unsigned int, 40692, 0, 2147483399> >]’
+/usr/local/lib/R/site-library/StanHeaders/include/src/stan/mcmc/hmc/hamiltonians/dense_e_metric.hpp:21:0:   required from here
+/usr/local/lib/R/site-library/RcppEigen/include/Eigen/src/Core/DenseCoeffsBase.h:654:74: warning: ignoring attributes on template argument ‘Eigen::internal::packet_traits<double>::type’ {aka ‘__m128d’} [-Wignored-attributes]
+  654 |   return internal::first_aligned<int(unpacket_traits<DefaultPacketType>::alignment),Derived>(m);
+      |                                                                          ^~~~~~~~~
+g++: fatal error: Killed signal terminated program cc1plus
+compilation terminated.
+make: *** [/opt/R/4.4.0/lib/R/etc/Makeconf:202: stanExports_survival_param.o] Error 1
+ERROR: compilation failed for package ‘multinma’
+* removing ‘/tmp/workdir/multinma/new/multinma.Rcheck/multinma’
+
+
+```
+### CRAN
+
+```
+* installing *source* package ‘multinma’ ...
+** package ‘multinma’ successfully unpacked and MD5 sums checked
+** using staged installation
+** libs
+using C++ compiler: ‘g++ (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0’
+using C++17
+
+
+g++ -std=gnu++17 -I"/opt/R/4.4.0/lib/R/include" -DNDEBUG -I"../inst/include" -I"/usr/local/lib/R/site-library/StanHeaders/include/src" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error -DUSE_STANC3 -D_HAS_AUTO_PTR_ETC=0 -I'/usr/local/lib/R/site-library/BH/include' -I'/usr/local/lib/R/site-library/Rcpp/include' -I'/usr/local/lib/R/site-library/RcppEigen/include' -I'/usr/local/lib/R/site-library/RcppParallel/include' -I'/usr/local/lib/R/site-library/rstan/include' -I'/usr/local/lib/R/site-library/StanHeaders/include' -I/usr/local/include    -I'/usr/local/lib/R/site-library/RcppParallel/include' -D_REENTRANT -DSTAN_THREADS   -fpic  -g -O2   -c RcppExports.cpp -o RcppExports.o
+In file included from /usr/local/lib/R/site-library/RcppEigen/include/Eigen/Core:205,
+...
+/usr/local/lib/R/site-library/StanHeaders/include/src/stan/mcmc/hmc/hamiltonians/dense_e_metric.hpp:22:0:   required from ‘double stan::mcmc::dense_e_metric<Model, BaseRNG>::T(stan::mcmc::dense_e_point&) [with Model = model_survival_param_namespace::model_survival_param; BaseRNG = boost::random::additive_combine_engine<boost::random::linear_congruential_engine<unsigned int, 40014, 0, 2147483563>, boost::random::linear_congruential_engine<unsigned int, 40692, 0, 2147483399> >]’
+/usr/local/lib/R/site-library/StanHeaders/include/src/stan/mcmc/hmc/hamiltonians/dense_e_metric.hpp:21:0:   required from here
+/usr/local/lib/R/site-library/RcppEigen/include/Eigen/src/Core/DenseCoeffsBase.h:654:74: warning: ignoring attributes on template argument ‘Eigen::internal::packet_traits<double>::type’ {aka ‘__m128d’} [-Wignored-attributes]
+  654 |   return internal::first_aligned<int(unpacket_traits<DefaultPacketType>::alignment),Derived>(m);
+      |                                                                          ^~~~~~~~~
+g++: fatal error: Killed signal terminated program cc1plus
+compilation terminated.
+make: *** [/opt/R/4.4.0/lib/R/etc/Makeconf:202: stanExports_survival_param.o] Error 1
+ERROR: compilation failed for package ‘multinma’
+* removing ‘/tmp/workdir/multinma/old/multinma.Rcheck/multinma’
+
+
+```
+# myTAI (NA)
+
+* Github mirror: https://github.com/cran/myTAI
+* Maintainer: NA
+
+Run `revdepcheck::cloud_details(, "myTAI")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+
+
+
+```
+### CRAN
+
+```
+
+
+
+
+
+
+```
+# NanoMethViz (NA)
+
+* Github mirror: https://github.com/cran/NanoMethViz
+* Maintainer: NA
+
+Run `revdepcheck::cloud_details(, "NanoMethViz")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+
+
+
+```
+### CRAN
+
+```
+
+
+
+
+
+
+```
+# negligible (0.1.9)
+
+* Github mirror: https://github.com/cran/negligible
+* Maintainer: Robert Cribbie <cribbie@yorku.ca>
+
+Run `revdepcheck::cloud_details(, "negligible")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/negligible/new/negligible.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘negligible/DESCRIPTION’ ... OK
+...
+* this is package ‘negligible’ version ‘0.1.9’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘MBESS’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/negligible/old/negligible.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘negligible/DESCRIPTION’ ... OK
+...
+* this is package ‘negligible’ version ‘0.1.9’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘MBESS’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+# nesRdata (0.3.1)
+
+* GitHub: https://github.com/jsta/nesRdata
+* Github mirror: https://github.com/cran/nesRdata
+* Maintainer: Joseph Stachelek <stachel2@msu.edu>
+
+Run `revdepcheck::cloud_details(, "nesRdata")` for more info
+
+## In both
+
+*   checking whether package ‘nesRdata’ can be installed ... ERROR
+     ```
+     Installation failed.
+     See ‘/tmp/workdir/nesRdata/new/nesRdata.Rcheck/00install.out’ for details.
+     ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘nesRdata’ ...
+** package ‘nesRdata’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error in dyn.load(file, DLLpath = DLLpath, ...) : 
+  unable to load shared object '/usr/local/lib/R/site-library/redland/libs/redland.so':
+  librdf.so.0: cannot open shared object file: No such file or directory
+Calls: <Anonymous> ... namespaceImport -> loadNamespace -> library.dynam -> dyn.load
+Execution halted
+ERROR: lazy loading failed for package ‘nesRdata’
+* removing ‘/tmp/workdir/nesRdata/new/nesRdata.Rcheck/nesRdata’
+
+
+```
+### CRAN
+
+```
+* installing *source* package ‘nesRdata’ ...
+** package ‘nesRdata’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error in dyn.load(file, DLLpath = DLLpath, ...) : 
+  unable to load shared object '/usr/local/lib/R/site-library/redland/libs/redland.so':
+  librdf.so.0: cannot open shared object file: No such file or directory
+Calls: <Anonymous> ... namespaceImport -> loadNamespace -> library.dynam -> dyn.load
+Execution halted
+ERROR: lazy loading failed for package ‘nesRdata’
+* removing ‘/tmp/workdir/nesRdata/old/nesRdata.Rcheck/nesRdata’
+
+
+```
+# numbat (1.4.2)
+
+* GitHub: https://github.com/kharchenkolab/numbat
+* Github mirror: https://github.com/cran/numbat
+* Maintainer: Teng Gao <tgaoteng@gmail.com>
+
+Run `revdepcheck::cloud_details(, "numbat")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/numbat/new/numbat.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘numbat/DESCRIPTION’ ... OK
+...
+* this is package ‘numbat’ version ‘1.4.2’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Packages required but not available: 'ggtree', 'scistreer'
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/numbat/old/numbat.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘numbat/DESCRIPTION’ ... OK
+...
+* this is package ‘numbat’ version ‘1.4.2’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Packages required but not available: 'ggtree', 'scistreer'
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+# OlinkAnalyze (4.3.2)
+
+* GitHub: https://github.com/Olink-Proteomics/OlinkRPackage
+* Github mirror: https://github.com/cran/OlinkAnalyze
+* Maintainer: Kathleen Nevola <biostattools@olink.com>
+
+Run `revdepcheck::cloud_details(, "OlinkAnalyze")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/OlinkAnalyze/new/OlinkAnalyze.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘OlinkAnalyze/DESCRIPTION’ ... OK
+...
+* checking files in ‘vignettes’ ... OK
+* checking examples ... OK
+* checking for unstated dependencies in ‘tests’ ... OK
+* checking tests ... OK
+  Running ‘testthat.R’
+* checking for unstated dependencies in vignettes ... OK
+* checking package vignettes ... OK
+* checking re-building of vignette outputs ... OK
+* DONE
+Status: 1 NOTE
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/OlinkAnalyze/old/OlinkAnalyze.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘OlinkAnalyze/DESCRIPTION’ ... OK
+...
+* checking files in ‘vignettes’ ... OK
+* checking examples ... OK
+* checking for unstated dependencies in ‘tests’ ... OK
+* checking tests ... OK
+  Running ‘testthat.R’
+* checking for unstated dependencies in vignettes ... OK
+* checking package vignettes ... OK
+* checking re-building of vignette outputs ... OK
+* DONE
+Status: 1 NOTE
+
+
+
+
+
+```
+# ontologics (0.7.4)
+
+* GitHub: https://github.com/luckinet/ontologics
+* Github mirror: https://github.com/cran/ontologics
+* Maintainer: Steffen Ehrmann <steffen.ehrmann@posteo.de>
+
+Run `revdepcheck::cloud_details(, "ontologics")` for more info
+
+## In both
+
+*   checking whether package ‘ontologics’ can be installed ... ERROR
+     ```
+     Installation failed.
+     See ‘/tmp/workdir/ontologics/new/ontologics.Rcheck/00install.out’ for details.
+     ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘ontologics’ ...
+** package ‘ontologics’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error in dyn.load(file, DLLpath = DLLpath, ...) : 
+  unable to load shared object '/usr/local/lib/R/site-library/redland/libs/redland.so':
+  librdf.so.0: cannot open shared object file: No such file or directory
+Calls: <Anonymous> ... asNamespace -> loadNamespace -> library.dynam -> dyn.load
+Execution halted
+ERROR: lazy loading failed for package ‘ontologics’
+* removing ‘/tmp/workdir/ontologics/new/ontologics.Rcheck/ontologics’
+
+
+```
+### CRAN
+
+```
+* installing *source* package ‘ontologics’ ...
+** package ‘ontologics’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error in dyn.load(file, DLLpath = DLLpath, ...) : 
+  unable to load shared object '/usr/local/lib/R/site-library/redland/libs/redland.so':
+  librdf.so.0: cannot open shared object file: No such file or directory
+Calls: <Anonymous> ... asNamespace -> loadNamespace -> library.dynam -> dyn.load
+Execution halted
+ERROR: lazy loading failed for package ‘ontologics’
+* removing ‘/tmp/workdir/ontologics/old/ontologics.Rcheck/ontologics’
+
+
+```
+# pctax (0.1.3)
+
+* GitHub: https://github.com/Asa12138/pctax
+* Github mirror: https://github.com/cran/pctax
+* Maintainer: Chen Peng <pengchen2001@zju.edu.cn>
+
+Run `revdepcheck::cloud_details(, "pctax")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/pctax/new/pctax.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘pctax/DESCRIPTION’ ... OK
+...
+* checking LazyData ... OK
+* checking data for ASCII and uncompressed saves ... OK
+* checking installed files from ‘inst/doc’ ... OK
+* checking files in ‘vignettes’ ... OK
+* checking examples ... OK
+* checking for unstated dependencies in vignettes ... OK
+* checking package vignettes ... OK
+* checking re-building of vignette outputs ... OK
+* DONE
+Status: 3 NOTEs
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/pctax/old/pctax.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘pctax/DESCRIPTION’ ... OK
+...
+* checking LazyData ... OK
+* checking data for ASCII and uncompressed saves ... OK
+* checking installed files from ‘inst/doc’ ... OK
+* checking files in ‘vignettes’ ... OK
+* checking examples ... OK
+* checking for unstated dependencies in vignettes ... OK
+* checking package vignettes ... OK
+* checking re-building of vignette outputs ... OK
+* DONE
+Status: 3 NOTEs
+
+
+
+
+
+```
+# pkgstats (NA)
+
+* Github mirror: https://github.com/cran/pkgstats
+* Maintainer: NA
+
+Run `revdepcheck::cloud_details(, "pkgstats")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+
+
+
+```
+### CRAN
+
+```
+
+
+
+
+
+
+```
+# psychonetrics (0.13.1)
+
+* GitHub: https://github.com/SachaEpskamp/psychonetrics
+* Github mirror: https://github.com/cran/psychonetrics
+* Maintainer: Sacha Epskamp <mail@sachaepskamp.com>
+
+Run `revdepcheck::cloud_details(, "psychonetrics")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/psychonetrics/new/psychonetrics.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘psychonetrics/DESCRIPTION’ ... OK
+...
+* checking line endings in C/C++/Fortran sources/headers ... OK
+* checking line endings in Makefiles ... OK
+* checking compilation flags in Makevars ... OK
+* checking for GNU extensions in Makefiles ... OK
+* checking for portable use of $(BLAS_LIBS) and $(LAPACK_LIBS) ... OK
+* checking use of PKG_*FLAGS in Makefiles ... OK
+* checking compiled code ... OK
+* checking examples ... OK
+* DONE
+Status: 1 WARNING, 2 NOTEs
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/psychonetrics/old/psychonetrics.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘psychonetrics/DESCRIPTION’ ... OK
+...
+* checking line endings in C/C++/Fortran sources/headers ... OK
+* checking line endings in Makefiles ... OK
+* checking compilation flags in Makevars ... OK
+* checking for GNU extensions in Makefiles ... OK
+* checking for portable use of $(BLAS_LIBS) and $(LAPACK_LIBS) ... OK
+* checking use of PKG_*FLAGS in Makefiles ... OK
+* checking compiled code ... OK
+* checking examples ... OK
+* DONE
+Status: 1 WARNING, 2 NOTEs
+
+
+
+
+
+```
+# psycModel (0.5.0)
+
+* GitHub: https://github.com/jasonmoy28/psycModel
+* Github mirror: https://github.com/cran/psycModel
+* Maintainer: Jason Moy <jasonmoy28@gmail.com>
+
+Run `revdepcheck::cloud_details(, "psycModel")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/psycModel/new/psycModel.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘psycModel/DESCRIPTION’ ... OK
+...
+* checking files in ‘vignettes’ ... OK
+* checking examples ... OK
+* checking for unstated dependencies in ‘tests’ ... OK
+* checking tests ... OK
+  Running ‘testthat.R’
+* checking for unstated dependencies in vignettes ... OK
+* checking package vignettes ... OK
+* checking re-building of vignette outputs ... OK
+* DONE
+Status: 2 NOTEs
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/psycModel/old/psycModel.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘psycModel/DESCRIPTION’ ... OK
+...
+* checking files in ‘vignettes’ ... OK
+* checking examples ... OK
+* checking for unstated dependencies in ‘tests’ ... OK
+* checking tests ... OK
+  Running ‘testthat.R’
+* checking for unstated dependencies in vignettes ... OK
+* checking package vignettes ... OK
+* checking re-building of vignette outputs ... OK
+* DONE
+Status: 2 NOTEs
+
+
+
+
+
+```
+# pwr2ppl (0.5.0)
+
+* Github mirror: https://github.com/cran/pwr2ppl
+* Maintainer: Chris Aberson <chris.aberson@gmail.com>
+
+Run `revdepcheck::cloud_details(, "pwr2ppl")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/pwr2ppl/new/pwr2ppl.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘pwr2ppl/DESCRIPTION’ ... OK
+...
+* this is package ‘pwr2ppl’ version ‘0.5.0’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘MBESS’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/pwr2ppl/old/pwr2ppl.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘pwr2ppl/DESCRIPTION’ ... OK
+...
+* this is package ‘pwr2ppl’ version ‘0.5.0’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘MBESS’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+# rattle (5.5.1)
+
+* Github mirror: https://github.com/cran/rattle
+* Maintainer: Graham Williams <Graham.Williams@togaware.com>
+
+Run `revdepcheck::cloud_details(, "rattle")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/rattle/new/rattle.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘rattle/DESCRIPTION’ ... OK
+...
+--- failed re-building ‘rattle.Rnw’
+
+SUMMARY: processing the following file failed:
+  ‘rattle.Rnw’
+
+Error: Vignette re-building failed.
+Execution halted
+
+* DONE
+Status: 1 WARNING, 3 NOTEs
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/rattle/old/rattle.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘rattle/DESCRIPTION’ ... OK
+...
+--- failed re-building ‘rattle.Rnw’
+
+SUMMARY: processing the following file failed:
+  ‘rattle.Rnw’
+
+Error: Vignette re-building failed.
+Execution halted
+
+* DONE
+Status: 1 WARNING, 3 NOTEs
+
+
+
+
+
+```
+# rdflib (0.2.9)
+
+* GitHub: https://github.com/ropensci/rdflib
+* Github mirror: https://github.com/cran/rdflib
+* Maintainer: Carl Boettiger <cboettig@gmail.com>
+
+Run `revdepcheck::cloud_details(, "rdflib")` for more info
+
+## In both
+
+*   checking whether package ‘rdflib’ can be installed ... ERROR
+     ```
+     Installation failed.
+     See ‘/tmp/workdir/rdflib/new/rdflib.Rcheck/00install.out’ for details.
+     ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘rdflib’ ...
+** package ‘rdflib’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error in dyn.load(file, DLLpath = DLLpath, ...) : 
+  unable to load shared object '/usr/local/lib/R/site-library/redland/libs/redland.so':
+  librdf.so.0: cannot open shared object file: No such file or directory
+Calls: <Anonymous> ... asNamespace -> loadNamespace -> library.dynam -> dyn.load
+Execution halted
+ERROR: lazy loading failed for package ‘rdflib’
+* removing ‘/tmp/workdir/rdflib/new/rdflib.Rcheck/rdflib’
+
+
+```
+### CRAN
+
+```
+* installing *source* package ‘rdflib’ ...
+** package ‘rdflib’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error in dyn.load(file, DLLpath = DLLpath, ...) : 
+  unable to load shared object '/usr/local/lib/R/site-library/redland/libs/redland.so':
+  librdf.so.0: cannot open shared object file: No such file or directory
+Calls: <Anonymous> ... asNamespace -> loadNamespace -> library.dynam -> dyn.load
+Execution halted
+ERROR: lazy loading failed for package ‘rdflib’
+* removing ‘/tmp/workdir/rdflib/old/rdflib.Rcheck/rdflib’
+
+
+```
+# ReporterScore (0.1.9)
+
+* GitHub: https://github.com/Asa12138/ReporterScore
+* Github mirror: https://github.com/cran/ReporterScore
+* Maintainer: Chen Peng <pengchen2001@zju.edu.cn>
+
+Run `revdepcheck::cloud_details(, "ReporterScore")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/ReporterScore/new/ReporterScore.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘ReporterScore/DESCRIPTION’ ... OK
+...
+* checking data for non-ASCII characters ... OK
+* checking data for ASCII and uncompressed saves ... OK
+* checking installed files from ‘inst/doc’ ... OK
+* checking files in ‘vignettes’ ... OK
+* checking examples ... OK
+* checking for unstated dependencies in vignettes ... OK
+* checking package vignettes ... OK
+* checking re-building of vignette outputs ... OK
+* DONE
+Status: 1 NOTE
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/ReporterScore/old/ReporterScore.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘ReporterScore/DESCRIPTION’ ... OK
+...
+* checking data for non-ASCII characters ... OK
+* checking data for ASCII and uncompressed saves ... OK
+* checking installed files from ‘inst/doc’ ... OK
+* checking files in ‘vignettes’ ... OK
+* checking examples ... OK
+* checking for unstated dependencies in vignettes ... OK
+* checking package vignettes ... OK
+* checking re-building of vignette outputs ... OK
+* DONE
+Status: 1 NOTE
+
+
+
+
+
+```
+# rshift (3.1.2)
+
+* GitHub: https://github.com/alexhroom/rshift
+* Github mirror: https://github.com/cran/rshift
+* Maintainer: Alex H. Room <alexhroom+cran@protonmail.com>
+
+Run `revdepcheck::cloud_details(, "rshift")` for more info
+
+## In both
+
+*   checking whether package ‘rshift’ can be installed ... ERROR
+     ```
+     Installation failed.
+     See ‘/tmp/workdir/rshift/new/rshift.Rcheck/00install.out’ for details.
+     ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘rshift’ ...
+** package ‘rshift’ successfully unpacked and MD5 sums checked
+** using staged installation
+Using cargo 1.75.0
+Using rustc 1.75.0 (82e1608df 2023-12-21) (built from a source tarball)
+Building for CRAN.
+Writing `src/Makevars`.
+`tools/config.R` has finished.
+** libs
+using C compiler: ‘gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0’
+...
+export CARGO_HOME=/tmp/workdir/rshift/new/rshift.Rcheck/00_pkg_src/rshift/src/.cargo && \
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.cargo/bin" && \
+RUSTFLAGS=" --print=native-static-libs" cargo build -j 2 --offline --lib --release --manifest-path=./rust/Cargo.toml --target-dir ./rust/target
+error: failed to parse lock file at: /tmp/workdir/rshift/new/rshift.Rcheck/00_pkg_src/rshift/src/rust/Cargo.lock
+
+Caused by:
+  lock file version 4 requires `-Znext-lockfile-bump`
+make: *** [Makevars:28: rust/target/release/librshift.a] Error 101
+ERROR: compilation failed for package ‘rshift’
+* removing ‘/tmp/workdir/rshift/new/rshift.Rcheck/rshift’
+
+
+```
+### CRAN
+
+```
+* installing *source* package ‘rshift’ ...
+** package ‘rshift’ successfully unpacked and MD5 sums checked
+** using staged installation
+Using cargo 1.75.0
+Using rustc 1.75.0 (82e1608df 2023-12-21) (built from a source tarball)
+Building for CRAN.
+Writing `src/Makevars`.
+`tools/config.R` has finished.
+** libs
+using C compiler: ‘gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0’
+...
+export CARGO_HOME=/tmp/workdir/rshift/old/rshift.Rcheck/00_pkg_src/rshift/src/.cargo && \
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.cargo/bin" && \
+RUSTFLAGS=" --print=native-static-libs" cargo build -j 2 --offline --lib --release --manifest-path=./rust/Cargo.toml --target-dir ./rust/target
+error: failed to parse lock file at: /tmp/workdir/rshift/old/rshift.Rcheck/00_pkg_src/rshift/src/rust/Cargo.lock
+
+Caused by:
+  lock file version 4 requires `-Znext-lockfile-bump`
+make: *** [Makevars:28: rust/target/release/librshift.a] Error 101
+ERROR: compilation failed for package ‘rshift’
+* removing ‘/tmp/workdir/rshift/old/rshift.Rcheck/rshift’
+
+
+```
+# RVA (0.0.5)
+
+* GitHub: https://github.com/THERMOSTATS/RVA
+* Github mirror: https://github.com/cran/RVA
+* Maintainer: Xingpeng Li <xingpeng.li@pfizer.com>
+
+Run `revdepcheck::cloud_details(, "RVA")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/RVA/new/RVA.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘RVA/DESCRIPTION’ ... OK
+...
+* this is package ‘RVA’ version ‘0.0.5’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘clusterProfiler’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/RVA/old/RVA.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘RVA/DESCRIPTION’ ... OK
+...
+* this is package ‘RVA’ version ‘0.0.5’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘clusterProfiler’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+# SCpubr (3.0.0)
+
+* GitHub: https://github.com/enblacar/SCpubr
+* Github mirror: https://github.com/cran/SCpubr
+* Maintainer: Enrique Blanco-Carmona <scpubr@gmail.com>
+
+Run `revdepcheck::cloud_details(, "SCpubr")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/SCpubr/new/SCpubr.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘SCpubr/DESCRIPTION’ ... OK
+...
+* checking files in ‘vignettes’ ... OK
+* checking examples ... OK
+* checking for unstated dependencies in ‘tests’ ... OK
+* checking tests ... OK
+  Running ‘testthat.R’
+* checking for unstated dependencies in vignettes ... OK
+* checking package vignettes ... OK
+* checking re-building of vignette outputs ... OK
+* DONE
+Status: 1 NOTE
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/SCpubr/old/SCpubr.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘SCpubr/DESCRIPTION’ ... OK
+...
+* checking files in ‘vignettes’ ... OK
+* checking examples ... OK
+* checking for unstated dependencies in ‘tests’ ... OK
+* checking tests ... OK
+  Running ‘testthat.R’
+* checking for unstated dependencies in vignettes ... OK
+* checking package vignettes ... OK
+* checking re-building of vignette outputs ... OK
+* DONE
+Status: 1 NOTE
+
+
+
+
+
+```
+# semdrw (0.1.0)
+
+* Github mirror: https://github.com/cran/semdrw
+* Maintainer: Kartikeya Bolar <kartikeya.bolar@tapmi.edu.in>
+
+Run `revdepcheck::cloud_details(, "semdrw")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/semdrw/new/semdrw.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘semdrw/DESCRIPTION’ ... OK
+...
+* this is package ‘semdrw’ version ‘0.1.0’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘semPlot’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/semdrw/old/semdrw.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘semdrw/DESCRIPTION’ ... OK
+...
+* this is package ‘semdrw’ version ‘0.1.0’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘semPlot’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+# semtree (0.9.22)
+
+* GitHub: https://github.com/brandmaier/semtree
+* Github mirror: https://github.com/cran/semtree
+* Maintainer: Andreas M. Brandmaier <andy@brandmaier.de>
+
+Run `revdepcheck::cloud_details(, "semtree")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/semtree/new/semtree.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘semtree/DESCRIPTION’ ... OK
+...
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘OpenMx’
+
+Package suggested but not available for checking: ‘ctsemOMX’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/semtree/old/semtree.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘semtree/DESCRIPTION’ ... OK
+...
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘OpenMx’
+
+Package suggested but not available for checking: ‘ctsemOMX’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+# sprtt (0.2.0)
+
+* GitHub: https://github.com/MeikeSteinhilber/sprtt
+* Github mirror: https://github.com/cran/sprtt
+* Maintainer: Meike Steinhilber <Meike.Steinhilber@aol.com>
+
+Run `revdepcheck::cloud_details(, "sprtt")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/sprtt/new/sprtt.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘sprtt/DESCRIPTION’ ... OK
+...
+* this is package ‘sprtt’ version ‘0.2.0’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘MBESS’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/sprtt/old/sprtt.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘sprtt/DESCRIPTION’ ... OK
+...
+* this is package ‘sprtt’ version ‘0.2.0’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘MBESS’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+# ssdGSA (0.1.1)
+
+* Github mirror: https://github.com/cran/ssdGSA
+* Maintainer: Xingpeng Li <xingpeng.li@pfizer.com>
+
+Run `revdepcheck::cloud_details(, "ssdGSA")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/ssdGSA/new/ssdGSA.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘ssdGSA/DESCRIPTION’ ... OK
+...
+* this is package ‘ssdGSA’ version ‘0.1.1’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘clusterProfiler’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/ssdGSA/old/ssdGSA.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘ssdGSA/DESCRIPTION’ ... OK
+...
+* this is package ‘ssdGSA’ version ‘0.1.1’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘clusterProfiler’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+# SurprisalAnalysis (0.2)
+
+* Github mirror: https://github.com/cran/SurprisalAnalysis
+* Maintainer: Annice Najafi <annicenajafi27@gmail.com>
+
+Run `revdepcheck::cloud_details(, "SurprisalAnalysis")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/SurprisalAnalysis/new/SurprisalAnalysis.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘SurprisalAnalysis/DESCRIPTION’ ... OK
+...
+* this is package ‘SurprisalAnalysis’ version ‘0.2’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘clusterProfiler’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/SurprisalAnalysis/old/SurprisalAnalysis.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘SurprisalAnalysis/DESCRIPTION’ ... OK
+...
+* this is package ‘SurprisalAnalysis’ version ‘0.2’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘clusterProfiler’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+# Surrogate (3.4.1)
+
+* GitHub: https://github.com/florianstijven/Surrogate-development
+* Github mirror: https://github.com/cran/Surrogate
+* Maintainer: Wim Van Der Elst <wim.vanderelst@gmail.com>
+
+Run `revdepcheck::cloud_details(, "Surrogate")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/Surrogate/new/Surrogate.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘Surrogate/DESCRIPTION’ ... OK
+...
+* this is package ‘Surrogate’ version ‘3.4.1’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘MBESS’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/Surrogate/old/Surrogate.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘Surrogate/DESCRIPTION’ ... OK
+...
+* this is package ‘Surrogate’ version ‘3.4.1’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘MBESS’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+# tabledown (1.0.0)
+
+* GitHub: https://github.com/masiraji/tabledown
+* Github mirror: https://github.com/cran/tabledown
+* Maintainer: Mushfiqul Anwar Siraji <siraji1993@gmail.com>
+
+Run `revdepcheck::cloud_details(, "tabledown")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/tabledown/new/tabledown.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘tabledown/DESCRIPTION’ ... OK
+...
+* checking if there is a namespace ... OK
+* checking for executable files ... OK
+* checking for hidden files and directories ... OK
+* checking for portable file names ... OK
+* checking for sufficient/correct file permissions ... OK
+* checking whether package ‘tabledown’ can be installed ... ERROR
+Installation failed.
+See ‘/tmp/workdir/tabledown/new/tabledown.Rcheck/00install.out’ for details.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/tabledown/old/tabledown.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘tabledown/DESCRIPTION’ ... OK
+...
+* checking if there is a namespace ... OK
+* checking for executable files ... OK
+* checking for hidden files and directories ... OK
+* checking for portable file names ... OK
+* checking for sufficient/correct file permissions ... OK
+* checking whether package ‘tabledown’ can be installed ... ERROR
+Installation failed.
+See ‘/tmp/workdir/tabledown/old/tabledown.Rcheck/00install.out’ for details.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+# TestAnaAPP (1.1.2)
+
+* GitHub: https://github.com/jiangyouxiang/TestAnaAPP
+* Github mirror: https://github.com/cran/TestAnaAPP
+* Maintainer: Youxiang Jiang <jiangyouxiang34@163.com>
+
+Run `revdepcheck::cloud_details(, "TestAnaAPP")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/TestAnaAPP/new/TestAnaAPP.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘TestAnaAPP/DESCRIPTION’ ... OK
+...
+* this is package ‘TestAnaAPP’ version ‘1.1.2’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘semPlot’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/TestAnaAPP/old/TestAnaAPP.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘TestAnaAPP/DESCRIPTION’ ... OK
+...
+* this is package ‘TestAnaAPP’ version ‘1.1.2’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘semPlot’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+# tidybins (0.1.1)
+
+* GitHub: https://github.com/Harrison4192/tidybins
+* Github mirror: https://github.com/cran/tidybins
+* Maintainer: Harrison Tietze <Harrison4192@gmail.com>
+
+Run `revdepcheck::cloud_details(, "tidybins")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/tidybins/new/tidybins.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘tidybins/DESCRIPTION’ ... OK
+...
+* checking Rd contents ... OK
+* checking for unstated dependencies in examples ... OK
+* checking installed files from ‘inst/doc’ ... OK
+* checking files in ‘vignettes’ ... OK
+* checking examples ... OK
+* checking for unstated dependencies in vignettes ... OK
+* checking package vignettes ... OK
+* checking re-building of vignette outputs ... OK
+* DONE
+Status: 3 NOTEs
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/tidybins/old/tidybins.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘tidybins/DESCRIPTION’ ... OK
+...
+* checking Rd contents ... OK
+* checking for unstated dependencies in examples ... OK
+* checking installed files from ‘inst/doc’ ... OK
+* checking files in ‘vignettes’ ... OK
+* checking examples ... OK
+* checking for unstated dependencies in vignettes ... OK
+* checking package vignettes ... OK
+* checking re-building of vignette outputs ... OK
+* DONE
+Status: 3 NOTEs
+
+
+
+
+
+```
+# tidycomm (0.4.2)
+
+* GitHub: https://github.com/tidycomm/tidycomm
+* Github mirror: https://github.com/cran/tidycomm
+* Maintainer: Julian Unkel <julian.unkel@gmail.com>
+
+Run `revdepcheck::cloud_details(, "tidycomm")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/tidycomm/new/tidycomm.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘tidycomm/DESCRIPTION’ ... OK
+...
+* this is package ‘tidycomm’ version ‘0.4.2’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘MBESS’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/tidycomm/old/tidycomm.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘tidycomm/DESCRIPTION’ ... OK
+...
+* this is package ‘tidycomm’ version ‘0.4.2’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘MBESS’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+# tinyarray (2.4.3)
+
+* GitHub: https://github.com/xjsun1221/tinyarray
+* Github mirror: https://github.com/cran/tinyarray
+* Maintainer: Xiaojie Sun <18763899370@163.com>
+
+Run `revdepcheck::cloud_details(, "tinyarray")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/tinyarray/new/tinyarray.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘tinyarray/DESCRIPTION’ ... OK
+...
+* this is package ‘tinyarray’ version ‘2.4.3’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘clusterProfiler’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/tinyarray/old/tinyarray.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘tinyarray/DESCRIPTION’ ... OK
+...
+* this is package ‘tinyarray’ version ‘2.4.3’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘clusterProfiler’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+# TransProR (1.0.7)
+
+* GitHub: https://github.com/SSSYDYSSS/TransProR
+* Github mirror: https://github.com/cran/TransProR
+* Maintainer: Dongyue Yu <yudongyue@mail.nankai.edu.cn>
+
+Run `revdepcheck::cloud_details(, "TransProR")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/TransProR/new/TransProR.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘TransProR/DESCRIPTION’ ... OK
+...
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘ggtree’
+
+Package suggested but not available for checking: ‘ggtreeExtra’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/TransProR/old/TransProR.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘TransProR/DESCRIPTION’ ... OK
+...
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘ggtree’
+
+Package suggested but not available for checking: ‘ggtreeExtra’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+```
+# tricolore (1.2.4)
+
+* GitHub: https://github.com/jschoeley/tricolore
+* Github mirror: https://github.com/cran/tricolore
+* Maintainer: Jonas Schöley <jschoeley@gmail.com>
+
+Run `revdepcheck::cloud_details(, "tricolore")` for more info
+
+## In both
+
+*   checking whether package ‘tricolore’ can be installed ... ERROR
+     ```
+     Installation failed.
+     See ‘/tmp/workdir/tricolore/new/tricolore.Rcheck/00install.out’ for details.
+     ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘tricolore’ ...
+** package ‘tricolore’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error: .onLoad failed in loadNamespace() for 'ggtern', details:
+  call: NULL
+  error: <ggplot2::element_line> object properties are invalid:
+- @lineend must be <character> or <NULL>, not S3<arrow>
+Execution halted
+ERROR: lazy loading failed for package ‘tricolore’
+* removing ‘/tmp/workdir/tricolore/new/tricolore.Rcheck/tricolore’
+
+
+```
+### CRAN
+
+```
+* installing *source* package ‘tricolore’ ...
+** package ‘tricolore’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error: .onLoad failed in loadNamespace() for 'ggtern', details:
+  call: NULL
+  error: <ggplot2::element_line> object properties are invalid:
+- @lineend must be <character> or <NULL>, not S3<arrow>
+Execution halted
+ERROR: lazy loading failed for package ‘tricolore’
+* removing ‘/tmp/workdir/tricolore/old/tricolore.Rcheck/tricolore’
+
+
+```
+# TriDimRegression (1.0.2)
+
+* GitHub: https://github.com/alexander-pastukhov/tridim-regression
+* Github mirror: https://github.com/cran/TriDimRegression
+* Maintainer: Alexander (Sasha) Pastukhov <pastukhov.alexander@gmail.com>
+
+Run `revdepcheck::cloud_details(, "TriDimRegression")` for more info
+
+## In both
+
+*   checking whether package ‘TriDimRegression’ can be installed ... ERROR
+     ```
+     Installation failed.
+     See ‘/tmp/workdir/TriDimRegression/new/TriDimRegression.Rcheck/00install.out’ for details.
+     ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘TriDimRegression’ ...
+** package ‘TriDimRegression’ successfully unpacked and MD5 sums checked
+** using staged installation
+Error in loadNamespace(x) : there is no package called ‘rstantools’
+Calls: loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
+Execution halted
+ERROR: configuration failed for package ‘TriDimRegression’
+* removing ‘/tmp/workdir/TriDimRegression/new/TriDimRegression.Rcheck/TriDimRegression’
+
+
+```
+### CRAN
+
+```
+* installing *source* package ‘TriDimRegression’ ...
+** package ‘TriDimRegression’ successfully unpacked and MD5 sums checked
+** using staged installation
+Error in loadNamespace(x) : there is no package called ‘rstantools’
+Calls: loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
+Execution halted
+ERROR: configuration failed for package ‘TriDimRegression’
+* removing ‘/tmp/workdir/TriDimRegression/old/TriDimRegression.Rcheck/TriDimRegression’
+
+
+```
+# ufs (25.7.1)
+
+* Github mirror: https://github.com/cran/ufs
+* Maintainer: Gjalt-Jorn Peters <ufs@opens.science>
+
+Run `revdepcheck::cloud_details(, "ufs")` for more info
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/ufs/new/ufs.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘ufs/DESCRIPTION’ ... OK
+...
+* checking Rd \usage sections ... OK
+* checking Rd contents ... OK
+* checking for unstated dependencies in examples ... OK
+* checking contents of ‘data’ directory ... OK
+* checking data for non-ASCII characters ... OK
+* checking LazyData ... OK
+* checking data for ASCII and uncompressed saves ... OK
+* checking examples ... OK
+* DONE
+Status: 2 NOTEs
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/ufs/old/ufs.Rcheck’
+* using R version 4.4.0 (2024-04-24)
+* using platform: x86_64-pc-linux-gnu
+* R was compiled by
+    gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+    GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
+* running under: Ubuntu 24.04.2 LTS
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘ufs/DESCRIPTION’ ... OK
+...
+* checking Rd \usage sections ... OK
+* checking Rd contents ... OK
+* checking for unstated dependencies in examples ... OK
+* checking contents of ‘data’ directory ... OK
+* checking data for non-ASCII characters ... OK
+* checking LazyData ... OK
+* checking data for ASCII and uncompressed saves ... OK
+* checking examples ... OK
+* DONE
+Status: 2 NOTEs
+
+
+
 
 
 ```

--- a/revdep/problems.md
+++ b/revdep/problems.md
@@ -1,81 +1,4529 @@
-# exuber
+# activAnalyzer (2.1.2)
 
-<details>
+* GitHub: https://github.com/pydemull/activAnalyzer
+* Github mirror: https://github.com/cran/activAnalyzer
+* Maintainer: Pierre-Yves de Müllenheim <pydemull@uco.fr>
 
-* Version: 1.0.1
-* GitHub: https://github.com/kvasilopoulos/exuber
-* Source code: https://github.com/cran/exuber
-* Date/Publication: 2023-02-12 21:42:06 UTC
-* Number of recursive dependencies: 100
-
-Run `revdepcheck::cloud_details(, "exuber")` for more info
-
-</details>
+Run `revdepcheck::cloud_details(, "activAnalyzer")` for more info
 
 ## Newly broken
 
+*   checking examples ... ERROR
+     ```
+     ...
+     > mydata <- prepare_dataset(data = file)
+     > mydata_with_wear_marks <- mydata %>% mark_wear_time() %>% 
+     + dplyr::filter(days == 2 & time >= hms::as_hms("14:00:00") & time <= hms::as_hms("15:00:00")) 
+     frame is 90
+     streamFrame is 30
+     allowanceFrame is 2
+     > mets <- compute_mets(
+     +     data = mydata_with_wear_marks,
+     +     equation = "Sasaki et al. (2011) [Adults]", 
+     +     weight = 67, 
+     +     sex = "male"
+     +     )
+     Error in `dplyr::case_when()`:
+     ! `..1 (right)` must have size 1, not size 61.
+     Backtrace:
+         ▆
+      1. ├─activAnalyzer::compute_mets(...)
+      2. │ └─dplyr::case_when(...)
+      3. │   └─dplyr:::vec_case_when(...)
+      4. │     └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      5. └─vctrs:::stop_assert_size(...)
+      6.   └─vctrs:::stop_assert(...)
+      7.     └─vctrs:::stop_vctrs(...)
+      8.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
 *   checking tests ... ERROR
-    ```
-      Running ‘spelling.R’
-      Running ‘testthat.R’
-    Running the tests in ‘tests/testthat.R’ failed.
-    Last 13 lines of output:
-       33. │             └─base (local) withOneRestart(expr, restarts[[1L]])
-       34. │               └─base (local) doWithOneRestart(return(expr), restart)
-       35. └─dplyr (local) `<fn>`(`<vc______>`)
-       36.   └─dplyr:::rethrow_warning_join_relationship_many_to_many(cnd, error_call)
-       37.     └─dplyr:::warn_join(...)
-       38.       └─dplyr:::warn_dplyr(...)
-       39.         └─rlang::warn(...)
-       40.           └─base::warning(cnd)
-       41.             └─base::withRestarts(...)
-       42.               └─base (local) withOneRestart(expr, restarts[[1L]])
-       43.                 └─base (local) doWithOneRestart(return(expr), restart)
-      
-      [ FAIL 22 | WARN 29 | SKIP 4 | PASS 214 ]
-      Error: Test failures
-      Execution halted
-    ```
+     ```
+     ...
+       Caused by error in `dplyr::case_when()`:
+       ! `..1 (right)` must have size 1, not size 6900.
+       ── Error ('test-recap_by_day.R:139:1'): Kilocalories are correctly summed when changing the period of the day considered for analysis
+                 even with customized variable names ──
+       <dplyr:::mutate_error/rlang_error/error/condition>
+       Error in `dplyr::mutate(., SED = dplyr::if_else(.data[[col_axis]] < sed_cutpoint/cor_factor, 
+           1, 0), LPA = dplyr::if_else(.data[[col_axis]] >= sed_cutpoint/cor_factor & 
+           .data[[col_axis]] < mpa_cutpoint/cor_factor, 1, 0), MPA = dplyr::if_else(.data[[col_axis]] >= 
+           mpa_cutpoint/cor_factor & .data[[col_axis]] < vpa_cutpoint/cor_factor, 
+           1, 0), VPA = dplyr::if_else(.data[[col_axis]] >= vpa_cutpoint/cor_factor, 
+           1, 0), METS = suppressMessages(compute_mets(data = data %>% 
+           dplyr::mutate(axis1 = axis1 * cor_factor, vm = vm * cor_factor), 
+           equation = equation, weight = weight, sex = sex)), kcal = dplyr::case_when(SED == 
+           1 ~ bmr_kcal_min/cor_factor, equation == "Sasaki et al. (2011) [Adults]" | 
+           equation == "Freedson et al. (1998) [Adults]" ~ METS * weight * 
+           (1/60)/cor_factor, equation == "Santos-Lozano et al. (2013) [Adults]" | 
+           equation == "Santos-Lozano et al. (2013) [Older adults]" ~ 
+           METS * bmr_kcal_min/cor_factor), mets_hours_mvpa = dplyr::if_else(METS >= 
+           3, METS * (1/60)/cor_factor, 0), )`: i In argument: `METS = suppressMessages(...)`.
+       Caused by error in `dplyr::case_when()`:
+       ! `..1 (right)` must have size 1, not size 6900.
+       
+       [ FAIL 14 | WARN 4 | SKIP 1 | PASS 156 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     Error(s) in re-building vignettes:
+     --- re-building ‘activAnalyzer.Rmd’ using rmarkdown
+     ```
 
 ## In both
 
 *   checking installed package size ... NOTE
-    ```
-      installed size is  5.2Mb
-      sub-directories of 1Mb or more:
-        libs   4.3Mb
-    ```
+     ```
+       installed size is  5.8Mb
+       sub-directories of 1Mb or more:
+         R         1.5Mb
+         doc       1.0Mb
+         extdata   2.0Mb
+     ```
 
-# modelplotr
+# admiral (1.3.1)
 
-<details>
+* GitHub: https://github.com/pharmaverse/admiral
+* Github mirror: https://github.com/cran/admiral
+* Maintainer: Ben Straub <ben.x.straub@gsk.com>
 
-* Version: 1.1.0
-* GitHub: https://github.com/jurrr/modelplotr
-* Source code: https://github.com/cran/modelplotr
-* Date/Publication: 2020-10-13 04:20:05 UTC
-* Number of recursive dependencies: 150
-
-Run `revdepcheck::cloud_details(, "modelplotr")` for more info
-
-</details>
+Run `revdepcheck::cloud_details(, "admiral")` for more info
 
 ## Newly broken
 
-*   checking re-building of vignette outputs ... WARNING
-    ```
-    Error(s) in re-building vignettes:
-      ...
-    --- re-building ‘modelplotr.Rmd’ using rmarkdown
-    Quitting from lines 198-216 (modelplotr.Rmd) 
-    Error: processing vignette 'modelplotr.Rmd' failed with diagnostics:
-    replacement has length zero
-    --- failed re-building ‘modelplotr.Rmd’
-    
-    SUMMARY: processing the following file failed:
-      ‘modelplotr.Rmd’
-    
-    Error: Vignette re-building failed.
-    Execution halted
-    ```
+*   checking examples ... ERROR
+     ```
+     ...
+     Backtrace:
+          ▆
+       1. ├─admiral::call_derivation(...)
+       2. │ └─rlang::eval_tidy(call, env = eval_env)
+       3. ├─admiral (local) `<fn>`(...)
+       4. │ └─dataset %>% ...
+       5. ├─dplyr::mutate(...)
+       6. ├─dplyr:::mutate.data.frame(...)
+       7. │ └─dplyr:::mutate_cols(.data, dplyr_quosures(...), by)
+       8. │   ├─base::withCallingHandlers(...)
+       9. │   └─dplyr:::mutate_col(dots[[i]], data, mask, new_columns)
+      10. │     └─mask$eval_all_mutate(quo)
+      11. │       └─dplyr (local) eval()
+      12. ├─admiral::convert_dtc_to_dt(...)
+      13. │ └─admiral::impute_dtc_dt(...)
+      14. │   └─admiral:::get_imputation_targets(partial, date_imputation)
+      15. │     └─admiral:::get_imputation_target_date(...)
+      16. │       └─dplyr::case_when(...)
+      17. │         └─dplyr:::vec_case_when(...)
+      18. │           └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      19. └─vctrs:::stop_assert_size(...)
+      20.   └─vctrs:::stop_assert(...)
+      21.     └─vctrs:::stop_vctrs(...)
+      22.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+*   checking tests ... ERROR
+     ```
+     ...
+           day = "01"), date_imputation == "mid" ~ list(year = "xxxx", 
+           month = "06", day = if_else(is.na(month), "30", "15")), date_imputation == 
+           "last" ~ list(year = "9999", month = "12", day = "28"), TRUE ~ 
+           list(year = "xxxx", month = str_sub(date_imputation, 1, 2), 
+               day = str_sub(date_imputation, 4, 5)))`: `..1 (right)` must have size 1, not size 3.
+       Backtrace:
+            ▆
+         1. ├─admiral::slice_derivation(...) at test-slice_derivation.R:120:3
+         2. │ └─rlang::eval_tidy(call, env = eval_env)
+         3. ├─admiral (local) `<fn>`(data, dtc = VSDTC, new_vars_prefix = "A", time_imputation = "first")
+         4. │ └─admiral::convert_dtc_to_dtm(...)
+         5. │   └─admiral::impute_dtc_dtm(...)
+         6. │     └─admiral:::get_imputation_targets(partial, date_imputation, time_imputation)
+         7. │       └─admiral:::get_imputation_target_date(...)
+         8. │         └─dplyr::case_when(...)
+         9. │           └─dplyr:::vec_case_when(...)
+        10. │             └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+        11. └─vctrs:::stop_assert_size(...)
+        12.   └─vctrs:::stop_assert(...)
+        13.     └─vctrs:::stop_vctrs(...)
+        14.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+       
+       [ FAIL 77 | WARN 0 | SKIP 125 | PASS 722 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     ...
+     ℹ In argument: `ADT = convert_dtc_to_dt(...)`.
+     Caused by error in `case_when()`:
+     ! `..1 (right)` must have size 1, not size 3.
+     --- failed re-building ‘questionnaires.Rmd’
+     
+     --- re-building ‘visits_periods.Rmd’ using rmarkdown
+     
+     Quitting from visits_periods.Rmd:193-215 [unnamed-chunk-7]
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     NULL
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     
+     Error: processing vignette 'visits_periods.Rmd' failed with diagnostics:
+     ℹ In argument: `APERSDT = convert_dtc_to_dt(EXSTDTC)`.
+     Caused by error in `case_when()`:
+     ! `..1 (right)` must have size 1, not size 3.
+     --- failed re-building ‘visits_periods.Rmd’
+     
+     SUMMARY: processing the following files failed:
+       ‘adsl.Rmd’ ‘bds_exposure.Rmd’ ‘bds_finding.Rmd’ ‘bds_tte.Rmd’
+       ‘higher_order.Rmd’ ‘imputation.Rmd’ ‘occds.Rmd’ ‘pk_adnca.Rmd’
+       ‘questionnaires.Rmd’ ‘visits_periods.Rmd’
+     
+     Error: Vignette re-building failed.
+     Execution halted
+     ```
+
+## In both
+
+*   checking installed package size ... NOTE
+     ```
+       installed size is  5.2Mb
+       sub-directories of 1Mb or more:
+         doc    2.3Mb
+         help   1.8Mb
+     ```
+
+*   checking data for non-ASCII characters ... NOTE
+     ```
+       Note: found 24 marked UTF-8 strings
+     ```
+
+# admiralmetabolic (0.2.0)
+
+* GitHub: https://github.com/pharmaverse/admiralmetabolic
+* Github mirror: https://github.com/cran/admiralmetabolic
+* Maintainer: Anders Askeland <iakd@novonordisk.com>
+
+Run `revdepcheck::cloud_details(, "admiralmetabolic")` for more info
+
+## Newly broken
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     ...
+     Caused by error in `case_when()`:
+     ! `..1 (right)` must have size 1, not size 3.
+     --- failed re-building ‘adlb.Rmd’
+     
+     --- re-building ‘admiralmetabolic.Rmd’ using rmarkdown
+     --- finished re-building ‘admiralmetabolic.Rmd’
+     
+     --- re-building ‘advs.Rmd’ using rmarkdown
+     
+     Quitting from advs.Rmd:90-102 [unnamed-chunk-3]
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     NULL
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     
+     Error: processing vignette 'advs.Rmd' failed with diagnostics:
+     ℹ In argument: `ADT = convert_dtc_to_dt(...)`.
+     Caused by error in `case_when()`:
+     ! `..1 (right)` must have size 1, not size 3.
+     --- failed re-building ‘advs.Rmd’
+     
+     SUMMARY: processing the following files failed:
+       ‘adcoeq.Rmd’ ‘adlb.Rmd’ ‘advs.Rmd’
+     
+     Error: Vignette re-building failed.
+     Execution halted
+     ```
+
+# admiralneuro (0.1.0)
+
+* GitHub: https://github.com/pharmaverse/admiralneuro
+* Github mirror: https://github.com/cran/admiralneuro
+* Maintainer: Jian Wang <wang_jian_wj@lilly.com>
+
+Run `revdepcheck::cloud_details(, "admiralneuro")` for more info
+
+## Newly broken
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     Error(s) in re-building vignettes:
+       ...
+     --- re-building ‘admiralneuro.Rmd’ using rmarkdown
+     --- finished re-building ‘admiralneuro.Rmd’
+     
+     --- re-building ‘adpet.Rmd’ using rmarkdown
+     
+     Quitting from adpet.Rmd:84-103 [unnamed-chunk-4]
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     NULL
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     
+     Error: processing vignette 'adpet.Rmd' failed with diagnostics:
+     ℹ In argument: `ADT = convert_dtc_to_dt(...)`.
+     Caused by error in `case_when()`:
+     ! `..1 (right)` must have size 1, not size 3.
+     --- failed re-building ‘adpet.Rmd’
+     
+     SUMMARY: processing the following file failed:
+       ‘adpet.Rmd’
+     
+     Error: Vignette re-building failed.
+     Execution halted
+     ```
+
+# admiralonco (1.3.0)
+
+* GitHub: https://github.com/pharmaverse/admiralonco
+* Github mirror: https://github.com/cran/admiralonco
+* Maintainer: Stefan Bundfuss <stefan.bundfuss@roche.com>
+
+Run `revdepcheck::cloud_details(, "admiralonco")` for more info
+
+## Newly broken
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     ...
+     Error: processing vignette 'irecist.Rmd' failed with diagnostics:
+     ℹ In argument: `ADT = convert_dtc_to_dt(...)`.
+     Caused by error in `case_when()`:
+     ! `..1 (right)` must have size 1, not size 3.
+     --- failed re-building ‘irecist.Rmd’
+     
+     --- re-building ‘nactdt.Rmd’ using rmarkdown
+     
+     Quitting from nactdt.Rmd:75-85 [unnamed-chunk-3]
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     NULL
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     
+     Error: processing vignette 'nactdt.Rmd' failed with diagnostics:
+     ℹ In argument: `NACTDT = convert_dtc_to_dt(CMSTDTC)`.
+     Caused by error in `case_when()`:
+     ! `..1 (right)` must have size 1, not size 3.
+     --- failed re-building ‘nactdt.Rmd’
+     
+     SUMMARY: processing the following files failed:
+       ‘adrs.Rmd’ ‘adrs_basic.Rmd’ ‘adrs_gcig.Rmd’ ‘adrs_imwg.Rmd’
+       ‘adrs_pcwg3.Rmd’ ‘adtr.Rmd’ ‘irecist.Rmd’ ‘nactdt.Rmd’
+     
+     Error: Vignette re-building failed.
+     Execution halted
+     ```
+
+# admiralophtha (1.3.0)
+
+* GitHub: https://github.com/pharmaverse/admiralophtha
+* Github mirror: https://github.com/cran/admiralophtha
+* Maintainer: Edoardo Mancini <edoardo.mancini@roche.com>
+
+Run `revdepcheck::cloud_details(, "admiralophtha")` for more info
+
+## Newly broken
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     ...
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     
+     Error: processing vignette 'adbcva.Rmd' failed with diagnostics:
+     ℹ In argument: `ADT = convert_dtc_to_dt(...)`.
+     Caused by error in `case_when()`:
+     ! `..1 (right)` must have size 1, not size 3.
+     --- failed re-building ‘adbcva.Rmd’
+     
+     --- re-building ‘admiralophtha.Rmd’ using rmarkdown
+     --- finished re-building ‘admiralophtha.Rmd’
+     
+     --- re-building ‘adoe.Rmd’ using rmarkdown
+     --- finished re-building ‘adoe.Rmd’
+     
+     --- re-building ‘advfq.Rmd’ using rmarkdown
+     --- finished re-building ‘advfq.Rmd’
+     
+     --- re-building ‘standards.Rmd’ using rmarkdown
+     --- finished re-building ‘standards.Rmd’
+     
+     SUMMARY: processing the following file failed:
+       ‘adbcva.Rmd’
+     
+     Error: Vignette re-building failed.
+     Execution halted
+     ```
+
+# admiralpeds (0.2.1)
+
+* GitHub: https://github.com/pharmaverse/admiralpeds
+* Github mirror: https://github.com/cran/admiralpeds
+* Maintainer: Fanny Gautier <fanny.gautier@cytel.com>
+
+Run `revdepcheck::cloud_details(, "admiralpeds")` for more info
+
+## Newly broken
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     Error(s) in re-building vignettes:
+       ...
+     --- re-building ‘admiralpeds.Rmd’ using rmarkdown
+     --- finished re-building ‘admiralpeds.Rmd’
+     
+     --- re-building ‘advs.Rmd’ using rmarkdown
+     
+     Quitting from advs.Rmd:234-304 [unnamed-chunk-7]
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     NULL
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     
+     Error: processing vignette 'advs.Rmd' failed with diagnostics:
+     ℹ In argument: `BRTHDT = convert_dtc_to_dt(...)`.
+     Caused by error in `case_when()`:
+     ! `..1 (right)` must have size 1, not size 3.
+     --- failed re-building ‘advs.Rmd’
+     
+     SUMMARY: processing the following file failed:
+       ‘advs.Rmd’
+     
+     Error: Vignette re-building failed.
+     Execution halted
+     ```
+
+# admiralvaccine (0.5.0)
+
+* GitHub: https://github.com/pharmaverse/admiralvaccine
+* Github mirror: https://github.com/cran/admiralvaccine
+* Maintainer: Arjun Rubalingam <arjun.rubalingam@pfizer.com>
+
+Run `revdepcheck::cloud_details(, "admiralvaccine")` for more info
+
+## Newly broken
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     ...
+     Error: processing vignette 'adis.Rmd' failed with diagnostics:
+     ℹ In argument: `ADT = convert_dtc_to_dt(...)`.
+     Caused by error in `case_when()`:
+     ! `..1 (right)` must have size 1, not size 3.
+     --- failed re-building ‘adis.Rmd’
+     
+     --- re-building ‘admiralvaccine.Rmd’ using rmarkdown
+     --- finished re-building ‘admiralvaccine.Rmd’
+     
+     --- re-building ‘adsl.Rmd’ using rmarkdown
+     
+     Quitting from adsl.Rmd:123-158 [unnamed-chunk-5]
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     NULL
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     
+     Error: processing vignette 'adsl.Rmd' failed with diagnostics:
+     `..1 (right)` must have size 1, not size 3.
+     --- failed re-building ‘adsl.Rmd’
+     
+     SUMMARY: processing the following files failed:
+       ‘adce.Rmd’ ‘adface.Rmd’ ‘adis.Rmd’ ‘adsl.Rmd’
+     
+     Error: Vignette re-building failed.
+     Execution halted
+     ```
+
+# AeroSampleR (0.2.0)
+
+* Github mirror: https://github.com/cran/AeroSampleR
+* Maintainer: Mark Hogue <mark.hogue.chp@gmail.com>
+
+Run `revdepcheck::cloud_details(, "AeroSampleR")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     > 
+     > ### ** Examples
+     > 
+     > df <- particle_dist() # set up particle distribution
+     > params <- set_params_1("D_tube" = 2.54, "Q_lpm" = 100,
+     + "T_C" = 25, "P_kPa" = 101.325) #example system parameters
+     > df <- set_params_2(df, params) #particle size-dependent parameters
+     > df <- probe_eff(df, params, orient = 'h') #probe orientation - horizontal
+     > df <- bend_eff(df, params, method='Zhang', bend_angle=90,
+     + bend_radius=0.1, elnum=3)
+     > df <- tube_eff(df, params, L = 100,
+     + angle_to_horiz = 90, elnum = 3)
+     Error in `dplyr::case_when()`:
+     ! `..1 (right)` must have size 1, not size 1003.
+     Backtrace:
+         ▆
+      1. ├─AeroSampleR::tube_eff(...)
+      2. │ └─dplyr::case_when(params$Re < 2100 ~ lam, params$Re > 4000 ~ turb, TRUE ~ mixed)
+      3. │   └─dplyr:::vec_case_when(...)
+      4. │     └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      5. └─vctrs:::stop_assert_size(...)
+      6.   └─vctrs:::stop_assert(...)
+      7.     └─vctrs:::stop_vctrs(...)
+      8.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     Error(s) in re-building vignettes:
+     --- re-building ‘AeroSampleR_vignette.Rmd’ using rmarkdown
+     ```
+
+## In both
+
+*   checking dependencies in R code ... NOTE
+     ```
+     Namespace in Imports field not imported from: ‘flextable’
+       All declared Imports should be used.
+     ```
+
+# aggreCAT (1.0.0)
+
+* Github mirror: https://github.com/cran/aggreCAT
+* Maintainer: David Wilkinson <david.wilkinson.research@gmail.com>
+
+Run `revdepcheck::cloud_details(, "aggreCAT")` for more info
+
+## Newly broken
+
+*   checking tests ... ERROR
+     ```
+     ...
+       > library(testthat)
+       > library(pointblank)
+       > 
+       > test_check("aggreCAT")
+       Loading required package: aggreCAT
+       ══ aggreCAT ════════════════════════════════════════════════════════════════════
+       Version: 1.0.0 
+       Please do not feed the cat. 
+       ════════════════════════════════════════════════════════════════════════════════
+       Starting 2 test processes
+       [ FAIL 1 | WARN 0 | SKIP 0 | PASS 412 ]
+       
+       ══ Failed tests ════════════════════════════════════════════════════════════════
+       ── Error ('test-agg_methods.R:6:3'): (code run outside of `test_that()`) ───────
+       <dplyr:::mutate_error/rlang_error/error/condition>
+       Error in `dplyr::mutate(., agg_weight = dplyr::case_when(all(agg_weight == 
+           0) ~ 1, TRUE ~ agg_weight))`: ℹ In argument: `agg_weight = dplyr::case_when(all(agg_weight == 0) ~ 1,
+         TRUE ~ agg_weight)`.
+       ℹ In group 1: `paper_id = "100"`.
+       Caused by error in `dplyr::case_when()`:
+       ! `..2 (right)` must have size 1, not size 25.
+       
+       [ FAIL 1 | WARN 0 | SKIP 0 | PASS 412 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+## In both
+
+*   checking dependencies in R code ... NOTE
+     ```
+     Namespace in Imports field not imported from: ‘mathjaxr’
+       All declared Imports should be used.
+     ```
+
+*   checking data for non-ASCII characters ... NOTE
+     ```
+       Note: found 13 marked UTF-8 strings
+     ```
+
+# ale (0.5.3)
+
+* GitHub: https://github.com/tripartio/ale
+* Github mirror: https://github.com/cran/ale
+* Maintainer: Chitu Okoli <Chitu.Okoli@skema.edu>
+
+Run `revdepcheck::cloud_details(, "ale")` for more info
+
+## Newly broken
+
+*   checking tests ... ERROR
+     ```
+     ...
+        2.   └─cli::cli_abort(...)
+        3.     └─rlang::abort(...)
+       ── Error ('test-ALEpDist.R:108:5'): ALEpDist works with binary outcome ─────────
+       Error in `ALEpDist(test_gam_binary, data = test_cars, y_col = "vs", parallel = 0, 
+           silent = TRUE, rand_it = 10, .skip_validation = TRUE)`: No random p-value distributions could be created.
+       i See `warnings()()` for error messages.
+       Backtrace:
+           ▆
+        1. └─ale::ALEpDist(...) at test-ALEpDist.R:108:5
+        2.   └─cli::cli_abort(...)
+        3.     └─rlang::abort(...)
+       ── Error ('test-ALEpDist.R:125:5'): ALEpDist works with categorical outcome ────
+       Error in `ALEpDist(test_nn_categorical, model_packages = "nnet", data = test_cars, 
+           y_col = "continent", pred_type = "probs", parallel = 0, silent = TRUE, 
+           rand_it = 10, .skip_validation = TRUE)`: No random p-value distributions could be created.
+       i See `warnings()()` for error messages.
+       Backtrace:
+           ▆
+        1. └─ale::ALEpDist(...) at test-ALEpDist.R:125:5
+        2.   └─cli::cli_abort(...)
+        3.     └─rlang::abort(...)
+       
+       [ FAIL 14 | WARN 445 | SKIP 2 | PASS 83 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+# arcpullr (0.3.0)
+
+* Github mirror: https://github.com/cran/arcpullr
+* Maintainer: Paul Frater <paul.frater@wisconsin.gov>
+
+Run `revdepcheck::cloud_details(, "arcpullr")` for more info
+
+## Newly broken
+
+*   checking tests ... ERROR
+     ```
+     ...
+       Loading required package: sf
+       Linking to GEOS 3.12.1, GDAL 3.8.4, PROJ 9.4.0; sf_use_s2() is TRUE
+       > 
+       > test_check("arcpullr")
+       [ FAIL 2 | WARN 0 | SKIP 0 | PASS 46 ]
+       
+       ══ Failed tests ════════════════════════════════════════════════════════════════
+       ── Error ('test_format_spatial_coords.R:70:5'): format_line_coords properly formats multiple lines ──
+       <dplyr:::mutate_error/rlang_error/error/condition>
+       Error in `dplyr::mutate(do.call("rbind", out), coordinates = dplyr::case_when(geom_type == 
+           "multipoint" ~ .data$coordinates, TRUE ~ paste0("[", .data$coordinates, 
+           "]")))`: ℹ In argument: `coordinates = dplyr::case_when(...)`.
+       Caused by error in `dplyr::case_when()`:
+       ! `..1 (right)` must have size 1, not size 2.
+       ── Error ('test_format_spatial_coords.R:86:5'): format_polygon_coords properly formats multiple polygons ──
+       <dplyr:::mutate_error/rlang_error/error/condition>
+       Error in `dplyr::mutate(do.call("rbind", out), coordinates = dplyr::case_when(geom_type == 
+           "multipoint" ~ .data$coordinates, TRUE ~ paste0("[", .data$coordinates, 
+           "]")))`: ℹ In argument: `coordinates = dplyr::case_when(...)`.
+       Caused by error in `dplyr::case_when()`:
+       ! `..1 (right)` must have size 1, not size 2.
+       
+       [ FAIL 2 | WARN 0 | SKIP 0 | PASS 46 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+## In both
+
+*   checking dependencies in R code ... NOTE
+     ```
+     Namespace in Imports field not imported from: ‘methods’
+       All declared Imports should be used.
+     ```
+
+# BayesGrowth (1.0.0)
+
+* GitHub: https://github.com/jonathansmart/BayesGrowth
+* Github mirror: https://github.com/cran/BayesGrowth
+* Maintainer: Jonathan Smart <jonsmartphd@gmail.com>
+
+Run `revdepcheck::cloud_details(, "BayesGrowth")` for more info
+
+## Newly broken
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     Error(s) in re-building vignettes:
+     --- re-building ‘MCMC-example.Rmd’ using rmarkdown
+     ```
+
+## In both
+
+*   checking installed package size ... NOTE
+     ```
+       installed size is 82.3Mb
+       sub-directories of 1Mb or more:
+         data   1.5Mb
+         libs  80.1Mb
+     ```
+
+*   checking for GNU extensions in Makefiles ... NOTE
+     ```
+     GNU make is a SystemRequirements.
+     ```
+
+# BiVariAn (1.0.2)
+
+* GitHub: https://github.com/AndresFloresG/BiVariAn
+* Github mirror: https://github.com/cran/BiVariAn
+* Maintainer: José Andrés Flores-García <andres.flores@uaslp.mx>
+
+Run `revdepcheck::cloud_details(, "BiVariAn")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     > ### Aliases: auto_pie_categ
+     > 
+     > ### ** Examples
+     > 
+     > data <- data.frame(categ = rep(c("Categ1", "Categ2"), 25),
+     + var1 = rbinom(50, 2, prob = 0.3),
+     + var2 = rbinom(50, 2, prob = 0.8),
+     + var3 = rbinom(50, 2, prob = 0.7))
+     > data$categ <- as.factor(data$categ)
+     > data$var1 <- as.factor(data$var1)
+     > data$var2 <- as.factor(data$var2)
+     > data$var3 <- as.factor(data$var3)
+     > 
+     > pieplot_list <- auto_pie_categ(data = data)
+     Error in `if_else()`:
+     ! `condition` can't be an array.
+     Backtrace:
+         ▆
+      1. └─BiVariAn::auto_pie_categ(data = data)
+      2.   └─dplyr::if_else(is.na(pos), freq/2, pos)
+      3.     └─dplyr:::vec_case_when(...)
+      4.       └─dplyr:::check_no_dim(condition, arg = condition_arg, call = call)
+      5.         └─cli::cli_abort("{.arg {arg}} can't be an array.", call = call)
+      6.           └─rlang::abort(...)
+     Execution halted
+     ```
+
+*   checking tests ... ERROR
+     ```
+     ...
+       > 
+       > test_check("BiVariAn")
+       [ FAIL 1 | WARN 0 | SKIP 7 | PASS 144 ]
+       
+       ══ Skipped tests (7) ═══════════════════════════════════════════════════════════
+       • On CRAN (7): 'test-auto_shapiro_raw.R:64:3', 'test-continuous_2g.R:30:3',
+         'test-continuous_2g.R:87:3', 'test-continuous_2g_pair.R:55:3',
+         'test-dichotomous_2k_2sid.R:19:3', 'test-ss_multreg.R:2:3',
+         'test-step_bw_firth.R:6:3'
+       
+       ══ Failed tests ════════════════════════════════════════════════════════════════
+       ── Error ('test-auto_pie_categ.R:11:3'): auto_pie_categ works ──────────────────
+       Error in `if_else(is.na(pos), freq/2, pos)`: `condition` can't be an array.
+       Backtrace:
+           ▆
+        1. └─BiVariAn::auto_pie_categ(data = data) at test-auto_pie_categ.R:11:3
+        2.   └─dplyr::if_else(is.na(pos), freq/2, pos)
+        3.     └─dplyr:::vec_case_when(...)
+        4.       └─dplyr:::check_no_dim(condition, arg = condition_arg, call = call)
+        5.         └─cli::cli_abort("{.arg {arg}} can't be an array.", call = call)
+        6.           └─rlang::abort(...)
+       
+       [ FAIL 1 | WARN 0 | SKIP 7 | PASS 144 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+# bp (2.1.0)
+
+* GitHub: https://github.com/johnschwenck/bp
+* Github mirror: https://github.com/cran/bp
+* Maintainer: John Schwenck <jschwenck12@gmail.com>
+
+Run `revdepcheck::cloud_details(, "bp")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     Error in `dplyr::mutate()`:
+     ℹ In argument: `BP_CLASS = dplyr::case_when(...)`.
+     Caused by error in `dplyr::case_when()`:
+     ! `..1 (right)` must have size 1, not size 250.
+     Backtrace:
+          ▆
+       1. ├─bp::process_data(...)
+       2. │ └─bp::bp_stages(...)
+       3. │   └─... %>% dplyr::relocate(BP_CLASS, .after = DBP)
+       4. ├─dplyr::relocate(., BP_CLASS, .after = DBP)
+       5. ├─dplyr::mutate(...)
+       6. ├─dplyr:::mutate.data.frame(...)
+       7. │ └─dplyr:::mutate_cols(.data, dplyr_quosures(...), by)
+       8. │   ├─base::withCallingHandlers(...)
+       9. │   └─dplyr:::mutate_col(dots[[i]], data, mask, new_columns)
+      10. │     └─mask$eval_all_mutate(quo)
+      11. │       └─dplyr (local) eval()
+      12. ├─dplyr::case_when(...)
+      13. │ └─dplyr:::vec_case_when(...)
+      14. │   └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      15. └─vctrs:::stop_assert_size(...)
+      16.   └─vctrs:::stop_assert(...)
+      17.     └─vctrs:::stop_vctrs(...)
+      18.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     Error(s) in re-building vignettes:
+       ...
+     --- re-building ‘bp.Rmd’ using rmarkdown
+     
+     Quitting from bp.Rmd:81-99 [unnamed-chunk-2]
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     NULL
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     
+     Error: processing vignette 'bp.Rmd' failed with diagnostics:
+     ℹ In argument: `BP_CLASS = dplyr::case_when(...)`.
+     Caused by error in `dplyr::case_when()`:
+     ! `..1 (right)` must have size 1, not size 250.
+     --- failed re-building ‘bp.Rmd’
+     
+     SUMMARY: processing the following file failed:
+       ‘bp.Rmd’
+     
+     Error: Vignette re-building failed.
+     Execution halted
+     ```
+
+## In both
+
+*   checking Rd files ... NOTE
+     ```
+     checkRd: (-1) bp_rats.Rd:41: Escaped LaTeX specials: \&
+     checkRd: (-1) bp_sv.Rd:75: Lost braces; missing escapes or markup?
+         75 | $$SV = sqrt(sum(x_{i+1} - x_i)^2/n-1)$$
+            |                   ^
+     checkRd: (-1) bp_sv.Rd:80: Lost braces; missing escapes or markup?
+         80 | $$SD = sqrt(sum(x_{i+1} - xbar)^2/n-1)$$
+            |                   ^
+     checkRd: (-1) sv.Rd:78: Lost braces; missing escapes or markup?
+         78 | $$SV = sqrt(sum(x_{i+1} - x_i)^2/n-1)$$
+            |                   ^
+     checkRd: (-1) sv.Rd:82: Lost braces; missing escapes or markup?
+         82 | $$SD = sqrt(sum(x_{i+1} - xbar)^2/n-1)$$
+            |                   ^
+     ```
+
+# brandr (0.1.0)
+
+* GitHub: https://github.com/danielvartan/brandr
+* Github mirror: https://github.com/cran/brandr
+* Maintainer: Daniel Vartanian <danvartan@gmail.com>
+
+Run `revdepcheck::cloud_details(, "brandr")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     
+     > ### Name: color_brand_sequential
+     > ### Title: Brand color palettes
+     > ### Aliases: color_brand_sequential color_brand_diverging
+     > ###   color_brand_qualitative
+     > 
+     > ### ** Examples
+     > 
+     > color_brand_sequential(5)
+     Error in `dplyr::case_when()`:
+     ! `..3 (right)` must have size 1, not size 5.
+     Backtrace:
+          ▆
+       1. ├─brandr::color_brand_sequential(5)
+       2. │ └─brandr::interpolate_colors(...)
+       3. │   └─brandr:::make_color_ramp(...)
+       4. │     └─brandr (local) color_fun(n)
+       5. │       └─dplyr::case_when(n == 0 ~ color_ramp_fun(1), is.na(n) ~ NA, TRUE ~ color_ramp_fun(n))
+       6. │         └─dplyr:::vec_case_when(...)
+       7. │           └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+       8. └─vctrs:::stop_assert_size(...)
+       9.   └─vctrs:::stop_assert(...)
+      10.     └─vctrs:::stop_vctrs(...)
+      11.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+*   checking tests ... ERROR
+     ```
+     ...
+        11.   └─vctrs:::stop_assert(...)
+        12.     └─vctrs:::stop_vctrs(...)
+        13.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+       ── Error ('test-interpolate_colors.R:189:3'): make_color_ramp() | General test ──
+       <vctrs_error_assert_size/vctrs_error_assert/vctrs_error/rlang_error/error/condition>
+       Error in `dplyr::case_when(n == 0 ~ color_ramp_fun(1), is.na(n) ~ NA, TRUE ~ 
+           color_ramp_fun(n))`: `..3 (right)` must have size 1, not size 3.
+       Backtrace:
+            ▆
+         1. ├─testthat::expect_equal(...) at test-interpolate_colors.R:189:3
+         2. │ └─testthat::quasi_label(enquo(object), label, arg = "object")
+         3. │   └─rlang::eval_bare(expr, quo_get_env(quo))
+         4. ├─brandr:::make_color_ramp(n = 3, colors = c("red", "blue"), direction = 1)
+         5. │ └─brandr (local) color_fun(n)
+         6. │   └─dplyr::case_when(n == 0 ~ color_ramp_fun(1), is.na(n) ~ NA, TRUE ~ color_ramp_fun(n))
+         7. │     └─dplyr:::vec_case_when(...)
+         8. │       └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+         9. └─vctrs:::stop_assert_size(...)
+        10.   └─vctrs:::stop_assert(...)
+        11.     └─vctrs:::stop_vctrs(...)
+        12.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+       
+       [ FAIL 4 | WARN 0 | SKIP 0 | PASS 118 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+# bulkreadr (1.2.1)
+
+* GitHub: https://github.com/gbganalyst/bulkreadr
+* Github mirror: https://github.com/cran/bulkreadr
+* Maintainer: Ezekiel Ogundepo <gbganalyst@gmail.com>
+
+Run `revdepcheck::cloud_details(, "bulkreadr")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     ℹ In argument: `across(...)`.
+     Caused by error in `across()`:
+     ! Can't compute column `Sepal_Length`.
+     Caused by error in `case_when()`:
+     ! `..1 (right)` must have size 1, not size 7.
+     Backtrace:
+          ▆
+       1. ├─bulkreadr::fill_missing_values(df, method = "mean")
+       2. │ └─df %>% ...
+       3. ├─dplyr::mutate(...)
+       4. ├─dplyr:::mutate.data.frame(...)
+       5. │ └─dplyr:::mutate_cols(.data, dplyr_quosures(...), by)
+       6. │   ├─base::withCallingHandlers(...)
+       7. │   └─dplyr:::mutate_col(dots[[i]], data, mask, new_columns)
+       8. │     ├─base::withCallingHandlers(...)
+       9. │     └─mask$eval_all_mutate(quo)
+      10. │       └─dplyr (local) eval()
+      11. ├─dplyr::case_when(...)
+      12. │ └─dplyr:::vec_case_when(...)
+      13. │   └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      14. └─vctrs:::stop_assert_size(...)
+      15.   └─vctrs:::stop_assert(...)
+      16.     └─vctrs:::stop_vctrs(...)
+      17.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+*   checking tests ... ERROR
+     ```
+     ...
+         5. │ └─dplyr:::mutate_cols(.data, dplyr_quosures(...), by)
+         6. │   ├─base::withCallingHandlers(...)
+         7. │   └─dplyr:::mutate_col(dots[[i]], data, mask, new_columns)
+         8. │     ├─base::withCallingHandlers(...)
+         9. │     └─mask$eval_all_mutate(quo)
+        10. │       └─dplyr (local) eval()
+        11. ├─dplyr::case_when(...)
+        12. │ └─dplyr:::vec_case_when(...)
+        13. │   └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+        14. ├─vctrs:::stop_assert_size(...)
+        15. │ └─vctrs:::stop_assert(...)
+        16. │   └─vctrs:::stop_vctrs(...)
+        17. │     └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+        18. │       └─rlang:::signal_abort(cnd, .file)
+        19. │         └─base::signalCondition(cnd)
+        20. ├─dplyr (local) `<fn>`(`<vctrs___>`)
+        21. │ └─rlang::abort(msg, call = call("across"), parent = cnd)
+        22. │   └─rlang:::signal_abort(cnd, .file)
+        23. │     └─base::signalCondition(cnd)
+        24. └─dplyr (local) `<fn>`(`<rlng_rrr>`)
+        25.   └─rlang::abort(message, class = error_class, parent = parent, call = error_call)
+       
+       [ FAIL 1 | WARN 0 | SKIP 0 | PASS 21 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     ...
+     --- finished re-building ‘intro-to-bulkreadr.Rmd’
+     
+     --- re-building ‘labelled-data.Rmd’ using rmarkdown
+     --- finished re-building ‘labelled-data.Rmd’
+     
+     --- re-building ‘other-functions.Rmd’ using rmarkdown
+     
+     Quitting from other-functions.Rmd:135-139 [unnamed-chunk-5]
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     NULL
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     
+     Error: processing vignette 'other-functions.Rmd' failed with diagnostics:
+     ℹ In argument: `across(...)`.
+     Caused by error in `across()`:
+     ! Can't compute column `Sepal_Length`.
+     Caused by error in `case_when()`:
+     ! `..1 (right)` must have size 1, not size 7.
+     --- failed re-building ‘other-functions.Rmd’
+     
+     SUMMARY: processing the following file failed:
+       ‘other-functions.Rmd’
+     
+     Error: Vignette re-building failed.
+     Execution halted
+     ```
+
+# canadianmaps (2.0.0)
+
+* GitHub: https://github.com/joellecayen/canadianmaps
+* Github mirror: https://github.com/cran/canadianmaps
+* Maintainer: Joelle Cayen <joelle.cayen@phac-aspc.gc.ca>
+
+Run `revdepcheck::cloud_details(, "canadianmaps")` for more info
+
+## Newly broken
+
+*   checking tests ... ERROR
+     ```
+     ...
+               "#525183", "#ACBCD3")))(num), palette == "Starbs" ~ (grDevices::colorRampPalette(c("#0C5C41", 
+               "#5A9C84", "#D3E4DF", "#3EC8A9")))(num), palette == "Purples" ~ 
+               (grDevices::colorRampPalette(c("#E7E7EF", "#646CAC", 
+                   "#393F93", "#0E0F40")))(num), palette == "PHAC" ~ 
+               (grDevices::colorRampPalette(c("#F4CDD0", "#D33F49", 
+                   "#B72A33", "#851E25")))(num), palette == "CNISP" ~ 
+               (grDevices::colorRampPalette(c("#4F666C", "#6E8B93", 
+                   "#8CACB5", "#B1C7CD", "#D8E5EB")))(num), palette == 
+               "Jess" ~ (grDevices::colorRampPalette(c("#FFC55E", "#D49D43", 
+               "#556F60", "#3E543F")))(num), palette == "HAI" ~ (grDevices::colorRampPalette(c("#BF2431", 
+               "#563c98", "#154360", "#48C9B0")))(num))`: `..1 (right)` must have size 1, not size 5.
+       Backtrace:
+           ▆
+        1. ├─canadianmaps::scale_color_map(palette = "Kelly", num = 5) at test-functions.R:21:3
+        2. │ └─dplyr::case_when(...)
+        3. │   └─dplyr:::vec_case_when(...)
+        4. │     └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+        5. └─vctrs:::stop_assert_size(...)
+        6.   └─vctrs:::stop_assert(...)
+        7.     └─vctrs:::stop_vctrs(...)
+        8.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+       
+       [ FAIL 2 | WARN 0 | SKIP 0 | PASS 4 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+## In both
+
+*   checking installed package size ... NOTE
+     ```
+       installed size is  8.1Mb
+       sub-directories of 1Mb or more:
+         data   8.0Mb
+     ```
+
+*   checking dependencies in R code ... NOTE
+     ```
+     Namespace in Imports field not imported from: ‘sf’
+       All declared Imports should be used.
+     ```
+
+*   checking data for non-ASCII characters ... NOTE
+     ```
+       Note: found 3061 marked UTF-8 strings
+     ```
+
+# care4cmodel (1.0.3)
+
+* Github mirror: https://github.com/cran/care4cmodel
+* Maintainer: Peter Biber <p.biber@tum.de>
+
+Run `revdepcheck::cloud_details(, "care4cmodel")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     > 
+     > 
+     >   sim_base_out <- simulate_single_concept(
+     +     pine_thinning_from_above_1,
+     +     init_areas = c(1000, 0, 0, 0, 0, 0),
+     +     time_span  = 200,
+     +     risk_level = 3
+     +   )
+     > 
+     >   # Make a plot
+     >   plot(sim_base_out, variable = "area")
+     Error in `dplyr::case_when()`:
+     ! `..1 (right)` must have size 1, not size 5.
+     Backtrace:
+         ▆
+      1. ├─base::plot(sim_base_out, variable = "area")
+      2. ├─care4cmodel:::plot.c4c_base_result(sim_base_out, variable = "area")
+      3. │ └─dplyr::case_when(...)
+      4. │   └─dplyr:::vec_case_when(...)
+      5. │     └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      6. └─vctrs:::stop_assert_size(...)
+      7.   └─vctrs:::stop_assert(...)
+      8.     └─vctrs:::stop_vctrs(...)
+      9.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     Error(s) in re-building vignettes:
+       ...
+     --- re-building ‘getting-started-with-care4cmodel.Rmd’ using rmarkdown
+     
+     Quitting from getting-started-with-care4cmodel.Rmd:82-90 [quickstart_plot_base]
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     NULL
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     
+     Error: processing vignette 'getting-started-with-care4cmodel.Rmd' failed with diagnostics:
+     `..1 (right)` must have size 1, not size 5.
+     --- failed re-building ‘getting-started-with-care4cmodel.Rmd’
+     
+     SUMMARY: processing the following file failed:
+       ‘getting-started-with-care4cmodel.Rmd’
+     
+     Error: Vignette re-building failed.
+     Execution halted
+     ```
+
+# CATAcode (1.0.0)
+
+* GitHub: https://github.com/knickodem/CATAcode
+* Github mirror: https://github.com/cran/CATAcode
+* Maintainer: Kyle Nickodem <kyle.nickodem@gmail.com>
+
+Run `revdepcheck::cloud_details(, "CATAcode")` for more info
+
+## Newly broken
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     Error(s) in re-building vignettes:
+       ...
+     --- re-building ‘CATAcode-overview.Rmd’ using rmarkdown
+     
+     Quitting from CATAcode-overview.Rmd:245-258 [multiple]
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     NULL
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     
+     Error: processing vignette 'CATAcode-overview.Rmd' failed with diagnostics:
+     ℹ In argument: `new = case_when(n() == 1 ~ Barriers, TRUE ~
+       multi.name)`.
+     ℹ In group 1: `ID = 1`.
+     Caused by error in `case_when()`:
+     ! `..1 (right)` must have size 1, not size 4.
+     --- failed re-building ‘CATAcode-overview.Rmd’
+     
+     SUMMARY: processing the following file failed:
+       ‘CATAcode-overview.Rmd’
+     
+     Error: Vignette re-building failed.
+     Execution halted
+     ```
+
+# CGPfunctions (0.6.3)
+
+* GitHub: https://github.com/ibecav/CGPfunctions
+* Github mirror: https://github.com/cran/CGPfunctions
+* Maintainer: Chuck Powell <ibecav@gmail.com>
+
+Run `revdepcheck::cloud_details(, "CGPfunctions")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     6 1     8         2
+     Error in `mutate()`:
+     ℹ In argument: `LowerBound = case_when(...)`.
+     ℹ In group 1: `am = 0`.
+     Caused by error in `case_when()`:
+     ! `..1 (right)` must have size 1, not size 3.
+     Backtrace:
+          ▆
+       1. ├─CGPfunctions::Plot2WayANOVA(mpg ~ am * cyl, mtcars, plottype = "line")
+       2. │ └─... %>% ...
+       3. ├─dplyr::mutate(...)
+       4. ├─dplyr:::mutate.data.frame(...)
+       5. │ └─dplyr:::mutate_cols(.data, dplyr_quosures(...), by)
+       6. │   ├─base::withCallingHandlers(...)
+       7. │   └─dplyr:::mutate_col(dots[[i]], data, mask, new_columns)
+       8. │     └─mask$eval_all_mutate(quo)
+       9. │       └─dplyr (local) eval()
+      10. ├─dplyr::case_when(...)
+      11. │ └─dplyr:::vec_case_when(...)
+      12. │   └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      13. └─vctrs:::stop_assert_size(...)
+      14.   └─vctrs:::stop_assert(...)
+      15.     └─vctrs:::stop_vctrs(...)
+      16.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     Error(s) in re-building vignettes:
+     --- re-building ‘Using-Plot2WayANOVA.Rmd’ using rmarkdown
+     
+     Quitting from Using-Plot2WayANOVA.Rmd:147-149 [Plot2WayANOVA]
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     NULL
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     
+     Error: processing vignette 'Using-Plot2WayANOVA.Rmd' failed with diagnostics:
+     ℹ In argument: `LowerBound = case_when(...)`.
+     ℹ In group 1: `am = 0`.
+     Caused by error in `case_when()`:
+     ! `..1 (right)` must have size 1, not size 3.
+     --- failed re-building ‘Using-Plot2WayANOVA.Rmd’
+     
+     --- re-building ‘Using-PlotXTabs.Rmd’ using rmarkdown
+     ```
+
+## In both
+
+*   checking package dependencies ... NOTE
+     ```
+     Package suggested but not available for checking: ‘hrbrthemes’
+     ```
+
+# cocoon (0.2.1)
+
+* GitHub: https://github.com/JeffreyRStevens/cocoon
+* Github mirror: https://github.com/cran/cocoon
+* Maintainer: Jeffrey R. Stevens <jeffrey.r.stevens@protonmail.com>
+
+Run `revdepcheck::cloud_details(, "cocoon")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     > format_p(0.001)
+     [1] "_p_ = .001"
+     > 
+     > # Format p-value vector
+     > format_p(c(0.001, 0.01))
+     Error in `dplyr::case_when()`:
+     ! Failed to evaluate the right-hand side of formula 3.
+     Caused by error in `dplyr::case_when()`:
+     ! `..1 (right)` must have size 1, not size 2.
+     Backtrace:
+          ▆
+       1. ├─cocoon::format_p(c(0.001, 0.01))
+       2. │ └─dplyr::case_when(...)
+       3. │   └─dplyr:::case_formula_evaluate(...)
+       4. │     ├─base::withCallingHandlers(...)
+       5. │     └─rlang::eval_tidy(pair$rhs, env = default_env)
+       6. ├─cocoon::format_num(x, digits = digits)
+       7. │ └─dplyr::case_when(...)
+       8. │   └─dplyr:::vec_case_when(...)
+       9. │     └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      10. └─vctrs:::stop_assert_size(...)
+      11.   └─vctrs:::stop_assert(...)
+      12.     └─vctrs:::stop_vctrs(...)
+      13.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+*   checking tests ... ERROR
+     ```
+     ...
+         8. │     └─dplyr::case_when(...)
+         9. │       └─dplyr:::vec_case_when(...)
+        10. │         └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+        11. └─vctrs:::stop_assert_size(...)
+        12.   └─vctrs:::stop_assert(...)
+        13.     └─vctrs:::stop_vctrs(...)
+        14.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+       ── Error ('test-format_statvalues.R:55:3'): format_bf() works properly ─────────
+       Error in `dplyr::case_when(bf >= 1000 ~ format_scientific(bf, digits = digits1, 
+           type = type), bf <= 1/10^digits2 ~ format_scientific(bf, 
+           digits = digits1, type = type), bf >= 1 ~ format_num(bf, 
+           digits = digits1), bf < 1 ~ format_num(bf, digits = digits2))`: Failed to evaluate the right-hand side of formula 1.
+       Caused by error in `dplyr::case_when()`:
+       ! `..1 (right)` must have size 1, not size 8.
+       ── Error ('test-format_statvalues.R:99:3'): format_p() works properly ──────────
+       Error in `dplyr::case_when(x < cutoff & pzero ~ as.character(as.numeric(paste0("1e-", 
+           digits))), x < cutoff & !pzero ~ sub("0\\.", "\\.", as.character(as.numeric(paste0("1e-", 
+           digits)))), x >= cutoff & pzero ~ format_num(x, digits = digits), 
+           x >= cutoff & !pzero ~ sub("0\\.", "\\.", format_num(x, digits = digits)))`: Failed to evaluate the right-hand side of formula 3.
+       Caused by error in `dplyr::case_when()`:
+       ! `..1 (right)` must have size 1, not size 2.
+       
+       [ FAIL 8 | WARN 0 | SKIP 0 | PASS 233 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     Error(s) in re-building vignettes:
+       ...
+     --- re-building ‘cocoon.Rmd’ using rmarkdown
+     
+     Quitting from cocoon.Rmd:52-52
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     NULL
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     
+     Error: processing vignette 'cocoon.Rmd' failed with diagnostics:
+     `..1 (right)` must have size 1, not size 2.
+     --- failed re-building ‘cocoon.Rmd’
+     
+     SUMMARY: processing the following file failed:
+       ‘cocoon.Rmd’
+     
+     Error: Vignette re-building failed.
+     Execution halted
+     ```
+
+# ConSciR (0.3.0)
+
+* GitHub: https://github.com/BhavShah01/ConSciR
+* Github mirror: https://github.com/cran/ConSciR
+* Maintainer: Bhavesh Shah <bhaveshshah01@gmail.com>
+
+Run `revdepcheck::cloud_details(, "ConSciR")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     +   alpha = 0.7,
+     +   limit_caption = "Example limit box"
+     + )
+     Error in `dplyr::mutate()`:
+     ℹ In argument: `ColorValue = dplyr::case_when(...)`.
+     Caused by error in `dplyr::case_when()`:
+     ! `..2 (right)` must have size 1, not size 100.
+     Backtrace:
+          ▆
+       1. ├─ConSciR::graph_TRHbivariate(...)
+       2. │ ├─dplyr::mutate(...)
+       3. │ └─dplyr:::mutate.data.frame(...)
+       4. │   └─dplyr:::mutate_cols(.data, dplyr_quosures(...), by)
+       5. │     ├─base::withCallingHandlers(...)
+       6. │     └─dplyr:::mutate_col(dots[[i]], data, mask, new_columns)
+       7. │       └─mask$eval_all_mutate(quo)
+       8. │         └─dplyr (local) eval()
+       9. ├─dplyr::case_when(...)
+      10. │ └─dplyr:::vec_case_when(...)
+      11. │   └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      12. └─vctrs:::stop_assert_size(...)
+      13.   └─vctrs:::stop_assert(...)
+      14.     └─vctrs:::stop_vctrs(...)
+      15.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+# cpsvote (0.1.0)
+
+* GitHub: https://github.com/Reed-EVIC/cpsvote
+* Github mirror: https://github.com/cran/cpsvote
+* Maintainer: Jay Lee <jaylee@reed.edu>
+
+Run `revdepcheck::cloud_details(, "cpsvote")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     > 
+     > cps_label(cps_2016_10k)
+     Error in `dplyr::mutate()`:
+     ℹ In argument: `YEAR = dplyr::case_when(...)`.
+     Caused by error in `dplyr::case_when()`:
+     ! `..1 (right)` must have size 1, not size 10000.
+     Backtrace:
+          ▆
+       1. ├─cpsvote::cps_label(cps_2016_10k)
+       2. │ └─... %>% ...
+       3. ├─dplyr::mutate(...)
+       4. ├─dplyr:::mutate.data.frame(...)
+       5. │ └─dplyr:::mutate_cols(.data, dplyr_quosures(...), by)
+       6. │   ├─base::withCallingHandlers(...)
+       7. │   └─dplyr:::mutate_col(dots[[i]], data, mask, new_columns)
+       8. │     └─mask$eval_all_mutate(quo)
+       9. │       └─dplyr (local) eval()
+      10. ├─dplyr::case_when(expand_year ~ as.integer(YEAR%%1900 + 1900), TRUE ~ YEAR)
+      11. │ └─dplyr:::vec_case_when(...)
+      12. │   └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      13. └─vctrs:::stop_assert_size(...)
+      14.   └─vctrs:::stop_assert(...)
+      15.     └─vctrs:::stop_vctrs(...)
+      16.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+# debkeepr (0.1.1)
+
+* GitHub: https://github.com/jessesadler/debkeepr
+* Github mirror: https://github.com/cran/debkeepr
+* Maintainer: Jesse Sadler <jrsadler@icloud.com>
+
+Run `revdepcheck::cloud_details(, "debkeepr")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     > 
+     > 
+     > x <- deb_decimal(c(8.825, 15.125, 3.65))
+     > y <- deb_decimal(c(56.45, 106.525, 200.4), unit = "s")
+     > z <- deb_decimal(c(8472, 14520,  3504),
+     +                  unit = "f",
+     +                  bases = c(20, 12, 4))
+     > 
+     > deb_convert_unit(x, to = "s")
+     Error in `dplyr::case_when()`:
+     ! `..1 (right)` must have size 1, not size 3.
+     Backtrace:
+          ▆
+       1. ├─debkeepr::deb_convert_unit(x, to = "s")
+       2. │ └─vctrs::vec_cast(x, deb_decimal(unit = to_unit, bases = deb_bases(x)))
+       3. │   └─vctrs (local) `<fn>`()
+       4. │     └─debkeepr:::vec_cast.deb_decimal.deb_decimal(...)
+       5. │       └─dplyr::case_when(...)
+       6. │         └─dplyr:::vec_case_when(...)
+       7. │           └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+       8. └─vctrs:::stop_assert_size(...)
+       9.   └─vctrs:::stop_assert(...)
+      10.     └─vctrs:::stop_vctrs(...)
+      11.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+*   checking tests ... ERROR
+     ```
+     ...
+           from_unit == "s" & to_unit == "d" ~ x * bases[[2]], from_unit == 
+               "s" & to_unit == "l" ~ x/bases[[1]], from_unit == "d" & 
+               to_unit == "l" ~ x/prod(bases[1:2]), from_unit == "d" & 
+               to_unit == "s" ~ x/bases[[2]])`: `..1 (right)` must have size 1, not size 4.
+       Backtrace:
+            ▆
+         1. ├─testthat::expect_equal(sum(x, deb_decimal(1.8375)), deb_decimal(15.340625)) at test-mathematics.R:54:3
+         2. │ └─testthat::quasi_label(enquo(object), label, arg = "object")
+         3. │   └─rlang::eval_bare(expr, quo_get_env(quo))
+         4. ├─vctrs:::Summary.vctrs_vctr(...)
+         5. │ ├─vctrs::vec_math(.Generic, vec_c(...), na.rm = na.rm)
+         6. │ └─vctrs::vec_c(...)
+         7. │   └─vctrs (local) `<fn>`()
+         8. │     └─debkeepr:::vec_cast.deb_decimal.deb_decimal(...)
+         9. │       └─dplyr::case_when(...)
+        10. │         └─dplyr:::vec_case_when(...)
+        11. │           └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+        12. └─vctrs:::stop_assert_size(...)
+        13.   └─vctrs:::stop_assert(...)
+        14.     └─vctrs:::stop_vctrs(...)
+        15.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+       
+       [ FAIL 2 | WARN 0 | SKIP 74 | PASS 853 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+## In both
+
+*   checking data for non-ASCII characters ... NOTE
+     ```
+       Note: found 53 marked UTF-8 strings
+     ```
+
+# DeSciDe (1.0.2)
+
+* GitHub: https://github.com/camdouglas/DeSciDe
+* Github mirror: https://github.com/cran/DeSciDe
+* Maintainer: Cameron Douglas <camerondouglas@ufl.edu>
+
+Run `revdepcheck::cloud_details(, "DeSciDe")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     Running examples in ‘DeSciDe-Ex.R’ failed
+     The error most likely occurred in:
+     
+     > ### Name: search_pubmed
+     > ### Title: Search PubMed with Multiple Genes and Terms
+     > ### Aliases: search_pubmed
+     > 
+     > ### ** Examples
+     > 
+     > genes <- c("TP53", "BRCA1")
+     > terms <- c("cancer", "tumor")
+     > search_results <- search_pubmed(genes, terms, rank_method = "weighted", verbose = FALSE)
+     Error in entrez_check(response) : 
+       HTTP failure: 429, too many requests. Functions that contact the NCBI should not be called in parallel. If you are using a shared IP, consider registerring for an API key as described in the rate-limiting section of rentrez tutorial. NCBI message:
+      {"error":"API rate limit exceeded","api-key":"3.211.47.164","count":"4","limit":"3"}
+     Calls: search_pubmed ... single_pubmed_search -> entrez_search -> make_entrez_query -> entrez_check
+     Execution halted
+     ```
+
+# describedata (0.1.1)
+
+* GitHub: https://github.com/craigjmcgowan/describedata
+* Github mirror: https://github.com/cran/describedata
+* Maintainer: Craig McGowan <mcgowan.cj@gmail.com>
+
+Run `revdepcheck::cloud_details(, "describedata")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+       7. ├─purrr::when(...)
+       8. ├─purrr::when(...)
+       9. ├─purrr::when(...)
+      10. │ └─base::eval(dots[[i]][[action]], env, env)
+      11. │   └─base::eval(dots[[i]][[action]], env, env)
+      12. │     ├─dplyr::bind_rows(...)
+      13. │     │ └─rlang::list2(...)
+      14. │     └─... %>% ...
+      15. ├─purrr::when(...)
+      16. ├─dplyr::select(., .data$variable, .data$value, .data$display)
+      17. ├─dplyr::mutate(...)
+      18. ├─dplyr:::mutate.data.frame(...)
+      19. │ └─dplyr:::mutate_cols(.data, dplyr_quosures(...), by)
+      20. │   ├─base::withCallingHandlers(...)
+      21. │   └─dplyr:::mutate_col(dots[[i]], data, mask, new_columns)
+      22. │     └─mask$eval_all_mutate(quo)
+      23. │       └─dplyr (local) eval()
+      24. ├─dplyr::case_when(...)
+      25. │ └─dplyr:::vec_case_when(...)
+      26. │   └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      27. └─vctrs:::stop_assert_size(...)
+      28.   └─vctrs:::stop_assert(...)
+      29.     └─vctrs:::stop_vctrs(...)
+      30.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+# discord (1.2.4.1)
+
+* GitHub: https://github.com/R-Computing-Lab/discord
+* Github mirror: https://github.com/cran/discord
+* Maintainer: S. Mason Garrison <garrissm@wfu.edu>
+
+Run `revdepcheck::cloud_details(, "discord")` for more info
+
+## Newly broken
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     Error(s) in re-building vignettes:
+     --- re-building ‘Power.Rmd’ using rmarkdown
+     ```
+
+# DisImpact (0.0.21)
+
+* GitHub: https://github.com/vinhdizzo/DisImpact
+* Github mirror: https://github.com/cran/DisImpact
+* Maintainer: Vinh Nguyen <nguyenvq714@gmail.com>
+
+Run `revdepcheck::cloud_details(, "DisImpact")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+      12. ├─dplyr::arrange(...)
+      13. ├─dplyr::mutate(...)
+      14. ├─dplyr::bind_rows(.)
+      15. │ └─rlang::list2(...)
+      16. ├─dplyr::select(...)
+      17. ├─dplyr::mutate(...)
+      18. ├─dplyr::left_join(...)
+      19. ├─dplyr::left_join(...)
+      20. ├─dplyr::rename(...)
+      21. ├─dplyr::ungroup(.)
+      22. ├─dplyr::mutate(...)
+      23. ├─dplyr:::mutate.data.frame(...)
+      24. │ └─dplyr:::mutate_cols(.data, dplyr_quosures(...), by)
+      25. │   ├─base::withCallingHandlers(...)
+      26. │   └─dplyr:::mutate_col(dots[[i]], data, mask, new_columns)
+      27. │     └─mask$eval_all_mutate(quo)
+      28. │       └─dplyr (local) eval()
+      29. ├─dplyr::case_when(...)
+      30. │ └─dplyr:::vec_case_when(...)
+      31. │   └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      32. └─vctrs:::stop_assert_size(...)
+      33.   └─vctrs:::stop_assert(...)
+      34.     └─vctrs:::stop_vctrs(...)
+      35.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+*   checking tests ... ERROR
+     ```
+     ...
+        18. ├─dplyr::arrange(...)
+        19. ├─dplyr::mutate(...)
+        20. ├─dplyr::bind_rows(.)
+        21. │ └─rlang::list2(...)
+        22. ├─dplyr::select(...)
+        23. ├─dplyr::mutate(...)
+        24. ├─dplyr::left_join(...)
+        25. ├─dplyr::left_join(...)
+        26. ├─dplyr::rename(...)
+        27. ├─dplyr::ungroup(.)
+        28. ├─dplyr::mutate(...)
+        29. ├─dplyr:::mutate.data.frame(...)
+        30. │ └─dplyr:::mutate_cols(.data, dplyr_quosures(...), by)
+        31. │   ├─base::withCallingHandlers(...)
+        32. │   └─dplyr:::mutate_col(dots[[i]], data, mask, new_columns)
+        33. │     └─mask$eval_all_mutate(quo)
+        34. │       └─dplyr (local) eval()
+        35. ├─dplyr::case_when(...)
+        36. │ └─dplyr:::vec_case_when(...)
+        37. │   └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+        38. └─vctrs:::stop_assert_size(...)
+        39.   └─vctrs:::stop_assert(...)
+        40.     └─vctrs:::stop_vctrs(...)
+        41.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+       Execution halted
+     ```
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     ...
+     --- failed re-building ‘Multi-Ethnicity.Rmd’
+     
+     --- re-building ‘Scaling-DI-Calculations.Rmd’ using rmarkdown
+     --- finished re-building ‘Scaling-DI-Calculations.Rmd’
+     
+     --- re-building ‘Tutorial.Rmd’ using rmarkdown
+     
+     Quitting from Tutorial.Rmd:70-76 [unnamed-chunk-4]
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     NULL
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     
+     Error: processing vignette 'Tutorial.Rmd' failed with diagnostics:
+     ℹ In argument: `reference = case_when(...)`.
+     ℹ In group 1: `cohort = 1`.
+     Caused by error in `case_when()`:
+     ! `..3 (right)` must have size 1, not size 6.
+     --- failed re-building ‘Tutorial.Rmd’
+     
+     SUMMARY: processing the following files failed:
+       ‘DI-On-Long-Summarized-Data.Rmd’ ‘Intersectionality.Rmd’
+       ‘Multi-Ethnicity.Rmd’ ‘Tutorial.Rmd’
+     
+     Error: Vignette re-building failed.
+     Execution halted
+     ```
+
+# duckplyr (1.1.2)
+
+* GitHub: https://github.com/tidyverse/duckplyr
+* Github mirror: https://github.com/cran/duckplyr
+* Maintainer: Kirill Müller <kirill@cynkra.com>
+
+Run `revdepcheck::cloud_details(, "duckplyr")` for more info
+
+## Newly broken
+
+*   checking tests ... ERROR
+     ```
+     ...
+            ▆
+         1. ├─testthat::expect_identical(...) at test-dplyr-case-when.R:218:3
+         2. │ └─testthat::quasi_label(enquo(object), label, arg = "object")
+         3. │   └─rlang::eval_bare(expr, quo_get_env(quo))
+         4. ├─dplyr::case_when(FALSE ~ 1:5, .default = 2)
+         5. │ └─dplyr:::vec_case_when(...)
+         6. │   └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+         7. └─vctrs:::stop_assert_size(...)
+         8.   └─vctrs:::stop_assert(...)
+         9.     └─vctrs:::stop_vctrs(...)
+        10.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+       
+       [ FAIL 3 | WARN 0 | SKIP 600 | PASS 2287 ]
+       Deleting unused snapshots:
+       • fallback/fallback-2.dcf
+       • fallback/fallback.dcf
+       Error: Test failures
+       
+       🛠: 2208
+       🔨: 1172
+       🦆: 1036
+       add_count, anti_join, anti_join.data.frame, arrange, arrange.data.frame, compute, count, count.data.frame, cross_join, distinct, distinct.data.frame, do, eval, filter, filter.data.frame, full_join, group_by, group_indices, group_keys, group_map, group_modify, group_nest, group_size, group_split, group_trim, head, inner_join, inner_join.data.frame, intersect, left_join, left_join.data.frame, mutate, mutate.data.frame, n_groups, nest_by, nest_join, pull, reframe, relocate, rename, rename_with, right_join, rows_append, rows_delete, rows_insert, rows_patch, rows_update, rows_upsert, rowwise, select, select.data.frame, semi_join, semi_join.data.frame, setdiff, setequal, slice, slice_head, slice_head.data.frame, slice_sample, slice_tail, summarise, summarise.data.frame, symdiff, transmute, ungroup, union_all
+       
+       00:01:22.243784
+       Execution halted
+     ```
+
+## In both
+
+*   checking package dependencies ... NOTE
+     ```
+     Package which this enhances but not available for checking: ‘qs’
+     ```
+
+# dynwrap (1.2.4)
+
+* GitHub: https://github.com/dynverse/dynwrap
+* Github mirror: https://github.com/cran/dynwrap
+* Maintainer: Robrecht Cannoodt <rcannood@gmail.com>
+
+Run `revdepcheck::cloud_details(, "dynwrap")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+       4. │ └─dynwrap::simplify_igraph_network(...)
+       5. │   └─purrr::map(...)
+       6. │     └─purrr:::map_("list", .x, .f, ..., .progress = .progress)
+       7. │       ├─purrr:::with_indexed_errors(...)
+       8. │       │ └─base::withCallingHandlers(...)
+       9. │       ├─purrr:::call_with_cleanup(...)
+      10. │       └─dynwrap (local) .f(.x[[i]], ...)
+      11. │         └─dynwrap:::simplify_replace_edges(...)
+      12. │           └─... %>% select(id, from, to, percentage)
+      13. ├─dplyr::select(., id, from, to, percentage)
+      14. ├─dplyr::mutate(...)
+      15. ├─dplyr:::mutate.data.frame(...)
+      16. │ └─dplyr:::mutate_cols(.data, dplyr_quosures(...), by)
+      17. │   ├─base::withCallingHandlers(...)
+      18. │   └─dplyr:::mutate_col(dots[[i]], data, mask, new_columns)
+      19. │     └─mask$eval_all_mutate(quo)
+      20. │       └─dplyr (local) eval()
+      21. ├─dplyr::case_when(path_len == 0 ~ 0.5, TRUE ~ (cs + percentage * weight)/path_len)
+      22. │ └─dplyr:::vec_case_when(...)
+      23. │   └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      24. └─vctrs:::stop_assert_size(...)
+      25.   └─vctrs:::stop_assert(...)
+      26.     └─vctrs:::stop_vctrs(...)
+      27.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+*   checking tests ... ERROR
+     ```
+     ...
+        17. │ └─dplyr:::mutate_cols(.data, dplyr_quosures(...), by)
+        18. │   ├─base::withCallingHandlers(...)
+        19. │   └─dplyr:::mutate_col(dots[[i]], data, mask, new_columns)
+        20. │     └─mask$eval_all_mutate(quo)
+        21. │       └─dplyr (local) eval()
+        22. ├─dplyr::case_when(...)
+        23. │ └─dplyr:::vec_case_when(...)
+        24. │   └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+        25. ├─vctrs:::stop_assert_size(...)
+        26. │ └─vctrs:::stop_assert(...)
+        27. │   └─vctrs:::stop_vctrs(...)
+        28. │     └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+        29. │       └─rlang:::signal_abort(cnd, .file)
+        30. │         └─base::signalCondition(cnd)
+        31. ├─dplyr (local) `<fn>`(`<vctrs___>`)
+        32. │ └─rlang::abort(message, class = error_class, parent = parent, call = error_call)
+        33. │   └─rlang:::signal_abort(cnd, .file)
+        34. │     └─base::signalCondition(cnd)
+        35. └─purrr (local) `<fn>`(`<dply:::_>`)
+        36.   └─cli::cli_abort(...)
+        37.     └─rlang::abort(...)
+       
+       [ FAIL 6 | WARN 23 | SKIP 3 | PASS 486 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+# ecocomDP (1.3.2)
+
+* GitHub: https://github.com/EDIorg/ecocomDP
+* Github mirror: https://github.com/cran/ecocomDP
+* Maintainer: Colin Smith <colin.smith@wisc.edu>
+
+Run `revdepcheck::cloud_details(, "ecocomDP")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     Error in `dplyr::mutate()`:
+     ℹ In argument: `datetime = dplyr::case_when(...)`.
+     Caused by error in `dplyr::case_when()`:
+     ! `..1 (right)` must have size 1, not size 689.
+     Backtrace:
+          ▆
+       1. ├─ecocomDP::plot_taxa_diversity(ants_L1)
+       2. │ └─... %>% dplyr::summarize(ntaxa = length(unique(taxon_id)))
+       3. ├─dplyr::summarize(., ntaxa = length(unique(taxon_id)))
+       4. ├─dplyr::group_by(., .data$location_id, .data$datetime)
+       5. ├─dplyr::mutate(...)
+       6. ├─dplyr:::mutate.data.frame(...)
+       7. │ └─dplyr:::mutate_cols(.data, dplyr_quosures(...), by)
+       8. │   ├─base::withCallingHandlers(...)
+       9. │   └─dplyr:::mutate_col(dots[[i]], data, mask, new_columns)
+      10. │     └─mask$eval_all_mutate(quo)
+      11. │       └─dplyr (local) eval()
+      12. ├─dplyr::case_when(...)
+      13. │ └─dplyr:::vec_case_when(...)
+      14. │   └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      15. └─vctrs:::stop_assert_size(...)
+      16.   └─vctrs:::stop_assert(...)
+      17.     └─vctrs:::stop_vctrs(...)
+      18.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     ...
+     
+     --- re-building ‘model_overview.Rmd’ using rmarkdown
+     --- finished re-building ‘model_overview.Rmd’
+     
+     --- re-building ‘shared_practices_create.Rmd’ using rmarkdown
+     --- finished re-building ‘shared_practices_create.Rmd’
+     
+     --- re-building ‘use.Rmd’ using rmarkdown
+     
+     Quitting from use.Rmd:225-250 [unnamed-chunk-14]
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     NULL
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     
+     Error: processing vignette 'use.Rmd' failed with diagnostics:
+     ℹ In argument: `datetime = dplyr::case_when(...)`.
+     Caused by error in `dplyr::case_when()`:
+     ! `..1 (right)` must have size 1, not size 689.
+     --- failed re-building ‘use.Rmd’
+     
+     SUMMARY: processing the following file failed:
+       ‘use.Rmd’
+     
+     Error: Vignette re-building failed.
+     Execution halted
+     ```
+
+# efdm (0.2.1)
+
+* GitHub: https://github.com/mikkoku/efdm
+* Github mirror: https://github.com/cran/efdm
+* Maintainer: Mikko Kuronen <mikko.kuronen@luke.fi>
+
+Run `revdepcheck::cloud_details(, "efdm")` for more info
+
+## Newly broken
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     Error(s) in re-building vignettes:
+     --- re-building ‘example.Rmd’ using rmarkdown
+     ```
+
+# emery (0.6.0)
+
+* GitHub: https://github.com/therealcfdrake/emery
+* Github mirror: https://github.com/cran/emery
+* Maintainer: Corie Drake <therealcfdrake@gmail.com>
+
+Run `revdepcheck::cloud_details(, "emery")` for more info
+
+## Newly broken
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     Error(s) in re-building vignettes:
+       ...
+     --- re-building ‘emery.Rmd’ using rmarkdown
+     
+     Quitting from emery.Rmd:66-68 [unnamed-chunk-3]
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     NULL
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     
+     Error: processing vignette 'emery.Rmd' failed with diagnostics:
+     ℹ In argument: `color_col = dplyr::case_when(...)`.
+     Caused by error in `dplyr::case_when()`:
+     ! `..1 (right)` must have size 1, not size 25.
+     --- failed re-building ‘emery.Rmd’
+     
+     SUMMARY: processing the following file failed:
+       ‘emery.Rmd’
+     
+     Error: Vignette re-building failed.
+     Execution halted
+     ```
+
+# eph (1.0.2)
+
+* GitHub: https://github.com/ropensci/eph
+* Github mirror: https://github.com/cran/eph
+* Maintainer: Carolina Pradier <carolinapradier@gmail.com>
+
+Run `revdepcheck::cloud_details(, "eph")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     +   window = "trimestral"
+     + )
+     Error in `dplyr::mutate()`:
+     ℹ In argument: `Periodo = dplyr::case_when(...)`.
+     Caused by error in `dplyr::case_when()`:
+     ! `..1 (right)` must have size 1, not size 3996.
+     Backtrace:
+          ▆
+       1. ├─eph::organize_panels(...)
+       2. │ └─... %>% ...
+       3. ├─dplyr::mutate(...)
+       4. ├─dplyr:::mutate.data.frame(...)
+       5. │ └─dplyr:::mutate_cols(.data, dplyr_quosures(...), by)
+       6. │   ├─base::withCallingHandlers(...)
+       7. │   └─dplyr:::mutate_col(dots[[i]], data, mask, new_columns)
+       8. │     └─mask$eval_all_mutate(quo)
+       9. │       └─dplyr (local) eval()
+      10. ├─dplyr::case_when(...)
+      11. │ └─dplyr:::vec_case_when(...)
+      12. │   └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      13. └─vctrs:::stop_assert_size(...)
+      14.   └─vctrs:::stop_assert(...)
+      15.     └─vctrs:::stop_vctrs(...)
+      16.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+*   checking tests ... ERROR
+     ```
+     ...
+       11  2016        2     2        4       0.0278         0.0194 
+       12  2016        2     2        5       0.0349         0.0184 
+       13  2016        2     2        6       0              0      
+       14  2016        2     2        7       0.0125         0.0109 
+       [ FAIL 1 | WARN 0 | SKIP 11 | PASS 38 ]
+       
+       ══ Skipped tests (11) ══════════════════════════════════════════════════════════
+       • On CRAN (11): 'test-get_eahu.R:2:3', 'test-get_eahu.R:10:3',
+         'test-get_eahu.R:18:3', 'test-get_microdata.R:4:3',
+         'test-get_microdata.R:13:3', 'test-get_microdata.R:22:3',
+         'test-get_poverty_lines.R:4:3', 'test-get_poverty_lines.R:12:3',
+         'test-get_total_urbano.R:10:3', 'test-is_in_github.R:3:5',
+         'test-is_in_github.R:10:5'
+       
+       ══ Failed tests ════════════════════════════════════════════════════════════════
+       ── Error ('test-organize_panels.R:5:3'): consistencia constante ────────────────
+       <dplyr:::mutate_error/rlang_error/error/condition>
+       Error in `dplyr::mutate(., Periodo = dplyr::case_when(window == "anual" ~ 
+           Periodo - 1, window == "trimestral" ~ Periodo - 0.25))`: ℹ In argument: `Periodo = dplyr::case_when(...)`.
+       Caused by error in `dplyr::case_when()`:
+       ! `..1 (right)` must have size 1, not size 3996.
+       
+       [ FAIL 1 | WARN 0 | SKIP 11 | PASS 38 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     Error(s) in re-building vignettes:
+     --- re-building ‘eph.Rmd’ using rmarkdown
+     
+     Quitting from eph.Rmd:123-151 [unnamed-chunk-7]
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     NULL
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     
+     Error: processing vignette 'eph.Rmd' failed with diagnostics:
+     ℹ In argument: `Periodo = dplyr::case_when(...)`.
+     Caused by error in `dplyr::case_when()`:
+     ! `..1 (right)` must have size 1, not size 115642.
+     --- failed re-building ‘eph.Rmd’
+     
+     --- re-building ‘estimacion_pobreza.Rmd’ using rmarkdown
+     trying URL 'https://github.com/holatam/data/raw/master/eph/canasta/canastas.rds'
+     Content type 'application/octet-stream' length 3499 bytes
+     ==================================================
+     downloaded 3499 bytes
+     ```
+
+## In both
+
+*   checking data for non-ASCII characters ... NOTE
+     ```
+       Note: found 1 marked Latin-1 string
+       Note: found 1508 marked UTF-8 strings
+     ```
+
+# epikit (0.1.6)
+
+* GitHub: https://github.com/R4EPI/epikit
+* Github mirror: https://github.com/cran/epikit
+* Maintainer: Zhian N. Kamvar <zkamvar@gmail.com>
+
+Run `revdepcheck::cloud_details(, "epikit")` for more info
+
+## Newly broken
+
+*   checking tests ... ERROR
+     ```
+     ...
+       > test_check("epikit")
+       [ FAIL 1 | WARN 1 | SKIP 1 | PASS 120 ]
+       
+       ══ Skipped tests (1) ═══════════════════════════════════════════════════════════
+       • On CRAN (1): 'test-relabel_proportions.R:22:3'
+       
+       ══ Failed tests ════════════════════════════════════════════════════════════════
+       ── Error ('test-age-categories.R:179:3'): years alone give years ───────────────
+       <vctrs_error_assert_size/vctrs_error_assert/vctrs_error/rlang_error/error/condition>
+       Error in `dplyr::case_when(!is.na(da) ~ dac, !is.na(we) ~ wec, !is.na(mo) ~ 
+           moc, TRUE ~ yec)`: `..4 (right)` must have size 1, not size 30.
+       Backtrace:
+           ▆
+        1. ├─epikit::group_age_categories(df, years = years, one_column = FALSE) at test-age-categories.R:179:3
+        2. │ └─dplyr::case_when(...)
+        3. │   └─dplyr:::vec_case_when(...)
+        4. │     └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+        5. └─vctrs:::stop_assert_size(...)
+        6.   └─vctrs:::stop_assert(...)
+        7.     └─vctrs:::stop_vctrs(...)
+        8.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+       
+       [ FAIL 1 | WARN 1 | SKIP 1 | PASS 120 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+# findSVI (0.2.0)
+
+* GitHub: https://github.com/heli-xu/findSVI
+* Github mirror: https://github.com/cran/findSVI
+* Maintainer: Heli Xu <xuheli91@gmail.com>
+
+Run `revdepcheck::cloud_details(, "findSVI")` for more info
+
+## Newly broken
+
+*   checking tests ... ERROR
+     ```
+     ...
+       ── Error ('test-get_svi.R:77:3'): 2018 svi calculation works ───────────────────
+       <dplyr:::mutate_error/rlang_error/error/condition>
+       Error in `dplyr::mutate(., dplyr::across(tidyselect::all_of(EP_var_name), 
+           ~round(.x, 1)), E_AGE65 = dplyr::case_when(year >= 2017 ~ 
+           E_AGE65, TRUE ~ round(E_AGE65, 0)))`: i In argument: `E_AGE65 = dplyr::case_when(...)`.
+       Caused by error in `dplyr::case_when()`:
+       ! `..1 (right)` must have size 1, not size 67.
+       ── Error ('test-get_svi.R:113:3'): 2016 svi calculation works ──────────────────
+       <dplyr:::mutate_error/rlang_error/error/condition>
+       Error in `dplyr::mutate(., dplyr::across(tidyselect::all_of(EP_var_name), 
+           ~round(.x, 1)), E_AGE65 = dplyr::case_when(year >= 2017 ~ 
+           E_AGE65, TRUE ~ round(E_AGE65, 0)))`: i In argument: `E_AGE65 = dplyr::case_when(...)`.
+       Caused by error in `dplyr::case_when()`:
+       ! `..1 (right)` must have size 1, not size 67.
+       ── Error ('test-get_svi.R:149:3'): 2014 svi calculation works ──────────────────
+       <dplyr:::mutate_error/rlang_error/error/condition>
+       Error in `dplyr::mutate(., dplyr::across(tidyselect::all_of(EP_var_name), 
+           ~round(.x, 1)), E_AGE65 = dplyr::case_when(year >= 2017 ~ 
+           E_AGE65, TRUE ~ round(E_AGE65, 0)))`: i In argument: `E_AGE65 = dplyr::case_when(...)`.
+       Caused by error in `dplyr::case_when()`:
+       ! `..1 (right)` must have size 1, not size 67.
+       
+       [ FAIL 5 | WARN 0 | SKIP 0 | PASS 0 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+## In both
+
+*   checking data for non-ASCII characters ... NOTE
+     ```
+       Note: found 298 marked UTF-8 strings
+     ```
+
+# flowchart (0.9.0)
+
+* GitHub: https://github.com/bruigtp/flowchart
+* Github mirror: https://github.com/cran/flowchart
+* Maintainer: Pau Satorra <psatorra@igtp.cat>
+
+Run `revdepcheck::cloud_details(, "flowchart")` for more info
+
+## Newly broken
+
+*   checking tests ... ERROR
+     ```
+     ...
+         'test-fc_export.R:4:3', 'test-fc_export.R:9:3', 'test-fc_export.R:14:3',
+         'test-fc_export.R:19:3', 'test-fc_export.R:24:3', 'test-fc_export.R:29:3',
+         'test-fc_export.R:34:3', 'test-fc_export.R:39:3', 'test-fc_filter.R:4:3',
+         'test-fc_filter.R:9:3', 'test-fc_filter.R:14:3', 'test-fc_filter.R:20:3',
+         'test-fc_filter.R:25:3', 'test-fc_filter.R:30:3', 'test-fc_filter.R:35:3',
+         'test-fc_filter.R:90:3', 'test-fc_split.R:4:3', 'test-fc_split.R:9:3',
+         'test-fc_split.R:14:3', 'test-fc_split.R:19:3', 'test-fc_split.R:24:3',
+         'test-fc_view.R:4:3', 'test-utils.R:51:3'
+       
+       ══ Failed tests ════════════════════════════════════════════════════════════════
+       ── Error ('test-fc_stack.R:35:3'): successfully handles stacking when unite = TRUE ──
+       <dplyr:::mutate_error/rlang_error/error/condition>
+       Error in `dplyr::mutate(dplyr::group_by(dplyr::mutate(do.call(rbind, purrr::map(seq_along(object$fc), 
+           ~dplyr::mutate(object$fc[[.x]], fc = .x))), y = update_y_stack_unite(.data$y, 
+           .data$x, .data$type), change = dplyr::case_when(is.na(dplyr::lag(.data$fc)) ~ 
+           FALSE, fc != dplyr::lag(.data$fc) ~ TRUE, TRUE ~ FALSE)), 
+           .data$y), type = dplyr::case_when(any(.data$change) ~ "stack", 
+           TRUE ~ .data$type))`: i In argument: `type = dplyr::case_when(any(.data$change) ~ "stack", TRUE ~ .data$type)`.
+       i In group 1: `y = 0.2`.
+       Caused by error in `dplyr::case_when()`:
+       ! `..2 (right)` must have size 1, not size 3.
+       
+       [ FAIL 1 | WARN 0 | SKIP 29 | PASS 177 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+# fluxible (1.3.3)
+
+* GitHub: https://github.com/Plant-Functional-Trait-Course/fluxible
+* Github mirror: https://github.com/cran/fluxible
+* Maintainer: Joseph Gaudard <joseph.gaudard@pm.me>
+
+Run `revdepcheck::cloud_details(, "fluxible")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     > data(co2_conc)
+     > slopes <- flux_fitting(co2_conc, conc, datetime, fit_type = "exp_zhao18")
+     Error in `mutate()`:
+     ℹ In argument: `f_start = case_when(...)`.
+     ℹ In group 1: `f_fluxid = 1`.
+     Caused by error in `case_when()`:
+     ! `..1 (right)` must have size 1, not size 210.
+     Backtrace:
+          ▆
+       1. ├─fluxible::flux_fitting(co2_conc, conc, datetime, fit_type = "exp_zhao18")
+       2. │ ├─dplyr::mutate(...)
+       3. │ └─dplyr:::mutate.data.frame(...)
+       4. │   └─dplyr:::mutate_cols(.data, dplyr_quosures(...), by)
+       5. │     ├─base::withCallingHandlers(...)
+       6. │     └─dplyr:::mutate_col(dots[[i]], data, mask, new_columns)
+       7. │       └─mask$eval_all_mutate(quo)
+       8. │         └─dplyr (local) eval()
+       9. ├─dplyr::case_when(...)
+      10. │ └─dplyr:::vec_case_when(...)
+      11. │   └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      12. └─vctrs:::stop_assert_size(...)
+      13.   └─vctrs:::stop_assert(...)
+      14.     └─vctrs:::stop_vctrs(...)
+      15.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+*   checking tests ... ERROR
+     ```
+     ...
+               f_datetime
+           }
+       } >= {
+           {
+               f_end
+           }
+       } ~ "cut", TRUE ~ "keep"), f_cut = as_factor(.data$f_cut), f_n_conc = sum(!is.na(.data[[name_conc]])), 
+           .by = {
+               {
+                   f_fluxid
+               }
+           })`: i In argument: `f_start = case_when(...)`.
+       i In group 1: `f_fluxid = 1`.
+       Caused by error in `case_when()`:
+       ! `..1 (right)` must have size 1, not size 210.
+       
+       [ FAIL 82 | WARN 0 | SKIP 32 | PASS 30 ]
+       Deleting unused snapshots:
+       • flux_plot/ggssave-and-print.svg
+       • flux_plot/longpdf-and-print.svg
+       • flux_plot/plot-as-an-object.svg
+       • flux_plot/plot-for-linear-fit.svg
+       • flux_plot/plot-with-custom-facet-id.svg
+       Error: Test failures
+       Execution halted
+     ```
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     ...
+     ℹ In argument: `f_start = case_when(...)`.
+     ℹ In group 1: `f_fluxid = "ACJ_C_10apr2019_plot1_p.txt"`.
+     Caused by error in `case_when()`:
+     ! `..1 (right)` must have size 1, not size 90.
+     --- failed re-building ‘li7500.Rmd’
+     
+     --- re-building ‘two-gases.Rmd’ using rmarkdown
+     
+     Quitting from two-gases.Rmd:43-59 [fitting-twogases]
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     NULL
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     
+     Error: processing vignette 'two-gases.Rmd' failed with diagnostics:
+     ℹ In argument: `f_start = case_when(...)`.
+     ℹ In group 1: `f_fluxid = 1`.
+     Caused by error in `case_when()`:
+     ! `..1 (right)` must have size 1, not size 180.
+     --- failed re-building ‘two-gases.Rmd’
+     
+     SUMMARY: processing the following files failed:
+       ‘fluxible.Rmd’ ‘li7500.Rmd’ ‘two-gases.Rmd’
+     
+     Error: Vignette re-building failed.
+     Execution halted
+     ```
+
+# ggfacto (0.3.2)
+
+* GitHub: https://github.com/BriceNocenti/ggfacto
+* Github mirror: https://github.com/cran/ggfacto
+* Maintainer: Brice Nocenti <brice.nocenti@gmail.com>
+
+Run `revdepcheck::cloud_details(, "ggfacto")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+      10. │             └─pillar:::emit_pillars(x, tier_widths, cb_pillars, focus)
+      11. │               └─pillar:::do_emit_focus_pillars(x, tier_widths, cb, focus)
+      12. │                 └─pillar:::do_emit_pillars(x, tier_widths, cb)
+      13. │                   ├─pillar::ctl_new_pillar_list(...)
+      14. │                   └─pillar:::ctl_new_pillar_list.tbl(...)
+      15. │                     └─pillar:::new_data_frame_pillar_list(...)
+      16. │                       ├─pillar::ctl_new_pillar_list(...)
+      17. │                       └─pillar:::ctl_new_pillar_list.tbl(...)
+      18. │                         ├─pillar::ctl_new_pillar(controller, x, width, ..., title = prepare_title(title))
+      19. │                         └─pillar:::ctl_new_pillar.tbl(controller, x, width, ..., title = prepare_title(title))
+      20. │                           └─pillar::pillar(x, title, if (!is.null(width)) max0(width))
+      21. │                             ├─pillar:::pillar_from_shaft(...)
+      22. │                             │ └─pillar:::get_min_width(data)
+      23. │                             │   └─attr(x, "min_width", exact = TRUE) %||% get_width(x)
+      24. │                             ├─pillar::pillar_shaft(x, ...)
+      25. │                             └─tabxplor:::pillar_shaft.tabxplor_fmt(x, ...)
+      26. │                               └─tabxplor:::get_reference(x, mode = "all_totals")
+      27. │                                 └─dplyr::case_when(...)
+      28. │                                   └─dplyr:::vec_case_when(...)
+      29. │                                     └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      30. └─vctrs:::stop_assert_size(...)
+      31.   └─vctrs:::stop_assert(...)
+      32.     └─vctrs:::stop_vctrs(...)
+      33.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+# gglyph (0.2.0)
+
+* GitHub: https://github.com/valentinsvelev/gglyph
+* Github mirror: https://github.com/cran/gglyph
+* Maintainer: Valentin Velev <valentin.velev@uni-konstanz.de>
+
+Run `revdepcheck::cloud_details(, "gglyph")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     
+     > ### Name: geom_glyph
+     > ### Title: Create a directed network-style graph
+     > ### Aliases: geom_glyph
+     > 
+     > ### ** Examples
+     > 
+     > # For non-grouped/-facetted plot
+     > data <- gglyph::generate_mock_data(n_groups = 1)
+     > 
+     > ggplot2::ggplot(data = data) +
+     +   gglyph::geom_glyph()
+     Error in `case_when()`:
+     ! `..1 (right)` must have size 1, not size 5.
+     Backtrace:
+         ▆
+      1. ├─gglyph::geom_glyph()
+      2. │ └─dplyr::case_when(...)
+      3. │   └─dplyr:::vec_case_when(...)
+      4. │     └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      5. └─vctrs:::stop_assert_size(...)
+      6.   └─vctrs:::stop_assert(...)
+      7.     └─vctrs:::stop_vctrs(...)
+      8.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+*   checking tests ... ERROR
+     ```
+     ...
+       ── Error ('test-geom_glyph.R:26:3'): geom_glyph - edge_fill defaults to edge_colour when edge_fill is NULL ──
+       <vctrs_error_assert_size/vctrs_error_assert/vctrs_error/rlang_error/error/condition>
+       Error in `case_when(node_count == 3 ~ rep(c(0.5, 0.5, 0.5), length.out = node_count), 
+           node_count == 4 ~ rep(c(0.5, 0, 0.5, 1), length.out = node_count), 
+           node_count == 5 ~ rep(c(0.5, 0, 0.5, 0.5, 1), length.out = node_count), 
+           node_count == 6 ~ rep(c(0.5, 0, 0, 0.5, 1, 1), length.out = node_count), 
+           node_count == 7 ~ rep(c(0.5, 0, 0, 0, 1, 1, 1), length.out = node_count), 
+           node_count == 8 ~ rep(c(0.5, 0, -1.45, 0, 0.5, 1, 2.45, 1), 
+               length.out = node_count), node_count == 9 ~ rep(c(0.5, 
+               0, -1.45, 0, 0, 1, 1, 2.45, 1), length.out = node_count), 
+           TRUE ~ rep(0.5, node_count))`: `..1 (right)` must have size 1, not size 5.
+       Backtrace:
+           ▆
+        1. ├─gglyph::geom_glyph(data = df, edge_colour = "red") at test-geom_glyph.R:26:3
+        2. │ └─dplyr::case_when(...)
+        3. │   └─dplyr:::vec_case_when(...)
+        4. │     └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+        5. └─vctrs:::stop_assert_size(...)
+        6.   └─vctrs:::stop_assert(...)
+        7.     └─vctrs:::stop_vctrs(...)
+        8.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+       
+       [ FAIL 2 | WARN 0 | SKIP 0 | PASS 31 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     Error(s) in re-building vignettes:
+       ...
+     --- re-building ‘gglyph.Rmd’ using rmarkdown
+     
+     Quitting from gglyph.Rmd:134-143 [example_glyphs_base]
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     NULL
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     
+     Error: processing vignette 'gglyph.Rmd' failed with diagnostics:
+     `..1 (right)` must have size 1, not size 5.
+     --- failed re-building ‘gglyph.Rmd’
+     
+     SUMMARY: processing the following file failed:
+       ‘gglyph.Rmd’
+     
+     Error: Vignette re-building failed.
+     Execution halted
+     ```
+
+# ggstatsplot (0.13.2)
+
+* GitHub: https://github.com/IndrajeetPatil/ggstatsplot
+* Github mirror: https://github.com/cran/ggstatsplot
+* Maintainer: Indrajeet Patil <patilindrajeet.science@gmail.com>
+
+Run `revdepcheck::cloud_details(, "ggstatsplot")` for more info
+
+## Newly broken
+
+*   checking tests ... ERROR
+     ```
+     ...
+       • ggscatterstats/robust-correlation-with-nas.svg
+       • ggwithinstats/centrality-path-can-be-turned-off.svg
+       • ggwithinstats/defaults-plots-more-than-two-groups.svg
+       • ggwithinstats/defaults-plots-two-groups.svg
+       • ggwithinstats/grouped-plots-default.svg
+       • pairwise-ggsignif/between-bayes.svg
+       • pairwise-ggsignif/between-non-parametric-all.svg
+       • pairwise-ggsignif/between-non-parametric-only-non-significant.svg
+       • pairwise-ggsignif/between-non-parametric-only-significant.svg
+       • pairwise-ggsignif/between-parametric-all.svg
+       • pairwise-ggsignif/between-parametric-only-significant.svg
+       • pairwise-ggsignif/between-robust-all.svg
+       • pairwise-ggsignif/between-robust-only-non-significant.svg
+       • pairwise-ggsignif/between-robust-only-significant.svg
+       • pairwise-ggsignif/within-bayes.svg
+       • pairwise-ggsignif/within-non-parametric-all.svg
+       • pairwise-ggsignif/within-non-parametric-only-non-significant.svg
+       • pairwise-ggsignif/within-non-parametric-only-significant.svg
+       • pairwise-ggsignif/within-parametric-all.svg
+       • pairwise-ggsignif/within-parametric-only-significant.svg
+       • pairwise-ggsignif/within-robust-all.svg
+       • pairwise-ggsignif/within-robust-only-non-significant.svg
+       • pairwise-ggsignif/within-robust-only-significant.svg
+       Error: Test failures
+       Execution halted
+     ```
+
+# ggsurveillance (0.5.1)
+
+* GitHub: https://github.com/biostats-dev/ggsurveillance
+* Github mirror: https://github.com/cran/ggsurveillance
+* Maintainer: Alexander Bartel <alexander.bartel@fu-berlin.de>
+
+Run `revdepcheck::cloud_details(, "ggsurveillance")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+         intersect, setdiff, setequal, union
+     
+     > library(tidyr)
+     > 
+     > set.seed(123)
+     > df_6cat <- data.frame(matrix(sample(1:6, 600, replace = TRUE), ncol = 6)) |>
+     +   mutate_all(~ ordered(., labels = c("+++", "++", "+", "-", "--", "---"))) |>
+     +   pivot_longer(cols = everything())
+     > 
+     > ggplot(df_6cat, aes(y = name, fill = value)) +
+     +   geom_bar_diverging() + # Bars
+     +   stat_diverging() + # Labels
+     +   scale_x_continuous_diverging() + # Scale
+     +   theme_classic()
+     Warning: Computation failed in `stat_diverging()`.
+     Caused by error in `case_when()`:
+     ! `..1 (right)` must have size 1, not size 2.
+     Warning: Computation failed in `stat_diverging()`.
+     Caused by error in `case_when()`:
+     ! `..1 (right)` must have size 1, not size 2.
+     Warning in max(abs(x - center)) :
+       no non-missing arguments to max; returning -Inf
+     Error in sign(x) : non-numeric argument to mathematical function
+     Calls: <Anonymous> ... <Anonymous> -> get_limits -> <Anonymous> -> <Anonymous> -> limits
+     Execution halted
+     ```
+
+*   checking tests ... ERROR
+     ```
+     ...
+       • geom_vline_year/3-geom-vline-year-day-mix.svg
+       • geom_vline_year/3-geom-vline-year-week-mix.svg
+       • geom_vline_year/3-geom-vline-year-week2.svg
+       • geom_vline_year/4-geom-vline-year-epiweek.svg
+       • geom_vline_year/4-geom-vline-year-epiweek2.svg
+       • geom_vline_year/5-geom-hline-year-basic2.svg
+       • geom_vline_year/5-geom-hline-year-epiweek.svg
+       • geom_vline_year/5-geom-hline-year-isoweek.svg
+       • geom_vline_year/5-geom-hline-year-week.svg
+       • scale_discrete_reverse/2-scale-reverse.svg
+       • scale_discrete_reverse/3-scale-reverse.svg
+       • scale_discrete_reverse/4-scale-reverse.svg
+       • stat_last_value/1-stat-last-value-multiple-lines.svg
+       • stat_last_value/2-geom-text-last-value-labeller.svg
+       • stat_last_value/2-geom-text-last-value-percent.svg
+       • stat_last_value/3-geom-label-last-value-nudge.svg
+       • stat_last_value/4-geom-text-last-value-repel-min-segment.svg
+       • stat_last_value/5-geom-label-last-value-repel-custom.svg
+       • stat_last_value/6-stat-last-value-abs-nudge-date.svg
+       • stat_last_value/7-stat-last-value-na-at-end.svg
+       Error: Test failures
+       In addition: Warning message:
+       In Sys.setlocale("LC_ALL", "en_GB.UTF-8") :
+         OS reports request to set locale to "en_GB.UTF-8" cannot be honored
+       Execution halted
+     ```
+
+## In both
+
+*   checking data for non-ASCII characters ... NOTE
+     ```
+       Note: found 364 marked UTF-8 strings
+     ```
+
+# goldilocks (0.4.0)
+
+* GitHub: https://github.com/graemeleehickey/goldilocks
+* Github mirror: https://github.com/cran/goldilocks
+* Maintainer: Graeme L. Hickey <graemeleehickey@gmail.com>
+
+Run `revdepcheck::cloud_details(, "goldilocks")` for more info
+
+## Newly broken
+
+*   checking tests ... ERROR
+     ```
+       Running ‘testthat.R’
+     Running the tests in ‘tests/testthat.R’ failed.
+     Complete output:
+       > library(testthat)
+       > library(goldilocks)
+       Loading required package: survival
+       > 
+       > test_check("goldilocks")
+       [ FAIL 1 | WARN 0 | SKIP 1 | PASS 17 ]
+       
+       ══ Skipped tests (1) ═══════════════════════════════════════════════════════════
+       • On CRAN (1): 'test-survival_adapt.R:81:3'
+       
+       ══ Failed tests ════════════════════════════════════════════════════════════════
+       ── Error ('test-survival_adapt.R:54:3'): survival_adapt-cox ────────────────────
+       Error in `if (prob_now > prob_ha) {
+           expected_success_test <- expected_success_test + 1
+       }`: missing value where TRUE/FALSE needed
+       Backtrace:
+           ▆
+        1. └─goldilocks::survival_adapt(...) at test-survival_adapt.R:54:3
+       
+       [ FAIL 1 | WARN 0 | SKIP 1 | PASS 17 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+# Goodreader (0.1.2)
+
+* GitHub: https://github.com/chaoliu-cl/Goodreader
+* Github mirror: https://github.com/cran/Goodreader
+* Maintainer: Chao Liu <chaoliu@cedarville.edu>
+
+Run `revdepcheck::cloud_details(, "Goodreader")` for more info
+
+## Newly broken
+
+*   checking tests ... ERROR
+     ```
+     ...
+       <dplyr:::mutate_error/rlang_error/error/condition>
+       Error in `dplyr::mutate(., period = dplyr::case_when(time_period == "day" ~ 
+           as.character(.data$review_date), time_period == "week" ~ 
+           as.character(lubridate::floor_date(.data$review_date, "week")), 
+           time_period == "month" ~ as.character(lubridate::floor_date(.data$review_date, 
+               "month")), time_period == "year" ~ as.character(lubridate::floor_date(.data$review_date, 
+               "year")), TRUE ~ as.character(lubridate::floor_date(.data$review_date, 
+               "month"))))`: i In argument: `period = dplyr::case_when(...)`.
+       Caused by error in `dplyr::case_when()`:
+       ! `..1 (right)` must have size 1, not size 5.
+       ── Error ('test-sentiment_plots.R:49:5'): sentiment_trend function handles different time periods ──
+       <dplyr:::mutate_error/rlang_error/error/condition>
+       Error in `dplyr::mutate(., period = dplyr::case_when(time_period == "day" ~ 
+           as.character(.data$review_date), time_period == "week" ~ 
+           as.character(lubridate::floor_date(.data$review_date, "week")), 
+           time_period == "month" ~ as.character(lubridate::floor_date(.data$review_date, 
+               "month")), time_period == "year" ~ as.character(lubridate::floor_date(.data$review_date, 
+               "year")), TRUE ~ as.character(lubridate::floor_date(.data$review_date, 
+               "month"))))`: i In argument: `period = dplyr::case_when(...)`.
+       Caused by error in `dplyr::case_when()`:
+       ! `..1 (right)` must have size 1, not size 5.
+       
+       [ FAIL 2 | WARN 0 | SKIP 4 | PASS 45 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+# gtreg (0.4.1)
+
+* GitHub: https://github.com/shannonpileggi/gtreg
+* Github mirror: https://github.com/cran/gtreg
+* Maintainer: Shannon Pileggi <shannon.pileggi@gmail.com>
+
+Run `revdepcheck::cloud_details(, "gtreg")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     Running examples in ‘gtreg-Ex.R’ failed
+     The error most likely occurred in:
+     
+     > ### Name: style_xxx
+     > ### Title: Style numbers as x's
+     > ### Aliases: style_xxx
+     > 
+     > ### ** Examples
+     > 
+     > style_xxx(7:10, digits = 0)
+     Error in `dplyr::case_when()`:
+     ! `..1 (right)` must have size 1, not size 4.
+     Backtrace:
+         ▆
+      1. ├─gtreg::style_xxx(7:10, digits = 0)
+      2. │ └─dplyr::case_when(...)
+      3. │   └─dplyr:::vec_case_when(...)
+      4. │     └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      5. └─vctrs:::stop_assert_size(...)
+      6.   └─vctrs:::stop_assert(...)
+      7.     └─vctrs:::stop_vctrs(...)
+      8.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+*   checking tests ... ERROR
+     ```
+     ...
+        12.   └─vctrs:::stop_assert(...)
+        13.     └─vctrs:::stop_vctrs(...)
+        14.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+       ── Error ('test-style_xxx.R:6:3'): style_xxx works ─────────────────────────────
+       <vctrs_error_assert_size/vctrs_error_assert/vctrs_error/rlang_error/error/condition>
+       Error in `dplyr::case_when(digits == 0 ~ paste(rep_len("x", width), collapse = "") %>% 
+           rep_len(length(x)), TRUE ~ paste(rep_len("x", width - digits - 
+           1), collapse = "") %>% rep_len(length(x)))`: `..1 (right)` must have size 1, not size 4.
+       Backtrace:
+            ▆
+         1. ├─testthat::expect_equal(...) at test-style_xxx.R:6:3
+         2. │ └─testthat::quasi_label(enquo(object), label, arg = "object")
+         3. │   └─rlang::eval_bare(expr, quo_get_env(quo))
+         4. ├─gtreg::style_xxx(7:10, width = 2, digits = 0)
+         5. │ └─dplyr::case_when(...)
+         6. │   └─dplyr:::vec_case_when(...)
+         7. │     └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+         8. └─vctrs:::stop_assert_size(...)
+         9.   └─vctrs:::stop_assert(...)
+        10.     └─vctrs:::stop_vctrs(...)
+        11.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+       
+       [ FAIL 2 | WARN 14 | SKIP 6 | PASS 85 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+# heiscore (0.1.4)
+
+* GitHub: https://github.com/abhrastat/heiscore
+* Github mirror: https://github.com/cran/heiscore
+* Maintainer: Vijetha Ramdas <vramdas06@gmail.com>
+
+Run `revdepcheck::cloud_details(, "heiscore")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     Backtrace:
+          ▆
+       1. ├─heiscore::plotScore(...)
+       2. │ └─heiscore::score(...)
+       3. │   ├─... %>% tidyr::drop_na(score)
+       4. │   └─heiscore:::simpleScore(finalScoringData, scoringVariable, age[1])
+       5. │     └─... %>% ...
+       6. ├─tidyr::drop_na(., score)
+       7. ├─dplyr::mutate(...)
+       8. ├─dplyr::select(., SEQN, WTDR2D, SEX, AGE, RACE_ETH, FAMINC, score)
+       9. ├─dplyr::mutate(...)
+      10. ├─dplyr:::mutate.data.frame(...)
+      11. │ └─dplyr:::mutate_cols(.data, dplyr_quosures(...), by)
+      12. │   ├─base::withCallingHandlers(...)
+      13. │   └─dplyr:::mutate_col(dots[[i]], data, mask, new_columns)
+      14. │     └─mask$eval_all_mutate(quo)
+      15. │       └─dplyr (local) eval()
+      16. ├─dplyr::case_when(...)
+      17. │ └─dplyr:::vec_case_when(...)
+      18. │   └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      19. └─vctrs:::stop_assert_size(...)
+      20.   └─vctrs:::stop_assert(...)
+      21.     └─vctrs:::stop_vctrs(...)
+      22.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+## In both
+
+*   checking installed package size ... NOTE
+     ```
+       installed size is  7.8Mb
+       sub-directories of 1Mb or more:
+         R   7.6Mb
+     ```
+
+# heuristicsmineR (0.3.0)
+
+* GitHub: https://github.com/bupaverse/heuristicsmineR
+* Github mirror: https://github.com/cran/heuristicsmineR
+* Maintainer: Felix Mannhardt <f.mannhardt@tue.nl>
+
+Run `revdepcheck::cloud_details(, "heuristicsmineR")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     ℹ In argument: `label = case_when(...)`.
+     Caused by error in `case_when()`:
+     ! `..1 (right)` must have size 1, not size 7.
+     Backtrace:
+          ▆
+       1. ├─heuristicsmineR::causal_net(L_heur_1, threshold = 0.8)
+       2. │ └─attr(type_nodes, "create_nodes")(bindings, type_nodes, extra_data)
+       3. │   └─... %>% na.omit()
+       4. ├─stats::na.omit(.)
+       5. ├─dplyr::mutate(...)
+       6. ├─dplyr::mutate(...)
+       7. ├─dplyr:::mutate.data.frame(...)
+       8. │ └─dplyr:::mutate_cols(.data, dplyr_quosures(...), by)
+       9. │   ├─base::withCallingHandlers(...)
+      10. │   └─dplyr:::mutate_col(dots[[i]], data, mask, new_columns)
+      11. │     └─mask$eval_all_mutate(quo)
+      12. │       └─dplyr (local) eval()
+      13. ├─dplyr::case_when(...)
+      14. │ └─dplyr:::vec_case_when(...)
+      15. │   └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      16. └─vctrs:::stop_assert_size(...)
+      17.   └─vctrs:::stop_assert(...)
+      18.     └─vctrs:::stop_vctrs(...)
+      19.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+## In both
+
+*   checking installed package size ... NOTE
+     ```
+       installed size is  5.6Mb
+       sub-directories of 1Mb or more:
+         data   2.0Mb
+         libs   3.2Mb
+     ```
+
+# iglu (4.2.2)
+
+* GitHub: https://github.com/irinagain/iglu
+* Github mirror: https://github.com/cran/iglu
+* Maintainer: Irina Gaynanova <irinagn@umich.edu>
+
+Run `revdepcheck::cloud_details(, "iglu")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     ℹ In argument: `gl = dplyr::case_when(...)`.
+     ℹ In group 1: `level_group = 1`.
+     Caused by error in `dplyr::case_when()`:
+     ! `..1 (right)` must have size 1, not size 346.
+     Backtrace:
+          ▆
+       1. ├─iglu::plot_daily(example_data_1_subject)
+       2. │ └─... %>% ...
+       3. ├─dplyr::reframe(...)
+       4. ├─dplyr:::reframe.data.frame(...)
+       5. │ └─dplyr:::summarise_cols(.data, dplyr_quosures(...), by, "reframe")
+       6. │   ├─base::withCallingHandlers(...)
+       7. │   └─dplyr:::map(quosures, summarise_eval_one, mask = mask)
+       8. │     └─base::lapply(.x, .f, ...)
+       9. │       └─dplyr (local) FUN(X[[i]], ...)
+      10. │         └─mask$eval_all_summarise(quo)
+      11. │           └─dplyr (local) eval()
+      12. ├─dplyr::case_when(...)
+      13. │ └─dplyr:::vec_case_when(...)
+      14. │   └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      15. └─vctrs:::stop_assert_size(...)
+      16.   └─vctrs:::stop_assert(...)
+      17.     └─vctrs:::stop_vctrs(...)
+      18.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     Error(s) in re-building vignettes:
+     --- re-building ‘AGP_and_Episodes.Rmd’ using rmarkdown
+     
+     Quitting from AGP_and_Episodes.Rmd:23-25 [unnamed-chunk-1]
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     NULL
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     
+     Error: processing vignette 'AGP_and_Episodes.Rmd' failed with diagnostics:
+     ℹ In argument: `gl = dplyr::case_when(...)`.
+     ℹ In group 1: `level_group = 1`.
+     Caused by error in `dplyr::case_when()`:
+     ! `..1 (right)` must have size 1, not size 346.
+     --- failed re-building ‘AGP_and_Episodes.Rmd’
+     
+     --- re-building ‘MAGE.Rmd’ using rmarkdown
+     ```
+
+# inspectdf (0.0.12.1)
+
+* GitHub: https://github.com/alastairrushworth/inspectdf
+* Github mirror: https://github.com/cran/inspectdf
+* Maintainer: Alastair Rushworth <alastairmrushworth@gmail.com>
+
+Run `revdepcheck::cloud_details(, "inspectdf")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     > data("starwars", package = "dplyr")
+     > 
+     > # Horizontal bar plot for categorical column composition
+     > x <- inspect_cat(starwars) 
+     > show_plot(x)
+     Error in `group_by()`:
+     ! Must group by variables found in `.data`.
+     ✖ Column `col_name` is not found.
+     Backtrace:
+          ▆
+       1. ├─inspectdf::show_plot(x)
+       2. │ └─inspectdf:::plot_cat(x, ...)
+       3. │   └─inspectdf:::collapse_levels(lvl_df, i)
+       4. │     └─... %>% mutate(level_key = paste0(value, "-", col_name))
+       5. ├─dplyr::mutate(., level_key = paste0(value, "-", col_name))
+       6. ├─dplyr::arrange(., col_name)
+       7. ├─dplyr::ungroup(.)
+       8. ├─dplyr::mutate(., colvalstretch = colvalstretch * (1 - 0.8 * (1/length(colval))))
+       9. ├─dplyr::mutate(...)
+      10. ├─dplyr::mutate(., colval = cumsum(prop))
+      11. ├─dplyr::group_by(., col_name)
+      12. └─dplyr:::group_by.data.frame(., col_name)
+      13.   └─dplyr::group_by_prepare(.data, ..., .add = .add, error_call = current_env())
+      14.     └─rlang::abort(bullets, call = error_call)
+     Execution halted
+     ```
+
+# iNZightPlots (2.16.0)
+
+* GitHub: https://github.com/iNZightVIT/iNZightPlots
+* Github mirror: https://github.com/cran/iNZightPlots
+* Maintainer: Tom Elliott <tom.elliott@auckland.ac.nz>
+
+Run `revdepcheck::cloud_details(, "iNZightPlots")` for more info
+
+## Newly broken
+
+*   checking tests ... ERROR
+     ```
+     ...
+       • {waffle} is not installed (2): 'test_dictionary.R:12:1',
+         'test_interaction.R:27:5'
+       
+       ══ Failed tests ════════════════════════════════════════════════════════════════
+       ── Error ('test_datetimes.R:52:1'): (code run outside of `test_that()`) ────────
+       <vctrs_error_assert_size/vctrs_error_assert/vctrs_error/rlang_error/error/condition>
+       Error in `dplyr::case_when(pipe %in% c("dplyr", "%>%", "magrittr") ~ rlang::expr_deparse(expr), 
+           TRUE ~ stringr::str_replace_all(rlang::expr_deparse(expr), 
+               "%>%", "|>"))`: `..1 (right)` must have size 1, not size 2.
+       Backtrace:
+            ▆
+         1. ├─iNZightTools::extract_part(...) at test_datetimes.R:52:1
+         2. │ └─iNZightTools::extract_dt_comp(.data, varname, part, name)
+         3. │   └─iNZightTools:::eval_code(expr)
+         4. │     └─dplyr::case_when(...)
+         5. │       └─dplyr:::vec_case_when(...)
+         6. │         └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+         7. └─vctrs:::stop_assert_size(...)
+         8.   └─vctrs:::stop_assert(...)
+         9.     └─vctrs:::stop_vctrs(...)
+        10.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+       
+       [ FAIL 1 | WARN 0 | SKIP 13 | PASS 281 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+## In both
+
+*   checking package dependencies ... NOTE
+     ```
+     Package suggested but not available for checking: ‘waffle’
+     ```
+
+# iNZightTools (2.0.3)
+
+* GitHub: https://github.com/iNZightVIT/iNZightTools
+* Github mirror: https://github.com/cran/iNZightTools
+* Maintainer: Tom Elliott <tom.elliott@auckland.ac.nz>
+
+Run `revdepcheck::cloud_details(, "iNZightTools")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     > ### Name: aggregate_data
+     > ### Title: Aggregate data by categorical variables
+     > ### Aliases: aggregate_data aggregate_dt
+     > 
+     > ### ** Examples
+     > 
+     > aggregated <-
+     +     aggregate_data(iris,
+     +         group_vars = c("Species"),
+     +         summaries = c("mean", "sd", "iqr")
+     +     )
+     Error in `dplyr::case_when()`:
+     ! `..1 (right)` must have size 1, not size 9.
+     Backtrace:
+         ▆
+      1. ├─iNZightTools::aggregate_data(...)
+      2. │ └─iNZightTools:::eval_code(expr)
+      3. │   └─dplyr::case_when(...)
+      4. │     └─dplyr:::vec_case_when(...)
+      5. │       └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      6. └─vctrs:::stop_assert_size(...)
+      7.   └─vctrs:::stop_assert(...)
+      8.     └─vctrs:::stop_vctrs(...)
+      9.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+*   checking tests ... ERROR
+     ```
+     ...
+        5. │       └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+        6. └─vctrs:::stop_assert_size(...)
+        7.   └─vctrs:::stop_assert(...)
+        8.     └─vctrs:::stop_vctrs(...)
+        9.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+       ── Error ('test_standardize_vars.R:14:5'): Standardization works for surveys ───
+       <vctrs_error_assert_size/vctrs_error_assert/vctrs_error/rlang_error/error/condition>
+       Error in `dplyr::case_when(pipe %in% c("dplyr", "%>%", "magrittr") ~ rlang::expr_deparse(expr), 
+           TRUE ~ stringr::str_replace_all(rlang::expr_deparse(expr), 
+               "%>%", "|>"))`: `..1 (right)` must have size 1, not size 5.
+       Backtrace:
+           ▆
+        1. ├─iNZightTools::standardize_vars(svy, c("api99", "api00")) at test_standardize_vars.R:14:5
+        2. │ └─iNZightTools:::eval_code(expr)
+        3. │   └─dplyr::case_when(...)
+        4. │     └─dplyr:::vec_case_when(...)
+        5. │       └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+        6. └─vctrs:::stop_assert_size(...)
+        7.   └─vctrs:::stop_assert(...)
+        8.     └─vctrs:::stop_vctrs(...)
+        9.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+       
+       [ FAIL 36 | WARN 0 | SKIP 4 | PASS 287 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+# iNZightTS (2.0.2)
+
+* GitHub: https://github.com/iNZightVIT/iNZightTS
+* Github mirror: https://github.com/cran/iNZightTS
+* Maintainer: Tom Elliott <tom.elliott@auckland.ac.nz>
+
+Run `revdepcheck::cloud_details(, "iNZightTS")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     ! `..1 (right)` must have size 1, not size 54.
+     Backtrace:
+          ▆
+       1. ├─iNZightTS::decomp(ts)
+       2. │ ├─(function(.) structure(., class = c("inz_dcmp", class(.)), mult_fit = mult_fit))(...)
+       3. │ │ └─base::structure(., class = c("inz_dcmp", class(.)), mult_fit = mult_fit)
+       4. │ ├─rlang::inject(...)
+       5. │ ├─iNZightTS:::.decomp(use_decomp_method(sm_model), x, var, mult_fit)
+       6. │ └─iNZightTS:::.decomp.use_stl(...)
+       7. │   ├─dplyr::mutate(...)
+       8. │   └─dplyr:::mutate.data.frame(...)
+       9. │     └─dplyr:::mutate_cols(.data, dplyr_quosures(...), by)
+      10. │       ├─base::withCallingHandlers(...)
+      11. │       └─dplyr:::mutate_col(dots[[i]], data, mask, new_columns)
+      12. │         ├─base::withCallingHandlers(...)
+      13. │         └─mask$eval_all_mutate(quo)
+      14. │           └─dplyr (local) eval()
+      15. ├─dplyr::case_when(mult_fit ~ exp(Australia), TRUE ~ as.numeric(Australia))
+      16. │ └─dplyr:::vec_case_when(...)
+      17. │   └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      18. └─vctrs:::stop_assert_size(...)
+      19.   └─vctrs:::stop_assert(...)
+      20.     └─vctrs:::stop_vctrs(...)
+      21.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+*   checking tests ... ERROR
+     ```
+     ...
+        17. │         └─dplyr:::mutate_cols(.data, dplyr_quosures(...), by)
+        18. │           ├─base::withCallingHandlers(...)
+        19. │           └─dplyr:::mutate_col(dots[[i]], data, mask, new_columns)
+        20. │             ├─base::withCallingHandlers(...)
+        21. │             └─mask$eval_all_mutate(quo)
+        22. │               └─dplyr (local) eval()
+        23. ├─dplyr::case_when(mult_fit ~ exp(Daily_Deaths), TRUE ~ as.numeric(Daily_Deaths))
+        24. │ └─dplyr:::vec_case_when(...)
+        25. │   └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+        26. ├─vctrs:::stop_assert_size(...)
+        27. │ └─vctrs:::stop_assert(...)
+        28. │   └─vctrs:::stop_vctrs(...)
+        29. │     └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+        30. │       └─rlang:::signal_abort(cnd, .file)
+        31. │         └─base::signalCondition(cnd)
+        32. ├─dplyr (local) `<fn>`(`<vctrs___>`)
+        33. │ └─rlang::abort(msg, call = call("across"), parent = cnd)
+        34. │   └─rlang:::signal_abort(cnd, .file)
+        35. │     └─base::signalCondition(cnd)
+        36. └─dplyr (local) `<fn>`(`<rlng_rrr>`)
+        37.   └─rlang::abort(message, class = error_class, parent = parent, call = error_call)
+       
+       [ FAIL 16 | WARN 16 | SKIP 0 | PASS 55 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+## In both
+
+*   checking Rd cross-references ... NOTE
+     ```
+     Package unavailable to check Rd xrefs: ‘plotly’
+     ```
+
+# mantis (0.4.3)
+
+* GitHub: https://github.com/phuongquan/mantis
+* Github mirror: https://github.com/cran/mantis
+* Maintainer: T. Phuong Quan <phuong.quan@ndm.ox.ac.uk>
+
+Run `revdepcheck::cloud_details(, "mantis")` for more info
+
+## Newly broken
+
+*   checking tests ... ERROR
+     ```
+     ...
+       ! `..1 (right)` must have size 1, not size 10.
+       ── Error ('test-report.R:494:3'): mantis_report() appends timestamp to filename appropriately ──
+       <dplyr:::mutate_error/rlang_error/error/condition>
+       Error in `dplyr::mutate(dplyr::arrange(dplyr::group_by(dplyr::mutate(prepared_df, 
+           item_order_final = dplyr::row_number()), dplyr::across(dplyr::all_of(item_cols_prefix(inputspec$item_cols)))), 
+           timepoint), value_for_history = dplyr::case_when(plot_value_type == 
+           "value" ~ as.numeric(value), plot_value_type == "delta" ~ 
+           as.numeric(value) - dplyr::lag(as.numeric(value))))`: i In argument: `value_for_history = dplyr::case_when(...)`.
+       i In group 1: `item.item = "a"`.
+       Caused by error in `dplyr::case_when()`:
+       ! `..1 (right)` must have size 1, not size 10.
+       ── Error ('test-report.R:546:3'): mantis_report() creates report in wd when no path supplied ──
+       <dplyr:::mutate_error/rlang_error/error/condition>
+       Error in `dplyr::mutate(dplyr::arrange(dplyr::group_by(dplyr::mutate(prepared_df, 
+           item_order_final = dplyr::row_number()), dplyr::across(dplyr::all_of(item_cols_prefix(inputspec$item_cols)))), 
+           timepoint), value_for_history = dplyr::case_when(plot_value_type == 
+           "value" ~ as.numeric(value), plot_value_type == "delta" ~ 
+           as.numeric(value) - dplyr::lag(as.numeric(value))))`: i In argument: `value_for_history = dplyr::case_when(...)`.
+       i In group 1: `item.item = "a"`.
+       Caused by error in `dplyr::case_when()`:
+       ! `..1 (right)` must have size 1, not size 10.
+       
+       [ FAIL 14 | WARN 0 | SKIP 3 | PASS 417 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+# matlib (1.0.0)
+
+* GitHub: https://github.com/friendly/matlib
+* Github mirror: https://github.com/cran/matlib
+* Maintainer: Michael Friendly <friendly@yorku.ca>
+
+Run `revdepcheck::cloud_details(, "matlib")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     Warning in matrix2latex(cbind(A/2, b), fractions = TRUE) :
+       Function is deprecated. See latexMatrix() and Eqn() for more recent approaches
+     \left[
+      \begin{array}{llll}
+       1 & 1/2 & -1/2 & 8 \\ 
+       -3/2 & -1/2 & 1 & -11 \\ 
+       -1 & 1/2 & 1 & -3 \\ 
+       \end{array} \right]
+     > 
+     > matrix2latex(A, digits=0, brackets="p", show.size = TRUE)
+     Warning in matrix2latex(A, digits = 0, brackets = "p", show.size = TRUE) :
+       Function is deprecated. See latexMatrix() and Eqn() for more recent approaches
+     Error in `dplyr::case_when()`:
+     ! `..1 (right)` must have size 1, not size 2.
+     Backtrace:
+         ▆
+      1. ├─matlib::matrix2latex(A, digits = 0, brackets = "p", show.size = TRUE)
+      2. │ └─dplyr::case_when(...)
+      3. │   └─dplyr:::vec_case_when(...)
+      4. │     └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      5. └─vctrs:::stop_assert_size(...)
+      6.   └─vctrs:::stop_assert(...)
+      7.     └─vctrs:::stop_vctrs(...)
+      8.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     Error(s) in re-building vignettes:
+     --- re-building ‘data-beta.Rmd’ using rmarkdown
+     ```
+
+## In both
+
+*   checking Rd cross-references ... NOTE
+     ```
+     Package unavailable to check Rd xrefs: ‘plotrix’
+     ```
+
+# metan (1.19.0)
+
+* GitHub: https://github.com/nepem-ufsc/metan
+* Github mirror: https://github.com/cran/metan
+* Maintainer: Tiago Olivoto <tiagoolivoto@gmail.com>
+
+Run `revdepcheck::cloud_details(, "metan")` for more info
+
+## Newly broken
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     Error(s) in re-building vignettes:
+     --- re-building ‘metan_start.Rmd’ using rmarkdown
+     ```
+
+# processmapR (0.5.7)
+
+* GitHub: https://github.com/bupaverse/processmapr
+* Github mirror: https://github.com/cran/processmapR
+* Maintainer: Gert Janssenswillen <gert.janssenswillen@uhasselt.be>
+
+Run `revdepcheck::cloud_details(, "processmapR")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     > ### ** Examples
+     > 
+     > library(processmapR)
+     > library(eventdataR)
+     > 
+     > patients %>%
+     +  dotted_chart(x = "absolute", sort = "start", color = "employee")
+     Error in `case_when()`:
+     ! `..1 (right)` must have size 1, not size 2.
+     Backtrace:
+          ▆
+       1. ├─patients %>% ...
+       2. ├─processmapR::dotted_chart(...)
+       3. ├─processmapR:::dotted_chart.eventlog(...)
+       4. │ └─log %>% dotted_chart_data(color, units) %>% ...
+       5. ├─processmapR:::dotted_chart_plot(...)
+       6. │ └─processmapR:::configure_x_aes(x)
+       7. │   └─dplyr::case_when(...)
+       8. │     └─dplyr:::vec_case_when(...)
+       9. │       └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      10. └─vctrs:::stop_assert_size(...)
+      11.   └─vctrs:::stop_assert(...)
+      12.     └─vctrs:::stop_vctrs(...)
+      13.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+*   checking tests ... ERROR
+     ```
+     ...
+            ▆
+         1. ├─testthat::expect_warning(patients_act %>% lined_chart(), NA) at test_lined_chart.R:203:3
+         2. │ └─testthat:::expect_condition_matching(...)
+         3. │   └─testthat:::quasi_capture(...)
+         4. │     ├─testthat (local) .capture(...)
+         5. │     │ └─base::withCallingHandlers(...)
+         6. │     └─rlang::eval_bare(quo_get_expr(.quo), quo_get_env(.quo))
+         7. ├─patients_act %>% lined_chart()
+         8. ├─processmapR::lined_chart(.)
+         9. ├─processmapR:::lined_chart.activitylog(.)
+        10. │ └─processmapR:::lined_chart.eventlog(...)
+        11. │   └─log %>% lined_chart_data(color, units) %>% ...
+        12. ├─processmapR:::lined_chart_plot(...)
+        13. │ └─processmapR:::configure_x_aes_lined(x)
+        14. │   └─dplyr::case_when(...)
+        15. │     └─dplyr:::vec_case_when(...)
+        16. │       └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+        17. └─vctrs:::stop_assert_size(...)
+        18.   └─vctrs:::stop_assert(...)
+        19.     └─vctrs:::stop_vctrs(...)
+        20.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+       
+       [ FAIL 54 | WARN 0 | SKIP 11 | PASS 47 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+# radsafer (2.3.0)
+
+* GitHub: https://github.com/markhogue/radsafer
+* Github mirror: https://github.com/cran/radsafer
+* Maintainer: Mark Hogue <mark.hogue.chp@gmail.com>
+
+Run `revdepcheck::cloud_details(, "radsafer")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     Warning in dk_correct(RN_select = "Sr-90", date1 = "2009-01-01", date2 = "2019-01-01",  :
+       Date mode only provides precision to the day. Use time_lapse mode if more precision is needed.
+         RN half_life units decay_mode
+      Sr-90     28.79     y         B-
+     
+     > 
+     > #   RN_select and time_lapse (random sample)
+     > dk_correct(
+     +   RN_select = base::sample(RadData::ICRP_07.NDX$RN, 1),
+     +   time_lapse = 1:10,
+     +   time_unit = base::sample(c("y", "d", "h", "m", "s"), 1)
+     + )
+     Error in `dplyr::case_when()`:
+     ! `..1 (right)` must have size 1, not size 10.
+     Backtrace:
+         ▆
+      1. ├─radsafer::dk_correct(...)
+      2. │ └─dplyr::case_when(...)
+      3. │   └─dplyr:::vec_case_when(...)
+      4. │     └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      5. └─vctrs:::stop_assert_size(...)
+      6.   └─vctrs:::stop_assert(...)
+      7.     └─vctrs:::stop_vctrs(...)
+      8.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+# REDCapTidieR (1.2.4)
+
+* GitHub: https://github.com/CHOP-CGTInformatics/REDCapTidieR
+* Github mirror: https://github.com/cran/REDCapTidieR
+* Maintainer: Richard Hanna <hannar1@chop.edu>
+
+Run `revdepcheck::cloud_details(, "REDCapTidieR")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     Backtrace:
+          ▆
+       1. ├─... %>% dplyr::first()
+       2. ├─dplyr::first(.)
+       3. │ └─dplyr::nth(x, 1L, order_by = order_by, default = default, na_rm = na_rm)
+       4. │   └─vctrs::vec_size(x)
+       5. ├─dplyr::pull(., redcap_data)
+       6. ├─REDCapTidieR::combine_checkboxes(...)
+       7. │ └─REDCapTidieR:::get_metadata_spec(...)
+       8. │   └─out %>% ...
+       9. ├─dplyr::mutate(...)
+      10. ├─dplyr:::mutate.data.frame(...)
+      11. │ └─dplyr:::mutate_cols(.data, dplyr_quosures(...), by)
+      12. │   ├─base::withCallingHandlers(...)
+      13. │   └─dplyr:::mutate_col(dots[[i]], data, mask, new_columns)
+      14. │     └─mask$eval_all_mutate(quo)
+      15. │       └─dplyr (local) eval()
+      16. ├─dplyr::case_when(...)
+      17. │ └─dplyr:::vec_case_when(...)
+      18. │   └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      19. └─vctrs:::stop_assert_size(...)
+      20.   └─vctrs:::stop_assert(...)
+      21.     └─vctrs:::stop_vctrs(...)
+      22.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+*   checking tests ... ERROR
+     ```
+     ...
+       ── Error ('test-combine_checkboxes.R:209:3'): combine_checkboxes works for multiple checkbox fields ──
+       <dplyr:::mutate_error/rlang_error/error/condition>
+       Error in `mutate(., .new_value = case_when(names_prefix != "" ~ paste(names_prefix, 
+           .data$.value, sep = names_sep), .default = paste(names_prefix, 
+           .data$.value, sep = "")))`: i In argument: `.new_value = case_when(...)`.
+       Caused by error in `case_when()`:
+       ! `..1 (right)` must have size 1, not size 4.
+       ── Error ('test-combine_checkboxes.R:233:3'): combine_checkboxes works for multiple checkbox fields with concatenation ──
+       <dplyr:::mutate_error/rlang_error/error/condition>
+       Error in `mutate(., .new_value = case_when(names_prefix != "" ~ paste(names_prefix, 
+           .data$.value, sep = names_sep), .default = paste(names_prefix, 
+           .data$.value, sep = "")))`: i In argument: `.new_value = case_when(...)`.
+       Caused by error in `case_when()`:
+       ! `..1 (right)` must have size 1, not size 4.
+       ── Error ('test-combine_checkboxes.R:254:3'): combine_checkboxes works for multiple checkbox fields with logicals ──
+       <dplyr:::mutate_error/rlang_error/error/condition>
+       Error in `mutate(., .new_value = case_when(names_prefix != "" ~ paste(names_prefix, 
+           .data$.value, sep = names_sep), .default = paste(names_prefix, 
+           .data$.value, sep = "")))`: i In argument: `.new_value = case_when(...)`.
+       Caused by error in `case_when()`:
+       ! `..1 (right)` must have size 1, not size 4.
+       
+       [ FAIL 8 | WARN 1 | SKIP 5 | PASS 315 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+# retroharmonize (0.2.0)
+
+* GitHub: https://github.com/rOpenGov/retroharmonize
+* Github mirror: https://github.com/cran/retroharmonize
+* Maintainer: Daniel Antal <daniel.antal@ceemid.eu>
+
+Run `revdepcheck::cloud_details(, "retroharmonize")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     > ### ** Examples
+     > 
+     > test_survey <- retroharmonize::read_rds (
+     +    file = system.file("examples", "ZA7576.rds",
+     +                   package = "retroharmonize"), 
+     +    id = "test"
+     + )
+     > example_metadata <- metadata_create (test_survey)
+     Error in `dplyr::case_when()`:
+     ! `..1 (right)` must have size 1, not size 56.
+     Backtrace:
+          ▆
+       1. ├─retroharmonize::metadata_create(test_survey)
+       2. │ └─tibble::tibble(...)
+       3. │   └─tibble:::tibble_quos(xs, .rows, .name_repair)
+       4. │     └─rlang::eval_tidy(xs[[j]], mask)
+       5. ├─retroharmonize (local) to_list_column(.f = "labels")
+       6. │ └─dplyr::case_when(...)
+       7. │   └─dplyr:::vec_case_when(...)
+       8. │     └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+       9. └─vctrs:::stop_assert_size(...)
+      10.   └─vctrs:::stop_assert(...)
+      11.     └─vctrs:::stop_vctrs(...)
+      12.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+*   checking tests ... ERROR
+     ```
+     ...
+       ── Error ('test-suggest_var_names.R:14:1'): (code run outside of `test_that()`) ──
+       <vctrs_error_assert_size/vctrs_error_assert/vctrs_error/rlang_error/error/condition>
+       Error in `dplyr::case_when(.f == "na_labels" ~ sapply(survey, na_labels), 
+           .f == "na_range" ~ sapply(survey, labelled::na_range), .f == 
+               "valid_range" ~ sapply(survey, fn_valid_range), .f == 
+               "labels" ~ sapply(survey, labelled::val_labels))`: `..1 (right)` must have size 1, not size 38.
+       Backtrace:
+            ▆
+         1. ├─base::lapply(X = example_surveys, FUN = metadata_create) at test-suggest_var_names.R:14:1
+         2. │ └─retroharmonize (local) FUN(X[[i]], ...)
+         3. │   └─tibble::tibble(...)
+         4. │     └─tibble:::tibble_quos(xs, .rows, .name_repair)
+         5. │       └─rlang::eval_tidy(xs[[j]], mask)
+         6. ├─retroharmonize (local) to_list_column(.f = "labels")
+         7. │ └─dplyr::case_when(...)
+         8. │   └─dplyr:::vec_case_when(...)
+         9. │     └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+        10. └─vctrs:::stop_assert_size(...)
+        11.   └─vctrs:::stop_assert(...)
+        12.     └─vctrs:::stop_vctrs(...)
+        13.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+       
+       [ FAIL 8 | WARN 0 | SKIP 2 | PASS 80 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+## In both
+
+*   checking installed package size ... NOTE
+     ```
+       installed size is  5.7Mb
+       sub-directories of 1Mb or more:
+         doc        1.1Mb
+         examples   1.9Mb
+     ```
+
+*   checking Rd files ... NOTE
+     ```
+     checkRd: (-1) harmonize_values.Rd:44: Lost braces; missing escapes or markup?
+         44 | \item{perl}{Use perl-like regex? Defaults to {FALSE}.}
+            |                                              ^
+     ```
+
+# rfars (2.0.0)
+
+* GitHub: https://github.com/s87jackson/rfars
+* Github mirror: https://github.com/cran/rfars
+* Maintainer: Steve Jackson <steve.jackson@toxcel.com>
+
+Run `revdepcheck::cloud_details(, "rfars")` for more info
+
+## Newly broken
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     Error(s) in re-building vignettes:
+     --- re-building ‘Alcohol_Counts.Rmd’ using rmarkdown
+     trying URL 'https://zenodo.org/records/17162673/files/FARS.rds?download=1'
+     Content type 'application/octet-stream' length 87386771 bytes (83.3 MB)
+     ==================================================
+     downloaded 83.3 MB
+     
+     --- finished re-building ‘Alcohol_Counts.Rmd’
+     
+     --- re-building ‘Counts.Rmd’ using rmarkdown
+     ```
+
+## In both
+
+*   checking installed package size ... NOTE
+     ```
+       installed size is  5.1Mb
+       sub-directories of 1Mb or more:
+         data   2.0Mb
+         help   1.9Mb
+     ```
+
+*   checking data for non-ASCII characters ... NOTE
+     ```
+       Note: found 53224 marked UTF-8 strings
+     ```
+
+# rFIA (1.1.2)
+
+* GitHub: https://github.com/doserjef/rFIA
+* Github mirror: https://github.com/cran/rFIA
+* Maintainer: Jeffrey Doser <jwdoser@ncsu.edu>
+
+Run `revdepcheck::cloud_details(, "rFIA")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     Caused by error in `dplyr::case_when()`:
+     ! `..1 (right)` must have size 1, not size 3422.
+     Backtrace:
+          ▆
+       1. ├─rFIA::vitalRates(db = fiaRI_mr, landType = "timber", treeType = "gs")
+       2. │ └─base::lapply(...)
+       3. │   └─rFIA (local) FUN(X[[i]], ...)
+       4. │     └─... %>% ...
+       5. ├─dplyr::select(...)
+       6. ├─dplyr::mutate(...)
+       7. ├─dplyr:::mutate.data.frame(...)
+       8. │ └─dplyr:::mutate_cols(.data, dplyr_quosures(...), by)
+       9. │   ├─base::withCallingHandlers(...)
+      10. │   └─dplyr:::mutate_col(dots[[i]], data, mask, new_columns)
+      11. │     └─mask$eval_all_mutate(quo)
+      12. │       └─dplyr (local) eval()
+      13. ├─rFIA:::vrAttHelper(...)
+      14. │ └─dplyr::case_when(...)
+      15. │   └─dplyr:::vec_case_when(...)
+      16. │     └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      17. └─vctrs:::stop_assert_size(...)
+      18.   └─vctrs:::stop_assert(...)
+      19.     └─vctrs:::stop_vctrs(...)
+      20.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+## In both
+
+*   checking installed package size ... NOTE
+     ```
+       installed size is 16.5Mb
+       sub-directories of 1Mb or more:
+         R      2.3Mb
+         data  13.0Mb
+         help   1.1Mb
+     ```
+
+# risk.assessr (2.0.1)
+
+* GitHub: https://github.com/Sanofi-Public/risk.assessr
+* Github mirror: https://github.com/cran/risk.assessr
+* Maintainer: Edward Gillian <edward.gillian-ext@sanofi.com>
+
+Run `revdepcheck::cloud_details(, "risk.assessr")` for more info
+
+## Newly broken
+
+*   checking tests ... ERROR
+     ```
+     ...
+         9. │       ├─dplyr::mutate(...)
+        10. │       └─dplyr:::mutate.data.frame(...)
+        11. │         └─dplyr:::mutate_cols(.data, dplyr_quosures(...), by)
+        12. │           ├─base::withCallingHandlers(...)
+        13. │           └─dplyr:::mutate_col(dots[[i]], data, mask, new_columns)
+        14. │             └─mask$eval_all_mutate(quo)
+        15. │               └─dplyr (local) eval()
+        16. ├─dplyr::case_when(...)
+        17. │ └─dplyr:::vec_case_when(...)
+        18. │   └─dplyr:::check_no_dim(condition, arg = condition_arg, call = call)
+        19. │     └─cli::cli_abort("{.arg {arg}} can't be an array.", call = call)
+        20. │       └─rlang::abort(...)
+        21. │         └─rlang:::signal_abort(cnd, .file)
+        22. │           └─base::signalCondition(cnd)
+        23. ├─dplyr (local) `<fn>`(`<rlng_rrr>`)
+        24. │ └─rlang::abort(message, class = error_class, parent = parent, call = error_call)
+        25. │   └─rlang:::signal_abort(cnd, .file)
+        26. │     └─base::signalCondition(cnd)
+        27. └─purrr (local) `<fn>`(`<dply:::_>`)
+        28.   └─cli::cli_abort(...)
+        29.     └─rlang::abort(...)
+       
+       [ FAIL 1 | WARN 0 | SKIP 26 | PASS 609 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+# scSpatialSIM (0.1.3.4)
+
+* GitHub: https://github.com/FridleyLab/scSpatialSIM
+* Github mirror: https://github.com/cran/scSpatialSIM
+* Maintainer: Fridley Lab <fridley.lab@moffitt.org>
+
+Run `revdepcheck::cloud_details(, "scSpatialSIM")` for more info
+
+## Newly broken
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     Error(s) in re-building vignettes:
+     --- re-building ‘a01_Introduction.Rmd’ using rmarkdown
+     ```
+
+# sdtmval (0.4.1)
+
+* GitHub: https://github.com/skgithub14/sdtmval
+* Github mirror: https://github.com/cran/sdtmval
+* Maintainer: Stephen Knapp <stephen@knappconsultingllc.com>
+
+Run `revdepcheck::cloud_details(, "sdtmval")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     Caused by error in `dplyr::case_when()`:
+     ! `..2 (right)` must have size 1, not size 2.
+     Backtrace:
+          ▆
+       1. ├─sdtmval::create_STAT(df = df, domain = "XX", nd_ind = "ND", nd_ind_cd = "Y")
+       2. │ └─... %>% dplyr::ungroup()
+       3. ├─dplyr::ungroup(.)
+       4. ├─dplyr::select(., -tidyselect::all_of(tmp_var))
+       5. ├─dplyr::filter(...)
+       6. ├─dplyr::mutate(...)
+       7. ├─dplyr::mutate(...)
+       8. ├─dplyr:::mutate.data.frame(...)
+       9. │ └─dplyr:::mutate_cols(.data, dplyr_quosures(...), by)
+      10. │   ├─base::withCallingHandlers(...)
+      11. │   └─dplyr:::mutate_col(dots[[i]], data, mask, new_columns)
+      12. │     └─mask$eval_all_mutate(quo)
+      13. │       └─dplyr (local) eval()
+      14. ├─dplyr::case_when(all(!is.na(XXSTAT)) ~ paste0(domain, "ALL"), TRUE ~ XXTESTCD)
+      15. │ └─dplyr:::vec_case_when(...)
+      16. │   └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      17. └─vctrs:::stop_assert_size(...)
+      18.   └─vctrs:::stop_assert(...)
+      19.     └─vctrs:::stop_vctrs(...)
+      20.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+*   checking tests ... ERROR
+     ```
+     ...
+       > 
+       > library(testthat)
+       > library(sdtmval)
+       > 
+       > test_check("sdtmval")
+       
+       
+       processing file: /tmp/RtmpdpEp5i/test_notebook.Rmd
+       output file: /tmp/RtmpdpEp5i/test_notebook.R
+       
+       [ FAIL 1 | WARN 0 | SKIP 0 | PASS 25 ]
+       
+       ══ Failed tests ════════════════════════════════════════════════════════════════
+       ── Error ('test-methods.R:93:3'): STAT ─────────────────────────────────────────
+       <dplyr:::mutate_error/rlang_error/error/condition>
+       Error in `dplyr::mutate(., `:=`("{domain}TESTCD", dplyr::case_when(all(!is.na(!!rlang::sym(paste0(domain, 
+           "STAT")))) ~ paste0(domain, "ALL"), TRUE ~ !!rlang::sym(paste0(domain, 
+           "TESTCD")))))`: i In argument: `XXTESTCD = dplyr::case_when(...)`.
+       i In group 3: `USUBJID = "Subject B"`, `VISIT = "Visit 1"`.
+       Caused by error in `dplyr::case_when()`:
+       ! `..2 (right)` must have size 1, not size 2.
+       
+       [ FAIL 1 | WARN 0 | SKIP 0 | PASS 25 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+# shinyHugePlot (0.3.0)
+
+* Github mirror: https://github.com/cran/shinyHugePlot
+* Maintainer: Junta Tagusari <j.tagusari@eng.hokudai.ac.jp>
+
+Run `revdepcheck::cloud_details(, "shinyHugePlot")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     +   x = noise_fluct$time, y = noise_fluct$f500, n_out = 1000
+     +   )
+     Error in `dplyr::case_when()`:
+     ! `..1 (right)` must have size 1, not size 32001.
+     Backtrace:
+          ▆
+       1. ├─agg$aggregate(x = noise_fluct$time, y = noise_fluct$f500, n_out = 1000)
+       2. │ └─private$aggregate_exec(x, y, n_out)
+       3. │   ├─private$LTTB(...)
+       4. │   │ └─assertthat::assert_that(length(x) == length(y), msg = "x and y must be the same-length vectors")
+       5. │   │   └─assertthat::see_if(..., env = env, msg = msg)
+       6. │   │     ├─base::tryCatch(...)
+       7. │   │     │ └─base (local) tryCatchList(expr, classes, parentenv, handlers)
+       8. │   │     │   └─base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])
+       9. │   │     │     └─base (local) doTryCatch(return(expr), name, parentenv, handler)
+      10. │   │     └─base::eval(assertion, env)
+      11. │   │       └─base::eval(assertion, env)
+      12. │   └─dplyr::case_when(...)
+      13. │     └─dplyr:::vec_case_when(...)
+      14. │       └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      15. └─vctrs:::stop_assert_size(...)
+      16.   └─vctrs:::stop_assert(...)
+      17.     └─vctrs:::stop_vctrs(...)
+      18.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+# SingleCaseES (0.7.3)
+
+* GitHub: https://github.com/jepusto/SingleCaseES
+* Github mirror: https://github.com/cran/SingleCaseES
+* Maintainer: James E. Pustejovsky <jepusto@gmail.com>
+
+Run `revdepcheck::cloud_details(, "SingleCaseES")` for more info
+
+## Newly broken
+
+*   checking tests ... ERROR
+     ```
+     ...
+                   "n_A * n_B") ~ as.numeric(A * B), weighting %in% 
+                   c("1/nA+1/nB", "1/nA + 1/nB", "1/n_A+1/n_B", "1/n_A + 1/n_B") ~ 
+                   as.numeric(1/A + 1/B)))`: ℹ In argument: `weights = dplyr::case_when(...)`.
+       Caused by error in `dplyr::case_when()`:
+       ! `..1 (right)` must have size 1, not size 12.
+       ── Error ('test-batch-calc-ES.R:397:18'): Synonyms for weighting argument in batch_calc_ES() are equivalent. ──
+       <dplyr:::mutate_error/rlang_error/error/condition>
+       Error in `dplyr::mutate(dplyr::ungroup(tidyr::pivot_wider(dplyr::summarise(dplyr::group_by(dplyr::mutate(dplyr::filter(dat, 
+           !!rlang::sym(condition) %in% c(baseline_phase, intervention_phase)), 
+           `:=`(!!rlang::sym(condition), ifelse(!!rlang::sym(condition) == 
+               baseline_phase, "A", "B"))), !!!rlang::syms(c(grouping, 
+           aggregate, condition))), n = dplyr::n(), .groups = "drop"), 
+           names_from = !!rlang::sym(condition), values_from = n)), 
+           weights = dplyr::case_when(weighting %in% c("nA", "n_A") ~ 
+               as.numeric(A), weighting %in% c("nB", "n_B") ~ as.numeric(B), 
+               weighting %in% c("nAnB", "nA*nB", "nA * nB", "n_A*n_B", 
+                   "n_A * n_B") ~ as.numeric(A * B), weighting %in% 
+                   c("1/nA+1/nB", "1/nA + 1/nB", "1/n_A+1/n_B", "1/n_A + 1/n_B") ~ 
+                   as.numeric(1/A + 1/B)))`: ℹ In argument: `weights = dplyr::case_when(...)`.
+       Caused by error in `dplyr::case_when()`:
+       ! `..1 (right)` must have size 1, not size 12.
+       
+       [ FAIL 3 | WARN 0 | SKIP 2 | PASS 275 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+# srppp (1.1.0)
+
+* GitHub: https://github.com/agroscope-ch/srppp
+* Github mirror: https://github.com/cran/srppp
+* Maintainer: Johannes Ranke <johannes.ranke@agroscope.admin.ch>
+
+Run `revdepcheck::cloud_details(, "srppp")` for more info
+
+## Newly broken
+
+*   checking tests ... ERROR
+     ```
+     ...
+               min_dosage, max_dosage)), rate = case_when(aggregation == 
+           "mean" ~ (rate_min + rate_max)/2, aggregation == "max" ~ 
+           rate_max, aggregation == "min" ~ rate_min), dosage = case_when(aggregation == 
+           "mean" ~ (dosage_min + dosage_max)/2, aggregation == "max" ~ 
+           dosage_max, aggregation == "min" ~ dosage_min))`: i In argument: `rate = case_when(...)`.
+       Caused by error in `case_when()`:
+       ! `..1 (right)` must have size 1, not size 7.
+       ── Error ('test-use_rates.R:86:1'): (code run outside of `test_that()`) ────────
+       <dplyr:::mutate_error/rlang_error/error/condition>
+       Error in `mutate(mutate(mutate(product_uses, min_rate = na_if(min_rate, 
+           0), max_rate = na_if(max_rate, 0), min_dosage = na_if(min_dosage, 
+           0), max_dosage = na_if(max_dosage, 0)), rate_min = min_rate, 
+           rate_max = if_else(is.na(max_rate), min_rate, max_rate), 
+           dosage_min = min_dosage, dosage_max = if_else(is.na(max_dosage), 
+               min_dosage, max_dosage)), rate = case_when(aggregation == 
+           "mean" ~ (rate_min + rate_max)/2, aggregation == "max" ~ 
+           rate_max, aggregation == "min" ~ rate_min), dosage = case_when(aggregation == 
+           "mean" ~ (dosage_min + dosage_max)/2, aggregation == "max" ~ 
+           dosage_max, aggregation == "min" ~ dosage_min))`: ℹ In argument: `rate = case_when(...)`.
+       Caused by error in `case_when()`:
+       ! `..1 (right)` must have size 1, not size 6.
+       
+       [ FAIL 2 | WARN 0 | SKIP 0 | PASS 16 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     ...
+     
+     Quitting from srppp.rmd:276-282 [unnamed-chunk-15]
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     NULL
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     
+     Error: processing vignette 'srppp.rmd' failed with diagnostics:
+     ℹ In argument: `rate = case_when(...)`.
+     Caused by error in `case_when()`:
+     ! `..1 (right)` must have size 1, not size 11.
+     --- failed re-building ‘srppp.rmd’
+     
+     --- re-building ‘srppp_products_with_MO.rmd’ using rmarkdown
+     trying URL 'https://www.blv.admin.ch/dam/blv/de/dokumente/zulassung-pflanzenschutzmittel/pflanzenschutzmittelverzeichnis/daten-pflanzenschutzmittelverzeichnis.zip.download.zip/Daten%20Pflanzenschutzmittelverzeichnis.zip'
+     Content type 'application/x-zip-compressed' length 2501553 bytes (2.4 MB)
+     ==================================================
+     downloaded 2.4 MB
+     
+     --- finished re-building ‘srppp_products_with_MO.rmd’
+     
+     SUMMARY: processing the following file failed:
+       ‘srppp.rmd’
+     
+     Error: Vignette re-building failed.
+     Execution halted
+     ```
+
+# statsExpressions (1.7.1)
+
+* GitHub: https://github.com/IndrajeetPatil/statsExpressions
+* Github mirror: https://github.com/cran/statsExpressions
+* Maintainer: Indrajeet Patil <patilindrajeet.science@gmail.com>
+
+Run `revdepcheck::cloud_details(, "statsExpressions")` for more info
+
+## Newly broken
+
+*   checking tests ... ERROR
+     ```
+     ...
+         'test-two-sample-bayes.R:45:5', 'test-two-sample-nonparametric.R:17:5',
+         'test-two-sample-nonparametric.R:39:5', 'test-two-sample-parametric.R:18:5',
+         'test-two-sample-parametric.R:40:5', 'test-two-sample-parametric.R:60:5',
+         'test-two-sample-parametric.R:80:5', 'test-two-sample-robust.R:20:5',
+         'test-two-sample-robust.R:39:5', 'test-two-sample-robust.R:63:5',
+         'test-two-sample-robust.R:83:5', 'test-oneway-anova-robust.R:31:5',
+         'test-oneway-anova-robust.R:56:5'
+       • On Linux (1): 'test-centrality-description.R:27:5'
+       
+       ══ Failed tests ════════════════════════════════════════════════════════════════
+       ── Error ('test-oneway-anova-bayes.R:13:5'): bayesian (between-subjects - anova) ──
+       <subscriptOutOfBoundsError/error/condition>
+       Error in `data$method[[1L]]`: subscript out of bounds
+       Backtrace:
+           ▆
+        1. ├─base::suppressWarnings(...) at test-oneway-anova-bayes.R:13:5
+        2. │ └─base::withCallingHandlers(...)
+        3. └─statsExpressions::oneway_anova(...)
+        4.   └─statsExpressions::add_expression_col(...)
+        5.     └─base::grepl("contingency", data$method[[1L]], fixed = TRUE)
+        6.       └─base::is.factor(x)
+       
+       [ FAIL 1 | WARN 0 | SKIP 64 | PASS 24 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+# STICr (1.1.1)
+
+* GitHub: https://github.com/HEAL-KGS/STICr
+* Github mirror: https://github.com/cran/STICr
+* Maintainer: Sam Zipper <samzipper@ku.edu>
+
+Run `revdepcheck::cloud_details(, "STICr")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     Running examples in ‘STICr-Ex.R’ failed
+     The error most likely occurred in:
+     
+     > ### Name: classify_wetdry
+     > ### Title: classify_wetdry
+     > ### Aliases: classify_wetdry
+     > 
+     > ### ** Examples
+     > 
+     > classified_df <-
+     +   classify_wetdry(calibrated_stic_data,
+     +     classify_var = "SpC", method = "absolute", threshold = 200
+     +   )
+     Error in `dplyr::if_else()`:
+     ! `condition` can't be an array.
+     Backtrace:
+         ▆
+      1. └─STICr::classify_wetdry(...)
+      2.   └─dplyr::if_else(class_var >= threshold, "wet", "dry")
+      3.     └─dplyr:::vec_case_when(...)
+      4.       └─dplyr:::check_no_dim(condition, arg = condition_arg, call = call)
+      5.         └─cli::cli_abort("{.arg {arg}} can't be an array.", call = call)
+      6.           └─rlang::abort(...)
+     Execution halted
+     ```
+
+# surveyexplorer (0.2.0)
+
+* Github mirror: https://github.com/cran/surveyexplorer
+* Maintainer: Liam Haller <liamhllr2@gmail.com>
+
+Run `revdepcheck::cloud_details(, "surveyexplorer")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     Running examples in ‘surveyexplorer-Ex.R’ failed
+     The error most likely occurred in:
+     
+     > ### Name: matrix_freq
+     > ### Title: Matrix Frequency Plot
+     > ### Aliases: matrix_freq
+     > 
+     > ### ** Examples
+     > 
+     >  #Array question (1-5)
+     >   matrix_freq(berlinbears, dplyr::starts_with('p_'))
+     Error in `dplyr::case_when()`:
+     ! `..1 (right)` must have size 1, not size 500.
+     Backtrace:
+         ▆
+      1. ├─surveyexplorer::matrix_freq(berlinbears, dplyr::starts_with("p_"))
+      2. │ └─surveyexplorer::multi_summary(...)
+      3. │   └─dplyr::case_when(...)
+      4. │     └─dplyr:::vec_case_when(...)
+      5. │       └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      6. └─vctrs:::stop_assert_size(...)
+      7.   └─vctrs:::stop_assert(...)
+      8.     └─vctrs:::stop_vctrs(...)
+      9.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+*   checking tests ... ERROR
+     ```
+     ...
+        8.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+       ── Failure ('test-multiplechoice.R:90:3'): Graph: subgroup, weights ────────────
+       Expected `multi_freq(...)` to run without any errors.
+       i Actually got a <vctrs_error_assert_size> with text:
+         `..1 (right)` must have size 1, not size 500.
+       ── Failure ('test-multiplechoice.R:96:3'): Graph: subgroup, weights, na.rm ─────
+       Expected `multi_freq(...)` to run without any errors.
+       i Actually got a <vctrs_error_assert_size> with text:
+         `..1 (right)` must have size 1, not size 500.
+       ── Failure ('test-multiplechoice.R:113:3'): Table: columns only ────────────────
+       Expected `multi_table(berlinbears, question = dplyr::starts_with("will_eat"))` to run without any errors.
+       i Actually got a <vctrs_error_assert_size> with text:
+         `..1 (right)` must have size 1, not size 500.
+       ── Failure ('test-multiplechoice.R:127:3'): Table: subgroup ────────────────────
+       Expected `multi_table(...)` to run without any errors.
+       i Actually got a <vctrs_error_assert_size> with text:
+         `..1 (right)` must have size 1, not size 500.
+       ── Failure ('test-multiplechoice.R:133:3'): Table: subgroup, weights, exclude NA ──
+       Expected `multi_table(...)` to run without any errors.
+       i Actually got a <vctrs_error_assert_size> with text:
+         `..1 (right)` must have size 1, not size 500.
+       
+       [ FAIL 37 | WARN 0 | SKIP 0 | PASS 32 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+# tabxplor (1.3.1)
+
+* GitHub: https://github.com/BriceNocenti/tabxplor
+* Github mirror: https://github.com/cran/tabxplor
+* Maintainer: Brice Nocenti <brice.nocenti@gmail.com>
+
+Run `revdepcheck::cloud_details(, "tabxplor")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     ℹ With name: age.
+     Caused by error in `dplyr::case_when()`:
+     ! `..1 (right)` must have size 1, not size 25.
+     Backtrace:
+          ▆
+       1. ├─dplyr::mutate(...)
+       2. ├─tabxplor::tab_num(...)
+       3. │ └─purrr::pmap_dfc(...)
+       4. │   └─purrr::pmap(.l, .f, ...)
+       5. │     └─purrr:::pmap_("list", .l, .f, ..., .progress = .progress)
+       6. │       ├─purrr:::with_indexed_errors(...)
+       7. │       │ └─base::withCallingHandlers(...)
+       8. │       ├─purrr:::call_with_cleanup(...)
+       9. │       └─tabxplor (local) .f(...)
+      10. │         ├─tabxplor:::new_fmt(...)
+      11. │         │ └─vctrs::new_rcrd(...)
+      12. │         │   └─vctrs::obj_is_list(fields)
+      13. │         └─dplyr::case_when(...)
+      14. │           └─dplyr:::vec_case_when(...)
+      15. │             └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      16. └─vctrs:::stop_assert_size(...)
+      17.   └─vctrs:::stop_assert(...)
+      18.     └─vctrs:::stop_vctrs(...)
+      19.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+*   checking tests ... ERROR
+     ```
+     ...
+        15. │             │ └─base::withCallingHandlers(...)
+        16. │             ├─purrr:::call_with_cleanup(...)
+        17. │             └─tabxplor (local) .f(.x[[i]], ...)
+        18. │               └─tabxplor:::get_reference(., mode = "all_totals")
+        19. │                 └─dplyr::case_when(...)
+        20. │                   └─dplyr:::vec_case_when(...)
+        21. │                     └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+        22. ├─vctrs:::stop_assert_size(...)
+        23. │ └─vctrs:::stop_assert(...)
+        24. │   └─vctrs:::stop_vctrs(...)
+        25. │     └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+        26. │       └─rlang:::signal_abort(cnd, .file)
+        27. │         └─base::signalCondition(cnd)
+        28. ├─purrr (local) `<fn>`(`<vctrs___>`)
+        29. │ └─cli::cli_abort(...)
+        30. │   └─rlang::abort(...)
+        31. │     └─rlang:::signal_abort(cnd, .file)
+        32. │       └─base::signalCondition(cnd)
+        33. └─purrr (local) `<fn>`(`<prrr_rr_>`)
+        34.   └─cli::cli_abort(...)
+        35.     └─rlang::abort(...)
+       
+       [ FAIL 14 | WARN 0 | SKIP 0 | PASS 144 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     Error(s) in re-building vignettes:
+       ...
+     --- re-building ‘tabxplor.Rmd’ using rmarkdown
+     
+     Quitting from tabxplor.Rmd:79-85 [unnamed-chunk-6]
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     NULL
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     
+     Error: processing vignette 'tabxplor.Rmd' failed with diagnostics:
+     [1m[22m[36mℹ[39m In index: 1.
+     [36mℹ[39m With name: Never married.
+     [1mCaused by error in `dplyr::case_when()`:[22m
+     [33m![39m `..1 (right)` must have size 1, not size 13.
+     --- failed re-building ‘tabxplor.Rmd’
+     
+     SUMMARY: processing the following file failed:
+       ‘tabxplor.Rmd’
+     
+     Error: Vignette re-building failed.
+     Execution halted
+     ```
+
+# tcpl (3.3.0)
+
+* GitHub: https://github.com/USEPA/CompTox-ToxCast-tcpl
+* Github mirror: https://github.com/cran/tcpl
+* Maintainer: Madison Feshuk <feshuk.madison@epa.gov>
+
+Run `revdepcheck::cloud_details(, "tcpl")` for more info
+
+## Newly broken
+
+*   checking tests ... ERROR
+     ```
+     ...
+           table == "mcagg" ~ list(tbls = "mc3,mc4,mc4_agg", joins = "mc3.m3id = mc4_agg.m3id AND mc4.m4id = mc4_agg.m4id"), 
+           table == "mc4" && add.fld == FALSE ~ list(tbls = "mc4", joins = NULL), 
+           table == "mc4" && add.fld == TRUE ~ list(tbls = "mc4,mc4_param", 
+               joins = "mc4.m4id = mc4_param.m4id"), table == "mc5" && 
+               add.fld == FALSE ~ list(tbls = "mc4,mc5", joins = "mc4.m4id = mc5.m4id"), 
+           table == "mc5" && add.fld == TRUE ~ list(tbls = "mc4,mc5,mc5_param", 
+               joins = "mc4.m4id = mc5.m4id AND mc5.m5id = mc5_param.m5id"), 
+           table == "mc6" ~ list(tbls = "mc4,mc6", joins = "mc6.m4id = mc4.m4id"), 
+           table == "mc7" ~ list(tbls = "mc4,mc7", joins = "mc7.m4id = mc4.m4id"), 
+           TRUE ~ list(tbls = NULL, joins = NULL))`: `..1 (right)` must have size 1, not size 2.
+       Backtrace:
+           ▆
+        1. ├─tcpl::tcplPlotLoadData(type = "sc", fld = "aeid", val = mocked$aeid) at test-tcplggplot2Utils.R:406:3
+        2. │ └─tcpl::tcplLoadData(lvl = lvl, fld = fld, val = val, type = type)
+        3. │   └─dplyr::case_when(...)
+        4. │     └─dplyr:::vec_case_when(...)
+        5. │       └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+        6. └─vctrs:::stop_assert_size(...)
+        7.   └─vctrs:::stop_assert(...)
+        8.     └─vctrs:::stop_vctrs(...)
+        9.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+       
+       [ FAIL 167 | WARN 4 | SKIP 5 | PASS 355 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+# tidyCDISC (0.2.1)
+
+* GitHub: https://github.com/Biogen-Inc/tidyCDISC
+* Github mirror: https://github.com/cran/tidyCDISC
+* Maintainer: Aaron Clark <clark.aaronchris@gmail.com>
+
+Run `revdepcheck::cloud_details(, "tidyCDISC")` for more info
+
+## Newly broken
+
+*   checking tests ... ERROR
+     ```
+     ...
+        39. │     └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+        40. │       └─rlang:::signal_abort(cnd, .file)
+        41. │         └─base::signalCondition(cnd)
+        42. ├─purrr (local) `<fn>`(`<vctrs___>`)
+        43. │ └─cli::cli_abort(...)
+        44. │   └─rlang::abort(...)
+        45. │     └─rlang:::signal_abort(cnd, .file)
+        46. │       └─base::signalCondition(cnd)
+        47. ├─purrr (local) `<fn>`(`<prrr_rr_>`)
+        48. │ └─cli::cli_abort(...)
+        49. │   └─rlang::abort(...)
+        50. │     └─rlang:::signal_abort(cnd, .file)
+        51. │       └─base::signalCondition(cnd)
+        52. ├─purrr (local) `<fn>`(`<prrr_rr_>`)
+        53. │ └─cli::cli_abort(...)
+        54. │   └─rlang::abort(...)
+        55. │     └─rlang:::signal_abort(cnd, .file)
+        56. │       └─base::signalCondition(cnd)
+        57. └─purrr (local) `<fn>`(`<prrr_rr_>`)
+        58.   └─cli::cli_abort(...)
+        59.     └─rlang::abort(...)
+       
+       [ FAIL 3 | WARN 1 | SKIP 14 | PASS 92 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+## In both
+
+*   checking installed package size ... NOTE
+     ```
+       installed size is  6.5Mb
+       sub-directories of 1Mb or more:
+         R      1.5Mb
+         data   2.0Mb
+         doc    1.8Mb
+     ```
+
+# tidydice (1.0.0)
+
+* GitHub: https://github.com/rolkra/tidydice
+* Github mirror: https://github.com/cran/tidydice
+* Maintainer: Roland Krasser <roland.krasser@gmail.com>
+
+Run `revdepcheck::cloud_details(, "tidydice")` for more info
+
+## Newly broken
+
+*   checking tests ... ERROR
+     ```
+     ...
+           ))`: ℹ In argument: `result = case_when(...)`.
+       Caused by error in `case_when()`:
+       ! `..1 (right)` must have size 1, not size 200.
+       ── Error ('test_dice_formula.R:206:3'): arithmetic operations ──────────────────
+       <dplyr:::mutate_error/rlang_error/error/condition>
+       Error in `mutate(., result = case_when(dice_op_sign == "+" ~ result + dice_op_n, 
+           dice_op_sign == "-" ~ result - dice_op_n, dice_op_sign == 
+               "*" ~ result * dice_op_n, dice_op_sign == "/" ~ result/dice_op_n, 
+           dice_op_sign %in% c("^", "**") ~ result^dice_op_n, T ~ as.numeric(result), 
+           ))`: ℹ In argument: `result = case_when(...)`.
+       Caused by error in `case_when()`:
+       ! `..1 (right)` must have size 1, not size 2000.
+       ── Error ('test_dice_formula.R:237:3'): piping ─────────────────────────────────
+       <dplyr:::mutate_error/rlang_error/error/condition>
+       Error in `mutate(., result = case_when(dice_op_sign == "+" ~ result + dice_op_n, 
+           dice_op_sign == "-" ~ result - dice_op_n, dice_op_sign == 
+               "*" ~ result * dice_op_n, dice_op_sign == "/" ~ result/dice_op_n, 
+           dice_op_sign %in% c("^", "**") ~ result^dice_op_n, T ~ as.numeric(result), 
+           ))`: ℹ In argument: `result = case_when(...)`.
+       Caused by error in `case_when()`:
+       ! `..1 (right)` must have size 1, not size 20.
+       
+       [ FAIL 5 | WARN 0 | SKIP 0 | PASS 127 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     Error(s) in re-building vignettes:
+     --- re-building ‘tidydice.Rmd’ using rmarkdown
+     ```
+
+# tidyfinance (0.4.4)
+
+* GitHub: https://github.com/tidy-finance/r-tidyfinance
+* Github mirror: https://github.com/cran/tidyfinance
+* Maintainer: Christoph Scheuch <christoph@tidy-intelligence.com>
+
+Run `revdepcheck::cloud_details(, "tidyfinance")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     > 
+     > estimate_fama_macbeth(data, "ret_excess ~ beta + bm + log_mktcap")
+     Error in `mutate()`:
+     ℹ In argument: `t_statistic = case_when(...)`.
+     Caused by error in `case_when()`:
+     ! `..1 (right)` must have size 1, not size 4.
+     Backtrace:
+          ▆
+       1. ├─tidyfinance::estimate_fama_macbeth(data, "ret_excess ~ beta + bm + log_mktcap")
+       2. │ ├─dplyr::select(...)
+       3. │ ├─dplyr::mutate(...)
+       4. │ └─dplyr:::mutate.data.frame(...)
+       5. │   └─dplyr:::mutate_cols(.data, dplyr_quosures(...), by)
+       6. │     ├─base::withCallingHandlers(...)
+       7. │     └─dplyr:::mutate_col(dots[[i]], data, mask, new_columns)
+       8. │       └─mask$eval_all_mutate(quo)
+       9. │         └─dplyr (local) eval()
+      10. ├─dplyr::case_when(...)
+      11. │ └─dplyr:::vec_case_when(...)
+      12. │   └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      13. └─vctrs:::stop_assert_size(...)
+      14.   └─vctrs:::stop_assert(...)
+      15.     └─vctrs:::stop_vctrs(...)
+      16.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+*   checking tests ... ERROR
+     ```
+     ...
+       <dplyr:::mutate_error/rlang_error/error/condition>
+       Error in `mutate(mutate(tidyr::nest(cross_sections, data = c(all_of(data_options$date), 
+           value)), model = purrr::map(data, ~lm("value ~ 1", data = .)), 
+           risk_premium = purrr::map_dbl(model, ~.$coefficients), n = purrr::map_dbl(data, 
+               nrow), standard_error = purrr::map_dbl(model, ~compute_standard_error(., 
+               vcov, vcov_options))), t_statistic = case_when(vcov == 
+           "iid" ~ risk_premium/standard_error * sqrt(n), vcov == "newey-west" ~ 
+           risk_premium/standard_error))`: i In argument: `t_statistic = case_when(...)`.
+       Caused by error in `case_when()`:
+       ! `..1 (right)` must have size 1, not size 4.
+       ── Error ('test-estimate_fama_macbeth.R:119:3'): estimate_fama_macbeth computes correct number of rows ──
+       <dplyr:::mutate_error/rlang_error/error/condition>
+       Error in `mutate(mutate(tidyr::nest(cross_sections, data = c(all_of(data_options$date), 
+           value)), model = purrr::map(data, ~lm("value ~ 1", data = .)), 
+           risk_premium = purrr::map_dbl(model, ~.$coefficients), n = purrr::map_dbl(data, 
+               nrow), standard_error = purrr::map_dbl(model, ~compute_standard_error(., 
+               vcov, vcov_options))), t_statistic = case_when(vcov == 
+           "iid" ~ risk_premium/standard_error * sqrt(n), vcov == "newey-west" ~ 
+           risk_premium/standard_error))`: i In argument: `t_statistic = case_when(...)`.
+       Caused by error in `case_when()`:
+       ! `..1 (right)` must have size 1, not size 4.
+       
+       [ FAIL 3 | WARN 0 | SKIP 8 | PASS 84 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+# TreatmentPatterns (3.1.1)
+
+* GitHub: https://github.com/darwin-eu/TreatmentPatterns
+* Github mirror: https://github.com/cran/TreatmentPatterns
+* Maintainer: Maarten van Kessel <m.l.vankessel@erasmusmc.nl>
+
+Run `revdepcheck::cloud_details(, "TreatmentPatterns")` for more info
+
+## Newly broken
+
+*   checking tests ... ERROR
+     ```
+     ...
+         'test-pathwaysLogical.R:1754:3', 'test-pathwaysLogical.R:1801:3',
+         'test-pathwaysLogical.R:1857:3', 'test-pathwaysLogical.R:1912:3',
+         'test-pathwaysMultipleTargetsLogical.R:18:3',
+         'test-pathwaysMultipleTargetsLogical.R:220:3',
+         'test-pathwaysMultipleTargetsLogical.R:311:3',
+         'test-plotEventDuration.R:2:3', 'test-plotEventDuration.R:12:3',
+         'test-plotEventDuration.R:37:3', 'test-plotEventDuration.R:63:3'
+       
+       ══ Failed tests ════════════════════════════════════════════════════════════════
+       ── Error ('test-CRAN.R:55:3'): CRAN Tests ──────────────────────────────────────
+       Error in `filter(., .data$event_count >= minCellCount, case_when(treatmentGroups == 
+           "both" ~ .data$event_name == .data$event_name, treatmentGroups == 
+           "group" ~ .data$event_name %in% c("mono-event", "combination-event"), 
+           treatmentGroups == "individual" ~ !.data$event_name %in% 
+               c("mono-event", "combination-event")), case_when(is.null(eventLines) ~ 
+           .data$event_name == .data$event_name, .default = .data$line %in% 
+           c(as.character(eventLines), "overall")), case_when(includeOverall ~ 
+           .data$event_name == .data$event_name, .default = !.data$line == 
+           "overall"))`: i In argument: `case_when(...)`.
+       Caused by error in `case_when()`:
+       ! `..1 (right)` must have size 1, not size 21.
+       
+       [ FAIL 1 | WARN 1 | SKIP 123 | PASS 20 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     ...
+       adding: counts_sex.csv (deflated 36%)
+       adding: counts_year.csv (deflated 83%)
+       adding: metadata.csv (deflated 25%)
+       adding: summary_event_duration.csv (deflated 75%)
+       adding: treatment_pathways.csv (deflated 95%)
+     
+     Quitting from a030_Evaluating_Output.Rmd:132-134 [summaryStatsTherapyDuration]
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     NULL
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     
+     Error: processing vignette 'a030_Evaluating_Output.Rmd' failed with diagnostics:
+     ℹ In argument: `case_when(...)`.
+     Caused by error in `case_when()`:
+     ! `..1 (right)` must have size 1, not size 88.
+     --- failed re-building ‘a030_Evaluating_Output.Rmd’
+     
+     --- re-building ‘a999_Strategus.Rmd’ using rmarkdown
+     --- finished re-building ‘a999_Strategus.Rmd’
+     
+     SUMMARY: processing the following file failed:
+       ‘a030_Evaluating_Output.Rmd’
+     
+     Error: Vignette re-building failed.
+     Execution halted
+     ```
+
+## In both
+
+*   checking installed package size ... NOTE
+     ```
+       installed size is  7.0Mb
+       sub-directories of 1Mb or more:
+         doc   5.0Mb
+     ```
+
+# trendtestR (1.0.1)
+
+* GitHub: https://github.com/GrahnH/trendtestR
+* Github mirror: https://github.com/cran/trendtestR
+* Maintainer: Gelan Huang <huanggelan97@icloud.com>
+
+Run `revdepcheck::cloud_details(, "trendtestR")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     ...
+     Input Value Spalte Datentyp: discrete
+     Error in `dplyr::mutate()`:
+     ℹ In argument: `jahr_group = dplyr::case_when(...)`.
+     Caused by error in `dplyr::case_when()`:
+     ! `..1 (right)` must have size 1, not size 94.
+     Backtrace:
+          ▆
+       1. ├─trendtestR::compare_monthly_cases(...)
+       2. │ └─... %>% filter(monat_num %in% months, jahr_group %in% years)
+       3. ├─dplyr::filter(., monat_num %in% months, jahr_group %in% years)
+       4. ├─dplyr::mutate(...)
+       5. ├─dplyr:::mutate.data.frame(...)
+       6. │ └─dplyr:::mutate_cols(.data, dplyr_quosures(...), by)
+       7. │   ├─base::withCallingHandlers(...)
+       8. │   └─dplyr:::mutate_col(dots[[i]], data, mask, new_columns)
+       9. │     └─mask$eval_all_mutate(quo)
+      10. │       └─dplyr (local) eval()
+      11. ├─dplyr::case_when(...)
+      12. │ └─dplyr:::vec_case_when(...)
+      13. │   └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+      14. └─vctrs:::stop_assert_size(...)
+      15.   └─vctrs:::stop_assert(...)
+      16.     └─vctrs:::stop_vctrs(...)
+      17.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+     Execution halted
+     ```
+
+*   checking tests ... ERROR
+     ```
+     ...
+           monat = lubridate::month(.data[[datum_col]], label = TRUE, 
+               abbr = TRUE), jahr_group = dplyr::case_when(shift_month == 
+               "mth_to_next" ~ lubridate::year(.data[[datum_col]]) + 
+               (monat_num %in% head(months, 1):12), shift_month == "mth_to_prev" ~ 
+               lubridate::year(.data[[datum_col]]) - (monat_num %in% 
+                   1:tail(months, 1)), TRUE ~ lubridate::isoyear(.data[[datum_col]])), 
+           jahr = as.factor(jahr_group))`: i In argument: `jahr_group = dplyr::case_when(...)`.
+       Caused by error in `dplyr::case_when()`:
+       ! `..1 (right)` must have size 1, not size 9.
+       ── Error ('test-compare_monthly_cases.R:83:3'): handles 3-level group_col, cross-year shift (prev), and negative values ──
+       <dplyr:::mutate_error/rlang_error/error/condition>
+       Error in `dplyr::mutate(., monat_num = lubridate::month(.data[[datum_col]]), 
+           monat = lubridate::month(.data[[datum_col]], label = TRUE, 
+               abbr = TRUE), jahr_group = dplyr::case_when(shift_month == 
+               "mth_to_next" ~ lubridate::year(.data[[datum_col]]) + 
+               (monat_num %in% head(months, 1):12), shift_month == "mth_to_prev" ~ 
+               lubridate::year(.data[[datum_col]]) - (monat_num %in% 
+                   1:tail(months, 1)), TRUE ~ lubridate::isoyear(.data[[datum_col]])), 
+           jahr = as.factor(jahr_group))`: i In argument: `jahr_group = dplyr::case_when(...)`.
+       Caused by error in `dplyr::case_when()`:
+       ! `..1 (right)` must have size 1, not size 12.
+       
+       [ FAIL 9 | WARN 24 | SKIP 1 | PASS 471 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+# vcdExtra (0.8-6)
+
+* GitHub: https://github.com/friendly/vcdExtra
+* Github mirror: https://github.com/cran/vcdExtra
+* Maintainer: Michael Friendly <friendly@yorku.ca>
+
+Run `revdepcheck::cloud_details(, "vcdExtra")` for more info
+
+## Newly broken
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     Error(s) in re-building vignettes:
+     --- re-building ‘a1-creating.Rmd’ using rmarkdown
+     ```
+
+## In both
+
+*   checking Rd cross-references ... NOTE
+     ```
+     Package unavailable to check Rd xrefs: ‘factoextra’
+     ```
+
+# vigicaen (0.16.1)
+
+* GitHub: https://github.com/pharmacologie-caen/vigicaen
+* Github mirror: https://github.com/cran/vigicaen
+* Maintainer: Charles Dolladille <cdolladille@hotmail.com>
+
+Run `revdepcheck::cloud_details(, "vigicaen")` for more info
+
+## Newly broken
+
+*   checking tests ... ERROR
+     ```
+     ...
+        10. │     └─vctrs::vec_check_size(value, size = size, arg = value_arg, call = call)
+        11. └─vctrs:::stop_assert_size(...)
+        12.   └─vctrs:::stop_assert(...)
+        13.     └─vctrs:::stop_vctrs(...)
+        14.       └─rlang::abort(message, class = c(class, "vctrs_error"), ..., call = call)
+       
+       [ FAIL 9 | WARN 0 | SKIP 104 | PASS 312 ]
+       Deleting unused snapshots:
+       • vigi_routine/arrow-table.svg
+       • vigi_routine/base-graphic.svg
+       • vigi_routine/case-time-to-onset.svg
+       • vigi_routine/case-tto-above-90-days.svg
+       • vigi_routine/case-tto-below-90-days.svg
+       • vigi_routine/custom-drug-and-adr-labels.svg
+       • vigi_routine/dual-drug-analysis.svg
+       • vigi_routine/exporting.svg
+       • vigi_routine/ic025-below-0.svg
+       • vigi_routine/no-cases.svg
+       • vigi_routine/no-rechallenge.svg
+       • vigi_routine/no-time-to-onset-export.svg
+       • vigi_routine/no-time-to-onset-with-2-drugs.svg
+       • vigi_routine/no-time-to-onset.svg
+       • vigi_routine/suspect-only-true.svg
+       Error: Test failures
+       Execution halted
+     ```
+
+*   checking re-building of vignette outputs ... ERROR
+     ```
+     Error(s) in re-building vignettes:
+     --- re-building ‘basic_workflow.Rmd’ using rmarkdown
+     --- finished re-building ‘basic_workflow.Rmd’
+     
+     --- re-building ‘descriptive.Rmd’ using rmarkdown
+     --- finished re-building ‘descriptive.Rmd’
+     
+     --- re-building ‘getting_started.Rmd’ using rmarkdown
+     --- finished re-building ‘getting_started.Rmd’
+     
+     --- re-building ‘interactions.Rmd’ using rmarkdown
+     --- finished re-building ‘interactions.Rmd’
+     
+     --- re-building ‘routine_pharmacovigilance.Rmd’ using rmarkdown
+     ```
+
+## In both
+
+*   checking dependencies in R code ... NOTE
+     ```
+     Namespace in Imports field not imported from: ‘fst’
+       All declared Imports should be used.
+     ```
+
+# vital (2.0.0)
+
+* GitHub: https://github.com/robjhyndman/vital
+* Github mirror: https://github.com/cran/vital
+* Maintainer: Rob Hyndman <Rob.Hyndman@monash.edu>
+
+Run `revdepcheck::cloud_details(, "vital")` for more info
+
+## Newly broken
+
+*   checking examples ... ERROR
+     ```
+     Running examples in ‘vital-Ex.R’ failed
+     The error most likely occurred in:
+     
+     > ### Name: FDM
+     > ### Title: Functional data model
+     > ### Aliases: FDM report.FDM
+     > 
+     > ### ** Examples
+     > 
+     > hu <- norway_mortality |>
+     +   dplyr::filter(Sex == "Female", Year > 2010) |>
+     +   smooth_mortality(Mortality) |>
+     +   model(hyndman_ullah = FDM(log(.smooth)))
+     Warning: 1 error encountered for hyndman_ullah
+     [1] In argument: `.innov = if_else(.innov < -1e+20, NA, .innov)`.
+     
+     > report(hu)
+     Series: .smooth 
+     Model: NULL model 
+     Transformation: log(.smooth) 
+     NULL model> autoplot(hu)
+     Error: C stack usage  9964732 is too close to the limit
+     Execution halted
+     ```
+
+*   checking tests ... ERROR
+     ```
+     ...
+       The following object is masked from 'package:testthat':
+       
+           matches
+       
+       The following objects are masked from 'package:stats':
+       
+           filter, lag
+       
+       The following objects are masked from 'package:base':
+       
+           intersect, setdiff, setequal, union
+       
+       > 
+       > test_check("vital")
+       
+       CNTRY not found
+       [ FAIL 1 | WARN 7 | SKIP 0 | PASS 144 ]
+       
+       ══ Failed tests ════════════════════════════════════════════════════════════════
+       ── Failure ('test-coherent-forecast.R:31:3'): Coherent forecasts ───────────────
+       mean(fc1$diff) is not strictly less than 0.0021. Difference: NA
+       
+       [ FAIL 1 | WARN 7 | SKIP 0 | PASS 144 ]
+       Error: Test failures
+       Execution halted
+     ```
+
+# xlr (1.0.3)
+
+* GitHub: https://github.com/NHilder/xlr
+* Github mirror: https://github.com/cran/xlr
+* Maintainer: Nicholas Hilderson <nhilderson.code@gmail.com>
+
+Run `revdepcheck::cloud_details(, "xlr")` for more info
+
+## Newly broken
+
+*   checking tests ... ERROR
+     ```
+     ...
+       ── Failure ('test-build_multiple_response_table.R:551:3'): build_mtable works with weights, one multiple response col,
+                 and cut column ──
+       `func_output` (`actual`) not equal to `expected_output` (`expected`).
+       
+         `attr(actual, 'row.names')`:                
+       `attr(expected, 'row.names')`: 1 2 3 4 5 6 7 8
+       
+       `actual$col_1`:                                  
+       `expected$col_1`: "a" "a" "a" "b" "b" "c" "c" "c"
+       
+       `actual$enjoy_fruit` is an S3 object of class <xlr_vector/vctrs_vctr>, a logical vector
+       `expected$enjoy_fruit` is an S3 object of class <xlr_vector/vctrs_vctr>, a character vector
+       
+       `actual$N`:                                                  
+       `expected$N`: "0.4" "0.2" "0.4" "0.2" "0.2" "0.3" "0.3" "0.3"
+       
+       `actual$N_group`:                                                  
+       `expected$N_group`: "0.4" "0.4" "0.4" "0.2" "0.2" "0.6" "0.6" "0.6"
+       
+       `actual$Percent`:                                                      
+       `expected$Percent`: "100%" "50%" "100%" "100%" "100%" "50%" "50%" "50%"
+       
+       [ FAIL 10 | WARN 0 | SKIP 81 | PASS 506 ]
+       Error: Test failures
+       Execution halted
+     ```
 

--- a/tests/testthat/_snaps/case-when.md
+++ b/tests/testthat/_snaps/case-when.md
@@ -20,7 +20,7 @@
       case_when(TRUE ~ 1:2, .size = 3)
     Condition
       Error in `case_when()`:
-      ! Can't recycle `..1 (right)` (size 2) to size 3.
+      ! `..1 (right)` must have size 3, not size 2.
 
 # invalid type errors are correct (#6261) (#6206)
 
@@ -66,14 +66,57 @@
       Caused by error:
       ! oh no!
 
+# only LHS sizes are consulted to compute the output size (#7082)
+
+    Code
+      x <- 1
+      case_when(x == 1 ~ "a", x == 2 ~ character(), .default = "other")
+    Condition
+      Error in `case_when()`:
+      ! `..2 (right)` must have size 1, not size 0.
+
+---
+
+    Code
+      case_when(TRUE ~ 1:3, FALSE ~ 4:6)
+    Condition
+      Error in `case_when()`:
+      ! `..1 (right)` must have size 1, not size 3.
+
+---
+
+    Code
+      case_when(NA ~ 1:3, TRUE ~ 4:6)
+    Condition
+      Error in `case_when()`:
+      ! `..1 (right)` must have size 1, not size 3.
+
+---
+
+    Code
+      x <- 1:3
+      my_scalar_condition <- is.double(x)
+      case_when(my_scalar_condition ~ x, TRUE ~ 4:6)
+    Condition
+      Error in `case_when()`:
+      ! `..1 (right)` must have size 1, not size 3.
+
+---
+
+    Code
+      case_when(TRUE ~ integer(), FALSE ~ integer())
+    Condition
+      Error in `case_when()`:
+      ! `..1 (right)` must have size 1, not size 0.
+
 # case_when() give meaningful errors
 
     Code
       (expect_error(case_when(c(TRUE, FALSE) ~ 1:3, c(FALSE, TRUE) ~ 1:2)))
     Output
-      <error/vctrs_error_incompatible_size>
+      <error/vctrs_error_assert_size>
       Error in `case_when()`:
-      ! Can't recycle `..1 (left)` (size 2) to match `..1 (right)` (size 3).
+      ! `..1 (right)` must have size 2, not size 3.
     Code
       (expect_error(case_when(c(TRUE, FALSE) ~ 1, c(FALSE, TRUE, FALSE) ~ 2, c(FALSE,
         TRUE, FALSE, NA) ~ 3)))
@@ -86,7 +129,7 @@
     Output
       <error/rlang_error>
       Error in `case_when()`:
-      ! `..1 (left)` must be a logical vector, not a double vector.
+      ! `..1 (left)` must be a logical vector, not the number 50.
     Code
       (expect_error(case_when(paste(50))))
     Output

--- a/tests/testthat/_snaps/case-when.md
+++ b/tests/testthat/_snaps/case-when.md
@@ -35,6 +35,25 @@
     Code
       case_when(1 ~ NULL)
     Condition
+      Warning:
+      Calling `case_when()` with size 1 LHS inputs and size >1 RHS inputs was deprecated in dplyr 1.2.0.
+      i This `case_when()` statement can result in subtle silent bugs and is very inefficient.
+      
+        Please use a series of if statements instead:
+      
+        ```
+        # Previously
+        case_when(scalar_lhs1 ~ rhs1, scalar_lhs2 ~ rhs2, .default = default)
+      
+        # Now
+        if (scalar_lhs1) {
+          rhs1
+        } else if (scalar_lhs2) {
+          rhs2
+        } else {
+          default
+        }
+        ```
       Error in `case_when()`:
       ! `..1 (right)` must be a vector, not `NULL`.
 
@@ -66,57 +85,14 @@
       Caused by error:
       ! oh no!
 
-# only LHS sizes are consulted to compute the output size (#7082)
-
-    Code
-      x <- 1
-      case_when(x == 1 ~ "a", x == 2 ~ character(), .default = "other")
-    Condition
-      Error in `case_when()`:
-      ! `..2 (right)` must have size 1, not size 0.
-
----
-
-    Code
-      case_when(TRUE ~ 1:3, FALSE ~ 4:6)
-    Condition
-      Error in `case_when()`:
-      ! `..1 (right)` must have size 1, not size 3.
-
----
-
-    Code
-      case_when(NA ~ 1:3, TRUE ~ 4:6)
-    Condition
-      Error in `case_when()`:
-      ! `..1 (right)` must have size 1, not size 3.
-
----
-
-    Code
-      x <- 1:3
-      my_scalar_condition <- is.double(x)
-      case_when(my_scalar_condition ~ x, TRUE ~ 4:6)
-    Condition
-      Error in `case_when()`:
-      ! `..1 (right)` must have size 1, not size 3.
-
----
-
-    Code
-      case_when(TRUE ~ integer(), FALSE ~ integer())
-    Condition
-      Error in `case_when()`:
-      ! `..1 (right)` must have size 1, not size 0.
-
 # case_when() give meaningful errors
 
     Code
       (expect_error(case_when(c(TRUE, FALSE) ~ 1:3, c(FALSE, TRUE) ~ 1:2)))
     Output
-      <error/vctrs_error_assert_size>
+      <error/vctrs_error_incompatible_size>
       Error in `case_when()`:
-      ! `..1 (right)` must have size 2, not size 3.
+      ! Can't recycle `..1 (right)` (size 3) to match `..2 (right)` (size 2).
     Code
       (expect_error(case_when(c(TRUE, FALSE) ~ 1, c(FALSE, TRUE, FALSE) ~ 2, c(FALSE,
         TRUE, FALSE, NA) ~ 3)))
@@ -125,11 +101,11 @@
       Error in `case_when()`:
       ! Can't recycle `..1 (left)` (size 2) to match `..2 (left)` (size 3).
     Code
-      (expect_error(case_when(50 ~ 1:3)))
+      (expect_error(case_when(51:53 ~ 1:3)))
     Output
       <error/rlang_error>
       Error in `case_when()`:
-      ! `..1 (left)` must be a logical vector, not the number 50.
+      ! `..1 (left)` must be a logical vector, not an integer vector.
     Code
       (expect_error(case_when(paste(50))))
     Output
@@ -160,4 +136,62 @@
       <error/rlang_error>
       Error in `case_when()`:
       ! Case 1 (`~1:2`) must be a two-sided formula.
+
+# Using scalar LHS with vector RHS is deprecated (#7082)
+
+    Code
+      x <- 1:5
+      y <- 6:10
+      code <- 1L
+      sex <- "M"
+      expect_identical(case_when(code == 1L && sex == "M" ~ x, code == 1L && sex ==
+        "F" ~ y, code == 1L && sex == "M" ~ x + 1L, .default = 0L), x)
+    Condition
+      Warning:
+      Calling `case_when()` with size 1 LHS inputs and size >1 RHS inputs was deprecated in dplyr 1.2.0.
+      i This `case_when()` statement can result in subtle silent bugs and is very inefficient.
+      
+        Please use a series of if statements instead:
+      
+        ```
+        # Previously
+        case_when(scalar_lhs1 ~ rhs1, scalar_lhs2 ~ rhs2, .default = default)
+      
+        # Now
+        if (scalar_lhs1) {
+          rhs1
+        } else if (scalar_lhs2) {
+          rhs2
+        } else {
+          default
+        }
+        ```
+
+---
+
+    Code
+      x <- 1
+      case_when(x == 1 ~ "a", x == 2 ~ character(), .default = "other")
+    Condition
+      Warning:
+      Calling `case_when()` with size 1 LHS inputs and size >1 RHS inputs was deprecated in dplyr 1.2.0.
+      i This `case_when()` statement can result in subtle silent bugs and is very inefficient.
+      
+        Please use a series of if statements instead:
+      
+        ```
+        # Previously
+        case_when(scalar_lhs1 ~ rhs1, scalar_lhs2 ~ rhs2, .default = default)
+      
+        # Now
+        if (scalar_lhs1) {
+          rhs1
+        } else if (scalar_lhs2) {
+          rhs2
+        } else {
+          default
+        }
+        ```
+    Output
+      character(0)
 


### PR DESCRIPTION
*This description is outdated but I've left it for historical purposes, see below comments*

Closes https://github.com/tidyverse/dplyr/issues/7082

This is a breaking change.

Motivating example with CRAN dplyr:

``` r
x <- 5

# The user has made a typo here with `character()` on the RHS
#
# Note that all LHS inputs are size 1
#
# The common size from consulting BOTH the LHS and RHS inputs is 0, which
# results in a silent confusing result of `character()`
dplyr::case_when(
  x == 5 ~ "hello",
  x > 10 ~ character(),
  .default = "other"
)
#> character(0)
```

With this PR

``` r
x <- 5

# If you ONLY consult the size of the LHS inputs, then the common size is 1,
# and then all RHS inputs are recycled to this size, which RHS-2 `character()` can't
# do, and we correctly catch your error!
dplyr::case_when(
  x == 5 ~ "hello",
  x > 10 ~ character(),
  .default = "other"
)
#> Error in `dplyr::case_when()`:
#> ! `..2 (right)` must have size 1, not size 0.
```

In https://github.com/tidyverse/dplyr/issues/7082#issuecomment-2334173589 I explained how changing to this behavior increases the safety of `case_when()` (as seen above) and brings us one step closer to my ideal `case_when()` behavior. Unfortunately, having to support `TRUE ~` will keep us from reaching `case_when()` nirvana.

In https://github.com/tidyverse/dplyr/issues/7082#issuecomment-2334181190, I note that this should only affect an extremely small fraction of cases - a prerequisite for this to be a change in behavior is that all of your LHS inputs must have been length 1, which is quite rare. Regardless, I will run revdeps to assess. `"8fa7eaf9-c4e6-4fe9-b7e9-7855b11046a6"`