### PR TITLE
Refresh `coalesce()` on top of `vctrs::vec_case_when()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,11 @@
 # dplyr (development version)
 
-* `if_else()` no longer allows `condition` to be a logical array. It must be a logical vector with no `dim` attribute (#7723).
+* The following vector functions have gotten significantly faster and use much less memory due to a rewrite in C via vctrs (#7723):
 
-* `if_else()` has gotten significantly faster and uses much less memory due to a rewrite in C via `vctrs::vec_if_else()` (#7723).
+  * `if_else()`
+  * `coalesce()`
+
+* `if_else()` no longer allows `condition` to be a logical array. It must be a logical vector with no `dim` attribute (#7723).
 
 * Passing `size` to `if_else()` is now deprecated. The output size is always taken from the `condition` (#7722).
 

--- a/tests/testthat/_snaps/coalesce.md
+++ b/tests/testthat/_snaps/coalesce.md
@@ -1,15 +1,16 @@
 # coalesce() gives meaningful error messages
 
     Code
-      (expect_error(coalesce(1:2, 1:3)))
-    Output
-      <error/vctrs_error_incompatible_size>
+      coalesce(1:2, 1:3)
+    Condition
       Error in `coalesce()`:
       ! Can't recycle `..1` (size 2) to match `..2` (size 3).
+
+---
+
     Code
-      (expect_error(coalesce(1:2, letters[1:2])))
-    Output
-      <error/vctrs_error_ptype2>
+      coalesce(1:2, letters[1:2])
+    Condition
       Error in `coalesce()`:
       ! Can't combine `..1` <integer> and `..2` <character>.
 
@@ -21,7 +22,7 @@
       Error in `coalesce()`:
       ! Can't recycle `..2` (size 2) to size 1.
 
-# must have at least one non-`NULL` vector
+# can't be empty
 
     Code
       coalesce()
@@ -29,13 +30,13 @@
       Error in `coalesce()`:
       ! `...` can't be empty.
 
----
+# must have at least one non-`NULL` vector
 
     Code
       coalesce(NULL, NULL)
     Condition
       Error in `coalesce()`:
-      ! `...` can't be empty.
+      ! `...` must contain at least 1 non-`NULL` value.
 
 # inputs must be vectors
 
@@ -60,4 +61,52 @@
     Condition
       Error in `coalesce()`:
       ! Can't combine `..1` <double> and `y` <character>.
+
+---
+
+    Code
+      coalesce(1:2, 1:3)
+    Condition
+      Error in `coalesce()`:
+      ! Can't recycle `..1` (size 2) to match `..2` (size 3).
+
+---
+
+    Code
+      coalesce(1:2, y = 1:3)
+    Condition
+      Error in `coalesce()`:
+      ! Can't recycle `..1` (size 2) to match `y` (size 3).
+
+---
+
+    Code
+      coalesce(1, NULL, "x")
+    Condition
+      Error in `coalesce()`:
+      ! Can't combine `..1` <double> and `..3` <character>.
+
+---
+
+    Code
+      coalesce(1, NULL, y = "x")
+    Condition
+      Error in `coalesce()`:
+      ! Can't combine `..1` <double> and `y` <character>.
+
+---
+
+    Code
+      coalesce(1:2, NULL, 1:3)
+    Condition
+      Error in `coalesce()`:
+      ! Can't recycle `..1` (size 2) to match `..3` (size 3).
+
+---
+
+    Code
+      coalesce(1:2, NULL, y = 1:3)
+    Condition
+      Error in `coalesce()`:
+      ! Can't recycle `..1` (size 2) to match `y` (size 3).
 

--- a/tests/testthat/test-coalesce.R
+++ b/tests/testthat/test-coalesce.R
@@ -12,6 +12,7 @@ test_that("coerces to common type", {
 
 test_that("inputs are recycled to their common size", {
   expect_identical(coalesce(1, c(2, 3)), c(1, 1))
+  expect_identical(coalesce(1, 2:3), c(1, 1))
 })
 
 test_that("finds non-missing values in multiple positions", {
@@ -23,9 +24,11 @@ test_that("finds non-missing values in multiple positions", {
 })
 
 test_that("coalesce() gives meaningful error messages", {
-  expect_snapshot({
-    (expect_error(coalesce(1:2, 1:3)))
-    (expect_error(coalesce(1:2, letters[1:2])))
+  expect_snapshot(error = TRUE, {
+    coalesce(1:2, 1:3)
+  })
+  expect_snapshot(error = TRUE, {
+    coalesce(1:2, letters[1:2])
   })
 })
 
@@ -36,28 +39,13 @@ test_that("coalesce() supports one-dimensional arrays (#5557)", {
 })
 
 test_that("only updates entirely missing matrix rows", {
-  x <- c(
-    1,
-    NA,
-    NA,
-    NA
-  )
+  x <- c(1, NA, NA, NA)
   x <- matrix(x, nrow = 2, byrow = TRUE)
 
-  y <- c(
-    2,
-    2,
-    NA,
-    1
-  )
+  y <- c(2, 2, NA, 1)
   y <- matrix(y, nrow = 2, byrow = TRUE)
 
-  expect <- c(
-    1,
-    NA,
-    NA,
-    1
-  )
+  expect <- c(1, NA, NA, 1)
   expect <- matrix(expect, nrow = 2, byrow = TRUE)
 
   expect_identical(coalesce(x, y), expect)
@@ -81,10 +69,6 @@ test_that("only updates entirely missing rcrd observations", {
   expect_identical(coalesce(x, y), expect)
 })
 
-test_that("recycling is done on the values early", {
-  expect_identical(coalesce(1, 1:2), c(1, 1))
-})
-
 test_that("`.ptype` overrides the common type (r-lib/funs#64)", {
   x <- c(1L, NA)
   expect_identical(coalesce(x, 99, .ptype = x), c(1L, 99L))
@@ -98,10 +82,13 @@ test_that("`.size` overrides the common size", {
   })
 })
 
-test_that("must have at least one non-`NULL` vector", {
+test_that("can't be empty", {
   expect_snapshot(error = TRUE, {
     coalesce()
   })
+})
+
+test_that("must have at least one non-`NULL` vector", {
   expect_snapshot(error = TRUE, {
     coalesce(NULL, NULL)
   })
@@ -111,6 +98,83 @@ test_that("`NULL`s are discarded (r-lib/funs#80)", {
   expect_identical(
     coalesce(c(1, NA, NA), NULL, c(1, 2, NA), NULL, 3),
     c(1, 2, 3)
+  )
+})
+
+test_that("works with multiple scalars", {
+  expect_identical(
+    coalesce(c(1, NA), 2, 3),
+    c(1, 2)
+  )
+})
+
+test_that("works with trailing `NA`", {
+  # Not promoted to `default`
+  expect_identical(
+    coalesce(c(1, NA), NA),
+    c(1, NA)
+  )
+})
+
+test_that("resulting names come from all inputs", {
+  expect_named(
+    coalesce(
+      c(x = 1, y = NA),
+      c(a = 3, b = 4)
+    ),
+    c("x", "b")
+  )
+
+  # No name if nothing stops the coalesce
+  expect_named(
+    coalesce(
+      c(x = 1, y = NA),
+      c(a = 3, b = NA)
+    ),
+    c("x", "")
+  )
+
+  # Unused inputs still force named output.
+  # "Common names" principle, like common type or size.
+  expect_named(
+    coalesce(
+      c(1, 2),
+      c(a = 3, b = 4)
+    ),
+    c("", "")
+  )
+  expect_named(
+    coalesce(
+      c(1, 2),
+      c(a = NA_real_)
+    ),
+    c("", "")
+  )
+
+  # Size 1 default name is recycled if used
+  expect_named(
+    coalesce(
+      c(a = 1, b = NA, c = 2, d = NA),
+      c(e = 0)
+    ),
+    c("a", "e", "c", "e")
+  )
+  expect_named(
+    coalesce(
+      c(a = 1, b = NA, c = 2, d = NA),
+      c(e = NA)
+    ),
+    c("a", "", "c", "")
+  )
+
+  # With multiple scalars that force namedness
+  expect_named(
+    coalesce(c(1, NA), 2, c(a = 3)),
+    c("", "")
+  )
+  expect_named(
+    coalesce(c(1, NA), c(a = 2), 3),
+    c("", "a")
   )
 })
 
@@ -126,5 +190,25 @@ test_that("names in error messages are indexed correctly", {
   })
   expect_snapshot(error = TRUE, {
     coalesce(1, y = "x")
+  })
+  expect_snapshot(error = TRUE, {
+    coalesce(1:2, 1:3)
+  })
+  expect_snapshot(error = TRUE, {
+    coalesce(1:2, y = 1:3)
+  })
+
+  # With `NULL`s, which get "dropped"
+  expect_snapshot(error = TRUE, {
+    coalesce(1, NULL, "x")
+  })
+  expect_snapshot(error = TRUE, {
+    coalesce(1, NULL, y = "x")
+  })
+  expect_snapshot(error = TRUE, {
+    coalesce(1:2, NULL, 1:3)
+  })
+  expect_snapshot(error = TRUE, {
+    coalesce(1:2, NULL, y = 1:3)
   })
 })


### PR DESCRIPTION
Five goals:

- Significantly speed up and reduce memory of `coalesce()` using `vctrs::vec_case_when()`
- Fix the error generated by `coalesce(1, NULL, "x")`, where the reported index was off due to compacting out `NULL` too early
- Give a better error when all inputs are `NULL`
- Get rid of usage of early-naming via `names_as_error_names()`, which is no longer required with the C impl of `vec_case_when()` (it falls out naturally when you rewrite in C)
- Improve on consistency regarding the output names generated by `coalesce()`

``` r
# Most common case
cross::bench_branches(\() {
  library(dplyr)
  set.seed(123)
  x <- sample(c(1, NA, 2), size = 1e7, replace = TRUE)
  bench::mark(coalesce(x, 0))
})
#> # A tibble: 2 × 7
#>   branch                    expression          min   median `itr/sec` mem_alloc `gc/sec`
#>   <chr>                     <bch:expr>     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 feature/coalesce-on-vctrs coalesce(x, 0)   24.5ms   29.9ms     27.4      162MB     37.1
#> 2 main                      coalesce(x, 0)    227ms    235ms      4.26     611MB     12.8

# Missings in `y`
cross::bench_branches(\() {
  library(dplyr)
  set.seed(123)
  x <- sample(c(1, NA, 2), size = 1e7, replace = TRUE)
  y <- sample(c(1, NA, 2), size = 1e7, replace = TRUE)
  bench::mark(coalesce(x, y))
})
#> # A tibble: 2 × 7
#>   branch                    expression          min   median `itr/sec` mem_alloc `gc/sec`
#>   <chr>                     <bch:expr>     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 feature/coalesce-on-vctrs coalesce(x, y)   30.4ms   34.4ms     25.6      229MB     41.4
#> 2 main                      coalesce(x, y)  209.1ms    211ms      4.63     572MB     18.5

# No missings in `y`
cross::bench_branches(\() {
  library(dplyr)
  set.seed(123)
  x <- sample(c(1, NA, 2), size = 1e7, replace = TRUE)
  y <- sample(c(1, 2), size = 1e7, replace = TRUE)
  bench::mark(coalesce(x, y))
})
#> # A tibble: 2 × 7
#>   branch                    expression          min   median `itr/sec` mem_alloc `gc/sec`
#>   <chr>                     <bch:expr>     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 feature/coalesce-on-vctrs coalesce(x, y)   25.5ms   26.1ms     35.4      162MB    165. 
#> 2 main                      coalesce(x, y)  223.7ms  226.3ms      4.30     534MB     17.2
```

I'm happy that I can explain where all of these remaining allocations come from:

``` r
# - 1 alloc for `vec_detect_missing` (40000048, lgl vec)
# - 1 alloc for `!` of the `vec_detect_missing` result (40000048, lgl vec)
# - 1 alloc for <double> output (80000048, dbl vec)
# - 1 alloc for determining where `0` goes (10000048, bool vec at C level)
profmem::profmem(coalesce(x, 0))
#> Rprofmem memory profiling of:
#> coalesce(x, 0)
#> 
#> Memory allocations:
#> Number of 'new page' entries not displayed: 3
#>        what     bytes                                                            calls
#> 3     alloc       216                                 coalesce() -> vec_ptype_common()
#> 4     alloc       216                                  coalesce() -> vec_size_common()
#> 6     alloc  40000048 coalesce() -> map() -> lapply() -> FUN() -> vec_detect_missing()
#> 7     alloc  40000048                         coalesce() -> map() -> lapply() -> FUN()
#> 8     alloc  80000048                                        coalesce() -> <Anonymous>
#> 9     alloc  10000048                                        coalesce() -> <Anonymous>
#> total       170000624
```