### PR TITLE
Rework `vec_case_match()` on `vctrs::vec_case_when()`

### DIFF
--- a/R/case-match.R
+++ b/R/case-match.R
@@ -168,6 +168,12 @@ vec_case_match <- function(
   obj_check_list(haystacks, arg = haystacks_arg, call = call)
   list_check_all_vectors(haystacks, arg = haystacks_arg, call = call)
 
+  if (length(haystacks) == 0L) {
+    # `case_match()` is like `case_when()` and doesn't allow empty `...`,
+    # even though `vec_case_when()` is well defined for this case.
+    abort("At least one condition must be supplied.", call = call)
+  }
+
   haystacks <- vec_cast_common(
     !!!haystacks,
     .to = needles,
@@ -175,19 +181,19 @@ vec_case_match <- function(
     .call = call
   )
 
-  conditions <- map(haystacks, vec_in, needles = needles)
+  cases <- map(haystacks, vec_in, needles = needles)
 
   size <- vec_size(needles)
 
-  vec_case_when(
-    conditions = conditions,
+  vctrs::vec_case_when(
+    cases = cases,
     values = values,
-    conditions_arg = "",
-    values_arg = values_arg,
     default = default,
-    default_arg = default_arg,
     ptype = ptype,
     size = size,
-    call = call
+    cases_arg = "",
+    values_arg = values_arg,
+    default_arg = default_arg,
+    error_call = call
   )
 }

--- a/tests/testthat/_snaps/case-match.md
+++ b/tests/testthat/_snaps/case-match.md
@@ -28,7 +28,7 @@
       case_match(1, 1 ~ 1L, .default = "x")
     Condition
       Error in `case_match()`:
-      ! Can't combine `..1 (right)` <integer> and `.default` <character>.
+      ! Can't combine <integer> and `.default` <character>.
 
 # `NULL` formula element throws meaningful error
 
@@ -124,7 +124,7 @@
       vec_case_match(1, haystacks = list(1), values = list(1:2))
     Condition
       Error in `vec_case_match()`:
-      ! `values[[1]]` must have size 1, not size 2.
+      ! Can't recycle `values[[1]]` (size 2) to size 1.
 
 # input must be a vector
 


### PR DESCRIPTION
This effectively freezes `case_match()`'s implementation in preparation for it to be superseded by `recode_values()`.

This removes the final usage of `dplyr:::vec_case_when()` outside of `case_when()` itself, which will come next, allowing us to delete that dplyr helper entirely.