### PR TITLE
Suggest `recode_values()` in the `recode()` docs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dplyr (development version)
 
+* The superseded `recode()` now has updated documentation showing how to migrate to `recode_values()` and `replace_values()`.
+
 * `case_when()` is now part of a family of 4 related functions, 3 of which are new:
 
   * Use `case_when()` to create a new vector based on logical conditions.

--- a/R/recode.R
+++ b/R/recode.R
@@ -3,8 +3,8 @@
 #' @description
 #' `r lifecycle::badge("superseded")`
 #'
-#' `recode()` is superseded in favor of [case_match()], which handles the most
-#' important cases of `recode()` with a more elegant interface.
+#' `recode()` is superseded in favor of [recode_values()] and
+#' [replace_values()], which are more general and have a much better interface.
 #' `recode_factor()` is also superseded, however, its direct replacement is not
 #' currently available but will eventually live in
 #' [forcats](https://forcats.tidyverse.org/). For creating new variables based
@@ -47,69 +47,129 @@
 #'   the first of `...`, `.default`, or `.missing`.
 #'   `recode_factor()` returns a factor whose levels are in the same order as
 #'   in `...`. The levels in `.default` and `.missing` come last.
-#' @seealso [na_if()] to replace specified values with a `NA`.
-#'
-#'   [coalesce()] to replace missing values with a specified value.
-#'
-#'   [tidyr::replace_na()] to replace `NA` with a value.
+#' @seealso [recode_values()]
 #' @export
 #' @examples
-#' char_vec <- sample(c("a", "b", "c"), 10, replace = TRUE)
+#' set.seed(1234)
 #'
-#' # `recode()` is superseded by `case_match()`
-#' recode(char_vec, a = "Apple", b = "Banana")
-#' case_match(char_vec, "a" ~ "Apple", "b" ~ "Banana", .default = char_vec)
+#' x <- sample(c("a", "b", "c"), 10, replace = TRUE)
 #'
-#' # With `case_match()`, you don't need typed missings like `NA_character_`
-#' recode(char_vec, a = "Apple", b = "Banana", .default = NA_character_)
-#' case_match(char_vec, "a" ~ "Apple", "b" ~ "Banana", .default = NA)
+#' # `recode()` is superseded by `recode_values()` and `replace_values()`
 #'
-#' # Throws an error as `NA` is logical, not character.
-#' try(recode(char_vec, a = "Apple", b = "Banana", .default = NA))
+#' # If you are fully recoding a vector use `recode_values()`
+#' recode(x, a = "Apple", b = "Banana", .default = NA_character_)
+#' recode_values(x, "a" ~ "Apple", "b" ~ "Banana")
 #'
-#' # `case_match()` is easier to use with numeric vectors, because you don't
+#' # With a default
+#' recode(x, a = "Apple", b = "Banana", .default = "unknown")
+#' recode_values(x, "a" ~ "Apple", "b" ~ "Banana", default = "unknown")
+#'
+#' # If you are partially updating a vector and want to retain the original
+#' # vector's values in locations you don't make a replacement, use
+#' # `replace_values()`
+#' recode(x, a = "Apple", b = "Banana")
+#' replace_values(x, "a" ~ "Apple", "b" ~ "Banana")
+#'
+#' # `replace_values()` is easier to use with numeric vectors, because you don't
 #' # need to turn the numeric values into names
-#' num_vec <- c(1:4, NA)
-#' recode(num_vec, `2` = 20L, `4` = 40L)
-#' case_match(num_vec, 2 ~ 20, 4 ~ 40, .default = num_vec)
+#' y <- c(1:4, NA)
+#' recode(y, `2` = 20L, `4` = 40L)
+#' replace_values(y, 2 ~ 20L, 4 ~ 40L)
 #'
-#' # `case_match()` doesn't have the ability to match by position like
-#' # `recode()` does with numeric vectors
-#' recode(num_vec, "a", "b", "c", "d")
-#' recode(c(1,5,3), "a", "b", "c", "d", .default = "nothing")
+#' # `recode()` is particularly confusing because it tries to handle both
+#' # full recodings to new vector types and partial updating of an existing
+#' # vector. With the above example, using doubles (20) rather than integers
+#' # (20L) results in a warning from `recode()`, because it thinks you are
+#' # doing a full recode and missed a case. `replace_values()` is type stable
+#' # on `y` and will instead coerce the double values to integer.
+#' recode(y, `2` = 20, `4` = 40)
+#' replace_values(y, 2 ~ 20, 4 ~ 40)
 #'
-#' # For `case_match()`, incompatible types are an error rather than a warning
-#' recode(num_vec, `2` = "b", `4` = "d")
-#' try(case_match(num_vec, 2 ~ "b", 4 ~ "d", .default = num_vec))
+#' # This also makes `replace_values()` much safer. If you provide
+#' # incompatible types, it will error.
+#' recode(y, `2` = "20", `4` = "40")
+#' try(replace_values(y, 2 ~ "20", 4 ~ "40"))
+#'
+#' # If you were trying to fully recode the vector and want a different output
+#' # type, use `recode_values()`
+#' recode_values(y, 2 ~ "20", 4 ~ "40")
+#'
+#' # And if you want to ensure you don't miss a case, use `unmatched`, which
+#' # errors rather than warns
+#' try(recode_values(y, 2 ~ "20", 4 ~ "40", unmatched = "error"))
+#'
+#' # ---------------------------------------------------------------------------
+#' # Lookup tables
+#'
+#' # If you were splicing an external lookup vector into `recode()`, you can
+#' # instead use the `from` and `to` arguments of `recode_values()`
+#' x <- c("a", "b", "a", "c", "d", "c")
+#'
+#' lookup <- c(
+#'   "a" = "A",
+#'   "b" = "B",
+#'   "c" = "C",
+#'   "d" = "D"
+#' )
+#'
+#' recode(x, !!!lookup)
+#' recode_values(x, from = names(lookup), to = unname(lookup))
+#'
+#' # `recode_values()` is much more flexible here because the lookup table
+#' # isn't restricted to just character values. We recommend using `tribble()`
+#' # to build your lookup tables.
+#' lookup <- tribble(
+#'   ~from, ~to,
+#'   "a", 1,
+#'   "b", 2,
+#'   "c", 3,
+#'   "d", 4
+#' )
+#'
+#' recode_values(x, from = lookup$from, to = lookup$to)
+#'
+#' # ---------------------------------------------------------------------------
+#' # Factors
 #'
 #' # The factor method of `recode()` can generally be replaced with
 #' # `forcats::fct_recode()`
-#' factor_vec <- factor(c("a", "b", "c"))
-#' recode(factor_vec, a = "Apple")
+#' x <- factor(c("a", "b", "c"))
+#' recode(x, a = "Apple")
+#' # forcats::fct_recode(x, "Apple" = "a")
 #'
 #' # `recode_factor()` does not currently have a direct replacement, but we
-#' # plan to add one to forcats. In the meantime, you can use the `.ptype`
-#' # argument to `case_match()`.
+#' # plan to add one to forcats. In the meantime, use a lookup table that
+#' # recodes every case, and then convert the `to` column to a factor. If you
+#' # define your lookup table in your preferred level order, then the conversion
+#' # to factor is straightforward!
+#' y <- c(3, 4, 1, 2, 4, NA)
+#'
 #' recode_factor(
-#'   num_vec,
-#'   `1` = "z",
-#'   `2` = "y",
-#'   `3` = "x",
-#'   .default = "D",
+#'   y,
+#'   `1` = "a",
+#'   `2` = "b",
+#'   `3` = "c",
+#'   `4` = "d",
 #'   .missing = "M"
 #' )
-#' case_match(
-#'   num_vec,
-#'   1 ~ "z",
-#'   2 ~ "y",
-#'   3 ~ "x",
-#'   NA ~ "M",
-#'   .default = "D",
-#'   .ptype = factor(levels = c("z", "y", "x", "D", "M"))
+#'
+#' lookup <- tribble(
+#'   ~from, ~to,
+#'   1, "a",
+#'   2, "b",
+#'   3, "c",
+#'   4, "d",
+#'   NA, "M"
 #' )
+#' # `factor()` generates levels by sorting the unique values of `to`, which we
+#' # don't want, so we supply `levels = to` directly. Alternatively, use
+#' # `forcats::fct(to)`, which generates levels in order of appearance.
+#' lookup <- mutate(lookup, to = factor(to, levels = to))
+#'
+#' recode_values(y, from = lookup$from, to = lookup$to)
 recode <- function(.x, ..., .default = NULL, .missing = NULL) {
   # Superseded in dplyr 1.1.0
-  lifecycle::signal_stage("superseded", "recode()", "case_match()")
+  lifecycle::signal_stage("superseded", "recode()", "recode_values()")
   UseMethod("recode")
 }
 
@@ -277,11 +337,8 @@ recode_factor <- function(
   .ordered = FALSE
 ) {
   # Superseded in dplyr 1.1.0
-  lifecycle::signal_stage(
-    "superseded",
-    "recode_factor()",
-    I("`case_match(.ptype = factor(levels = ))`")
-  )
+  lifecycle::signal_stage("superseded", "recode_factor()", "recode_values()")
+
   values <- list2(...)
   recoded <- recode(.x, !!!values, .default = .default, .missing = .missing)
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -105,7 +105,6 @@ reference:
   - ntile
   - order_by
   - percent_rank
-  - recode
   - row_number
 
 - title: Built in datasets
@@ -137,6 +136,7 @@ reference:
   - all_vars
   - vars
   - with_groups
+  - recode
 
 - title: Remote tables
   contents:

--- a/man/recode.Rd
+++ b/man/recode.Rd
@@ -48,8 +48,8 @@ in \code{...}. The levels in \code{.default} and \code{.missing} come last.
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
 
-\code{recode()} is superseded in favor of \code{\link[=case_match]{case_match()}}, which handles the most
-important cases of \code{recode()} with a more elegant interface.
+\code{recode()} is superseded in favor of \code{\link[=recode_values]{recode_values()}} and
+\code{\link[=replace_values]{replace_values()}}, which are more general and have a much better interface.
 \code{recode_factor()} is also superseded, however, its direct replacement is not
 currently available but will eventually live in
 \href{https://forcats.tidyverse.org/}{forcats}. For creating new variables based
@@ -65,64 +65,124 @@ values. Alternatively, you can use \code{recode_factor()}, which will change the
 order of levels to match the order of replacements.
 }
 \examples{
-char_vec <- sample(c("a", "b", "c"), 10, replace = TRUE)
+set.seed(1234)
 
-# `recode()` is superseded by `case_match()`
-recode(char_vec, a = "Apple", b = "Banana")
-case_match(char_vec, "a" ~ "Apple", "b" ~ "Banana", .default = char_vec)
+x <- sample(c("a", "b", "c"), 10, replace = TRUE)
 
-# With `case_match()`, you don't need typed missings like `NA_character_`
-recode(char_vec, a = "Apple", b = "Banana", .default = NA_character_)
-case_match(char_vec, "a" ~ "Apple", "b" ~ "Banana", .default = NA)
+# `recode()` is superseded by `recode_values()` and `replace_values()`
 
-# Throws an error as `NA` is logical, not character.
-try(recode(char_vec, a = "Apple", b = "Banana", .default = NA))
+# If you are fully recoding a vector use `recode_values()`
+recode(x, a = "Apple", b = "Banana", .default = NA_character_)
+recode_values(x, "a" ~ "Apple", "b" ~ "Banana")
 
-# `case_match()` is easier to use with numeric vectors, because you don't
+# With a default
+recode(x, a = "Apple", b = "Banana", .default = "unknown")
+recode_values(x, "a" ~ "Apple", "b" ~ "Banana", default = "unknown")
+
+# If you are partially updating a vector and want to retain the original
+# vector's values in locations you don't make a replacement, use
+# `replace_values()`
+recode(x, a = "Apple", b = "Banana")
+replace_values(x, "a" ~ "Apple", "b" ~ "Banana")
+
+# `replace_values()` is easier to use with numeric vectors, because you don't
 # need to turn the numeric values into names
-num_vec <- c(1:4, NA)
-recode(num_vec, `2` = 20L, `4` = 40L)
-case_match(num_vec, 2 ~ 20, 4 ~ 40, .default = num_vec)
+y <- c(1:4, NA)
+recode(y, `2` = 20L, `4` = 40L)
+replace_values(y, 2 ~ 20L, 4 ~ 40L)
 
-# `case_match()` doesn't have the ability to match by position like
-# `recode()` does with numeric vectors
-recode(num_vec, "a", "b", "c", "d")
-recode(c(1,5,3), "a", "b", "c", "d", .default = "nothing")
+# `recode()` is particularly confusing because it tries to handle both
+# full recodings to new vector types and partial updating of an existing
+# vector. With the above example, using doubles (20) rather than integers
+# (20L) results in a warning from `recode()`, because it thinks you are
+# doing a full recode and missed a case. `replace_values()` is type stable
+# on `y` and will instead coerce the double values to integer.
+recode(y, `2` = 20, `4` = 40)
+replace_values(y, 2 ~ 20, 4 ~ 40)
 
-# For `case_match()`, incompatible types are an error rather than a warning
-recode(num_vec, `2` = "b", `4` = "d")
-try(case_match(num_vec, 2 ~ "b", 4 ~ "d", .default = num_vec))
+# This also makes `replace_values()` much safer. If you provide
+# incompatible types, it will error.
+recode(y, `2` = "20", `4` = "40")
+try(replace_values(y, 2 ~ "20", 4 ~ "40"))
+
+# If you were trying to fully recode the vector and want a different output
+# type, use `recode_values()`
+recode_values(y, 2 ~ "20", 4 ~ "40")
+
+# And if you want to ensure you don't miss a case, use `unmatched`, which
+# errors rather than warns
+try(recode_values(y, 2 ~ "20", 4 ~ "40", unmatched = "error"))
+
+# ---------------------------------------------------------------------------
+# Lookup tables
+
+# If you were splicing an external lookup vector into `recode()`, you can
+# instead use the `from` and `to` arguments of `recode_values()`
+x <- c("a", "b", "a", "c", "d", "c")
+
+lookup <- c(
+  "a" = "A",
+  "b" = "B",
+  "c" = "C",
+  "d" = "D"
+)
+
+recode(x, !!!lookup)
+recode_values(x, from = names(lookup), to = unname(lookup))
+
+# `recode_values()` is much more flexible here because the lookup table
+# isn't restricted to just character values. We recommend using `tribble()`
+# to build your lookup tables.
+lookup <- tribble(
+  ~from, ~to,
+  "a", 1,
+  "b", 2,
+  "c", 3,
+  "d", 4
+)
+
+recode_values(x, from = lookup$from, to = lookup$to)
+
+# ---------------------------------------------------------------------------
+# Factors
 
 # The factor method of `recode()` can generally be replaced with
 # `forcats::fct_recode()`
-factor_vec <- factor(c("a", "b", "c"))
-recode(factor_vec, a = "Apple")
+x <- factor(c("a", "b", "c"))
+recode(x, a = "Apple")
+# forcats::fct_recode(x, "Apple" = "a")
 
 # `recode_factor()` does not currently have a direct replacement, but we
-# plan to add one to forcats. In the meantime, you can use the `.ptype`
-# argument to `case_match()`.
+# plan to add one to forcats. In the meantime, use a lookup table that
+# recodes every case, and then convert the `to` column to a factor. If you
+# define your lookup table in your preferred level order, then the conversion
+# to factor is straightforward!
+y <- c(3, 4, 1, 2, 4, NA)
+
 recode_factor(
-  num_vec,
-  `1` = "z",
-  `2` = "y",
-  `3` = "x",
-  .default = "D",
+  y,
+  `1` = "a",
+  `2` = "b",
+  `3` = "c",
+  `4` = "d",
   .missing = "M"
 )
-case_match(
-  num_vec,
-  1 ~ "z",
-  2 ~ "y",
-  3 ~ "x",
-  NA ~ "M",
-  .default = "D",
-  .ptype = factor(levels = c("z", "y", "x", "D", "M"))
+
+lookup <- tribble(
+  ~from, ~to,
+  1, "a",
+  2, "b",
+  3, "c",
+  4, "d",
+  NA, "M"
 )
+# `factor()` generates levels by sorting the unique values of `to`, which we
+# don't want, so we supply `levels = to` directly. Alternatively, use
+# `forcats::fct(to)`, which generates levels in order of appearance.
+lookup <- mutate(lookup, to = factor(to, levels = to))
+
+recode_values(y, from = lookup$from, to = lookup$to)
 }
 \seealso{
-\code{\link[=na_if]{na_if()}} to replace specified values with a \code{NA}.
-
-\code{\link[=coalesce]{coalesce()}} to replace missing values with a specified value.
-
-\code{\link[tidyr:replace_na]{tidyr::replace_na()}} to replace \code{NA} with a value.
+\code{\link[=recode_values]{recode_values()}}
 }

--- a/tests/testthat/_snaps/recode.md
+++ b/tests/testthat/_snaps/recode.md
@@ -4,7 +4,7 @@
       catch_cnd(recode("a", a = "A"))
     Output
       <lifecycle_stage: recode() is superseded
-      Please use `case_match()` instead.>
+      Please use `recode_values()` instead.>
 
 # `recode_factor()` signals that it is superseded
 
@@ -12,7 +12,7 @@
       catch_cnd(recode_factor("a", a = "A"))
     Output
       <lifecycle_stage: recode_factor() is superseded
-      Please use `case_match(.ptype = factor(levels = ))` instead.>
+      Please use `recode_values()` instead.>
 
 # recode() gives meaningful error messages
 


### PR DESCRIPTION
`recode_values()` and `replace_values()` are a much more holistic replacement for `recode()` than `case_match()`! 

- `recode()` was trying to be both a "full recode" and "partial replacement" function, which resulted in weird behavior that was pretty easy to run into. Even `case_match()` wasn't a good replacement, because to do a "partial replacement" the right way you needed the `.default` and `.ptype` arguments.

- `recode(x, !!!lookup)` wasn't supported by `case_match()`, making migration difficult. We can now use the `from` and `to` arguments, which also support more than just character values as well.