### PR TITLE
Add "Supported By Posit" badge to website

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -5,6 +5,7 @@ template:
   bootstrap: 5
   includes:
     in_header: |
+      <script src="https://cdn.jsdelivr.net/gh/posit-dev/supported-by-posit/js/badge.min.js" data-max-height="43" data-hide-below="1200" data-light-bg="#666f76" data-light-fg="#f9f9f9"></script>
       <script defer data-domain="dplyr.tidyverse.org,all.tidyverse.org" src="https://plausible.io/js/plausible.js"></script>
       <script async src="https://widget.kapa.ai/kapa-widget.bundle.js"
       data-button-hide="true"
@@ -150,7 +151,7 @@ reference:
 
 articles:
 - title: Get started
-  navbar: ~
+  navbar:
   contents:
   - dplyr
   - grouping


### PR DESCRIPTION
## Overview

This PR adds the "Supported by Posit" badge to the website.

## Background

We've recently started adding a "Supported by Posit" badge across all Posit package websites to create a more cohesive brand presence. The badge appears on the far right of the top navigation bar or at the bottom of the hamburger menu. It links to Posit’s main website. @hadley is involved with this initiative.

The following websites already have the "Supported by Posit" badge: [ggplot2](https://ggplot2.tidyverse.org), [Great Tables](https://posit-dev.github.io/great-tables/articles/intro.html), [gt](https://gt.rstudio.com), [Plotnine](https://plotnine.org), [Pointblank](https://posit-dev.github.io/pointblank/), [pointblank](https://rstudio.github.io/pointblank/), and [Quarto](https://quarto.org).

See https://posit-dev.github.io/supported-by-posit/ for more information.

## Changes

- Added a line to `_pkgdown.yml` to include the JavaScript file
- Standardized indentation in `_pkgdown.yml`

## Screenshots

The badge is hidden between 992px and 1199px browser width to prevent the header from breaking.

At 1200px browser width:

<img width="1200" height="300" alt="dplyr-1200" src="https://github.com/user-attachments/assets/ae75cd37-0f04-4a80-ae36-12b240d25a37" />

At 992px browser width:

<img width="992" height="300" alt="dplyr-992" src="https://github.com/user-attachments/assets/f4ea045b-b2f8-47f9-ba6d-663d643de135" />

At 991px browser width:

<img width="991" height="300" alt="dplyr-991" src="https://github.com/user-attachments/assets/6f0e5aec-e8c7-45e1-9ffe-6ebff4864e99" />

