### PR TITLE
Make `if_any()` and `if_all()` consistent in all contexts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # dplyr (development version)
 
+* `if_any()` and `if_all()` are now more consistent in all use cases (#7059, #7077, #7746, @jrwinget). In particular:
+
+  * When called with zero inputs, `if_any()` returns `FALSE` and `if_all()` returns `TRUE`.
+
+  * When called with one input, both now return logical vectors rather than the original column.
+
+  * The result of applying `.fns` now must be a logical vector.
+
 * `tally_n()` creates fully qualified funciton calls for duckplyr compatibility (#7046)
 
 * `storms` has been updated to include 2023 and 2024 data (#7111, @tomalrussell).
@@ -100,10 +108,6 @@
 
 * Fixed an issue where duckplyr's ALTREP data frames were being materialized
   early due to internal usage of `ncol()` (#7049).
-
-* `if_any()` and `if_all()` are now fully consistent with `any()` and `all()`.
-  In particular, when called with empty inputs `if_any()` returns `FALSE` and
-  `if_all()` returns `TRUE` (#7059, @jrwinget).
 
 ## Lifecycle changes
 

--- a/R/vctrs.R
+++ b/R/vctrs.R
@@ -21,3 +21,50 @@ dplyr_vec_ptype_common <- function(chunks, name) {
     error = common_handler(name)
   )
 }
+
+# Version of `vec_size_common()` that takes a list.
+# Useful for delaying `!!!` when used within an `expr()` call.
+dplyr_list_size_common <- function(
+  x,
+  ...,
+  size = NULL,
+  absent = 0L,
+  call = caller_env()
+) {
+  check_dots_empty0(...)
+  vec_size_common(!!!x, .size = size, .absent = absent, .call = call)
+}
+
+# Version of `vec_recycle_common()` that takes a list.
+# Useful for delaying `!!!` when used within an `expr()` call.
+dplyr_list_recycle_common <- function(
+  x,
+  ...,
+  size = NULL,
+  call = caller_env()
+) {
+  check_dots_empty0(...)
+  vec_recycle_common(!!!x, .size = size, .call = call)
+}
+
+dplyr_list_pall <- function(
+  x,
+  ...,
+  missing = NA,
+  size = NULL,
+  error_call = caller_env()
+) {
+  check_dots_empty0(...)
+  vec_pall(!!!x, .missing = missing, .size = size, .error_call = error_call)
+}
+
+dplyr_list_pany <- function(
+  x,
+  ...,
+  missing = NA,
+  size = NULL,
+  error_call = caller_env()
+) {
+  check_dots_empty0(...)
+  vec_pany(!!!x, .missing = missing, .size = size, .error_call = error_call)
+}

--- a/tests/testthat/_snaps/across.md
+++ b/tests/testthat/_snaps/across.md
@@ -295,6 +295,459 @@
       Caused by error:
       ! Can't subset `.data` outside of a data mask context.
 
+# `across()` recycle `.fns` results to common size
+
+    Code
+      mutate(df, across(c(x, y), fn))
+    Condition
+      Error in `mutate()`:
+      i In argument: `across(c(x, y), fn)`.
+      Caused by error in `across()`:
+      ! Can't compute column `x`.
+      Caused by error in `dplyr_internal_error()`:
+
+---
+
+    Code
+      mutate(df, (across(c(x, y), fn)))
+    Condition
+      Error in `mutate()`:
+      i In argument: `(across(c(x, y), fn))`.
+      Caused by error:
+      ! `(across(c(x, y), fn))` must be size 3 or 1, not 2.
+
+# `if_any()` and `if_all()` have consistent behavior across `filter()` and `mutate()`
+
+    Code
+      filter(df, if_any(y))
+    Condition
+      Error in `filter()`:
+      i In argument: `if_any(y)`.
+      Caused by error in `if_any()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      filter(df, (if_any(y)))
+    Condition
+      Error in `filter()`:
+      i In argument: `(if_any(y))`.
+      Caused by error in `if_any()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      mutate(df, a = if_any(y))
+    Condition
+      Error in `mutate()`:
+      i In argument: `a = if_any(y)`.
+      Caused by error in `if_any()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      filter(df, if_any(y, identity))
+    Condition
+      Error in `filter()`:
+      i In argument: `if_any(y, identity)`.
+      Caused by error in `if_any()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      filter(df, (if_any(y, identity)))
+    Condition
+      Error in `filter()`:
+      i In argument: `(if_any(y, identity))`.
+      Caused by error in `if_any()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      mutate(df, a = if_any(y, identity))
+    Condition
+      Error in `mutate()`:
+      i In argument: `a = if_any(y, identity)`.
+      Caused by error in `if_any()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      filter(df, if_all(y))
+    Condition
+      Error in `filter()`:
+      i In argument: `if_all(y)`.
+      Caused by error in `if_all()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      filter(df, (if_all(y)))
+    Condition
+      Error in `filter()`:
+      i In argument: `(if_all(y))`.
+      Caused by error in `if_all()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      mutate(df, a = if_all(y))
+    Condition
+      Error in `mutate()`:
+      i In argument: `a = if_all(y)`.
+      Caused by error in `if_all()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      filter(df, if_all(y, identity))
+    Condition
+      Error in `filter()`:
+      i In argument: `if_all(y, identity)`.
+      Caused by error in `if_all()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      filter(df, (if_all(y, identity)))
+    Condition
+      Error in `filter()`:
+      i In argument: `(if_all(y, identity))`.
+      Caused by error in `if_all()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      mutate(df, a = if_all(y, identity))
+    Condition
+      Error in `mutate()`:
+      i In argument: `a = if_all(y, identity)`.
+      Caused by error in `if_all()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      filter(df, if_any(c(y, z)))
+    Condition
+      Error in `filter()`:
+      i In argument: `if_any(c(y, z))`.
+      Caused by error in `if_any()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      filter(df, (if_any(c(y, z))))
+    Condition
+      Error in `filter()`:
+      i In argument: `(if_any(c(y, z)))`.
+      Caused by error in `if_any()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      mutate(df, a = if_any(c(y, z)))
+    Condition
+      Error in `mutate()`:
+      i In argument: `a = if_any(c(y, z))`.
+      Caused by error in `if_any()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      filter(df, if_any(c(y, z), identity))
+    Condition
+      Error in `filter()`:
+      i In argument: `if_any(c(y, z), identity)`.
+      Caused by error in `if_any()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      filter(df, (if_any(c(y, z), identity)))
+    Condition
+      Error in `filter()`:
+      i In argument: `(if_any(c(y, z), identity))`.
+      Caused by error in `if_any()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      mutate(df, a = if_any(c(y, z), identity))
+    Condition
+      Error in `mutate()`:
+      i In argument: `a = if_any(c(y, z), identity)`.
+      Caused by error in `if_any()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      filter(df, if_all(c(y, z)))
+    Condition
+      Error in `filter()`:
+      i In argument: `if_all(c(y, z))`.
+      Caused by error in `if_all()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      filter(df, (if_all(c(y, z))))
+    Condition
+      Error in `filter()`:
+      i In argument: `(if_all(c(y, z)))`.
+      Caused by error in `if_all()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      mutate(df, a = if_all(c(y, z)))
+    Condition
+      Error in `mutate()`:
+      i In argument: `a = if_all(c(y, z))`.
+      Caused by error in `if_all()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      filter(df, if_all(c(y, z), identity))
+    Condition
+      Error in `filter()`:
+      i In argument: `if_all(c(y, z), identity)`.
+      Caused by error in `if_all()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      filter(df, (if_all(c(y, z), identity)))
+    Condition
+      Error in `filter()`:
+      i In argument: `(if_all(c(y, z), identity))`.
+      Caused by error in `if_all()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      mutate(df, a = if_all(c(y, z), identity))
+    Condition
+      Error in `mutate()`:
+      i In argument: `a = if_all(c(y, z), identity)`.
+      Caused by error in `if_all()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      filter(df, if_any(c(y, z)), .by = g)
+    Condition
+      Error in `filter()`:
+      i In argument: `if_any(c(y, z))`.
+      i In group 1: `g = "a"`.
+      Caused by error in `if_any()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      filter(df, (if_any(c(y, z))), .by = g)
+    Condition
+      Error in `filter()`:
+      i In argument: `(if_any(c(y, z)))`.
+      i In group 1: `g = "a"`.
+      Caused by error in `if_any()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      mutate(df, a = if_any(c(y, z)), .by = g)
+    Condition
+      Error in `mutate()`:
+      i In argument: `a = if_any(c(y, z))`.
+      i In group 1: `g = "a"`.
+      Caused by error in `if_any()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      filter(df, if_any(c(y, z), identity), .by = g)
+    Condition
+      Error in `filter()`:
+      i In argument: `if_any(c(y, z), identity)`.
+      i In group 1: `g = "a"`.
+      Caused by error in `if_any()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      filter(df, (if_any(c(y, z), identity)), .by = g)
+    Condition
+      Error in `filter()`:
+      i In argument: `(if_any(c(y, z), identity))`.
+      i In group 1: `g = "a"`.
+      Caused by error in `if_any()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      mutate(df, a = if_any(c(y, z), identity), .by = g)
+    Condition
+      Error in `mutate()`:
+      i In argument: `a = if_any(c(y, z), identity)`.
+      i In group 1: `g = "a"`.
+      Caused by error in `if_any()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      filter(df, if_all(c(y, z)), .by = g)
+    Condition
+      Error in `filter()`:
+      i In argument: `if_all(c(y, z))`.
+      i In group 1: `g = "a"`.
+      Caused by error in `if_all()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      filter(df, (if_all(c(y, z))), .by = g)
+    Condition
+      Error in `filter()`:
+      i In argument: `(if_all(c(y, z)))`.
+      i In group 1: `g = "a"`.
+      Caused by error in `if_all()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      mutate(df, a = if_all(c(y, z)), .by = g)
+    Condition
+      Error in `mutate()`:
+      i In argument: `a = if_all(c(y, z))`.
+      i In group 1: `g = "a"`.
+      Caused by error in `if_all()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      filter(df, if_all(c(y, z), identity), .by = g)
+    Condition
+      Error in `filter()`:
+      i In argument: `if_all(c(y, z), identity)`.
+      i In group 1: `g = "a"`.
+      Caused by error in `if_all()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      filter(df, (if_all(c(y, z), identity)), .by = g)
+    Condition
+      Error in `filter()`:
+      i In argument: `(if_all(c(y, z), identity))`.
+      i In group 1: `g = "a"`.
+      Caused by error in `if_all()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+---
+
+    Code
+      mutate(df, a = if_all(c(y, z), identity), .by = g)
+    Condition
+      Error in `mutate()`:
+      i In argument: `a = if_all(c(y, z), identity)`.
+      i In group 1: `g = "a"`.
+      Caused by error in `if_all()`:
+      ! `y` must be a logical vector, not an integer vector.
+
+# `if_any()` and `if_all()` recycle `.fns` results to common size
+
+    Code
+      filter(df, if_any(c(x, y), fn))
+    Condition
+      Error in `filter()`:
+      i In argument: `if_any(c(x, y), fn)`.
+      Caused by error:
+      ! `..1` must be of size 3 or 1, not size 2.
+
+---
+
+    Code
+      filter(df, (if_any(c(x, y), fn)))
+    Condition
+      Error in `filter()`:
+      i In argument: `(if_any(c(x, y), fn))`.
+      Caused by error:
+      ! `..1` must be of size 3 or 1, not size 2.
+
+---
+
+    Code
+      mutate(df, a = if_any(c(x, y), fn))
+    Condition
+      Error in `mutate()`:
+      i In argument: `a = if_any(c(x, y), fn)`.
+      Caused by error:
+      ! `a` must be size 3 or 1, not 2.
+
+---
+
+    Code
+      filter(df, if_all(c(x, y), fn))
+    Condition
+      Error in `filter()`:
+      i In argument: `if_all(c(x, y), fn)`.
+      Caused by error:
+      ! `..1` must be of size 3 or 1, not size 2.
+
+---
+
+    Code
+      filter(df, (if_all(c(x, y), fn)))
+    Condition
+      Error in `filter()`:
+      i In argument: `(if_all(c(x, y), fn))`.
+      Caused by error:
+      ! `..1` must be of size 3 or 1, not size 2.
+
+---
+
+    Code
+      mutate(df, a = if_all(c(x, y), fn))
+    Condition
+      Error in `mutate()`:
+      i In argument: `a = if_all(c(x, y), fn)`.
+      Caused by error:
+      ! `a` must be size 3 or 1, not 2.
+
 # can't rename during selection (#6522)
 
     Code

--- a/tests/testthat/_snaps/pick.md
+++ b/tests/testthat/_snaps/pick.md
@@ -213,7 +213,7 @@
       filter(df, pick(x, y)$x)
     Condition
       Error in `filter()`:
-      i In argument: `asNamespace("dplyr")$dplyr_pick_tibble(x = x, y = y)$x`.
+      i In argument: `pick(x, y)$x`.
       Caused by error:
       ! `..1` must be a logical vector, not a double vector.
 

--- a/tests/testthat/test-pick.R
+++ b/tests/testthat/test-pick.R
@@ -492,7 +492,6 @@ test_that("`filter()` with `pick()` that uses invalid tidy-selection errors", {
 test_that("`filter()` that doesn't use `pick()` result correctly errors", {
   df <- tibble(x = c(1, 2, NA, 3), y = c(2, NA, 5, 3))
 
-  # TODO: Can we improve on the `In argument:` expression in the expansion case?
   expect_snapshot(error = TRUE, {
     filter(df, pick(x, y)$x)
   })


### PR DESCRIPTION
Closes https://github.com/tidyverse/dplyr/issues/7746
Closes https://github.com/tidyverse/dplyr/issues/7077

It turns out that our application of `if_any()` and `if_all()` was fairly inconsistent. This is due to the fact that they are tricky to get right, we have 2 different implementations of them. One for the expansion case and one for the evaluation case. I've now tried to unify these to use the same underlying implementation, `dplyr_list_pany()` or `dplyr_list_pall()` depending on the scenario (which just use `vec_pany()` and `vec_pall()` under the hood)

In addition to greater consistency across the board, you'll also note that in errors the `In argument:` label also now reports the _original_ expression pre-expansion in the `filter()` cases, which is a much better error

In the examples below, for `filter()`, note that adding `()` around the `if_any()` or `if_all()` calls triggers the evaluation case rather than the expansion case.

``` r
library(dplyr)

# With zero inputs, if_any

# Before
df <- tibble(x = 1:2)
filter(df, if_any(c(), identity))
#> # A tibble: 0 × 1
#> # ℹ 1 variable: x <int>
filter(df, (if_any(c(), identity)))
#> # A tibble: 2 × 1
#>       x
#>   <int>
#> 1     1
#> 2     2
filter(df, any())
#> # A tibble: 0 × 1
#> # ℹ 1 variable: x <int>

# After
df <- tibble(x = 1:2)
filter(df, if_any(c(), identity))
#> # A tibble: 0 × 1
#> # ℹ 1 variable: x <int>
filter(df, (if_any(c(), identity)))
#> # A tibble: 0 × 1
#> # ℹ 1 variable: x <int>
filter(df, any())
#> # A tibble: 0 × 1
#> # ℹ 1 variable: x <int>
```

```r
# With one non-logical input

# Before
df <- tibble(x = 1:2)
filter(df, if_any(x, identity))
#> Error in `filter()`:
#> ℹ In argument: `(function (x) ...`.
#> Caused by error:
#> ! `..1` must be a logical vector, not an integer vector.
filter(df, (if_any(x, identity)))
#> Error in `filter()`:
#> ℹ In argument: `(if_any(x, identity))`.
#> Caused by error:
#> ! `..1` must be a logical vector, not an integer vector.
mutate(df, a = if_any(x, identity))
#> # A tibble: 2 × 2
#>       x     a
#>   <int> <int>
#> 1     1     1
#> 2     2     2

# After
df <- tibble(x = 1:2)
filter(df, if_any(x, identity))
#> Error in `filter()`:
#> ℹ In argument: `if_any(x, identity)`.
#> Caused by error in `if_any()`:
#> ! `x` must be a logical vector, not an integer vector.
filter(df, (if_any(x, identity)))
#> Error in `filter()`:
#> ℹ In argument: `(if_any(x, identity))`.
#> Caused by error in `if_any()`:
#> ! `x` must be a logical vector, not an integer vector.
mutate(df, a = if_any(x, identity))
#> Error in `mutate()`:
#> ℹ In argument: `a = if_any(x, identity)`.
#> Caused by error in `if_any()`:
#> ! `x` must be a logical vector, not an integer vector.
```

```r
# In general, with non-logical types resulting from applying `.fns` we now error
# more appropriately

# Before
df <- tibble(x = c(TRUE, FALSE), y = c("a", "b"))
filter(df, if_any(c(x, y), identity))
#> Error in `filter()`:
#> ℹ In argument: `|...`.
#> Caused by error in `<function(x) x>(x) | <function(x) x>(y)`:
#> ! operations are possible only for numeric, logical or complex types
filter(df, (if_any(c(x, y), identity)))
#> Error in `filter()`:
#> ℹ In argument: `(if_any(c(x, y), identity))`.
#> Caused by error in `op()`:
#> ! operations are possible only for numeric, logical or complex types

# After
df <- tibble(x = c(TRUE, FALSE), y = c("a", "b"))
filter(df, if_any(c(x, y), identity))
#> Error in `filter()`:
#> ℹ In argument: `if_any(c(x, y), identity)`.
#> Caused by error in `if_any()`:
#> ! `y` must be a logical vector, not a character vector.
filter(df, (if_any(c(x, y), identity)))
#> Error in `filter()`:
#> ℹ In argument: `(if_any(c(x, y), identity))`.
#> Caused by error in `if_any()`:
#> ! `y` must be a logical vector, not a character vector.
```

