### PR TITLE
Use lifecycle tooling to deprecate `wt = n()` and add tests

### DIFF
--- a/tests/testthat/_snaps/count-tally.md
+++ b/tests/testthat/_snaps/count-tally.md
@@ -59,6 +59,24 @@
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
 
+# count() `wt = n()` is deprecated
+
+    Code
+      count(df, a, wt = n())
+    Condition
+      Warning:
+      `wt = n()` was deprecated in dplyr 1.0.1.
+      i You can now omit the `wt` argument.
+    Output
+      # A tibble: 5 x 2
+            a     n
+        <int> <int>
+      1     1     1
+      2     2     1
+      3     3     1
+      4     4     1
+      5     5     1
+
 # tally() owns errors (#6139)
 
     Code
@@ -69,6 +87,38 @@
       i In argument: `n = sum(1 + "", na.rm = TRUE)`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
+
+# tally() `wt = n()` is deprecated
+
+    Code
+      tally(df, wt = n())
+    Condition
+      Warning:
+      `wt = n()` was deprecated in dplyr 1.0.1.
+      i You can now omit the `wt` argument.
+    Output
+      # A tibble: 1 x 1
+            n
+        <int>
+      1     5
+
+# add_count() `wt = n()` is deprecated
+
+    Code
+      add_count(df, a, wt = n())
+    Condition
+      Warning:
+      `wt = n()` was deprecated in dplyr 1.0.1.
+      i You can now omit the `wt` argument.
+    Output
+      # A tibble: 5 x 2
+            a     n
+        <int> <int>
+      1     1     1
+      2     2     1
+      3     3     1
+      4     4     1
+      5     5     1
 
 # add_count() owns errors (#6139)
 
@@ -99,4 +149,22 @@
       i In argument: `n = sum(1 + "", na.rm = TRUE)`.
       Caused by error in `1 + ""`:
       ! non-numeric argument to binary operator
+
+# add_tally() `wt = n()` is deprecated
+
+    Code
+      add_tally(df, wt = n())
+    Condition
+      Warning:
+      `wt = n()` was deprecated in dplyr 1.0.1.
+      i You can now omit the `wt` argument.
+    Output
+      # A tibble: 5 x 2
+            a     n
+        <int> <int>
+      1     1     5
+      2     2     5
+      3     3     5
+      4     4     5
+      5     5     5
 

--- a/tests/testthat/test-count-tally.R
+++ b/tests/testthat/test-count-tally.R
@@ -123,15 +123,18 @@ test_that("can only explicitly chain together multiple tallies", {
   })
 })
 
-test_that("wt = n() is deprecated", {
-  df <- data.frame(x = 1:3)
-  expect_warning(count(df, wt = n()), "`wt = n()`", fixed = TRUE)
-})
-
 test_that("count() owns errors (#6139)", {
   expect_snapshot({
     (expect_error(count(mtcars, new = 1 + "")))
     (expect_error(count(mtcars, wt = 1 + "")))
+  })
+})
+
+test_that("count() `wt = n()` is deprecated", {
+  df <- tibble(a = 1:5)
+
+  expect_snapshot({
+    count(df, a, wt = n())
   })
 })
 
@@ -161,6 +164,14 @@ test_that("tally() owns errors (#6139)", {
   })
 })
 
+test_that("tally() `wt = n()` is deprecated", {
+  df <- tibble(a = 1:5)
+
+  expect_snapshot({
+    tally(df, wt = n())
+  })
+})
+
 # add_count ---------------------------------------------------------------
 
 test_that("add_count preserves grouping", {
@@ -176,6 +187,14 @@ test_that(".drop is deprecated", {
 
   df <- tibble(f = factor("b", levels = c("a", "b", "c")))
   expect_warning(out <- add_count(df, f, .drop = FALSE), "deprecated")
+})
+
+test_that("add_count() `wt = n()` is deprecated", {
+  df <- tibble(a = 1:5)
+
+  expect_snapshot({
+    add_count(df, a, wt = n())
+  })
 })
 
 test_that("add_count() owns errors (#6139)", {
@@ -213,5 +232,13 @@ test_that("can override output column", {
 test_that("add_tally() owns errors (#6139)", {
   expect_snapshot({
     (expect_error(add_tally(mtcars, wt = 1 + "")))
+  })
+})
+
+test_that("add_tally() `wt = n()` is deprecated", {
+  df <- tibble(a = 1:5)
+
+  expect_snapshot({
+    add_tally(df, wt = n())
   })
 })


### PR DESCRIPTION
A follow up on https://github.com/tidyverse/dplyr/pull/5349

Using official tooling and tests will help us remember to advance this deprecation. I've advanced it to `always = TRUE` warning.