### PR TITLE
Add `id`s for `deprecate_soft()` and `deprecate_warn()` calls

### DIFF
--- a/R/across.R
+++ b/R/across.R
@@ -275,7 +275,8 @@ across <- function(.cols, .fns, ..., .names = NULL, .unpack = FALSE) {
     lifecycle::deprecate_warn(
       when = "1.1.0",
       what = "across(...)",
-      details = details
+      details = details,
+      id = "dplyr-across-fns-dots"
     )
   }
 
@@ -859,7 +860,8 @@ across_missing_cols_deprecate_warn <- function() {
     what = I(glue("Using `{across_if_fn}()` without supplying `.cols`")),
     details = "Please supply `.cols` instead.",
     user_env = user_env,
-    always = TRUE
+    always = TRUE,
+    id = "dplyr-across-missing-cols"
   )
 }
 
@@ -869,7 +871,8 @@ c_across_missing_cols_deprecate_warn <- function(user_env = caller_env(2)) {
     what = I("Using `c_across()` without supplying `cols`"),
     details = "Please supply `cols` instead.",
     user_env = user_env,
-    always = TRUE
+    always = TRUE,
+    id = "dplyr-c-across-missing-cols"
   )
 }
 

--- a/R/all-equal.R
+++ b/R/all-equal.R
@@ -44,7 +44,8 @@ all_equal <- function(
     "all_equal()",
     "all.equal()",
     details = "And manually order the rows/cols as needed",
-    always = TRUE
+    always = TRUE,
+    id = "dplyr-all-equal"
   )
 
   equal_data_frame(

--- a/R/case-when.R
+++ b/R/case-when.R
@@ -470,7 +470,8 @@ warn_case_when_scalar_lhs_vector_rhs <- function(
     what = what,
     details = details,
     env = env,
-    user_env = user_env
+    user_env = user_env,
+    id = "dplyr-case-when-scalar-lhs-vector-rhs"
   )
 }
 

--- a/R/colwise-funs.R
+++ b/R/colwise-funs.R
@@ -49,7 +49,8 @@ as_fun_list <- function(
           details = "Please use a one-sided formula, a function, or a function name.",
           always = TRUE,
           env = .env,
-          user_env = .user_env
+          user_env = .user_env,
+          id = "dplyr-funs-quosures"
         )
         .x <- new_formula(NULL, quo_squash(.x), quo_get_env(.x))
       }

--- a/R/count-tally.R
+++ b/R/count-tally.R
@@ -254,7 +254,8 @@ compat_wt <- function(wt, env = caller_env(), user_env = caller_env(2)) {
     details = "You can now omit the `wt` argument.",
     env = env,
     user_env = user_env,
-    always = TRUE
+    always = TRUE,
+    id = "dplyr-count-wt"
   )
 
   quo(NULL)

--- a/R/deprec-context.R
+++ b/R/deprec-context.R
@@ -20,7 +20,8 @@ cur_data <- function() {
   lifecycle::deprecate_warn(
     when = "1.1.0",
     what = "cur_data()",
-    with = "pick()"
+    with = "pick()",
+    id = "dplyr-cur-data"
   )
   mask <- peek_mask()
   vars <- mask$current_non_group_vars()
@@ -33,7 +34,8 @@ cur_data_all <- function() {
   lifecycle::deprecate_warn(
     when = "1.1.0",
     what = "cur_data_all()",
-    with = "pick()"
+    with = "pick()",
+    id = "dplyr-cur-data-all"
   )
   mask <- peek_mask()
   vars <- mask$current_vars()

--- a/R/filter.R
+++ b/R/filter.R
@@ -444,7 +444,8 @@ warn_filter_one_column_matrix <- function(env, user_env) {
     with = I("one dimensional logical vectors"),
     env = env,
     user_env = user_env,
-    always = TRUE
+    always = TRUE,
+    id = "dplyr-filter-one-column-matrix"
   )
 }
 

--- a/R/group-data.R
+++ b/R/group-data.R
@@ -122,7 +122,8 @@ group_indices <- function(.data, ...) {
       "1.0.0",
       I("`group_indices()` with no arguments"),
       "cur_group_id()",
-      always = TRUE
+      always = TRUE,
+      id = "dplyr-group-indices-no-arguments"
     )
     return(cur_group_id())
   }

--- a/R/if-else.R
+++ b/R/if-else.R
@@ -65,7 +65,11 @@ if_else <- function(
   check_dots_empty0(...)
 
   if (!is_missing(size)) {
-    lifecycle::deprecate_warn("1.2.0", "if_else(size = )")
+    lifecycle::deprecate_warn(
+      when = "1.2.0",
+      what = "if_else(size = )",
+      id = "dplyr-if-else-size"
+    )
   }
 
   vec_if_else(

--- a/R/join.R
+++ b/R/join.R
@@ -934,6 +934,7 @@ warn_join_cross_by <- function(env = caller_env(), user_env = caller_env(2)) {
     what = I("Using `by = character()` to perform a cross join"),
     with = "cross_join()",
     env = env,
-    user_env = user_env
+    user_env = user_env,
+    id = "dplyr-by-for-cross-join"
   )
 }

--- a/R/locale.R
+++ b/R/locale.R
@@ -97,7 +97,8 @@ dplyr_legacy_locale <- function() {
         "and compare against {.run stringi::stri_locale_list()} to determine the `.locale` value to use."
       ))
     ),
-    user_env = globalenv()
+    user_env = globalenv(),
+    id = "dplyr-legacy-locale-option"
   )
 
   if (!is_bool(option)) {

--- a/R/progress.R
+++ b/R/progress.R
@@ -46,7 +46,8 @@ progress_estimated <- function(n, min_time = 0) {
   lifecycle::deprecate_warn(
     "1.0.0",
     "dplyr::progress_estimated()",
-    always = TRUE
+    always = TRUE,
+    id = "dplyr-progress-estimated"
   )
 
   Progress$new(n, min_time = min_time)

--- a/R/slice.R
+++ b/R/slice.R
@@ -443,7 +443,8 @@ slice_eval <- function(
           what = I("Slicing with a 1-column matrix"),
           env = error_call,
           user_env = user_env,
-          always = TRUE
+          always = TRUE,
+          id = "dplyr-slice-one-column-matrix"
         )
         slice_idx <- slice_idx[, 1]
       }


### PR DESCRIPTION
We discovered in lifecycle that adding a static `id` really does speed up `deprecate_soft()` and `deprecate_warn()` calls significantly. This can be most impactful in vector functions that get called in a group-by style call repeatedly, but I think it is good practice for important packages like dplyr to just start using and `id` everywhere.

``` r
library(dplyr)

# Baseline
bench::mark(if_else(TRUE, 1, 2))
#> # A tibble: 1 × 6
#>   expression               min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>          <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 if_else(TRUE, 1, 2)   2.21µs   2.42µs   395591.      17KB     39.6

# trigger warning once
if_else(TRUE, 1, 2, size = 1)
#> Warning: The `size` argument of `if_else()` is deprecated as of dplyr 1.2.0.
#> This warning is displayed once per session.
#> Call `lifecycle::last_lifecycle_warnings()` to see where this warning was
#> generated.
#> [1] 1

# current `main`, with no `id`
bench::mark(if_else(TRUE, 1, 2, size = 1))
#> # A tibble: 1 × 6
#>   expression                         min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                    <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 if_else(TRUE, 1, 2, size = 1)   46.1µs   48.5µs    19874.        0B     37.9

# this pr, with `id`
bench::mark(if_else(TRUE, 1, 2, size = 1))
#> # A tibble: 1 × 6
#>   expression                         min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                    <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 if_else(TRUE, 1, 2, size = 1)    8.9µs   9.72µs    97483.        0B     39.0
```