### PR TITLE
Switch to deprecating `case_match()`, not superceding

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -54,7 +54,7 @@
 
 * New `rbind()` method for `rowwise_df` to avoid creating corrupt rowwise data frames (r-lib/vctrs#1935).
 
-* `case_match()` is now superseded by `recode_values()` and `replace_values()`.
+* `case_match()` is soft-deprecated, and is fully replaced by `recode_values()` and `replace_values()`, which are more flexible, more powerful, and have much better names.
 
 * The superseded `recode()` now has updated documentation showing how to migrate to `recode_values()` and `replace_values()`.
 

--- a/R/case-match.R
+++ b/R/case-match.R
@@ -1,13 +1,13 @@
 #' A general vectorised `switch()`
 #'
 #' @description
-#' `r lifecycle::badge("superseded")`
+#' `r lifecycle::badge("deprecated")`
 #'
-#' `case_match()` is superseded by [recode_values()] and [replace_values()],
-#' which are more powerful, have more intuitive names, and have better safety.
-#' In addition to the familiar two-sided formula interface, these functions also
-#' have `from` and `to` arguments which allow you to incorporate a lookup table
-#' into the recoding process.
+#' `case_match()` is deprecated. Please use [recode_values()] and
+#' [replace_values()] instead, which are more powerful, have more intuitive
+#' names, and have better safety. In addition to the familiar two-sided formula
+#' interface, these functions also have `from` and `to` arguments which allow
+#' you to incorporate a lookup table into the recoding process.
 #'
 #' This function allows you to vectorise multiple [switch()] statements. Each
 #' case is evaluated sequentially and the first match for each element
@@ -43,9 +43,11 @@
 #' A vector with the same size as `.x` and the same type as the common type of
 #' the RHS inputs and `.default` (if not overridden by `.ptype`).
 #'
+#' @keywords internal
+#'
 #' @export
 #' @examples
-#' # `case_match()` has been superseded by `recode_values()` and
+#' # `case_match()` is deprecated and has been replaced by `recode_values()` and
 #' # `replace_values()`
 #'
 #' x <- c("a", "b", "a", "d", "b", NA, "c", "e")
@@ -159,12 +161,16 @@
 #'     .keep = "used"
 #'   )
 case_match <- function(.x, ..., .default = NULL, .ptype = NULL) {
-  # Superseded in dplyr 1.2.0
-  lifecycle::signal_stage("superseded", "case_match()", "recode_values()")
+  lifecycle::deprecate_soft(
+    when = "1.2.0",
+    what = "case_match()",
+    with = "recode_values()",
+    id = "dplyr-case-match"
+  )
 
   # Matching historical behavior of `case_match()`, which was to work like
   # `case_when()` and not allow empty `...`. Newer `replace_when()` and
-  # `replace_values()` are a no-op for this case, but we superseded
+  # `replace_values()` are a no-op for this case, but we deprecated
   # `case_match()` at that time so it never moved to the new behavior.
   allow_empty_dots <- FALSE
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -131,7 +131,6 @@ reference:
     ready, so the existing functions will stay around for several years.
   contents:
   - all_vars
-  - case_match
   - recode
   - sample_frac
   - scoped

--- a/man/case_match.Rd
+++ b/man/case_match.Rd
@@ -37,13 +37,13 @@ A vector with the same size as \code{.x} and the same type as the common type of
 the RHS inputs and \code{.default} (if not overridden by \code{.ptype}).
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{case_match()} is superseded by \code{\link[=recode_values]{recode_values()}} and \code{\link[=replace_values]{replace_values()}},
-which are more powerful, have more intuitive names, and have better safety.
-In addition to the familiar two-sided formula interface, these functions also
-have \code{from} and \code{to} arguments which allow you to incorporate a lookup table
-into the recoding process.
+\code{case_match()} is deprecated. Please use \code{\link[=recode_values]{recode_values()}} and
+\code{\link[=replace_values]{replace_values()}} instead, which are more powerful, have more intuitive
+names, and have better safety. In addition to the familiar two-sided formula
+interface, these functions also have \code{from} and \code{to} arguments which allow
+you to incorporate a lookup table into the recoding process.
 
 This function allows you to vectorise multiple \code{\link[=switch]{switch()}} statements. Each
 case is evaluated sequentially and the first match for each element
@@ -51,7 +51,7 @@ determines the corresponding value in the output vector. If no cases match,
 the \code{.default} is used.
 }
 \examples{
-# `case_match()` has been superseded by `recode_values()` and
+# `case_match()` is deprecated and has been replaced by `recode_values()` and
 # `replace_values()`
 
 x <- c("a", "b", "a", "d", "b", NA, "c", "e")
@@ -165,3 +165,4 @@ starwars |>
     .keep = "used"
   )
 }
+\keyword{internal}

--- a/tests/testthat/_snaps/case-match.md
+++ b/tests/testthat/_snaps/case-match.md
@@ -1,3 +1,14 @@
+# `case_match()` is soft deprecated
+
+    Code
+      case_match(1, 1 ~ "x")
+    Condition
+      Warning:
+      `case_match()` was deprecated in dplyr 1.2.0.
+      i Please use `recode_values()` instead.
+    Output
+      [1] "x"
+
 # requires at least one condition
 
     Code

--- a/tests/testthat/test-case-match.R
+++ b/tests/testthat/test-case-match.R
@@ -1,21 +1,31 @@
 # ------------------------------------------------------------------------------
 # case_match()
 
+test_that("`case_match()` is soft deprecated", {
+  expect_snapshot({
+    case_match(1, 1 ~ "x")
+  })
+})
+
 test_that("LHS can match multiple values", {
+  local_options(lifecycle_verbosity = "quiet")
   expect_equal(case_match(1, 1:2 ~ "x"), "x")
 })
 
 test_that("LHS can match special values", {
+  local_options(lifecycle_verbosity = "quiet")
   expect_equal(case_match(NA, NA ~ "x"), "x")
   expect_equal(case_match(NaN, NaN ~ "x"), "x")
 })
 
 test_that("RHS is recycled to match x", {
+  local_options(lifecycle_verbosity = "quiet")
   x <- 1:3
   expect_equal(case_match(x, c(1, 3) ~ x * 2), c(2, NA, 6))
 })
 
 test_that("`NULL` values in `...` are dropped", {
+  local_options(lifecycle_verbosity = "quiet")
   expect_identical(
     case_match(1:2, 1 ~ "a", NULL, 2 ~ "b", NULL),
     c("a", "b")
@@ -23,6 +33,7 @@ test_that("`NULL` values in `...` are dropped", {
 })
 
 test_that("requires at least one condition", {
+  local_options(lifecycle_verbosity = "quiet")
   expect_snapshot(error = TRUE, {
     case_match(1)
   })
@@ -32,12 +43,15 @@ test_that("requires at least one condition", {
 })
 
 test_that("passes through `.default` correctly", {
+  local_options(lifecycle_verbosity = "quiet")
   expect_identical(case_match(1, 3 ~ 1, .default = 2), 2)
   expect_identical(case_match(1:5, 6 ~ 1, .default = 2), rep(2, 5))
   expect_identical(case_match(1:5, 6 ~ 1:5, .default = 2:6), 2:6)
 })
 
 test_that("`.default` is part of common type computation", {
+  local_options(lifecycle_verbosity = "quiet")
+
   expect_identical(case_match(1, 1 ~ 1L, .default = 2), 1)
 
   expect_snapshot(error = TRUE, {
@@ -46,10 +60,12 @@ test_that("`.default` is part of common type computation", {
 })
 
 test_that("passes through `.ptype` correctly", {
+  local_options(lifecycle_verbosity = "quiet")
   expect_identical(case_match(1, 1 ~ 1, .ptype = integer()), 1L)
 })
 
 test_that("`NULL` formula element throws meaningful error", {
+  local_options(lifecycle_verbosity = "quiet")
   expect_snapshot(error = TRUE, {
     case_match(1, 1 ~ NULL)
   })
@@ -59,6 +75,7 @@ test_that("`NULL` formula element throws meaningful error", {
 })
 
 test_that("throws chained errors when formula evaluation fails", {
+  local_options(lifecycle_verbosity = "quiet")
   expect_snapshot(error = TRUE, {
     case_match(1, 1 ~ 2, 3 ~ stop("oh no!"))
   })


### PR DESCRIPTION
Because `recode_values()` is so clearly superior, and `case_match()` has not been out long enough that it needs to be superceded