### PR TITLE
chore: update readme to use `.by` instead of `group_by()`

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -100,15 +100,16 @@ starwars |>
   arrange(desc(mass))
 
 starwars |>
-  group_by(species) |>
   summarise(
     n = n(),
-    mass = mean(mass, na.rm = TRUE)
+    mass = mean(mass, na.rm = TRUE),
+    .by = species
   ) |>
   filter(
     n > 1,
     mass > 50
-  )
+  ) |> 
+  arrange(species)
 ```
 
 ## Getting help

--- a/README.md
+++ b/README.md
@@ -142,15 +142,16 @@ starwars |>
 #> #   vehicles <list>, starships <list>
 
 starwars |>
-  group_by(species) |>
   summarise(
     n = n(),
-    mass = mean(mass, na.rm = TRUE)
+    mass = mean(mass, na.rm = TRUE),
+    .by = species
   ) |>
   filter(
     n > 1,
     mass > 50
-  )
+  ) |> 
+  arrange(species)
 #> # A tibble: 9 × 3
 #>   species      n  mass
 #>   <chr>    <int> <dbl>


### PR DESCRIPTION
Please feel free to reject this if you prefer to keep as-is. Just thought the upcoming release might be a nice time to make this change since `.by` is no longer experimental :) 

Thanks for the great work on the latest release!