### PR TITLE
POC: Custom `summarise()` and `reframe()` groupings

### DIFF
--- a/R/reframe.R
+++ b/R/reframe.R
@@ -110,8 +110,12 @@ reframe <- function(.data, ..., .by = NULL) {
 }
 
 #' @export
-reframe.data.frame <- function(.data, ..., .by = NULL) {
-  by <- compute_by({{ .by }}, .data, by_arg = ".by", data_arg = ".data")
+reframe.data.frame <- function(.data, ..., .by = NULL, .with = NULL) {
+  if (is_null(.with)) {
+    by <- compute_by({{ .by }}, .data, by_arg = ".by", data_arg = ".data")
+  } else {
+    by <- .with(.data)
+  }
 
   cols <- summarise_cols(.data, dplyr_quosures(...), by, "reframe")
   out <- summarise_build(by, cols, "reframe")

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -117,8 +117,22 @@ summarise <- function(.data, ..., .by = NULL, .groups = NULL) {
 summarize <- summarise
 
 #' @export
-summarise.data.frame <- function(.data, ..., .by = NULL, .groups = NULL) {
-  by <- compute_by({{ .by }}, .data, by_arg = ".by", data_arg = ".data")
+summarise.data.frame <- function(
+  .data,
+  ...,
+  .by = NULL,
+  .with = NULL,
+  .groups = NULL
+) {
+  if (is_null(.with)) {
+    by <- compute_by({{ .by }}, .data, by_arg = ".by", data_arg = ".data")
+  } else {
+    if (is_list(.with)) {
+      by <- apply_list_of_with(.with, .data)
+    } else {
+      by <- .with(.data)
+    }
+  }
 
   cols <- summarise_cols(.data, dplyr_quosures(...), by, "summarise")
   out <- summarise_build(by, cols, "summarise")
@@ -134,6 +148,147 @@ summarise.data.frame <- function(.data, ..., .by = NULL, .groups = NULL) {
   }
 
   out
+}
+
+grouping_sets <- function(...) {
+  bys <- enquos(...)
+
+  function(data) {
+    n <- length(bys)
+    datas <- vector("list", length = n)
+
+    for (i in seq_len(n)) {
+      by <- bys[[i]]
+      by <- eval_select_by(by = by, data = data)
+      datas[[i]] <- compute_by_groups(data, by)
+    }
+
+    # Combine and make sure `.rows` ends up at the end
+    data <- vec_rbind(!!!datas)
+    rows <- data[[".rows"]]
+    data[[".rows"]] <- NULL
+    data[[".rows"]] <- rows
+
+    id <- data_frame(.id = vec_rep_each(seq_len(n), list_sizes(datas)))
+    data <- vec_cbind(id, data)
+
+    names <- setdiff(names(data), ".rows")
+    type <- "grouped"
+
+    new_by(type = type, names = names, data = data)
+  }
+}
+
+rollup <- function(by) {
+  by <- enquo(by)
+
+  function(data) {
+    by <- eval_select_by(by = by, data = data)
+    by <- lapply(length(by):0L, function(i) by[0L:i])
+    with <- grouping_sets(!!!by)
+    with(data)
+  }
+}
+
+cube <- function(by) {
+  by <- enquo(by)
+
+  function(data) {
+    by <- eval_select_by(by = by, data = data)
+    n <- length(by)
+    locs <- as.matrix(rev(expand.grid(rep(list(c(TRUE, FALSE)), n))))
+    by <- lapply(seq_len(nrow(locs)), function(i) by[locs[i, ]])
+    with <- grouping_sets(!!!by)
+    with(data)
+  }
+}
+
+windows <- function(
+  ...,
+  before = 0L,
+  after = 0L,
+  step = 1L,
+  complete = FALSE
+) {
+  function(data) {
+    locations <- slider::slide(
+      seq_len(nrow(data)),
+      identity,
+      .before = before,
+      .after = after,
+      .step = step,
+      .complete = complete
+    )
+
+    size <- length(locations)
+    data <- dplyr_new_tibble(
+      list(
+        .window = seq_len(size),
+        .rows = new_list_of(locations, ptype = integer())
+      ),
+      size = size
+    )
+
+    names <- ".window"
+    type <- "grouped"
+
+    new_by(type = type, names = names, data = data)
+  }
+}
+
+# `group_by(.drop = FALSE)`
+expanded <- function(by) {
+  by <- enquo(by)
+
+  function(data) {
+    by <- eval_select_by(by = by, data = data)
+    data <- compute_groups(data, by, drop = FALSE)
+    type <- "grouped"
+    new_by(type = type, names = by, data = data)
+  }
+}
+
+# Would be crazy slow due to repeated slicing of `data`
+# on smaller and smaller subgroups
+apply_list_of_with <- function(withs, data) {
+  groups <- group_data(data)
+  names <- character()
+
+  for (with in withs) {
+    list_of_rows <- unclass(groups[[".rows"]])
+    groups[[".rows"]] <- NULL
+
+    n_parents <- length(list_of_rows)
+    sub_data_list <- vector("list", length = n_parents)
+    sub_rows_list <- vector("list", length = n_parents)
+    sub_names <- character()
+
+    for (j in seq_len(n_parents)) {
+      rows <- list_of_rows[[j]]
+      slice <- vec_slice(data, rows)
+      sub_by <- with(slice)
+      sub_names <- sub_by$names
+
+      sub_groups <- sub_by$data
+      local_rows <- unclass(sub_groups[[".rows"]])
+      sub_groups[[".rows"]] <- NULL
+
+      sub_rows_list[[j]] <- vec_chop(rows, indices = local_rows)
+      sub_data_list[[j]] <- sub_groups
+    }
+
+    times <- list_sizes(sub_data_list)
+    groups <- vec_rep_each(groups, times = times)
+    groups <- vec_cbind(groups, vec_rbind(!!!sub_data_list))
+
+    new_rows <- vec_c(!!!sub_rows_list, .ptype = list())
+    groups[[".rows"]] <- new_list_of(new_rows, ptype = integer())
+
+    names <- c(names, sub_names)
+  }
+
+  type <- if (length(names) == 0L) "ungrouped" else "grouped"
+  new_by(type = type, names = names, data = groups)
 }
 
 #' @export

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -248,6 +248,17 @@ expanded <- function(by) {
   }
 }
 
+by_groups <- function(by) {
+  by <- enquo(by)
+
+  function(data) {
+    by <- eval_select_by(by = by, data = data)
+    data <- compute_by_groups(data, by)
+    type <- "grouped"
+    new_by(type = type, names = by, data = data)
+  }
+}
+
 # Would be crazy slow due to repeated slicing of `data`
 # on smaller and smaller subgroups
 apply_list_of_with <- function(withs, data) {


### PR DESCRIPTION
Noodling on #6532 

I'm going to open and close this immediately because we'd never merge in its current form, but its nice to fling this up somewhere.

The basic idea seems like it could be kind of useful. The implementation is quite bad, and it's hard to know where to bound this idea. Like, you probably want to enable something like `.by = cyl, .with = windows(.before = 2)`, but that gets horribly inefficient because to generate the `windows()` indices you have to slice `data` on each `cyl` first (and that gets recursively bad as you add more subgroup functions). See the last example for an example of this with `by_groups()`

The idea is quite interesting though. By scoping it to a transient type of grouping that exists _only_ within the `summarise()` call, you get to sidestep all of these issues related to the `grouped_df` class https://github.com/tidyverse/dplyr/issues/4722#issuecomment-577336343

``` r

# arbitrary grouping_sets()

as_tibble(mtcars) |>
  summarise(
    mpg = sum(mpg),
    .with = grouping_sets(c(cyl, am), c(gear, carb))
  )
#> # A tibble: 17 × 6
#>      .id   cyl    am  gear  carb   mpg
#>    <int> <dbl> <dbl> <dbl> <dbl> <dbl>
#>  1     1     6     1    NA    NA  61.7
#>  2     1     4     1    NA    NA 225. 
#>  3     1     6     0    NA    NA  76.5
#>  4     1     8     0    NA    NA 181. 
#>  5     1     4     0    NA    NA  68.7
#>  6     1     8     1    NA    NA  30.8
#>  7     2    NA    NA     4     4  79  
#>  8     2    NA    NA     4     1 116. 
#>  9     2    NA    NA     3     1  61  
#> 10     2    NA    NA     3     2  68.6
#> 11     2    NA    NA     3     4  63.1
#> 12     2    NA    NA     4     2  99  
#> 13     2    NA    NA     3     3  48.9
#> 14     2    NA    NA     5     2  56.4
#> 15     2    NA    NA     5     4  15.8
#> 16     2    NA    NA     5     6  19.7
#> 17     2    NA    NA     5     8  15
```

``` r

# rollup()

as_tibble(mtcars) |>
  summarise(
    mpg = sum(mpg),
    .with = grouping_sets(c(cyl, am), c(cyl), c(am), c())
  )
#> # A tibble: 12 × 4
#>      .id   cyl    am   mpg
#>    <int> <dbl> <dbl> <dbl>
#>  1     1     6     1  61.7
#>  2     1     4     1 225. 
#>  3     1     6     0  76.5
#>  4     1     8     0 181. 
#>  5     1     4     0  68.7
#>  6     1     8     1  30.8
#>  7     2     6    NA 138. 
#>  8     2     4    NA 293. 
#>  9     2     8    NA 211. 
#> 10     3    NA     1 317. 
#> 11     3    NA     0 326. 
#> 12     4    NA    NA 643.

# same but with rollup()
as_tibble(mtcars) |>
  summarise(
    mpg = sum(mpg),
    .with = rollup(c(cyl, am, vs))
  )
#> # A tibble: 17 × 5
#>      .id   cyl    am    vs   mpg
#>    <int> <dbl> <dbl> <dbl> <dbl>
#>  1     1     6     1     0  61.7
#>  2     1     4     1     1 199. 
#>  3     1     6     0     1  76.5
#>  4     1     8     0     0 181. 
#>  5     1     4     0     1  68.7
#>  6     1     4     1     0  26  
#>  7     1     8     1     0  30.8
#>  8     2     6     1    NA  61.7
#>  9     2     4     1    NA 225. 
#> 10     2     6     0    NA  76.5
#> 11     2     8     0    NA 181. 
#> 12     2     4     0    NA  68.7
#> 13     2     8     1    NA  30.8
#> 14     3     6    NA    NA 138. 
#> 15     3     4    NA    NA 293. 
#> 16     3     8    NA    NA 211. 
#> 17     4    NA    NA    NA 643.
```

``` r

# cube()

as_tibble(mtcars) |>
  summarise(
    mpg = sum(mpg),
    .with = grouping_sets(c(cyl, am), c(cyl), c(am), c())
  )
#> # A tibble: 12 × 4
#>      .id   cyl    am   mpg
#>    <int> <dbl> <dbl> <dbl>
#>  1     1     6     1  61.7
#>  2     1     4     1 225. 
#>  3     1     6     0  76.5
#>  4     1     8     0 181. 
#>  5     1     4     0  68.7
#>  6     1     8     1  30.8
#>  7     2     6    NA 138. 
#>  8     2     4    NA 293. 
#>  9     2     8    NA 211. 
#> 10     3    NA     1 317. 
#> 11     3    NA     0 326. 
#> 12     4    NA    NA 643.

# same but with cube()
as_tibble(mtcars) |>
  summarise(
    mpg = sum(mpg),
    .with = cube(c(cyl, am, vs))
  )
#> # A tibble: 30 × 5
#>      .id   cyl    am    vs   mpg
#>    <int> <dbl> <dbl> <dbl> <dbl>
#>  1     1     6     1     0  61.7
#>  2     1     4     1     1 199. 
#>  3     1     6     0     1  76.5
#>  4     1     8     0     0 181. 
#>  5     1     4     0     1  68.7
#>  6     1     4     1     0  26  
#>  7     1     8     1     0  30.8
#>  8     2     6     1    NA  61.7
#>  9     2     4     1    NA 225. 
#> 10     2     6     0    NA  76.5
#> # ℹ 20 more rows
```

``` r

# windows()

as_tibble(mtcars) |>
  reframe(
    data = pick(everything()),
    .with = windows(before = 2)
  )
#> # A tibble: 93 × 2
#>    .window data$mpg  $cyl $disp   $hp $drat   $wt $qsec   $vs   $am $gear $carb
#>      <int>    <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
#>  1       1     21       6   160   110  3.9   2.62  16.5     0     1     4     4
#>  2       2     21       6   160   110  3.9   2.62  16.5     0     1     4     4
#>  3       2     21       6   160   110  3.9   2.88  17.0     0     1     4     4
#>  4       3     21       6   160   110  3.9   2.62  16.5     0     1     4     4
#>  5       3     21       6   160   110  3.9   2.88  17.0     0     1     4     4
#>  6       3     22.8     4   108    93  3.85  2.32  18.6     1     1     4     1
#>  7       4     21       6   160   110  3.9   2.88  17.0     0     1     4     4
#>  8       4     22.8     4   108    93  3.85  2.32  18.6     1     1     4     1
#>  9       4     21.4     6   258   110  3.08  3.22  19.4     1     0     3     1
#> 10       5     22.8     4   108    93  3.85  2.32  18.6     1     1     4     1
#> # ℹ 83 more rows
```

``` r

# like group_by(.drop = FALSE)

as_tibble(iris[1:20, ]) |>
  summarise(
    sum = sum(Sepal.Length),
    .with = expanded(Species)
  )
#> # A tibble: 3 × 2
#>   Species      sum
#>   <fct>      <dbl>
#> 1 setosa      101.
#> 2 versicolor    0 
#> 3 virginica     0
```

``` r

# crazy but slow idea, list() of `.with` to recursively apply `.with`
# to each subgroup

# (technically some SQL impls do support multiple rollup() or cube() calls
# in the same GROUP BY like this, but idk how useful that really is. and its
# massively slow here because we slice `data` on each subgroup we generate)

# "within each group generated by the rollup, apply a second rollup"

summarise(
  as_tibble(mtcars),
  sum = sum(mpg),
  .with = list(rollup(c(vs, am)), rollup(c(gear, carb)))
)
#> New names:
#> • `.id` -> `.id...1`
#> • `.id` -> `.id...4`
#> # A tibble: 61 × 7
#>    .id...1    vs    am .id...4  gear  carb   sum
#>      <int> <dbl> <dbl>   <int> <dbl> <dbl> <dbl>
#>  1       1     0     1       1     4     4  42  
#>  2       1     0     1       1     5     2  26  
#>  3       1     0     1       1     5     4  15.8
#>  4       1     0     1       1     5     6  19.7
#>  5       1     0     1       1     5     8  15  
#>  6       1     0     1       2     4    NA  42  
#>  7       1     0     1       2     5    NA  76.5
#>  8       1     0     1       3    NA    NA 118. 
#>  9       1     1     1       1     4     1 116. 
#> 10       1     1     1       1     4     2  51.8
#> # ℹ 51 more rows


# its probably more useful as a way to do a custom grouping within a broader
# grouping, which does feel like something people would reach for. i.e.
# within each cyl, perform a rolling window analysis of some kind

summarise(
  as_tibble(mtcars),
  sum = sum(mpg),
  .with = list(by_groups(cyl), windows(before = 2))
)
#> # A tibble: 32 × 3
#>      cyl .window   sum
#>    <dbl>   <int> <dbl>
#>  1     6       1  21  
#>  2     6       2  42  
#>  3     6       3  63.4
#>  4     6       4  60.5
#>  5     6       5  58.7
#>  6     6       6  55.1
#>  7     6       7  56.7
#>  8     4       1  22.8
#>  9     4       2  47.2
#> 10     4       3  70  
#> # ℹ 22 more rows
```