### PR TITLE
Feature: group_modify() in R/group-map.R

### DIFF
--- a/R/group-map.R
+++ b/R/group-map.R
@@ -10,6 +10,16 @@ as_group_map_function <- function(.f, error_call = caller_env()) {
   .f
 }
 
+as_group_modify_col <- function(.col, .data, .keep = FALSE, error_call = caller_env()) {
+  vars <- names(.data)
+
+  if (is_grouped_df(.data) && !isTRUE(.keep)) {
+    vars <- setdiff(vars, group_vars(.data))
+  }
+
+  tidyselect::vars_pull(vars, !!.col, error_call = error_call)
+}
+
 #' Apply a function to each group
 #'
 #' @description
@@ -203,8 +213,8 @@ group_modify.data.frame <- function(
   col <- enquo(.col)
 
   if (!quo_is_null(by)) {
-    by_cols <- names(tidyselect::eval_select(by, .data))
-    .data <- group_by(.data, across(all_of(by_cols)))
+    by_cols <- eval_select_by(by, .data)
+    .data <- group_by(.data, !!!syms(by_cols))
     return(group_modify.grouped_df(
       .data,
       .f,
@@ -215,11 +225,12 @@ group_modify.data.frame <- function(
     ))
   }
 
-  .f <- as_group_map_function(.f)
-
   if (!quo_is_null(col)) {
-    .f(pull(.data, !!col), ...)
+    .f <- rlang::as_function(.f)
+    col <- as_group_modify_col(col, .data, error_call = current_env())
+    .f(.data[[col]], ...)
   } else {
+    .f <- as_group_map_function(.f)
     .f(.data, group_keys(.data), ...)
   }
 }
@@ -251,33 +262,42 @@ group_modify.grouped_df <- function(
   }
 
   col <- enquo(.col)
+  tbl_group_vars <- group_vars(.data)
+  error_call <- current_env()
 
   if (quo_is_null(col)) {
     .f <- as_group_map_function(.f)
+    fun <- function(.x, .y) {
+      res <- .f(.x, .y, ...)
+      if (!inherits(res, "data.frame")) {
+        abort("The result of `.f` must be a data frame.", call = error_call)
+      }
+      if (any(bad <- names(res) %in% tbl_group_vars)) {
+        msg <- glue(
+          "The returned data frame cannot contain the original grouping variables: {names}.",
+          names = paste(names(res)[bad], collapse = ", ")
+        )
+        abort(msg, call = error_call)
+      }
+      bind_cols(.y[rep(1L, nrow(res)), , drop = FALSE], res)
+    }
   } else {
     .f <- rlang::as_function(.f)
-  }
-
-  tbl_group_vars <- group_vars(.data)
-
-  error_call <- current_env()
-  fun <- function(.x, .y) {
-    res <- if (!quo_is_null(col)) {
-      .f(pull(.x, !!col), ...)
-    } else {
-      .f(.x, .y, ...)
+    col <- as_group_modify_col(col, .data, .keep = .keep, error_call = current_env())
+    fun <- function(.x, .y) {
+      res <- .f(.x[[col]], ...)
+      if (!inherits(res, "data.frame")) {
+        abort("The result of `.f` must be a data frame.", call = error_call)
+      }
+      if (any(bad <- names(res) %in% tbl_group_vars)) {
+        msg <- glue(
+          "The returned data frame cannot contain the original grouping variables: {names}.",
+          names = paste(names(res)[bad], collapse = ", ")
+        )
+        abort(msg, call = error_call)
+      }
+      bind_cols(.y[rep(1L, nrow(res)), , drop = FALSE], res)
     }
-    if (!inherits(res, "data.frame")) {
-      abort("The result of `.f` must be a data frame.", call = error_call)
-    }
-    if (any(bad <- names(res) %in% tbl_group_vars)) {
-      msg <- glue(
-        "The returned data frame cannot contain the original grouping variables: {names}.",
-        names = paste(names(res)[bad], collapse = ", ")
-      )
-      abort(msg, call = error_call)
-    }
-    bind_cols(.y[rep(1L, nrow(res)), , drop = FALSE], res)
   }
 
   chunks <- group_map(.data, fun, .keep = .keep)

--- a/R/group-map.R
+++ b/R/group-map.R
@@ -205,7 +205,14 @@ group_modify.data.frame <- function(
   if (!quo_is_null(by)) {
     by_cols <- names(tidyselect::eval_select(by, .data))
     .data <- group_by(.data, across(all_of(by_cols)))
-    return(group_modify.grouped_df(.data, .f, ..., .col = col, .keep = .keep))
+    return(group_modify.grouped_df(
+      .data,
+      .f,
+      ...,
+      .col = !!col,
+      .keep = .keep,
+      .inline_by = TRUE
+    ))
   }
 
   .f <- as_group_map_function(.f)
@@ -225,6 +232,7 @@ group_modify.grouped_df <- function(
   .by = NULL,
   ...,
   .keep = FALSE,
+  .inline_by = FALSE,
   keep = deprecated()
 ) {
   if (!missing(keep)) {
@@ -273,7 +281,12 @@ group_modify.grouped_df <- function(
   } else {
     attr(chunks, "ptype")
   }
-  grouped_df(res, group_vars(.data), group_by_drop_default(.data))
+
+  if (.inline_by) {
+    ungroup(res)
+  } else {
+    grouped_df(res, group_vars(.data), group_by_drop_default(.data))
+  }
 }
 
 

--- a/R/group-map.R
+++ b/R/group-map.R
@@ -54,6 +54,12 @@ as_group_map_function <- function(.f, error_call = caller_env()) {
 #' @param ... Additional arguments passed on to `.f`
 #' @param .keep are the grouping variables kept in `.x`
 #'
+#' @param .col <[`tidy-select`][dplyr_tidy_select]> Optionally, a column to
+#'   pass directly to `.f` as a vector, instead of the full chunk.
+#' @param .by <[`tidy-select`][dplyr_tidy_select]> Optionally, a selection of
+#'   columns to group by for just this operation, functioning as an alternative
+#'   to [group_by()]. For details and examples, see [?dplyr_by][dplyr_by].
+#'
 #' @return
 #'  - `group_modify()` returns a grouped tibble. In that case `.f` must return a data frame.
 #'  - `group_map()` returns a list of results from calling `.f` on each group.

--- a/R/group-map.R
+++ b/R/group-map.R
@@ -192,8 +192,23 @@ group_modify.data.frame <- function(
       "group_modify(.keep = )"
     )
   }
+
+  by <- enquo(.by)
+  col <- enquo(.col)
+
+  if (!quo_is_null(by)) {
+    by_cols <- names(tidyselect::eval_select(by, .data))
+    .data <- group_by(.data, across(all_of(by_cols)))
+    return(group_modify.grouped_df(.data, .f, ..., .col = col, .keep = .keep))
+  }
+
   .f <- as_group_map_function(.f)
-  .f(.data, group_keys(.data), ...)
+
+  if (!quo_is_null(col)) {
+    .f(pull(.data, !!col), ...)
+  } else {
+    .f(.data, group_keys(.data), ...)
+  }
 }
 
 #' @export

--- a/R/group-map.R
+++ b/R/group-map.R
@@ -251,9 +251,14 @@ group_modify.grouped_df <- function(
   }
 
   col <- enquo(.col)
-  tbl_group_vars <- group_vars(.data)
 
-  .f <- as_group_map_function(.f)
+  if (quo_is_null(col)) {
+    .f <- as_group_map_function(.f)
+  } else {
+    .f <- rlang::as_function(.f)
+  }
+
+  tbl_group_vars <- group_vars(.data)
 
   error_call <- current_env()
   fun <- function(.x, .y) {

--- a/R/group-map.R
+++ b/R/group-map.R
@@ -179,6 +179,8 @@ group_modify <- function(
 group_modify.data.frame <- function(
   .data,
   .f,
+  .col = NULL,
+  .by = NULL,
   ...,
   .keep = FALSE,
   keep = deprecated()

--- a/R/group-map.R
+++ b/R/group-map.R
@@ -172,9 +172,9 @@ group_map.data.frame <- function(
 group_modify <- function(
   .data,
   .f,
-  ...,
-  .by = NULL,
   .col = NULL,
+  .by = NULL,
+  ...,
   .keep = FALSE
 ) {
   lifecycle::signal_stage("experimental", "group_map()")

--- a/R/group-map.R
+++ b/R/group-map.R
@@ -163,7 +163,14 @@ group_map.data.frame <- function(
 
 #' @rdname group_map
 #' @export
-group_modify <- function(.data, .f, ..., .keep = FALSE) {
+group_modify <- function(
+  .data,
+  .f,
+  ...,
+  .by = NULL,
+  .col = NULL,
+  .keep = FALSE
+) {
   lifecycle::signal_stage("experimental", "group_map()")
   UseMethod("group_modify")
 }

--- a/R/group-map.R
+++ b/R/group-map.R
@@ -239,11 +239,7 @@ group_modify.grouped_df <- function(
   col <- enquo(.col)
   tbl_group_vars <- group_vars(.data)
 
-  if (!quo_is_null(col)) {
-    .f <- as_group_map_function(.f) # skip wrap, call directly
-  } else {
-    .f <- as_group_map_function(.f)
-  }
+  .f <- as_group_map_function(.f)
 
   error_call <- current_env()
   fun <- function(.x, .y) {

--- a/R/group-map.R
+++ b/R/group-map.R
@@ -215,6 +215,8 @@ group_modify.data.frame <- function(
 group_modify.grouped_df <- function(
   .data,
   .f,
+  .col = NULL,
+  .by = NULL,
   ...,
   .keep = FALSE,
   keep = deprecated()
@@ -227,12 +229,29 @@ group_modify.grouped_df <- function(
     )
   }
 
+  if (!quo_is_null(enquo(.by))) {
+    abort(
+      "Can't supply `.by` when `.data` is a grouped data frame. Use `ungroup()` first.",
+      call = current_env()
+    )
+  }
+
+  col <- enquo(.col)
   tbl_group_vars <- group_vars(.data)
-  .f <- as_group_map_function(.f)
+
+  if (!quo_is_null(col)) {
+    .f <- as_group_map_function(.f) # skip wrap, call directly
+  } else {
+    .f <- as_group_map_function(.f)
+  }
 
   error_call <- current_env()
   fun <- function(.x, .y) {
-    res <- .f(.x, .y, ...)
+    res <- if (!quo_is_null(col)) {
+      .f(pull(.x, !!col), ...)
+    } else {
+      .f(.x, .y, ...)
+    }
     if (!inherits(res, "data.frame")) {
       abort("The result of `.f` must be a data frame.", call = error_call)
     }
@@ -245,6 +264,7 @@ group_modify.grouped_df <- function(
     }
     bind_cols(.y[rep(1L, nrow(res)), , drop = FALSE], res)
   }
+
   chunks <- group_map(.data, fun, .keep = .keep)
   res <- if (length(chunks) > 0L) {
     bind_rows(!!!chunks)
@@ -253,6 +273,7 @@ group_modify.grouped_df <- function(
   }
   grouped_df(res, group_vars(.data), group_by_drop_default(.data))
 }
+
 
 #' @export
 #' @rdname group_map

--- a/tests/testthat/test-group-map.R
+++ b/tests/testthat/test-group-map.R
@@ -1,3 +1,44 @@
+# helper to test pr #7840
+md_iqr <- function(x, center = 0.5, spread = c(0.25, 0.75)) {
+  c <- quantile(x, center)
+  s <- quantile(x, spread)
+  data <- data.frame(y = c, ymin = min(s), ymax = max(s))
+
+  return(data)
+}
+
+test_that("group_modify() with .by returns an ungrouped data frame. pr #7840", {
+  res <- mtcars |> group_modify(md_iqr, .col = mpg, .by = gear)
+  expect_false(dplyr:::is_grouped_df(res))
+  expect_equal(nrow(res), 3L)
+  expect_true(all(c("gear", "y", "ymin", "ymax") %in% names(res)))
+})
+
+test_that("group_modify() with .by errors on already-grouped data. pr #7840", {
+  expect_error(
+    mtcars |> group_by(gear) |> group_modify(md_iqr, .col = mpg, .by = gear),
+    "Can't supply `.by`"
+  )
+})
+
+test_that("group_modify() with .col passes vector to .f. pr #7840", {
+  res_by <- mtcars |> group_modify(md_iqr, .col = mpg, .by = gear)
+  res_old <- mtcars |> group_by(gear) |> group_modify(~ md_iqr(.x$mpg))
+  expect_equal(res_by$y, ungroup(res_old)$y)
+  expect_equal(res_by$ymin, ungroup(res_old)$ymin)
+  expect_equal(res_by$ymax, ungroup(res_old)$ymax)
+})
+
+test_that("group_modify() with .col forwards ... to .f. pr #7840", {
+  res <- mtcars |>
+    group_modify(md_iqr, .col = mpg, .by = gear, spread = c(0.1, 0.9))
+  expect_equal(nrow(res), 3L)
+  # wider spread should produce larger range than default
+  res_default <- mtcars |> group_modify(md_iqr, .col = mpg, .by = gear)
+  expect_true(all(res$ymax >= res_default$ymax))
+})
+
+
 test_that("group_map() respects empty groups", {
   res <- group_by(mtcars, cyl) |>
     group_map(~ head(.x, 2L))


### PR DESCRIPTION
Closes #7839

The implemntation of my issue, where I added some examples.

This PR adds `.by` and `.col` arguments to `group_modify()`
`.by` instrad of `group_by()` and `.col` instead of `~.x$col`
Updated `group_modify.data.frame` and `group_modify.grouped_df` accordingly

## Out of scope
I didn't change `group_map()` and `group_walk()`  but it should be a natural follow up since the internal functions that they share have been modified..

## Main tests added:
```
res <- mtcars |> group_modify(med_iqr, .col = mpg, .by = gear)
expect_false(is_grouped_df(res))
```
```
expect_error(
    mtcars |> group_by(gear) |> group_modify(med_iqr, .col = mpg, .by = gear),
    "Can't supply `.by`"
  )
```
```
test_that("group_modify() with .col passes vector to .f. pr #7840", {
  res_by <- mtcars |> group_modify(md_iqr, .col = mpg, .by = gear)
  res_old <- mtcars |> group_by(gear) |> group_modify(~ md_iqr(.x$mpg))
  expect_equal(res_by$y, ungroup(res_old)$y)
  })
```