### PR TITLE
docs: clarify between comparison semantics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # dplyr (development version)
 
+* `between()` documentation now more precisely describes how local vectors are
+  cast to a common type and compared with vctrs (#7702, @LeonidasZhak).
+
 # dplyr 1.2.1
 
 * dplyr is now fully compliant with the R C API (#7819).

--- a/R/funs.R
+++ b/R/funs.R
@@ -1,11 +1,13 @@
 #' Detect where values fall in a specified range
 #'
-#' This is a shortcut for `x >= left & x <= right`, implemented for local
-#' vectors and translated to the appropriate SQL for remote tables.
+#' For local vectors, this is similar to `x >= left & x <= right`.
+#' For remote tables, it is translated to the appropriate SQL.
 #'
 #' @details
 #' `x`, `left`, and `right` are all cast to their common type before the
-#' comparison is made. Use the `ptype` argument to specify the type manually.
+#' comparison is made with [vctrs::vec_compare()]. This means that character
+#' strings are not parsed as dates or date-times. Use the `ptype` argument to
+#' specify the type manually.
 #'
 #' @inheritParams rlang::args_dots_empty
 #'

--- a/man/between.Rd
+++ b/man/between.Rd
@@ -22,12 +22,14 @@ default is to compute the common type of \code{x}, \code{left}, and \code{right}
 A logical vector the same size as \code{x} with a type determined by \code{ptype}.
 }
 \description{
-This is a shortcut for \code{x >= left & x <= right}, implemented for local
-vectors and translated to the appropriate SQL for remote tables.
+For local vectors, this is similar to \code{x >= left & x <= right}.
+For remote tables, it is translated to the appropriate SQL.
 }
 \details{
 \code{x}, \code{left}, and \code{right} are all cast to their common type before the
-comparison is made. Use the \code{ptype} argument to specify the type manually.
+comparison is made with \code{\link[vctrs:vec_compare]{vctrs::vec_compare()}}. This means that character
+strings are not parsed as dates or date-times. Use the \code{ptype} argument to
+specify the type manually.
 }
 \examples{
 between(1:12, 7, 9)


### PR DESCRIPTION
Fixes #7702.

## Summary
- describe local `between()` comparisons as similar to `x >= left & x <= right`, rather than an exact shortcut
- mention that local comparisons use vctrs after common-type casting
- clarify that character strings are not parsed as dates or date-times

## Checks
- `Rscript -e 'tools::checkRd("man/between.Rd")'`\n- `git diff --check`\n- `R CMD build --no-build-vignettes .` was attempted, but this local machine has `rlang` 1.1.6 loaded while dplyr now requires >= 1.1.7